### PR TITLE
Add device ID (330d)

### DIFF
--- a/drivers/net/wireless/rtl8192cu/hal/rtl8192c/usb/usb_halinit.c
+++ b/drivers/net/wireless/rtl8192cu/hal/rtl8192c/usb/usb_halinit.c
@@ -3783,6 +3783,8 @@ _ReadIDs(
 				pHalData->CustomerID = RT_CID_DLINK;
 			else if((pHalData->EEPROMVID == 0x2001) && (pHalData->EEPROMPID == 0x330a))
 				pHalData->CustomerID = RT_CID_DLINK;
+			else if((pHalData->EEPROMVID == 0x2001) && (pHalData->EEPROMPID == 0x330d))
+				pHalData->CustomerID = RT_CID_DLINK;
 			break;
 		case EEPROM_CID_WHQL:
 /*			

--- a/drivers/net/wireless/rtl8192cu/os_dep/linux/usb_intf.c
+++ b/drivers/net/wireless/rtl8192cu/os_dep/linux/usb_intf.c
@@ -138,6 +138,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x2001, 0x3307)},//D-Link - Cameo
 	{USB_DEVICE(0x2001, 0x330A)},//D-Link - Alpha
 	{USB_DEVICE(0x2001, 0x3309)},//D-Link - Alpha
+	{USB_DEVICE(0x2001, 0x330D)},//D-Link - Alpha(?)
 	{USB_DEVICE(0x0586, 0x341F)},//Zyxel - Abocom
 	{USB_DEVICE(0x7392, 0x7822)},//Edimax - Edimax
 	{USB_DEVICE(0x2019, 0xAB2B)},//Planex - Abocom


### PR DESCRIPTION
Added a device ID for D-Link DWA-131 B1.

Not sure if both changes were neccessary, please review. I can confirm that it works though.
