### PR TITLE
dwc_otg: Enable NAK holdoff for control split transactions

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
@@ -1857,8 +1857,7 @@ static int32_t handle_hc_nak_intr(dwc_otg_hcd_t * hcd,
 	 */
 	switch(dwc_otg_hcd_get_pipe_type(&qtd->urb->pipe_info)) {
 		case UE_BULK:
-		//case UE_INTERRUPT:
-		//case UE_CONTROL:
+		case UE_CONTROL:
 		if (nak_holdoff_enable)
 			hc->qh->nak_frame = dwc_otg_hcd_get_frame_number(hcd);
 	}


### PR DESCRIPTION
Certain low-speed devices take a very long time to complete a
data or status stage of a control transaction, producing NAK
responses until they complete internal processing - the USB2.0
spec limit is up to 500mS. This causes the same type of interrupt
storm as seen with USB-serial dongles prior to c8edb238.

In certain circumstances, usually while booting, this interrupt
storm could cause SD card timeouts.
