### PR TITLE
dwc_otg: prevent BUG() in TT allocation if hub address is > 16

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
@@ -983,7 +983,9 @@ int dwc_otg_hcd_init(dwc_otg_hcd_t * hcd, dwc_otg_core_if_t * core_if)
 	hcd->periodic_qh_count = 0;
 
 	DWC_MEMSET(hcd->hub_port, 0, sizeof(hcd->hub_port));
+#ifdef FIQ_DEBUG
 	DWC_MEMSET(hcd->hub_port_alloc, -1, sizeof(hcd->hub_port_alloc));
+#endif
 
 out:
 	return retval;
@@ -1317,7 +1319,9 @@ int dwc_otg_hcd_allocate_port(dwc_otg_hcd_t * hcd, dwc_otg_qh_t *qh)
 		qh->skip_count = 0;
 		hcd->hub_port[hub_addr] |= 1 << port_addr;
 		fiq_print(FIQDBG_PORTHUB, "H%dP%d:A %d", hub_addr, port_addr, DWC_CIRCLEQ_FIRST(&qh->qtd_list)->urb->pipe_info.ep_num);
+#ifdef FIQ_DEBUG
 		hcd->hub_port_alloc[hub_addr * 16 + port_addr] = dwc_otg_hcd_get_frame_number(hcd);
+#endif
 		return 0;
 	}
 }
@@ -1331,8 +1335,9 @@ void dwc_otg_hcd_release_port(dwc_otg_hcd_t * hcd, dwc_otg_qh_t *qh)
 	hcd->fops->hub_info(hcd, DWC_CIRCLEQ_FIRST(&qh->qtd_list)->urb->priv, &hub_addr, &port_addr);
 
 	hcd->hub_port[hub_addr] &= ~(1 << port_addr);
+#ifdef FIQ_DEBUG
 	hcd->hub_port_alloc[hub_addr * 16 + port_addr] = -1;
-
+#endif
 	fiq_print(FIQDBG_PORTHUB, "H%dP%d:RO%d", hub_addr, port_addr, DWC_CIRCLEQ_FIRST(&qh->qtd_list)->urb->pipe_info.ep_num);
 
 }

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd.h
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd.h
@@ -577,8 +577,10 @@ struct dwc_otg_hcd {
 	uint32_t *frame_list;
 
 	/** Hub - Port assignment */
-	int hub_port[16];
-	int hub_port_alloc[256];
+	int hub_port[128];
+#ifdef FIQ_DEBUG
+	int hub_port_alloc[2048];
+#endif
 
 	/** Frame List DMA address */
 	dma_addr_t frame_list_dma;

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
@@ -1419,8 +1419,9 @@ cleanup:
 		}
 
 		hcd->hub_port[hc->hub_addr] &= ~(1 << hc->port_addr);
+#ifdef FIQ_DEBUG
 		hcd->hub_port_alloc[hc->hub_addr * 16 + hc->port_addr] = -1;
-
+#endif
 		fiq_print(FIQDBG_PORTHUB, "H%dP%d:RR%d", hc->hub_addr, hc->port_addr, endp);
 	}
 


### PR DESCRIPTION
Previously if you did this with fiq_split_enable:

1) Use external hub
2a) Unplug and replug it lots of times, or
2b) Have a dodgy power supply or cable that caused lots of device resets

then a crash like this would invariably result:

```
[   53.436564] ------------[ cut here ]------------
[   53.453486] kernel BUG at drivers/usb/host/dwc_otg/dwc_otg_hcd.c:1310!
[   53.466059] Internal error: Oops - BUG: 0 [#1] PREEMPT ARM

Entering kdb (current=0xc05131c8, pid 0) Oops: (null)
due to oops @ 0xc0298678

Pid: 0, comm:              swapper
CPU: 0    Not tainted  (3.6.11portbug+ #16)
PC is at dwc_otg_hcd_allocate_port+0x9c/0xf4
LR is at dwc_otg_hcd_allocate_port+0xe0/0xf4
pc : [<c0298678>]    lr : [<c02986bc>]    psr: 200001d3
sp : c0509e58  ip : 60000193  fp : caa30768
r10: ca97f814  r9 : ca97f800  r8 : c05df3b8
r7 : caa30740  r6 : 00000001  r5 : ca97f800  r4 : caa30740
r3 : 00000000  r2 : 0000011f  r1 : 00000000  r0 : 00000025
Flags: nzCv  IRQs off  FIQs off  Mode SVC_32  ISA ARM  Segment kernel
Control: 00c5387d  Table: 09960008  DAC: 00000017
```

With the patch applied I can now unplug/replug the hub all the way to address 127, whereupon the address assignment wraps back around.
