### PR TITLE
The TIMER_PERIOD should be calculated using the timer interrupt frequenc...

### DIFF
--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -618,7 +618,7 @@ void __init bcm2708_init(void)
 #endif
 }
 
-#define TIMER_PERIOD 10000	/* HZ in microsecs */
+#define TIMER_PERIOD DIV_ROUND_CLOSEST(STC_FREQ_HZ, HZ)
 
 static void timer_set_mode(enum clock_event_mode mode,
 			   struct clock_event_device *clk)


### PR DESCRIPTION
If ever the timer interrupt frequency (HZ) changes, the timer period value needs to be updated. This update will calculate the timer period at compile time based on the value of HZ.
