### PR TITLE
bcm_vc_cma: create_proc_entry replaced by proc_create

### DIFF
--- a/drivers/char/broadcom/vc_cma/vc_cma.c
+++ b/drivers/char/broadcom/vc_cma/vc_cma.c
@@ -1085,15 +1085,13 @@ static int vc_cma_init(void)
 		goto out_class_destroy;
 	}
 
-	vc_cma_proc_entry = create_proc_entry(DRIVER_NAME, 0444, NULL);
+	vc_cma_proc_entry = proc_create(DRIVER_NAME, 0444, NULL, &vc_cma_proc_fops);
 	if (vc_cma_proc_entry == NULL) {
 		rc = -EFAULT;
-		LOG_ERR("%s: create_proc_entry failed", __func__);
+		LOG_ERR("%s: proc_create failed", __func__);
 		goto out_device_destroy;
 	}
-
-	vc_cma_proc_entry->proc_fops = &vc_cma_proc_fops;
-
+    
 	vc_cma_inited = 1;
 	return 0;
 
@@ -1131,7 +1129,7 @@ static void __exit vc_cma_exit(void)
 	LOG_DBG("%s: called", __func__);
 
 	if (vc_cma_inited) {
-		remove_proc_entry(vc_cma_proc_entry->name, NULL);
+		remove_proc_entry(DRIVER_NAME, NULL);
 		device_destroy(vc_cma_class, vc_cma_devnum);
 		class_destroy(vc_cma_class);
 		cdev_del(&vc_cma_cdev);


### PR DESCRIPTION
Commit 80e928f7 kills create_proc_entry, so need to get rid if it and replace by proc_create

drivers/char/broadcom/vc_cma/vc_cma.c: In function 'vc_cma_init':
drivers/char/broadcom/vc_cma/vc_cma.c:1088:2: error: implicit declaration of function 'create_proc_entry' [-Werror=implicit-function-declaration]
drivers/char/broadcom/vc_cma/vc_cma.c:1088:20: error: assignment makes pointer from integer without a cast [-Werror]
drivers/char/broadcom/vc_cma/vc_cma.c:1095:19: error: dereferencing pointer to incomplete type
drivers/char/broadcom/vc_cma/vc_cma.c: In function 'vc_cma_exit':
drivers/char/broadcom/vc_cma/vc_cma.c:1134:38: error: dereferencing pointer to incomplete type
cc1: all warnings being treated as errors
distcc[13074] ERROR: compile drivers/char/broadcom/vc_cma/vc_cma.c on localhost failed
make[4]: **\* [drivers/char/broadcom/vc_cma/vc_cma.o] Error 1
make[3]: **\* [drivers/char/broadcom/vc_cma] Error 2
make[2]: **\* [drivers/char/broadcom] Error 2
make[1]: **\* [drivers/char] Error 2
make: **\* [drivers] Error 2
