### PR TITLE
Smsc95xx patches

### DIFF
--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -1072,6 +1072,7 @@ static int smsc95xx_bind(struct usbnet *dev, struct usb_interface *intf)
 	dev->net->ethtool_ops = &smsc95xx_ethtool_ops;
 	dev->net->flags |= IFF_MULTICAST;
 	dev->net->hard_header_len += SMSC95XX_TX_OVERHEAD_CSUM;
+	dev->hard_mtu = dev->net->mtu + dev->net->hard_header_len;
 	return 0;
 }
 

--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -1247,7 +1247,7 @@ static const struct driver_info smsc95xx_info = {
 	.rx_fixup	= smsc95xx_rx_fixup,
 	.tx_fixup	= smsc95xx_tx_fixup,
 	.status		= smsc95xx_status,
-	.flags		= FLAG_ETHER | FLAG_SEND_ZLP,
+	.flags		= FLAG_ETHER | FLAG_SEND_ZLP | FLAG_LINK_INTR,
 };
 
 static const struct usb_device_id products[] = {


### PR DESCRIPTION
Hi! I'm Steve Glendinning, the kernel maintainer of the smsc95xx ethernet driver (as used by the Raspberry Pi).

Please apply these two driver patches to your Rasberry Pi kernel tree.  They're included in Linus's tree from 3.4.0-rc5+, and they address two issues that affect the ethernet hardware on Raspberry-Pi:

1 - MTU is only 1488 without these, so full size ethernet frames can't be sent or received properly
2 - The link patch makes it much quicker to properly detect a link at startup and run DHCP.  Without it you may also see some error frames reported before the link actually comes up.

Please also advise anyone else packaging kernels for Raspberry Pi distributions of these two patches.

Thanks!
steve.glendinning@shawell.net
