### PR TITLE
bcm2708: remove NEED_MACH_GPIO_H

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -374,7 +374,6 @@ config ARCH_BCM2708
 	select ARM_AMBA
 	select HAVE_CLK
 	select HAVE_SCHED_CLOCK
-	select NEED_MACH_GPIO_H
 	select NEED_MACH_MEMORY_H
 	select CLKDEV_LOOKUP
 	select ARCH_HAS_CPUFREQ

--- a/arch/arm/mach-bcm2708/bcm2708_gpio.c
+++ b/arch/arm/mach-bcm2708/bcm2708_gpio.c
@@ -16,7 +16,7 @@
 #include <linux/irq.h>
 #include <linux/interrupt.h>
 #include <linux/slab.h>
-#include <mach/gpio.h>
+#include <mach/gpio_irq.h>
 #include <linux/gpio.h>
 #include <linux/platform_device.h>
 #include <mach/platform.h>

--- a/arch/arm/mach-bcm2708/include/mach/gpio.h
+++ b/arch/arm/mach-bcm2708/include/mach/gpio.h
@@ -1,0 +1,15 @@
+/*
+ * arch/arm/mach-bcm2708/include/mach/gpio.h
+ *
+ * This file is licensed under the terms of the GNU General Public
+ * License version 2.  This program is licensed "as is" without any
+ * warranty of any kind, whether express or implied.
+ */
+
+#ifndef __ASM_ARCH_GPIO_H
+#define __ASM_ARCH_GPIO_H
+
+#error Use <mach/gpio_irq.h> and __bcm2708_gpio_to_irq() to achieve what you want. <mach/gpio.h> used to contain gpio_to_irq() which conflicted with the gpio subsystem function of the same name in subtle ways.
+
+#endif
+

--- a/arch/arm/mach-bcm2708/include/mach/gpio_irq.h
+++ b/arch/arm/mach-bcm2708/include/mach/gpio_irq.h
@@ -1,13 +1,13 @@
 /*
- * arch/arm/mach-bcm2708/include/mach/gpio.h
+ * arch/arm/mach-bcm2708/include/mach/gpio_irq.h
  *
  * This file is licensed under the terms of the GNU General Public
  * License version 2.  This program is licensed "as is" without any
  * warranty of any kind, whether express or implied.
  */
 
-#ifndef __ASM_ARCH_GPIO_H
-#define __ASM_ARCH_GPIO_H
+#ifndef __ASM_ARCH_GPIO_IRQ_H
+#define __ASM_ARCH_GPIO_IRQ_H
 
 #define ARCH_NR_GPIOS 54 // number of gpio lines
 


### PR DESCRIPTION
A recent commit of mine, f04ff75d39215e8b0ecd20c027abda45bf741213, removes the macro gpio_to_irq() from mach/gpio.h. Digging through the whole mess of the various gpio.h incarnations, I found that it's probably best to rename that file to gpio_irq.h, and to remove NEED_MACH_GPIO_H from the architecture.

See http://lists.infradead.org/pipermail/linux-arm-kernel/2012-September/118375.html which led me to the point that this has to go.
