### PR TITLE
Fixed build errors.

### DIFF
--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -759,7 +759,6 @@ void __init bcm2708_init(void)
 static void timer_set_mode(enum clock_event_mode mode,
 			   struct clock_event_device *clk)
 {
-	unsigned long stc;
 
 	switch (mode) {
 	case CLOCK_EVT_MODE_ONESHOT: /* Leave the timer disabled, .set_next_event will enable it */

--- a/drivers/usb/storage/realtek_cr.c
+++ b/drivers/usb/storage/realtek_cr.c
@@ -455,7 +455,7 @@ static int rts51x_check_status(struct us_data *us, u8 lun)
 	u8 buf[16];
 
 	retval = rts51x_read_status(us, lun, buf, 16, &(chip->status_len));
-	if (retval < 0)
+	if (retval != STATUS_SUCCESS)
 		return -EIO;
 
 	US_DEBUGP("chip->status_len = %d\n", chip->status_len);

--- a/kernel/trace/trace_events_filter.c
+++ b/kernel/trace/trace_events_filter.c
@@ -2002,7 +2002,8 @@ static int ftrace_function_set_regexp(struct ftrace_ops *ops, int filter,
 static int __ftrace_function_set_filter(int filter, char *buf, int len,
 					struct function_filter_data *data)
 {
-	int i, re_cnt, ret;
+	int i, re_cnt;
+	int ret = -EINVAL;
 	int *reset;
 	char **re;
 


### PR DESCRIPTION
kernel/trace/trace_events_filter.c: In function "ftrace_function_set_filter_cb":
kernel/trace/trace_events_filter.c:2074:8: warning: "ret" may be used uninitialized in this function [-Wuninitialized]
Patch has been queued mainline commit 92d8d4a "tracing/filter: Add missing initialization

arch/arm/mach-bcm2708/bcm2708.c: In function "timer_set_mode":
arch/arm/mach-bcm2708/bcm2708.c:780:16: warning: unused variable "stc" [-Wunused-variable]
Removed unused variable.

drivers/usb/storage/realtek_cr.c: In function "init_realtek_cr":
drivers/usb/storage/realtek_cr.c:476:33: warning: "buf[15]" may be used uninitia
lized in this function [-Wuninitialized]
Change conditional.
