### PR TITLE
fix build with CONFIG_BCM2708_VCHIQ is disabled

### DIFF
--- a/drivers/misc/Makefile
+++ b/drivers/misc/Makefile
@@ -48,4 +48,4 @@ obj-y				+= lis3lv02d/
 obj-y				+= carma/
 obj-$(CONFIG_USB_SWITCH_FSA9480) += fsa9480.o
 obj-$(CONFIG_ALTERA_STAPL)	+=altera-stapl/
-obj-y				+= vc04_services/
+obj-$(CONFIG_BCM2708_VCHIQ)	+= vc04_services/


### PR DESCRIPTION
this fixes the build if CONFIG_BCM2708_VCHIQ is disabled (non RPi systems)

```
  LD      drivers/misc/lis3lv02d/built-in.o
  LD      drivers/misc/ti-st/built-in.o
  LD      drivers/misc/built-in.o
/home/openelec/OpenELEC-DUAL/build.OpenELEC-Fusion.x86_64-devel/toolchain/bin/x86_64-openelec-linux-gnu-ld: cannot find drivers/misc/vc04_services/built-in.o: No such file or directory
make[3]: *** [drivers/misc/built-in.o] Error 1
make[2]: *** [drivers/misc] Error 2
make[1]: *** [drivers] Error 2
make[1]: Leaving directory `/home/openelec/OpenELEC-DUAL/build.OpenELEC-Fusion.x86_64-devel/linux-3.2.30'
make: *** [release] Error 2
```
