### PR TITLE
add mmap support and some cleanups to bcm2835 ALSA driver

### DIFF
--- a/sound/arm/bcm2835.c
+++ b/sound/arm/bcm2835.c
@@ -110,20 +110,20 @@ static int __devinit snd_bcm2835_alsa_probe(struct platform_device *pdev)
 
 	err = snd_bcm2835_create(g_card, pdev, &chip);
 	if (err < 0) {
-		printk(KERN_ERR "Failed to create bcm2835 chip\n");
+		dev_err(&pdev->dev, "Failed to create bcm2835 chip\n");
 		goto out_bcm2835_create;
 	}
 
 	g_chip = chip;
 	err = snd_bcm2835_new_pcm(chip);
 	if (err < 0) {
-		printk(KERN_ERR "Failed to create new BCM2835 pcm device\n");
+		dev_err(&pdev->dev, "Failed to create new BCM2835 pcm device\n");
 		goto out_bcm2835_new_pcm;
 	}
 
 	err = snd_bcm2835_new_ctl(chip);
 	if (err < 0) {
-		printk(KERN_ERR "Failed to create new BCM2835 ctl\n");
+		dev_err(&pdev->dev, "Failed to create new BCM2835 ctl\n");
 		goto out_bcm2835_new_ctl;
 	}
 
@@ -139,14 +139,14 @@ add_register_map:
 	if (dev == 0) {
 		err = snd_card_register(card);
 		if (err < 0) {
-			printk(KERN_ERR
-			       "Failed to register bcm2835 ALSA card \n");
+			dev_err(&pdev->dev,
+				"Failed to register bcm2835 ALSA card \n");
 			goto out_card_register;
 		}
 		platform_set_drvdata(pdev, card);
-		printk(KERN_INFO "bcm2835 ALSA card created!\n");
+		audio_info("bcm2835 ALSA card created!\n");
 	} else {
-		printk(KERN_INFO "bcm2835 ALSA chip created!\n");
+		audio_info("bcm2835 ALSA chip created!\n");
 		platform_set_drvdata(pdev, (void *)dev);
 	}
 
@@ -160,11 +160,11 @@ out_bcm2835_new_pcm:
 out_bcm2835_create:
 	BUG_ON(!g_card);
 	if (snd_card_free(g_card))
-		printk(KERN_ERR "Failed to free Registered alsa card\n");
+		dev_err(&pdev->dev, "Failed to free Registered alsa card\n");
 	g_card = NULL;
 out:
 	dev = SNDRV_CARDS;	/* stop more avail_substreams from being probed */
-	printk(KERN_ERR "BCM2835 ALSA Probe failed !!\n");
+	dev_err(&pdev->dev, "BCM2835 ALSA Probe failed !!\n");
 	return err;
 }
 
@@ -326,49 +326,49 @@ static int __devinit bcm2835_alsa_device_init(void)
 	int err;
 	err = platform_driver_register(&bcm2835_alsa0_driver);
 	if (err) {
-		printk("Error registering bcm2835_alsa0_driver %d .\n", err);
+		pr_err("Error registering bcm2835_alsa0_driver %d .\n", err);
 		goto out;
 	}
 
 	err = platform_driver_register(&bcm2835_alsa1_driver);
 	if (err) {
-		printk("Error registering bcm2835_alsa1_driver %d .\n", err);
+		pr_err("Error registering bcm2835_alsa0_driver %d .\n", err);
 		goto unregister_0;
 	}
 
 	err = platform_driver_register(&bcm2835_alsa2_driver);
 	if (err) {
-		printk("Error registering bcm2835_alsa2_driver %d .\n", err);
+		pr_err("Error registering bcm2835_alsa0_driver %d .\n", err);
 		goto unregister_1;
 	}
 
 	err = platform_driver_register(&bcm2835_alsa3_driver);
 	if (err) {
-		printk("Error registering bcm2835_alsa3_driver %d .\n", err);
+		pr_err("Error registering bcm2835_alsa0_driver %d .\n", err);
 		goto unregister_2;
 	}
 
 	err = platform_driver_register(&bcm2835_alsa4_driver);
 	if (err) {
-		printk("Error registering bcm2835_alsa4_driver %d .\n", err);
+		pr_err("Error registering bcm2835_alsa0_driver %d .\n", err);
 		goto unregister_3;
 	}
 
 	err = platform_driver_register(&bcm2835_alsa5_driver);
 	if (err) {
-		printk("Error registering bcm2835_alsa5_driver %d .\n", err);
+		pr_err("Error registering bcm2835_alsa0_driver %d .\n", err);
 		goto unregister_4;
 	}
 
 	err = platform_driver_register(&bcm2835_alsa6_driver);
 	if (err) {
-		printk("Error registering bcm2835_alsa6_driver %d .\n", err);
+		pr_err("Error registering bcm2835_alsa0_driver %d .\n", err);
 		goto unregister_5;
 	}
 
 	err = platform_driver_register(&bcm2835_alsa7_driver);
 	if (err) {
-		printk("Error registering bcm2835_alsa7_driver %d .\n", err);
+		pr_err("Error registering bcm2835_alsa0_driver %d .\n", err);
 		goto unregister_6;
 	}
 

--- a/sound/arm/bcm2835.h
+++ b/sound/arm/bcm2835.h
@@ -23,6 +23,7 @@
 #include <sound/initval.h>
 #include <sound/pcm.h>
 #include <sound/pcm_params.h>
+#include <sound/pcm-indirect.h>
 #include <linux/workqueue.h>
 
 /*
@@ -110,6 +111,7 @@ typedef struct bcm2835_chip {
 typedef struct bcm2835_alsa_stream {
 	bcm2835_chip_t *chip;
 	struct snd_pcm_substream *substream;
+	struct snd_pcm_indirect pcm_indirect;
 
 	struct semaphore buffers_update_sem;
 	struct semaphore control_sem;


### PR DESCRIPTION
Hello,

This series contains the following improvements to the ALSA bcm2835 driver:
- Use the kernel provided facility to wait for completion instead of an
  ad-hoc implementation using semaphores.
- Add defined constants to specify the deferred action to be processed by the
  driver workqueue instead of using magic numbers.
- Include PCM samples write in the deferred operations handled by the workqueue
- Add mmap support to allow Direct Read/Write transfers.
- Remove unnecessary log when the driver probe function is called if debug is
  not enabled. Also replace printk() usage by more suitable functions.

and fixes these open issues:

raspberrypi/linux#158 "bcm2835 ALSA driver hardware mixing or mmap?"
raspberrypi/firmware#173 "ALSA is not supporting 16 bits signed audio"
raspberrypi/linux#282 "ALSA boot messages"

The following changes since commit 07b8b7dbc2d698114a59c328c5e24681a12da6ca:

  Merge pull request #279 from P33M/rpi-3.6.y (2013-04-22 08:08:49 -0700)

are available in the git repository at:

  git://github.com/martinezjavier/linux-rpi.git rpi-3.6.y-dev

Javier Martinez Canillas (5):
      ALSA: bcm2835: show card and subdev creation msg only on debug
      ALSA: bcm2835: use a completion instead of a semaphore for sync
      ALSA: bcm2835: don't use magic numbers on audio start/stop workqueue
      ALSA: bcm2835: defer bcm2835 PCM write using the workqueue
      ALSA: bcm2835: add memory-mapped I/O mode for audio stream

 sound/arm/bcm2835-pcm.c   |   69 ++++++++++++++++++++++-------------
 sound/arm/bcm2835-vchiq.c |   89 +++++++++++++++++++++++++++++++--------------
 sound/arm/bcm2835.c       |   34 +++++++++---------
 sound/arm/bcm2835.h       |    2 +
 4 files changed, 124 insertions(+), 70 deletions(-)

Thanks a lot and best regards,
Javier
