### PR TITLE
ARM: VFP: fix emulation of second VFP instruction

### DIFF
--- a/arch/arm/vfp/vfpmodule.c
+++ b/arch/arm/vfp/vfpmodule.c
@@ -413,7 +413,7 @@ void VFP_bounce(u32 trigger, u32 fpexc, struct pt_regs *regs)
 	 * If there isn't a second FP instruction, exit now. Note that
 	 * the FPEXC.FP2V bit is valid only if FPEXC.EX is 1.
 	 */
-	if (fpexc ^ (FPEXC_EX | FPEXC_FP2V))
+	if ((fpexc & (FPEXC_EX | FPEXC_FP2V)) != (FPEXC_EX | FPEXC_FP2V))
 		goto exit;
 
 	/*


### PR DESCRIPTION
Martin Storsjö reports that the sequence:

```
ee312ac1    vsub.f32    s4, s3, s2
ee702ac0    vsub.f32    s5, s1, s0
e59f0028    ldr     r0, [pc, #40]
ee111a90    vmov        r1, s3
```

on Raspberry Pi (implementor 41 architecture 1 part 20 variant b rev 5)
where s3 is a denormal and s2 is zero results in incorrect behaviour -
the instruction "vsub.f32 s5, s1, s0" is not executed:

```
VFP: bounce: trigger ee111a90 fpexc d0000780
VFP: emulate: INST=0xee312ac1 SCR=0x00000000
...
```

As we can see, the instruction triggering the exception is the "vmov"
instruction, and we emulate the "vsub.f32 s4, s3, s2" but fail to
properly take account of the FPEXC_FP2V flag in FPEXC.  This is because
the test for the second instruction register being valid is bogus, and
will always skip emulation of the second instruction.

Cc: stable@vger.kernel.org
Reported-by: Martin Storsjö martin@martin.st
Tested-by: Martin Storsjö martin@martin.st
Signed-off-by: Russell King <rmk+kernel@arm.linux.org.uk>

---

This is a cherry-pick of this bugfix by Russell, taken from http://lists.arm.linux.org.uk/lurker/message/20130225.130449.bf10b98c.en.html.
