### PR TITLE
lirc: Fixes for some lirc_rpi issues

### DIFF
--- a/drivers/staging/media/lirc/lirc_rpi.c
+++ b/drivers/staging/media/lirc/lirc_rpi.c
@@ -590,8 +590,6 @@ static int __init lirc_rpi_init(void)
 
 static void lirc_rpi_exit(void)
 {
-	gpio_free(gpio_out_pin);
-	gpio_free(gpio_in_pin);
 	platform_device_unregister(lirc_rpi_dev);
 	platform_driver_unregister(&lirc_rpi_driver);
 	lirc_buffer_free(&rbuf);
@@ -623,6 +621,10 @@ static int __init lirc_rpi_init_module(void)
 		goto exit_rpi;
 	}
 
+	result = init_port();
+	if (result < 0)
+		goto exit_rpi;
+
 	driver.features = LIRC_CAN_SET_SEND_DUTY_CYCLE |
 			  LIRC_CAN_SET_SEND_CARRIER |
 			  LIRC_CAN_SEND_PULSE |
@@ -640,10 +642,6 @@ static int __init lirc_rpi_init_module(void)
 
 	printk(KERN_INFO LIRC_DRIVER_NAME ": driver registered!\n");
 
-	result = init_port();
-	if (result < 0)
-		goto exit_rpi;
-
 	return 0;
 
 	exit_rpi:
@@ -654,6 +652,9 @@ static int __init lirc_rpi_init_module(void)
 
 static void __exit lirc_rpi_exit_module(void)
 {
+	gpio_free(gpio_out_pin);
+	gpio_free(gpio_in_pin);
+
 	lirc_rpi_exit();
 
 	lirc_unregister_driver(driver.minor);

--- a/drivers/staging/media/lirc/lirc_rpi.c
+++ b/drivers/staging/media/lirc/lirc_rpi.c
@@ -63,13 +63,13 @@ static int gpio_in_pin = 18;
 /* set the default GPIO output pin */
 static int gpio_out_pin = 17;
 /* enable debugging messages */
-static int debug;
+static bool debug;
 /* -1 = auto, 0 = active high, 1 = active low */
 static int sense = -1;
 /* use softcarrier by default */
-static int softcarrier = 1;
+static bool softcarrier = 1;
 /* 0 = do not invert output, 1 = invert output */
-static int invert = 0;
+static bool invert = 0;
 
 struct gpio_chip *gpiochip;
 struct irq_chip *irqchip;
@@ -678,7 +678,7 @@ MODULE_PARM_DESC(gpio_in_pin, "GPIO input pin number of the BCM processor."
 		 " Valid pin numbers are: 0, 1, 4, 8, 7, 9, 10, 11, 14, 15,"
 		 " 17, 18, 21, 22, 23, 24, 25, default 18");
 
-module_param(sense, bool, S_IRUGO);
+module_param(sense, int, S_IRUGO);
 MODULE_PARM_DESC(sense, "Override autodetection of IR receiver circuit"
 		 " (0 = active high, 1 = active low )");
 


### PR DESCRIPTION
A couple of lirc_rpi fixes:
- Fix "warning: return from incompatible pointer type" compiler warnings,
- Fix lirc_rpi module loading when the requested in/out pins are already claimed.
