### PR TITLE
Adding support for additional i2s card/board drivers

### DIFF
--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -668,6 +668,19 @@ static struct platform_device snd_pcm1794a_codec_device = {
 };
 #endif
 
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_PROTO_MODULE
+static struct platform_device snd_rpi_proto_device = {
+	.name = "snd-rpi-proto",
+	.id = 0,
+	.num_resources = 0,
+};
+static struct i2c_board_info __initdata snd_rpi_proto_i2c_devices[] = {
+	{
+		I2C_BOARD_INFO("wm8731", 0x1a)
+	},
+};
+#endif
+
 int __init bcm_register_device(struct platform_device *pdev)
 {
 	int ret;
@@ -807,6 +820,12 @@ void __init bcm2708_init(void)
 #if defined(CONFIG_SND_BCM2708_SOC_RPI_DAC) || defined(CONFIG_SND_BCM2708_SOC_RPI_DAC_MODULE)
         bcm_register_device(&snd_rpi_dac_device);
         bcm_register_device(&snd_pcm1794a_codec_device);
+#endif
+
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_PROTO_MODULE
+	bcm_register_device(&snd_rpi_proto_device);
+	i2c_register_board_info(1, snd_rpi_proto_i2c_devices,
+			ARRAY_SIZE(snd_rpi_proto_i2c_devices));
 #endif
 
 	for (i = 0; i < ARRAY_SIZE(amba_devs); i++) {

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -642,29 +642,59 @@ static struct platform_device bcm2708_i2s_device = {
 
 #if defined(CONFIG_SND_BCM2708_SOC_HIFIBERRY_DAC) || defined(CONFIG_SND_BCM2708_SOC_HIFIBERRY_DAC_MODULE)
 static struct platform_device snd_hifiberry_dac_device = {
-        .name = "snd-hifiberry-dac",
-        .id = 0,
-        .num_resources = 0,
+	.name = "snd-hifiberry-dac",
+	.id = 0,
+	.num_resources = 0,
 };
 
 static struct platform_device snd_pcm5102a_codec_device = {
-        .name = "pcm5102a-codec",
-        .id = -1,
-        .num_resources = 0,
+	.name = "pcm5102a-codec",
+	.id = -1,
+	.num_resources = 0,
 };
 #endif
 
 #if defined(CONFIG_SND_BCM2708_SOC_RPI_DAC) || defined(CONFIG_SND_BCM2708_SOC_RPI_DAC_MODULE)
 static struct platform_device snd_rpi_dac_device = {
-        .name = "snd-rpi-dac",
-        .id = 0,
-        .num_resources = 0,
+	.name = "snd-rpi-dac",
+	.id = 0,
+	.num_resources = 0,
 };
 
 static struct platform_device snd_pcm1794a_codec_device = {
-        .name = "pcm1794a-codec",
-        .id = -1,
-        .num_resources = 0,
+	.name = "pcm1794a-codec",
+	.id = -1,
+	.num_resources = 0,
+};
+#endif
+
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_MBED_MODULE
+static struct platform_device snd_rpi_mbed_device = {
+	.name = "snd-rpi-mbed",
+	.id = 0,
+	.num_resources = 0,
+};
+
+
+static struct i2c_board_info __initdata snd_rpi_mbed_i2c_devices[] = {
+	{
+		I2C_BOARD_INFO("tlv320aic23", 0x1b)
+	},
+};
+#endif
+
+
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_TDA1541A_MODULE
+static struct platform_device snd_rpi_tda1541a_device = {
+	.name = "snd-rpi-tda1541a",
+	.id = 0,
+	.num_resources = 0,
+};
+
+static struct platform_device snd_rpi_tda1541a_codec_device = {
+	.name = "tda1541a-codec",
+	.id = -1,
+	.num_resources = 0,
 };
 #endif
 
@@ -674,10 +704,54 @@ static struct platform_device snd_rpi_proto_device = {
 	.id = 0,
 	.num_resources = 0,
 };
+
 static struct i2c_board_info __initdata snd_rpi_proto_i2c_devices[] = {
 	{
 		I2C_BOARD_INFO("wm8731", 0x1a)
 	},
+};
+#endif
+
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_CS534X_MODULE
+static struct platform_device snd_rpi_cs534x_device = {
+	.name = "snd-rpi-cs534x",
+	.id = 0,
+	.num_resources = 0,
+};
+
+static struct platform_device snd_rpi_cs534x_codec_device = {
+	.name = "cs534x-codec",
+	.id = -1,
+	.num_resources = 0,
+};
+
+#endif
+
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_ESS9018_MODULE
+static struct platform_device snd_rpi_ess9018_device = {
+	.name = "snd-rpi-ess9018",
+	.id = 0,
+	.num_resources = 0,
+};
+
+static struct platform_device snd_rpi_ess9018_codec_device = {
+	.name = "ess9018-codec",
+	.id = -1,
+	.num_resources = 0,
+};
+#endif
+
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_PCM5102A_MODULE
+static struct platform_device snd_rpi_pcm5102a_device = {
+	.name = "snd-rpi-pcm5102a",
+	.id = 0,
+	.num_resources = 0,
+};
+
+static struct platform_device snd_rpi_pcm5102a_codec_device = {
+	.name = "pcm5102a-codec",
+	.id = -1,
+	.num_resources = 0,
 };
 #endif
 
@@ -813,19 +887,44 @@ void __init bcm2708_init(void)
 #endif
 
 #if defined(CONFIG_SND_BCM2708_SOC_HIFIBERRY_DAC) || defined(CONFIG_SND_BCM2708_SOC_HIFIBERRY_DAC_MODULE)
-        bcm_register_device(&snd_hifiberry_dac_device);
-        bcm_register_device(&snd_pcm5102a_codec_device);
+	bcm_register_device(&snd_hifiberry_dac_device);
+	bcm_register_device(&snd_pcm5102a_codec_device);
 #endif
 
 #if defined(CONFIG_SND_BCM2708_SOC_RPI_DAC) || defined(CONFIG_SND_BCM2708_SOC_RPI_DAC_MODULE)
-        bcm_register_device(&snd_rpi_dac_device);
-        bcm_register_device(&snd_pcm1794a_codec_device);
+	bcm_register_device(&snd_rpi_dac_device);
+	bcm_register_device(&snd_pcm1794a_codec_device);
+#endif
+
+
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_MBED_MODULE
+	bcm_register_device(&snd_rpi_mbed_device);
+	i2c_register_board_info(1, snd_rpi_mbed_i2c_devices, ARRAY_SIZE(snd_rpi_mbed_i2c_devices));
+#endif
+
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_CS534X_MODULE
+	bcm_register_device(&snd_rpi_cs534x_device);
+	bcm_register_device(&snd_rpi_cs534x_codec_device);
+#endif
+
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_TDA1541A_MODULE
+	bcm_register_device(&snd_rpi_tda1541a_device);
+	bcm_register_device(&snd_rpi_tda1541a_codec_device);
 #endif
 
 #ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_PROTO_MODULE
 	bcm_register_device(&snd_rpi_proto_device);
-	i2c_register_board_info(1, snd_rpi_proto_i2c_devices,
-			ARRAY_SIZE(snd_rpi_proto_i2c_devices));
+	i2c_register_board_info(1, snd_rpi_proto_i2c_devices, ARRAY_SIZE(snd_rpi_proto_i2c_devices));
+#endif
+
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_ESS9018_MODULE
+	bcm_register_device(&snd_rpi_ess9018_device);
+	bcm_register_device(&snd_rpi_ess9018_codec_device);
+#endif
+
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_PCM5102A_MODULE
+	bcm_register_device(&snd_rpi_pcm5102a_device);
+	bcm_register_device(&snd_rpi_pcm5102a_codec_device);
 #endif
 
 	for (i = 0; i < ARRAY_SIZE(amba_devs); i++) {

--- a/sound/soc/bcm/Kconfig
+++ b/sound/soc/bcm/Kconfig
@@ -22,3 +22,56 @@ config SND_BCM2708_SOC_RPI_DAC
         select SND_SOC_PCM1794A
         help
          Say Y or M if you want to add support for RPi-DAC.
+
+config SND_BCM2708_SOC_I2S    
+	tristate "SoC Audio support for the Broadcom BCM2708 I2S module"
+	depends on MACH_BCM2708
+	select REGMAP_MMIO
+	select SND_SOC_DMAENGINE_PCM
+	select SND_SOC_GENERIC_DMAENGINE_PCM
+	help
+	 Say Y or M if you want to add support for codecs attached to
+	 the BCM2708 I2S interface. You will also need 
+	 to select the audio interfaces to support below.
+
+config SND_BCM2708_SOC_HIFIBERRY_MINI
+	tristate "Support for HifiBerry Mini"
+	depends on SND_BCM2708_SOC_I2S
+	select SND_SOC_PCM5102A
+	help
+	 Say Y or M if you want to add support for HifiBerry Mini.  
+
+config SND_BCM2708_SOC_RPI_CODEC_MBED
+	tristate "Support for AudioCODEC for mbed (TLV320AIC32B)"
+	depends on SND_BCM2708_SOC_I2S
+	select SND_SOC_TLV320AIC3X
+	help
+	 Say Y if you want to add support for AudioCODEC for mbed (TLV320AIC32B)
+
+config SND_BCM2708_SOC_RPI_CODEC_TDA1541A
+	tristate "Support for TDA1541A"
+	depends on SND_BCM2708_SOC_I2S
+	select SND_SOC_TDA1541A
+	help
+	 Say Y if you want to add support for TDA1541A
+
+config SND_BCM2708_SOC_RPI_CODEC_PROTO
+	tristate "Support for Audio Codec Board - PROTO (WM8731)"
+	depends on SND_BCM2708_SOC_I2S
+	select SND_SOC_WM8731
+	help
+	 Say Y if you want to add support for Audio Codec Board - PROTO (WM8731)
+
+config SND_BCM2708_SOC_RPI_CODEC_ESS9018
+	tristate "Support for ESS9018"
+	depends on SND_BCM2708_SOC_I2S
+	select SND_SOC_ESS9018
+	help
+	 Say Y if you want to add support for ESS9018
+
+config SND_BCM2708_SOC_RPI_CODEC_PCM5102A
+	tristate "Support for PCM5102A"
+	depends on SND_BCM2708_SOC_I2S
+	select SND_SOC_PCM5102A
+	help
+	 Say Y if you want to add support for PCM5102A

--- a/sound/soc/bcm/Makefile
+++ b/sound/soc/bcm/Makefile
@@ -6,6 +6,16 @@ obj-$(CONFIG_SND_BCM2708_SOC_I2S) += snd-soc-bcm2708-i2s.o
 # BCM2708 Machine Support
 snd-soc-hifiberry-dac-objs := hifiberry_dac.o
 snd-soc-rpi-dac-objs := rpi-dac.o
+snd-soc-rpi-mbed-objs := rpi-mbed.o
+snd-soc-rpi-tda1541a-objs := rpi-tda1541a.o
+snd-soc-rpi-proto-objs := rpi-proto.o
+snd-soc-rpi-ess9018-objs := rpi-ess9018.o
+snd-soc-rpi-pcm5102a-objs := rpi-pcm5102a.o
 
 obj-$(CONFIG_SND_BCM2708_SOC_HIFIBERRY_DAC) += snd-soc-hifiberry-dac.o
 obj-$(CONFIG_SND_BCM2708_SOC_RPI_DAC) += snd-soc-rpi-dac.o
+obj-$(CONFIG_SND_BCM2708_SOC_RPI_CODEC_MBED) += snd-soc-rpi-mbed.o
+obj-$(CONFIG_SND_BCM2708_SOC_RPI_CODEC_TDA1541A) += snd-soc-rpi-tda1541a.o
+obj-$(CONFIG_SND_BCM2708_SOC_RPI_CODEC_PROTO) += snd-soc-rpi-proto.o
+obj-$(CONFIG_SND_BCM2708_SOC_RPI_CODEC_ESS9018) += snd-soc-rpi-ess9018.o
+obj-$(CONFIG_SND_BCM2708_SOC_RPI_CODEC_PCM5102A) += snd-soc-rpi-pcm5102a.o

--- a/sound/soc/bcm/rpi-cs534x.c
+++ b/sound/soc/bcm/rpi-cs534x.c
@@ -1,0 +1,105 @@
+/*
+ * ASoC driver for CS5343/CS5344 ADC
+ * connected to a Raspberry Pi
+ *
+ * Author:      Wojciech M. Zabolotny <wzab01@gmail.com>
+ * Based on rpi-ess9018.c by:   Florian Meier, <koalo@koalo.de>
+ *                              Copyright 2013
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+
+#include <sound/core.h>
+#include <sound/pcm.h>
+#include <sound/soc.h>
+#include <sound/jack.h>
+
+static int snd_rpi_cs534x_init(struct snd_soc_pcm_runtime *rtd)
+{
+        return 0;
+}
+
+static int snd_rpi_cs534x_hw_params(struct snd_pcm_substream *substream,
+                                       struct snd_pcm_hw_params *params)
+{
+        return 0;
+}
+
+/* machine stream operations */
+static struct snd_soc_ops snd_rpi_cs534x_ops = {
+        .hw_params = snd_rpi_cs534x_hw_params,
+};
+
+static struct snd_soc_dai_link snd_rpi_cs534x_dai[] = {
+{
+        .name           = "cs5343",
+        .stream_name    = "cs5343 HiFi",
+        .cpu_dai_name   = "bcm2708-i2s.0",
+        .codec_dai_name = "cs534x-hifi",
+        .platform_name  = "bcm2708-pcm-audio.0",
+        .codec_name     = "cs534x-codec",
+        .dai_fmt        = SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
+                                SND_SOC_DAIFMT_CBM_CFM,
+        .ops            = &snd_rpi_cs534x_ops,
+        .init           = snd_rpi_cs534x_init,
+},
+{
+        .name           = "cs5344",
+        .stream_name    = "cs5344 HiFi",
+        .cpu_dai_name   = "bcm2708-i2s.0",
+        .codec_dai_name = "cs534x-hifi",
+        .platform_name  = "bcm2708-pcm-audio.0",
+        .codec_name     = "cs534x-codec",
+        .dai_fmt        = SND_SOC_DAIFMT_LEFT_J | SND_SOC_DAIFMT_NB_NF |
+                                SND_SOC_DAIFMT_CBM_CFM,
+        .ops            = &snd_rpi_cs534x_ops,
+        .init           = snd_rpi_cs534x_init,
+},
+};
+
+/* audio machine driver */
+static struct snd_soc_card snd_rpi_cs534x = {
+        .name         = "snd_rpi_cs534x",
+        .dai_link     = snd_rpi_cs534x_dai,
+        .num_links    = ARRAY_SIZE(snd_rpi_cs534x_dai),
+};
+
+static int snd_rpi_cs534x_probe(struct platform_device *pdev)
+{
+        int ret = 0;
+
+        snd_rpi_cs534x.dev = &pdev->dev;
+        ret = snd_soc_register_card(&snd_rpi_cs534x);
+        if (ret)
+        {
+                dev_err(&pdev->dev, "snd_soc_register_card() failed: %d\n", ret);
+        }
+
+        return ret;
+}
+
+
+static int snd_rpi_cs534x_remove(struct platform_device *pdev)
+{
+        return snd_soc_unregister_card(&snd_rpi_cs534x);
+}
+
+static struct platform_driver snd_rpi_cs534x_driver = {
+        .driver = {
+                .name   = "snd-rpi-cs534x",
+                .owner  = THIS_MODULE,
+        },
+        .probe          = snd_rpi_cs534x_probe,
+        .remove         = snd_rpi_cs534x_remove,
+};
+
+module_platform_driver(snd_rpi_cs534x_driver);
+
+MODULE_AUTHOR("Wojciech M. Zabolotny");
+MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to a cs534x");
+MODULE_LICENSE("GPL");

--- a/sound/soc/bcm/rpi-ess9018.c
+++ b/sound/soc/bcm/rpi-ess9018.c
@@ -1,0 +1,92 @@
+/*
+ * ASoC driver for ESS9018 codec
+ * connected to a Raspberry Pi
+ *
+ * Author:      Florian Meier, <koalo@koalo.de>
+ *              Copyright 2013
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+
+#include <sound/core.h>
+#include <sound/pcm.h>
+#include <sound/soc.h>
+#include <sound/jack.h>
+
+static int snd_rpi_ess9018_init(struct snd_soc_pcm_runtime *rtd)
+{
+	return 0;
+}
+
+static int snd_rpi_ess9018_hw_params(struct snd_pcm_substream *substream,
+				       struct snd_pcm_hw_params *params)
+{
+	return 0;
+}
+
+/* machine stream operations */
+static struct snd_soc_ops snd_rpi_ess9018_ops = {
+	.hw_params = snd_rpi_ess9018_hw_params,
+};
+
+static struct snd_soc_dai_link snd_rpi_ess9018_dai[] = {
+{
+	.name		= "ESS9018",
+	.stream_name	= "ESS9018 HiFi",
+	.cpu_dai_name	= "bcm2708-i2s.0",
+	.codec_dai_name	= "ess9018-hifi",
+	.platform_name	= "bcm2708-i2s.0",
+	.codec_name	= "ess9018-codec",
+	.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
+				SND_SOC_DAIFMT_CBS_CFS,
+	.ops		= &snd_rpi_ess9018_ops,
+	.init		= snd_rpi_ess9018_init,
+},
+};
+
+/* audio machine driver */
+static struct snd_soc_card snd_rpi_ess9018 = {
+	.name         = "snd_rpi_ess9018",
+	.dai_link     = snd_rpi_ess9018_dai,
+	.num_links    = ARRAY_SIZE(snd_rpi_ess9018_dai),
+};
+
+static int snd_rpi_ess9018_probe(struct platform_device *pdev)
+{
+	int ret = 0;
+
+	snd_rpi_ess9018.dev = &pdev->dev;
+	ret = snd_soc_register_card(&snd_rpi_ess9018);
+	if (ret)
+        {
+		dev_err(&pdev->dev, "snd_soc_register_card() failed: %d\n", ret);
+        }
+
+	return ret;
+}
+
+
+static int snd_rpi_ess9018_remove(struct platform_device *pdev)
+{
+	return snd_soc_unregister_card(&snd_rpi_ess9018);
+}
+
+static struct platform_driver snd_rpi_ess9018_driver = {
+        .driver = {
+                .name   = "snd-rpi-ess9018",
+                .owner  = THIS_MODULE,
+        },
+        .probe          = snd_rpi_ess9018_probe,
+        .remove         = snd_rpi_ess9018_remove,
+};
+
+module_platform_driver(snd_rpi_ess9018_driver);
+
+MODULE_AUTHOR("Florian Meier");
+MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to a ESS9018");
+MODULE_LICENSE("GPL");

--- a/sound/soc/bcm/rpi-mbed.c
+++ b/sound/soc/bcm/rpi-mbed.c
@@ -1,0 +1,103 @@
+/*
+ * ASoC driver for mbed AudioCODEC (with a TLV320AIC23b)
+ * connected to a Raspberry Pi
+ *
+ * Author:      Florian Meier, <koalo@koalo.de>
+ *	      Copyright 2013
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+
+#include <sound/core.h>
+#include <sound/pcm.h>
+#include <sound/soc.h>
+#include <sound/jack.h>
+
+#include "../codecs/tlv320aic23.h"
+
+static int snd_rpi_mbed_init(struct snd_soc_pcm_runtime *rtd)
+{
+	return 0;
+}
+
+static int snd_rpi_mbed_hw_params(struct snd_pcm_substream *substream,
+				       struct snd_pcm_hw_params *params)
+{
+	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_dai *codec_dai = rtd->codec_dai;
+	int sysclk;
+
+	sysclk = 12000000; /* this is fixed on this board */
+
+	/* set tlv320aic23 sysclk */
+	snd_soc_dai_set_sysclk(codec_dai, 0, sysclk, 0);
+
+	return 0;
+}
+
+/* machine stream operations */
+static struct snd_soc_ops snd_rpi_mbed_ops = {
+	.hw_params = snd_rpi_mbed_hw_params,
+};
+
+static struct snd_soc_dai_link snd_rpi_mbed_dai[] = {
+{
+	.name		= "TLV320AIC23",
+	.stream_name	= "TLV320AIC23 HiFi",
+	.cpu_dai_name	= "bcm2708-i2s.0",
+	.codec_dai_name	= "tlv320aic23-hifi",
+	.platform_name	= "bcm2708-i2s.0",
+	.codec_name	= "tlv320aic23-codec.1-001b",
+	.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
+				SND_SOC_DAIFMT_CBS_CFS,
+	.ops		= &snd_rpi_mbed_ops,
+	.init		= snd_rpi_mbed_init,
+},
+};
+
+/* audio machine driver */
+static struct snd_soc_card snd_rpi_mbed = {
+	.name	 = "snd_rpi_mbed",
+	.dai_link     = snd_rpi_mbed_dai,
+	.num_links    = ARRAY_SIZE(snd_rpi_mbed_dai),
+};
+
+static int snd_rpi_mbed_probe(struct platform_device *pdev)
+{
+	int ret = 0;
+
+	snd_rpi_mbed.dev = &pdev->dev;
+	ret = snd_soc_register_card(&snd_rpi_mbed);
+	if (ret) {
+		dev_err(&pdev->dev,
+				"snd_soc_register_card() failed: %d\n", ret);
+	}
+
+	return ret;
+}
+
+
+static int snd_rpi_mbed_remove(struct platform_device *pdev)
+{
+	return snd_soc_unregister_card(&snd_rpi_mbed);
+}
+
+static struct platform_driver snd_rpi_mbed_driver = {
+	.driver = {
+		.name   = "snd-rpi-mbed",
+		.owner  = THIS_MODULE,
+	},
+	.probe	  = snd_rpi_mbed_probe,
+	.remove	 = snd_rpi_mbed_remove,
+};
+
+module_platform_driver(snd_rpi_mbed_driver);
+
+MODULE_AUTHOR("Florian Meier");
+MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to mbed AudioCODEC");
+MODULE_LICENSE("GPL");

--- a/sound/soc/bcm/rpi-pcm5102a.c
+++ b/sound/soc/bcm/rpi-pcm5102a.c
@@ -1,0 +1,93 @@
+/*
+ * ASoC driver for PCM5102A codec
+ * connected to a Raspberry Pi
+ *
+ * Author:      		Francesco Valla, <valla.francesco@gmail.com>
+ * Based on rpi-ess9018.c by: 	Florian Meier, <koalo@koalo.de>
+ *              		Copyright 2013
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+
+#include <sound/core.h>
+#include <sound/pcm.h>
+#include <sound/soc.h>
+#include <sound/jack.h>
+
+static int snd_rpi_pcm5102a_init(struct snd_soc_pcm_runtime *rtd)
+{
+	return 0;
+}
+
+static int snd_rpi_pcm5102a_hw_params(struct snd_pcm_substream *substream,
+				       struct snd_pcm_hw_params *params)
+{
+	return 0;
+}
+
+/* machine stream operations */
+static struct snd_soc_ops snd_rpi_pcm5102a_ops = {
+	.hw_params = snd_rpi_pcm5102a_hw_params,
+};
+
+static struct snd_soc_dai_link snd_rpi_pcm5102a_dai[] = {
+{
+	.name		= "PCM5102A",
+	.stream_name	= "PCM5102A HiFi",
+	.cpu_dai_name	= "bcm2708-i2s.0",
+	.codec_dai_name	= "pcm5102a-hifi",
+	.platform_name	= "bcm2708-pcm-audio.0",
+	.codec_name	= "pcm5102a-codec",
+	.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
+				SND_SOC_DAIFMT_CBS_CFS,
+	.ops		= &snd_rpi_pcm5102a_ops,
+	.init		= snd_rpi_pcm5102a_init,
+},
+};
+
+/* audio machine driver */
+static struct snd_soc_card snd_rpi_pcm5102a = {
+	.name         = "snd_rpi_pcm5102a",
+	.dai_link     = snd_rpi_pcm5102a_dai,
+	.num_links    = ARRAY_SIZE(snd_rpi_pcm5102a_dai),
+};
+
+static int snd_rpi_pcm5102a_probe(struct platform_device *pdev)
+{
+	int ret = 0;
+
+	snd_rpi_pcm5102a.dev = &pdev->dev;
+	ret = snd_soc_register_card(&snd_rpi_pcm5102a);
+	if (ret)
+        {
+		dev_err(&pdev->dev, "snd_soc_register_card() failed: %d\n", ret);
+        }
+
+	return ret;
+}
+
+
+static int snd_rpi_pcm5102a_remove(struct platform_device *pdev)
+{
+	return snd_soc_unregister_card(&snd_rpi_pcm5102a);
+}
+
+static struct platform_driver snd_rpi_pcm5102a_driver = {
+        .driver = {
+                .name   = "snd-rpi-pcm5102a",
+                .owner  = THIS_MODULE,
+        },
+        .probe          = snd_rpi_pcm5102a_probe,
+        .remove         = snd_rpi_pcm5102a_remove,
+};
+
+module_platform_driver(snd_rpi_pcm5102a_driver);
+
+MODULE_AUTHOR("Francesco Valla");
+MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to a PCM5102A");
+MODULE_LICENSE("GPL");

--- a/sound/soc/bcm/rpi-proto.c
+++ b/sound/soc/bcm/rpi-proto.c
@@ -49,9 +49,10 @@ static int snd_rpi_proto_hw_params(struct snd_pcm_substream *substream,
 	int ret = snd_soc_dai_set_bclk_ratio(cpu_dai,32*2);
 	if (ret < 0){
 		dev_err(substream->pcm->dev,
-				"Failed to set BCLK ratio %d\n", ret);
+				"Failed to set WM8731 BCLK ratio %d\n", ret);
 		return ret;
 	}
+
 	int sysclk = 12288000; /* This is fixed on this board */
 
 	/* Set proto sysclk */

--- a/sound/soc/bcm/rpi-proto.c
+++ b/sound/soc/bcm/rpi-proto.c
@@ -44,6 +44,7 @@ static int snd_rpi_proto_hw_params(struct snd_pcm_substream *substream,
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	struct snd_soc_dai *codec_dai = rtd->codec_dai;
 	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
+	int sysclk = 12288000; /* This is fixed on this board */
 
 	/* Set proto bclk */
 	int ret = snd_soc_dai_set_bclk_ratio(cpu_dai,32*2);
@@ -52,8 +53,6 @@ static int snd_rpi_proto_hw_params(struct snd_pcm_substream *substream,
 				"Failed to set WM8731 BCLK ratio %d\n", ret);
 		return ret;
 	}
-
-	int sysclk = 12288000; /* This is fixed on this board */
 
 	/* Set proto sysclk */
 	ret = snd_soc_dai_set_sysclk(codec_dai, WM8731_SYSCLK_XTAL,

--- a/sound/soc/bcm/rpi-proto.c
+++ b/sound/soc/bcm/rpi-proto.c
@@ -1,0 +1,130 @@
+/*
+ * ASoC driver for PROTO AudioCODEC (with a WM8731)
+ * connected to a Raspberry Pi
+ *
+ * Author:      Florian Meier, <koalo@koalo.de>
+ *	      Copyright 2013
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+
+#include <sound/core.h>
+#include <sound/pcm.h>
+#include <sound/soc.h>
+#include <sound/jack.h>
+
+#include "../codecs/wm8731.h"
+
+static const unsigned int wm8731_rates_12288000[] = {
+	8000, 32000, 48000, 96000,
+};
+
+static struct snd_pcm_hw_constraint_list wm8731_constraints_12288000 = {
+	.list = wm8731_rates_12288000,
+	.count = ARRAY_SIZE(wm8731_rates_12288000),
+};
+
+static int snd_rpi_proto_startup(struct snd_pcm_substream *substream)
+{
+	/* Setup constraints, because there is a 12.288 MHz XTAL on the board */
+	snd_pcm_hw_constraint_list(substream->runtime, 0,
+				SNDRV_PCM_HW_PARAM_RATE,
+				&wm8731_constraints_12288000);
+	return 0;
+}
+
+static int snd_rpi_proto_hw_params(struct snd_pcm_substream *substream,
+				       struct snd_pcm_hw_params *params)
+{
+	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_dai *codec_dai = rtd->codec_dai;
+	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
+
+	/* Set proto bclk */
+	int ret = snd_soc_dai_set_bclk_ratio(cpu_dai,32*2);
+	if (ret < 0){
+		dev_err(substream->pcm->dev,
+				"Failed to set BCLK ratio %d\n", ret);
+		return ret;
+	}
+	int sysclk = 12288000; /* This is fixed on this board */
+
+	/* Set proto sysclk */
+	ret = snd_soc_dai_set_sysclk(codec_dai, WM8731_SYSCLK_XTAL,
+			sysclk, SND_SOC_CLOCK_IN);
+	if (ret < 0) {
+		dev_err(substream->pcm->dev,
+				"Failed to set WM8731 SYSCLK: %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/* machine stream operations */
+static struct snd_soc_ops snd_rpi_proto_ops = {
+	.startup = snd_rpi_proto_startup,
+	.hw_params = snd_rpi_proto_hw_params,
+};
+
+static struct snd_soc_dai_link snd_rpi_proto_dai[] = {
+{
+	.name		= "WM8731",
+	.stream_name	= "WM8731 HiFi",
+	.cpu_dai_name	= "bcm2708-i2s.0",
+	.codec_dai_name	= "wm8731-hifi",
+	.platform_name	= "bcm2708-i2s.0",
+	.codec_name	= "wm8731.1-001a",
+	.dai_fmt	= SND_SOC_DAIFMT_I2S
+				| SND_SOC_DAIFMT_NB_NF
+				| SND_SOC_DAIFMT_CBM_CFM,
+	.ops		= &snd_rpi_proto_ops,
+},
+};
+
+/* audio machine driver */
+static struct snd_soc_card snd_rpi_proto = {
+	.name		= "snd_rpi_proto",
+	.dai_link	= snd_rpi_proto_dai,
+	.num_links	= ARRAY_SIZE(snd_rpi_proto_dai),
+};
+
+static int snd_rpi_proto_probe(struct platform_device *pdev)
+{
+	int ret = 0;
+
+	snd_rpi_proto.dev = &pdev->dev;
+	ret = snd_soc_register_card(&snd_rpi_proto);
+	if (ret) {
+		dev_err(&pdev->dev,
+				"snd_soc_register_card() failed: %d\n", ret);
+	}
+
+	return ret;
+}
+
+
+static int snd_rpi_proto_remove(struct platform_device *pdev)
+{
+	return snd_soc_unregister_card(&snd_rpi_proto);
+}
+
+static struct platform_driver snd_rpi_proto_driver = {
+	.driver = {
+		.name   = "snd-rpi-proto",
+		.owner  = THIS_MODULE,
+	},
+	.probe	  = snd_rpi_proto_probe,
+	.remove	 = snd_rpi_proto_remove,
+};
+
+module_platform_driver(snd_rpi_proto_driver);
+
+MODULE_AUTHOR("Florian Meier");
+MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
+MODULE_LICENSE("GPL");

--- a/sound/soc/bcm/rpi-tda1541a.c
+++ b/sound/soc/bcm/rpi-tda1541a.c
@@ -1,0 +1,92 @@
+/*
+ * ASoC driver for TDA1541A codec
+ * connected to a Raspberry Pi
+ *
+ * Author:      Florian Meier, <koalo@koalo.de>
+ *              Copyright 2013
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+
+#include <sound/core.h>
+#include <sound/pcm.h>
+#include <sound/soc.h>
+#include <sound/jack.h>
+
+static int snd_rpi_tda1541a_init(struct snd_soc_pcm_runtime *rtd)
+{
+	return 0;
+}
+
+static int snd_rpi_tda1541a_hw_params(struct snd_pcm_substream *substream,
+				       struct snd_pcm_hw_params *params)
+{
+	return 0;
+}
+
+/* machine stream operations */
+static struct snd_soc_ops snd_rpi_tda1541a_ops = {
+	.hw_params = snd_rpi_tda1541a_hw_params,
+};
+
+static struct snd_soc_dai_link snd_rpi_tda1541a_dai[] = {
+{
+	.name		= "TDA1541A",
+	.stream_name	= "TDA1541A HiFi",
+	.cpu_dai_name	= "bcm2708-i2s.0",
+	.codec_dai_name	= "tda1541a-hifi",
+	.platform_name	= "bcm2708-i2s.0",
+	.codec_name	= "tda1541a-codec",
+	.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
+				SND_SOC_DAIFMT_CBS_CFS,
+	.ops		= &snd_rpi_tda1541a_ops,
+	.init		= snd_rpi_tda1541a_init,
+},
+};
+
+/* audio machine driver */
+static struct snd_soc_card snd_rpi_tda1541a = {
+	.name         = "snd_rpi_tda1541a",
+	.dai_link     = snd_rpi_tda1541a_dai,
+	.num_links    = ARRAY_SIZE(snd_rpi_tda1541a_dai),
+};
+
+static int snd_rpi_tda1541a_probe(struct platform_device *pdev)
+{
+	int ret = 0;
+
+	snd_rpi_tda1541a.dev = &pdev->dev;
+	ret = snd_soc_register_card(&snd_rpi_tda1541a);
+	if (ret)
+        {
+		dev_err(&pdev->dev, "snd_soc_register_card() failed: %d\n", ret);
+        }
+
+	return ret;
+}
+
+
+static int snd_rpi_tda1541a_remove(struct platform_device *pdev)
+{
+	return snd_soc_unregister_card(&snd_rpi_tda1541a);
+}
+
+static struct platform_driver snd_rpi_tda1541a_driver = {
+        .driver = {
+                .name   = "snd-rpi-tda1541a",
+                .owner  = THIS_MODULE,
+        },
+        .probe          = snd_rpi_tda1541a_probe,
+        .remove         = snd_rpi_tda1541a_remove,
+};
+
+module_platform_driver(snd_rpi_tda1541a_driver);
+
+MODULE_AUTHOR("Florian Meier");
+MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to a TDA1541A");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
As per a request from koalo, I attach the changes I have made to make the 3.8 i2s card/board drivers work with the 3.10 kernel.  This expands on the existing hifiberry support in 3.10 to include some other common i2s boards.

I have only tested the proto board driver (WM8731 chipset) so I can not vouch for the other drivers.  If you prefer, I am happy to reissue the pull request with just the drivers I have tested.

BBUK
