### PR TITLE
Revert "Disable IRQs in dwc_otg_hcd_qh_free" patch

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_queue.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_queue.c
@@ -54,11 +54,10 @@ extern bool microframe_schedule;
  */
 void dwc_otg_hcd_qh_free(dwc_otg_hcd_t * hcd, dwc_otg_qh_t * qh)
 {
-	dwc_irqflags_t flags;
 	dwc_otg_qtd_t *qtd, *qtd_tmp;
 
 	/* Free each QTD in the QTD list */
-	DWC_SPINLOCK_IRQSAVE(hcd->lock,&flags);
+	DWC_SPINLOCK(hcd->lock);
 	DWC_CIRCLEQ_FOREACH_SAFE(qtd, qtd_tmp, &qh->qtd_list, qtd_list_entry) {
 		DWC_CIRCLEQ_REMOVE(&qh->qtd_list, qtd, qtd_list_entry);
 		dwc_otg_hcd_qtd_free(qtd);
@@ -77,7 +76,7 @@ void dwc_otg_hcd_qh_free(dwc_otg_hcd_t * hcd, dwc_otg_qh_t * qh)
 	}
 
 	DWC_FREE(qh);
-	DWC_SPINUNLOCK_IRQRESTORE(hcd->lock,flags);
+	DWC_SPINUNLOCK(hcd->lock);
 	return;
 }
 


### PR DESCRIPTION
Revert "Disable IRQs in dwc_otg_hcd_qh_free" patch because DWC_DMA_FREE should be called with enabled IRQs.
# 

  300.944739 WARNING: at arch/arm/mm/dma-mapping.c:444 dma_free_coherent+0x1a0/0x204()  
  300.960062 Modules linked in: snd_usb_audio snd_usbmidi_lib snd_hwdep snd_seq_midi snd_seq_midi_event snd_rawmidi snd_pcm snd_p8
  300.991090 c00153d8 (unwind_backtrace+0x0/0xfc) from c0401f20 (dump_stack+0x20/0x24)  
  301.007152 c0401f20 (dump_stack+0x20/0x24) from c002e8f8 (warn_slowpath_common+0x5c/0x74)  
  301.023643 c002e8f8 (warn_slowpath_common+0x5c/0x74) from c002e93c (warn_slowpath_null+0x2c/0x34)  
  301.040858 c002e93c (warn_slowpath_null+0x2c/0x34) from c0018b14 (dma_free_coherent+0x1a0/0x204)  
  301.057991 c0018b14 (dma_free_coherent+0x1a0/0x204) from c03038d0 (__DWC_DMA_FREE+0x18/0x1c)  
  301.074774 c03038d0 (__DWC_DMA_FREE+0x18/0x1c) from c02fe70c (dwc_otg_hcd_qh_free+0xbc/0xec)  
  301.091546 c02fe70c (dwc_otg_hcd_qh_free+0xbc/0xec) from c02f9698 (dwc_otg_hcd_endpoint_disable+0xac/0xc0)  
  301.109550 c02f9698 (dwc_otg_hcd_endpoint_disable+0xac/0xc0) from c02fbcac (endpoint_disable+0x28/0x34)  
  301.127307 c02fbcac (endpoint_disable+0x28/0x34) from c02d69dc (usb_hcd_disable_endpoint+0x2c/0x30)  
  301.144698 c02d69dc (usb_hcd_disable_endpoint+0x2c/0x30) from c02d8fb0 (usb_disable_endpoint+0x70/0x90)  
  301.162611 c02d8fb0 (usb_disable_endpoint+0x70/0x90) from c02d901c (usb_disable_interface+0x4c/0x64)  
  301.180351 c02d901c (usb_disable_interface+0x4c/0x64) from c02d965c (usb_set_interface+0x154/0x244)  
  301.198129 c02d965c (usb_set_interface+0x154/0x244) from bf108970 (snd_usb_pcm_close+0x4c/0x70 snd_usb_audio)  
  301.217082 bf108970 (snd_usb_pcm_close+0x4c/0x70 snd_usb_audio) from bf1089b0 (snd_usb_capture_close+0x1c/0x20 snd_u)
  301.237706 bf1089b0 (snd_usb_capture_close+0x1c/0x20 snd_usb_audio) from bf0c38e4 (snd_pcm_release_substream+0x64/0xb)
  301.258411 bf0c38e4 (snd_pcm_release_substream+0x64/0xb8 snd_pcm) from bf0c3970 (snd_pcm_release+0x38/0x7c snd_pcm) 
  301.278001 bf0c3970 (snd_pcm_release+0x38/0x7c snd_pcm) from c00f5284 (fput+0xc0/0x218)  
  301.294816 c00f5284 (fput+0xc0/0x218) from c00f1644 (filp_close+0x74/0x98)  
  301.310277 c00f1644 (filp_close+0x74/0x98) from c00f1728 (sys_close+0xc0/0x114)  
  301.326162 c00f1728 (sys_close+0xc0/0x114) from c000e140 (ret_fast_syscall+0x0/0x48)  
  301.342456 --- end trace 90f17bd35cfc0b79 ---                                                                                 
