### PR TITLE
w1 - call request_module with w1 master mutex unlocked

### DIFF
--- a/drivers/w1/w1.c
+++ b/drivers/w1/w1.c
@@ -680,7 +680,10 @@ static int w1_attach_slave_device(struct w1_master *dev, struct w1_reg_num *rn)
 	atomic_set(&sl->refcnt, 0);
 	init_completion(&sl->released);
 
+	/* slave modules need to be loaded in a context with unlocked mutex */
+	mutex_unlock(&dev->mutex);
 	request_module("w1-family-0x%0x", rn->family);
+	mutex_lock(&dev->mutex);
 
 	spin_lock(&w1_flock);
 	f = w1_family_registered(rn->family);


### PR DESCRIPTION
request_module for w1 slave modules needs to be called with the w1
master mutex unlocked. Because w1_attach_slave_device gets always(?)
called with mutex locked, we need to temporarily unlock the w1 master
mutex for the loading of the w1 slave module.

Signed-off by: Hans-Frieder Vogt hfvogt@gmx.net
Acked-by: Evgeniy Polyakov zbr@ioremap.net
Cc: stable stable@vger.kernel.org # 3.11+

Signed-off-by: Greg Kroah-Hartman gregkh@linuxfoundation.org
(cherry picked from commit bc04d76d6942068f75c10790072280b847ec6f1f)
