### PR TITLE
dwc_otg: root port and FIQ bugfixes

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_driver.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_driver.c
@@ -1070,6 +1070,12 @@ static int __init dwc_otg_driver_init(void)
 	int retval = 0;
 	int error;
         struct device_driver *drv;
+
+	if(fiq_split_enable && !fiq_fix_enable) {
+		printk(KERN_WARNING "dwc_otg: fiq_split_enable was set without fiq_fix_enable! Correcting.\n");
+		fiq_fix_enable = 1;
+	}
+
 	printk(KERN_INFO "%s: version %s (%s bus)\n", dwc_driver_name,
 	       DWC_DRIVER_VERSION,
 #ifdef LM_INTERFACE

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
@@ -2660,6 +2660,13 @@ int32_t dwc_otg_hcd_handle_hc_n_intr(dwc_otg_hcd_t * dwc_otg_hcd, uint32_t num)
 
 	hc = dwc_otg_hcd->hc_ptr_array[num];
 	hc_regs = dwc_otg_hcd->core_if->host_if->hc_regs[num];
+	if(hc->halt_status == DWC_OTG_HC_XFER_URB_DEQUEUE) {
+		/* We are responding to a channel disable. Driver
+		 * state is cleared - our qtd has gone away.
+		 */
+		release_channel(dwc_otg_hcd, hc, NULL, hc->halt_status);
+		return 1;
+	}
 	qtd = DWC_CIRCLEQ_FIRST(&hc->qh->qtd_list);
 
 	hcint.d32 = DWC_READ_REG32(&hc_regs->hcint);

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
@@ -309,6 +309,9 @@ static int _complete(dwc_otg_hcd_t * hcd, void *urb_handle,
 	case -DWC_E_OVERFLOW:
 		status = -EOVERFLOW;
 		break;
+	case -DWC_E_SHUTDOWN:
+		status = -ESHUTDOWN;
+		break;
 	default:
 		if (status) {
 			DWC_PRINTF("Uknown urb status %d\n", status);

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
@@ -794,11 +794,19 @@ static int dwc_otg_urb_enqueue(struct usb_hcd *hcd,
 #if USB_URB_EP_LINKING
 			usb_hcd_unlink_urb_from_ep(hcd, urb);
 #endif
+			DWC_FREE(dwc_otg_urb);
 			urb->hcpriv = NULL;
 			if (retval == -DWC_E_NO_DEVICE)
 				retval = -ENODEV;
 		}
 	}
+#if USB_URB_EP_LINKING
+	else
+	{
+		DWC_FREE(dwc_otg_urb);
+		urb->hcpriv = NULL;
+	}
+#endif
 	DWC_SPINUNLOCK_IRQRESTORE(dwc_otg_hcd->lock, irqflags);
 	return retval;
 }


### PR DESCRIPTION
Predominantly on the model A, if devices were unplugged with USB activity then an OOPS would usually ensue as the driver would try to either
a) queue transfers using QHs that were no longer there
b) complete transfers using QTDs that were no longer there

In addition, there would be state leakage with the microframe scheduler and fiq_split saved registers leading to unresponsive USB after successive unplugs.

Root port unplugs should be much more reliable as a result. It is still possible to get corner cases relating to the FIQ triggering at just the wrong moment on IRQ entry (before we disable it) but these are quite rare.

Also add enforcing module parameters - it was possible to set fiq_split_enable and not fiq_fix_enable.
