### PR TITLE
smsc95xx: Fix hard_header_len

### DIFF
--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -1071,8 +1071,8 @@ static int smsc95xx_bind(struct usbnet *dev, struct usb_interface *intf)
 	dev->net->netdev_ops = &smsc95xx_netdev_ops;
 	dev->net->ethtool_ops = &smsc95xx_ethtool_ops;
 	dev->net->flags |= IFF_MULTICAST;
-	dev->net->hard_header_len += SMSC95XX_TX_OVERHEAD_CSUM;
-	dev->hard_mtu = dev->net->mtu + dev->net->hard_header_len;
+	dev->net->needed_headroom = SMSC95XX_TX_OVERHEAD_CSUM;
+	dev->hard_mtu = dev->net->mtu + dev->net->hard_header_len + dev->net->needed_headroom;
 	return 0;
 }
 


### PR DESCRIPTION
This device may require up-to 12 bytes of headroom. Assign the needed_headroom
but stop lying about hard_header_len which is used in many places throughout
the kernel.

Without this patch it is not possible to use "IFB + tc ... mirror / redirect " as per
http://www.linuxfoundation.org/collaborate/workgroups/networking/ifb.

Tested using Raspberry Pi as a router with trafficshaping and IFB.
