### PR TITLE
Update bcm2708.c to use CONFIG_BCM2708_SPIDEV rather than CONFIG_SPI

### DIFF
--- a/arch/arm/mach-bcm2708/Kconfig
+++ b/arch/arm/mach-bcm2708/Kconfig
@@ -38,4 +38,11 @@ config BCM2708_DMAER
         help
           Enable DMA helper for accelerating X composition
 
+config BCM2708_SPIDEV
+	bool "Bind spidev to SPI0 master"
+	depends on MACH_BCM2708  
+	depends on SPI
+        default y
+		help 
+			Binds spidev driver to the SPI0 master  
 endmenu

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -585,7 +585,7 @@ static struct platform_device bcm2708_spi_device = {
 	.resource = bcm2708_spi_resources,
 };
 
-#ifdef CONFIG_SPI
+#ifdef CONFIG_BCM2708_SPIDEV
 static struct spi_board_info bcm2708_spi_devices[] = {
 	{
 		.modalias = "spidev",
@@ -747,7 +747,7 @@ void __init bcm2708_init(void)
 	system_rev = boardrev;
 	system_serial_low = serial;
 
-#ifdef CONFIG_SPI
+#ifdef CONFIG_BCM2708_SPIDEV
 	spi_register_board_info(bcm2708_spi_devices,
 			ARRAY_SIZE(bcm2708_spi_devices));
 #endif


### PR DESCRIPTION
Current implementation of bcm2708.c unconditionally binds spare SPI chip selects to the spidev driver. Users who needs SPI bus for other needs have to patch the kernel.
Proposed solution introduces new configuration option CONFIG_BCM2708_SPIDEV
that turns off SPI binding in the kernel.
There is a similar pull request: https://github.com/raspberrypi/linux/pull/274
that proposes using CONFIG_SPI_SPIDEV for this purposes. Such approach, however, not suitable for users that needs both spidev and another spi driver with the same kernel. Therefore, I think, it is better to have a separate config option that would control only definition and registration of bcm2708_spi_devices.
