### PR TITLE
rtl8192cu: remove ampdu_enable from proc when unloading

### DIFF
--- a/drivers/net/wireless/rtl8192cu/os_dep/linux/os_intfs.c
+++ b/drivers/net/wireless/rtl8192cu/os_dep/linux/os_intfs.c
@@ -496,7 +496,7 @@ void rtw_proc_remove_one(struct net_device *dev)
 		remove_proc_entry("best_channel", dir_dev);
 #endif 
 		remove_proc_entry("rx_signal", dir_dev);
-
+		remove_proc_entry("ampdu_enable", dir_dev);
 		remove_proc_entry("rssi_disp", dir_dev);
 
 		remove_proc_entry(dev->name, rtw_proc);


### PR DESCRIPTION
The proc entry "ampdu_enable" is not removed when unloading the module, leading to the following
warning in `dmesg`:

```
[ 1408.204740] usbcore: deregistering interface driver rtl8192cu
[ 1409.560195] ------------[ cut here ]------------
[ 1409.564935] WARNING: at fs/proc/generic.c:849 remove_proc_entry+0x24c/0x284()
[ 1409.587290] remove_proc_entry: removing non-empty directory 'rtl819xC/wlan0', leaking at least 'ampdu_enable'
[ 1409.608515] Modules linked in: spidev 8192cu(-) leds_gpio led_class spi_bcm2708 i2c_bcm2708 snd_bcm2835 snd_pcm snd_page_alloc snd_timer snd rtc_fake(O) bcm2708_rng rng_core ipv6
[ 1409.635730] [<c0012af4>] (unwind_backtrace+0x0/0xf0) from [<c00200f0>] (warn_slowpath_common+0x4c/0x64)
[ 1409.655370] [<c00200f0>] (warn_slowpath_common+0x4c/0x64) from [<c002019c>] (warn_slowpath_fmt+0x30/0x40)
[ 1409.680179] [<c002019c>] (warn_slowpath_fmt+0x30/0x40) from [<c0150f74>] (remove_proc_entry+0x24c/0x284)
[ 1409.690164] [<c0150f74>] (remove_proc_entry+0x24c/0x284) from [<bf103d10>] (rtw_proc_remove_one+0xf4/0x188 [8192cu])
[ 1409.727996] [<bf103d10>] (rtw_proc_remove_one+0xf4/0x188 [8192cu]) from [<bf104c84>] (rtw_dev_remove+0x94/0x134 [8192cu])
[ 1409.759164] [<bf104c84>] (rtw_dev_remove+0x94/0x134 [8192cu]) from [<c03df5a4>] (usb_unbind_interface+0x4c/0x114)
[ 1409.787252] [<c03df5a4>] (usb_unbind_interface+0x4c/0x114) from [<c03943f4>] (__device_release_driver+0x58/0xb4)
[ 1409.815975] [<c03943f4>] (__device_release_driver+0x58/0xb4) from [<c0394bb4>] (driver_detach+0xcc/0xd8)
[ 1409.847048] [<c0394bb4>] (driver_detach+0xcc/0xd8) from [<c039423c>] (bus_remove_driver+0x7c/0xc0)
[ 1409.878924] [<c039423c>] (bus_remove_driver+0x7c/0xc0) from [<c03deeec>] (usb_deregister+0x5c/0xe8)
[ 1409.900538] [<c03deeec>] (usb_deregister+0x5c/0xe8) from [<bf10ddf4>] (rtw_drv_halt+0x18/0x20 [8192cu])
[ 1409.930010] [<bf10ddf4>] (rtw_drv_halt+0x18/0x20 [8192cu]) from [<c00681a0>] (sys_delete_module+0x1ac/0x248)
[ 1409.945640] [<c00681a0>] (sys_delete_module+0x1ac/0x248) from [<c000db20>] (ret_fast_syscall+0x0/0x30)
[ 1409.960526] ---[ end trace fa8e8cefc080b338 ]---
```
