### PR TITLE
Blind fix of raspberry halt due to unhandled int

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
@@ -2122,13 +2122,15 @@ static void handle_hc_chhltd_intr_dma(dwc_otg_hcd_t * hcd,
 				halt_channel(hcd, hc, qtd,
 					     DWC_OTG_HC_XFER_PERIODIC_INCOMPLETE);
 			} else {
-				DWC_ERROR
-				    ("%s: Channel %d, DMA Mode -- ChHltd set, but reason "
-				     "for halting is unknown, hcint 0x%08x, intsts 0x%08x\n",
-				     __func__, hc->hc_num, hcint.d32,
-				     DWC_READ_REG32(&hcd->
-						    core_if->core_global_regs->
-						    gintsts));
+				/*
+				* Even if the reason for landing here is unknown, handle
+				* it like previously. Someone that understands how the
+				* driver works should probably explain why this works
+				* or add a real fix
+				*/
+				
+				halt_channel(hcd, hc, qtd,
+					     DWC_OTG_HC_XFER_PERIODIC_INCOMPLETE);
 			}
 
 		}


### PR DESCRIPTION
Following this 
http://www.raspberrypi.org/phpBB3/viewtopic.php?f=28&t=23544&sid=5e54cf47d02ac7f344957b19d4f944b2&start=132
(first message should come up as by spiliot, 6th page)

I blind edited the int handler to do something with the interrupt instead of just exiting. This now works in my case without any implications.

The first time I send something to /dev/usb/lp0 (debug enabled) I get a 
usblp0: nonzero read bulk status received: -5 
which probably explains why the dwc_otg driver was entering the INT loop in the first place, but I lack the knowledge to pursue this further.
