### PR TITLE
Allow to build kernel with XZ compression

### DIFF
--- a/arch/arm/boot/compressed/decompress.c
+++ b/arch/arm/boot/compressed/decompress.c
@@ -47,6 +47,7 @@ extern void error(char *);
 #ifdef CONFIG_KERNEL_XZ
 #define memmove memmove
 #define memcpy memcpy
+extern char * strstr(const char *, const char *);
 #include "../../../../lib/decompress_unxz.c"
 #endif
 


### PR DESCRIPTION
arch/arm/boot/compressed/decompress.c:
without this line, it could not be possible to build a kernel using XZ compression.

gcc [...] arch/arm/boot/compressed/decompress.c
In file included from include/linux/kernel.h:23:0,
                 from arch/arm/boot/compressed/../../../../lib/xz/xz_private.h:15,
                 from arch/arm/boot/compressed/../../../../lib/decompress_unxz.c:145,
                 from arch/arm/boot/compressed/decompress.c:51:
include/linux/dynamic_debug.h: In function ‘ddebug_dyndbg_module_param_cb’:
include/linux/dynamic_debug.h:111:2: erreur: implicit declaration of function ‘strstr’ [-Werror=implicit-function-declaration]
  if (strstr(param, "dyndbg")) {
  ^
cc1: some warnings being treated as errors
