### PR TITLE
fix missing modulo for bit in bank computation, in bcm2708 gpio irq mask

### DIFF
--- a/arch/arm/mach-bcm2708/bcm2708_gpio.c
+++ b/arch/arm/mach-bcm2708/bcm2708_gpio.c
@@ -173,6 +173,8 @@ static void bcm2708_gpio_irq_mask(struct irq_data *d)
 	unsigned long rising = readl(gpio->base + GPIOREN(gb));
 	unsigned long falling = readl(gpio->base + GPIOFEN(gb));
 
+	gn = gn % 32;
+
 	writel(rising & ~(1 << gn), gpio->base + GPIOREN(gb));
 	writel(falling & ~(1 << gn), gpio->base + GPIOFEN(gb));
 }


### PR DESCRIPTION
Spotted this bug while searching something else.

I never had an error because of this myself, but this would happen for irq on GPIO numbers greater than 32, where the mask function has no effect.

If you compare the code of the mask and unmask function, you can see two variables "gn" (gpio number?) and "gb" (gpio bank ?).
The principle is that each bank seems to contains only 32 bits, so bits higher than 32 are in the second bank. For example, bit 50 should be decomposed as : bank 1 (means 32) + bit 18.
However, the line

```
gn = gn % 32;
```

is missing in the "mask" function, but present is the "unmask" one.

With the bit 50 example above, it would request bit 50 in bank 1, but bank 1 is only 32 bits wide. So 1<<50 would result in 0 => no effect.
