### PR TITLE
Support for cheap Ralink 3070 WiFi plug

### DIFF
--- a/drivers/net/wireless/rt2x00/rt2800.h
+++ b/drivers/net/wireless/rt2x00/rt2800.h
@@ -68,6 +68,7 @@
 #define RF3320				0x000b
 #define RF3322				0x000c
 #define RF3053				0x000d
+#define RF3070				0x3070
 #define RF3290				0x3290
 #define RF5360				0x5360
 #define RF5370				0x5370

--- a/drivers/net/wireless/rt2x00/rt2800lib.c
+++ b/drivers/net/wireless/rt2x00/rt2800lib.c
@@ -2184,6 +2184,7 @@ static void rt2800_config_channel(struct rt2x00_dev *rt2x00dev,
 		break;
 	case RF5360:
 	case RF5370:
+	case RF3070:
 	case RF5372:
 	case RF5390:
 	case RF5392:
@@ -2196,6 +2197,7 @@ static void rt2800_config_channel(struct rt2x00_dev *rt2x00dev,
 	if (rt2x00_rf(rt2x00dev, RF3290) ||
 	    rt2x00_rf(rt2x00dev, RF5360) ||
 	    rt2x00_rf(rt2x00dev, RF5370) ||
+	    rt2x00_rf(rt2x00dev, RF3070) ||
 	    rt2x00_rf(rt2x00dev, RF5372) ||
 	    rt2x00_rf(rt2x00dev, RF5390) ||
 	    rt2x00_rf(rt2x00dev, RF5392)) {
@@ -2692,6 +2694,7 @@ void rt2800_vco_calibration(struct rt2x00_dev *rt2x00dev)
 	case RF3290:
 	case RF5360:
 	case RF5370:
+	case RF3070:
 	case RF5372:
 	case RF5390:
 	case RF5392:
@@ -4586,6 +4589,7 @@ int rt2800_init_eeprom(struct rt2x00_dev *rt2x00dev)
 	case RF3320:
 	case RF5360:
 	case RF5370:
+	case RF3070:
 	case RF5372:
 	case RF5390:
 	case RF5392:
@@ -4903,6 +4907,7 @@ int rt2800_probe_hw_mode(struct rt2x00_dev *rt2x00dev)
 		   rt2x00_rf(rt2x00dev, RF3320) ||
 		   rt2x00_rf(rt2x00dev, RF5360) ||
 		   rt2x00_rf(rt2x00dev, RF5370) ||
+		   rt2x00_rf(rt2x00dev, RF3070) ||
 		   rt2x00_rf(rt2x00dev, RF5372) ||
 		   rt2x00_rf(rt2x00dev, RF5390) ||
 		   rt2x00_rf(rt2x00dev, RF5392)) {
@@ -4991,6 +4996,7 @@ int rt2800_probe_hw_mode(struct rt2x00_dev *rt2x00dev)
 	case RF3290:
 	case RF5360:
 	case RF5370:
+	case RF3070:
 	case RF5372:
 	case RF5390:
 	case RF5392:


### PR DESCRIPTION
Support for Ralink Media Tek cheap Ralink 3070 WiFi Plug.

Incorrect detection of 3070 chipset.

See http://www.geekamole.com/2013/rt2800usb-fix-for-ralinkmediatek-3070-gentoo-linux/
