### PR TITLE
dwc_otg: implement tasklet for returning URBs to usbcore hcd layer

### DIFF
--- a/drivers/usb/host/dwc_common_port/dwc_common_linux.c
+++ b/drivers/usb/host/dwc_common_port/dwc_common_linux.c
@@ -991,6 +991,11 @@ void DWC_TASK_SCHEDULE(dwc_tasklet_t *task)
 	tasklet_schedule(&task->t);
 }
 
+void DWC_TASK_HI_SCHEDULE(dwc_tasklet_t *task)
+{
+	tasklet_hi_schedule(&task->t);
+}
+
 
 /* workqueues
  - run in process context (can sleep)

--- a/drivers/usb/host/dwc_common_port/dwc_list.h
+++ b/drivers/usb/host/dwc_common_port/dwc_list.h
@@ -384,17 +384,17 @@ struct {								\
 #define DWC_TAILQ_PREV(elm, headname, field)				\
 	(*(((struct headname *)((elm)->field.tqe_prev))->tqh_last))
 #define DWC_TAILQ_EMPTY(head)						\
-	(TAILQ_FIRST(head) == TAILQ_END(head))
+	(DWC_TAILQ_FIRST(head) == DWC_TAILQ_END(head))
 
 #define DWC_TAILQ_FOREACH(var, head, field)				\
-	for((var) = TAILQ_FIRST(head);					\
-	    (var) != TAILQ_END(head);					\
-	    (var) = TAILQ_NEXT(var, field))
+	for ((var) = DWC_TAILQ_FIRST(head);				\
+	    (var) != DWC_TAILQ_END(head);				\
+	    (var) = DWC_TAILQ_NEXT(var, field))
 
 #define DWC_TAILQ_FOREACH_REVERSE(var, head, headname, field)		\
-	for((var) = TAILQ_LAST(head, headname);				\
-	    (var) != TAILQ_END(head);					\
-	    (var) = TAILQ_PREV(var, headname, field))
+	for ((var) = DWC_TAILQ_LAST(head, headname);			\
+	    (var) != DWC_TAILQ_END(head);				\
+	    (var) = DWC_TAILQ_PREV(var, headname, field))
 
 /*
  * Tail queue functions.

--- a/drivers/usb/host/dwc_common_port/dwc_os.h
+++ b/drivers/usb/host/dwc_common_port/dwc_os.h
@@ -981,6 +981,8 @@ extern void DWC_TASK_FREE(dwc_tasklet_t *task);
 extern void DWC_TASK_SCHEDULE(dwc_tasklet_t *task);
 #define dwc_task_schedule DWC_TASK_SCHEDULE
 
+extern void DWC_TASK_HI_SCHEDULE(dwc_tasklet_t *task);
+#define dwc_task_hi_schedule DWC_TASK_HI_SCHEDULE
 
 /** @name Timer
  *

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd.h
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd.h
@@ -374,6 +374,13 @@ typedef struct dwc_otg_qh {
 
 DWC_CIRCLEQ_HEAD(hc_list, dwc_hc);
 
+typedef struct urb_tq_entry {
+	struct urb *urb;
+	DWC_TAILQ_ENTRY(urb_tq_entry) urb_tq_entries;
+} urb_tq_entry_t;
+
+DWC_TAILQ_HEAD(urb_list, urb_tq_entry);
+
 /**
  * This structure holds the state of the HCD, including the non-periodic and
  * periodic schedules.
@@ -550,6 +557,9 @@ struct dwc_otg_hcd {
 
 	/* Tasket to do a reset */
 	dwc_tasklet_t *reset_tasklet;
+
+	dwc_tasklet_t *completion_tasklet;
+	struct urb_list completed_urb_list;
 
 	/*  */
 	dwc_spinlock_t *lock;


### PR DESCRIPTION
The dwc_otg driver interrupt handler for transfer completion will spend
a very long time with interrupts disabled when a URB is completed -
this is because usb_hcd_giveback_urb is called from within the handler
which for a USB device driver with complicated processing (e.g. webcam)
will take an exorbitant amount of time to complete. This results in
missed completion interrupts for other USB packets which lead to them
being dropped due to microframe overruns.

This patch splits returning the URB to the usb hcd layer into a
high-priority tasklet. This will have most benefit for isochronous IN
transfers but will also have incidental benefit where multiple periodic
devices are active at once.
