### PR TITLE
ARM: bcm2708: PL01X debug include was moved into arch/arm/include/debug/

### DIFF
--- a/arch/arm/mach-bcm2708/include/mach/debug-macro.S
+++ b/arch/arm/mach-bcm2708/include/mach/debug-macro.S
@@ -19,4 +19,4 @@
 		ldr	\rv, =IO_ADDRESS(UART0_BASE)
 		.endm
 
-#include <asm/hardware/debug-pl01x.S>
+#include <debug/pl01x.S>


### PR DESCRIPTION
This patch fixes a compilation error:
In file included from arch/arm/kernel/head.S:27:0:
arch/arm/mach-bcm2708/include/mach/debug-macro.S:22:38: fatal error: asm/hardware/debug-pl01x.S: No such file or directory
