### PR TITLE
dwc_otg: fix potential use-after-free case in interrupt handler

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
@@ -2223,7 +2223,8 @@ int32_t dwc_otg_hcd_handle_hc_n_intr(dwc_otg_hcd_t * dwc_otg_hcd, uint32_t num)
 		retval |= handle_hc_nak_intr(dwc_otg_hcd, hc, hc_regs, qtd);
 	}
 	if (hcint.b.ack) {
-		retval |= handle_hc_ack_intr(dwc_otg_hcd, hc, hc_regs, qtd);
+		if(!hcint.b.chhltd)
+			retval |= handle_hc_ack_intr(dwc_otg_hcd, hc, hc_regs, qtd);
 	}
 	if (hcint.b.nyet) {
 		retval |= handle_hc_nyet_intr(dwc_otg_hcd, hc, hc_regs, qtd);


### PR DESCRIPTION
If a transaction had previously aborted, certain interrupts are
enabled to track error counts and reset where necessary. On IN
endpoints the host generates an ACK interrupt near-simultaneously
with completion of transfer. In the case where this transfer had
previously had an error, this results in a use-after-free on
the QTD memory space with a 1-byte length being overwritten to
0x00.

Fixes the corruption found by SLUB debugging in #217. 
