### PR TITLE
dwc_otg: fix bug in dwc_otg_hcd.c resulting in silent kernel memory corruption

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
@@ -500,8 +500,6 @@ int dwc_otg_hcd_urb_enqueue(dwc_otg_hcd_t * hcd,
 		DWC_ERROR("DWC OTG HCD URB Enqueue failed adding QTD. "
 			  "Error status %d\n", retval);
 		dwc_otg_hcd_qtd_free(qtd);
-	} else {
-		qtd->qh = *ep_handle;
 	}
 	intr_mask.d32 = DWC_READ_REG32(&hcd->core_if->core_global_regs->gintmsk);
 	if (!intr_mask.b.sofintr && retval == 0) {

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_queue.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_queue.c
@@ -946,6 +946,7 @@ int dwc_otg_hcd_qtd_add(dwc_otg_qtd_t * qtd,
 	if (retval == 0) {
 		DWC_CIRCLEQ_INSERT_TAIL(&((*qh)->qtd_list), qtd,
 					qtd_list_entry);
+		qtd->qh = *qh;
 	}
 	DWC_SPINUNLOCK_IRQRESTORE(hcd->lock, flags);
 


### PR DESCRIPTION
Issue #189 - solved by applying this patch.

Additionally this patch has eliminated the " smsc95xx 1-1.1:1.0: eth0: kevent 2 may have been dropped" error messages that have been flooding the kernel log with smsc95xx.turbo_mode=Y enabled.
