### PR TITLE
spi/spi-bcm2708: respect per-transfer SPI clock speed_hz value

### DIFF
--- a/drivers/spi/spi-bcm2708.c
+++ b/drivers/spi/spi-bcm2708.c
@@ -259,6 +259,10 @@ static int bcm2708_setup_state(struct spi_master *master,
 	if (state) {
 		state->cs = cs;
 		state->cdiv = cdiv;
+		dev_dbg(dev, "setup: want %d Hz; "
+			"bus_hz=%lu / cdiv=%u == %lu Hz; "
+			"mode %u: cs 0x%08X\n",
+			hz, bus_hz, cdiv, bus_hz/cdiv, mode, cs);
 	}
 
 	return 0;
@@ -277,7 +281,8 @@ static int bcm2708_process_transfer(struct bcm2708_spi *bs,
 
 	if (xfer->bits_per_word || xfer->speed_hz) {
 		ret = bcm2708_setup_state(spi->master, &spi->dev, &state,
-			spi->max_speed_hz, spi->chip_select, spi->mode,
+			xfer->speed_hz ? xfer->speed_hz : spi->max_speed_hz,
+			spi->chip_select, spi->mode,
 			spi->bits_per_word);
 		if (ret)
 			return ret;


### PR DESCRIPTION
The bcm2708 SPI driver's bcm2708_process_transfer() was ignoring the
per-transfer speed_hz value even when it was provided (it always just
used the spi device's max_speed_hz value).  Now, per-transfer speed_hz
values are respected.

Also added debug print to bcm2708_setup_state() to help keep an eye on
the configured SPI parameters.

Signed-off-by: Kamal Mostafa kamal@whence.com
