### PR TITLE
Added ID for Atheros AR3011 found in ath3k.c.

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -123,6 +123,9 @@ static struct usb_device_id blacklist_table[] = {
 	/* Broadcom BCM2033 without firmware */
 	{ USB_DEVICE(0x0a5c, 0x2033), .driver_info = BTUSB_IGNORE },
 
+	/* Atheros AR3011 without firmware*/
+	{ USB_DEVICE(0x0CF3, 0x3000) },
+
 	/* Atheros 3011 with sflash firmware */
 	{ USB_DEVICE(0x0cf3, 0x3002), .driver_info = BTUSB_IGNORE },
 	{ USB_DEVICE(0x13d3, 0x3304), .driver_info = BTUSB_IGNORE },


### PR DESCRIPTION
As per the instructions on this page (http://wireless.kernel.org/en/users/Drivers/ath3k) I'm hoping this will enable support for my particular model of ASUS USB-BT211 which uses the AR3011 chipset.
