### PR TITLE
Update bcm2708.c

### DIFF
--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -587,6 +587,7 @@ static struct platform_device bcm2708_spi_device = {
 
 #ifdef CONFIG_SPI
 static struct spi_board_info bcm2708_spi_devices[] = {
+#ifdef CONFIG_SPI_SPIDEV
 	{
 		.modalias = "spidev",
 		.max_speed_hz = 500000,
@@ -600,6 +601,7 @@ static struct spi_board_info bcm2708_spi_devices[] = {
 		.chip_select = 1,
 		.mode = SPI_MODE_0,
 	}
+#endif	
 };
 #endif
 


### PR DESCRIPTION
spidev.c should not be compiled if CONFIG_SPI_SPIDEV is not set. If CONFIG_SPI_SPIDEV is not set, the bcm2708_spi_device variable should not contain the spidev module in order to be able to use another spi driver.
## Modified file: bcm2708.c

Hi, 

If I set 'CONFIG_SPI', I can't use my own SPI driver. The SPI bus was already in use (used by spidev module). However if I do not set the 'CONFIG_SPI' driver, I can't use the built-in SPI driver neither. It turns out that the spidev module is built even though the CONFIG_SPI_SPIDEV kernel parameter is not set. I think this is a bug which is resolved by inserting an '#ifdef CONFIG_SPI_SPIDEV' in the spi_board_info struct.

Greetings,
Brecht.
