### PR TITLE
dwc_otg: Call usb_hcd_unlink_urb_from_ep with lock held in completion ta...

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
@@ -704,6 +704,7 @@ static void completion_tasklet_func(void *ptr)
 	urb_tq_entry_t *item;
 	dwc_irqflags_t flags;
 
+	/* This could just be spin_lock_irq */
 	DWC_SPINLOCK_IRQSAVE(hcd->lock, &flags);
 	while (!DWC_TAILQ_EMPTY(&hcd->completed_urb_list)) {
 		item = DWC_TAILQ_FIRST(&hcd->completed_urb_list);
@@ -713,7 +714,6 @@ static void completion_tasklet_func(void *ptr)
 		DWC_SPINUNLOCK_IRQRESTORE(hcd->lock, flags);
 		DWC_FREE(item);
 
-		usb_hcd_unlink_urb_from_ep(hcd->priv, urb);
 		usb_hcd_giveback_urb(hcd->priv, urb, urb->status);
 
 		DWC_SPINLOCK_IRQSAVE(hcd->lock, &flags);


### PR DESCRIPTION
...sklet

This fixes a regression introduced in c4564d4a1a0a9b10d4419e48239f5d99e88d2667,
usb_hcd_unlink_urb_from_ep must be called with the lock held.  Not doing so
resulted in corruption of the list.
