### PR TITLE
i2c-bcm2708: fixed baudrate

### DIFF
--- a/drivers/i2c/busses/i2c-bcm2708.c
+++ b/drivers/i2c/busses/i2c-bcm2708.c
@@ -155,6 +155,8 @@ static inline void bcm2708_bsc_setup(struct bcm2708_i2c *bi)
 
 	bus_hz = clk_get_rate(bi->clk);
 	cdiv = bus_hz / baudrate;
+	if (cdiv > 0xffff)
+		cdiv = 0xffff;
 
 	if (bi->msg->flags & I2C_M_RD)
 		c |= BSC_C_INTR | BSC_C_READ;
@@ -268,6 +270,8 @@ static int bcm2708_i2c_probe(struct platform_device *pdev)
 	struct clk *clk;
 	struct bcm2708_i2c *bi;
 	struct i2c_adapter *adap;
+	unsigned long bus_hz;
+	u32 cdiv;
 
 	regs = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	if (!regs) {
@@ -343,8 +347,15 @@ static int bcm2708_i2c_probe(struct platform_device *pdev)
 		goto out_free_irq;
 	}
 
-	dev_info(&pdev->dev, "BSC%d Controller at 0x%08lx (irq %d) (baudrate %dk)\n",
-		pdev->id, (unsigned long)regs->start, irq, baudrate/1000);
+	bus_hz = clk_get_rate(bi->clk);
+	cdiv = bus_hz / baudrate;
+	if (cdiv > 0xffff) {
+		cdiv = 0xffff;
+		baudrate = bus_hz / cdiv;
+	}
+
+	dev_info(&pdev->dev, "BSC%d Controller at 0x%08lx (irq %d) (baudrate %d)\n",
+		pdev->id, (unsigned long)regs->start, irq, baudrate);
 
 	return 0;
 


### PR DESCRIPTION
Fixed issue where the wrong CDIV (Clock Divider) register value was set for baudrates below 3815 Hz (for 250MHz bus clock). In that case the computed CDIV value was more than 0xffff. However the CDIV register width is only 16 bits. This resulted in incorrect setting of CDIV and higher baudrate than intended. 
Example: baudrate=3500Hz -> CDIV=0x11704 -> CDIV(16bit)=0x1704 -> baudrate=42430Hz
