### PR TITLE
mach-bcm2708: Reserve 64 IRQs for peripherals

### DIFF
--- a/arch/arm/mach-bcm2708/include/mach/irqs.h
+++ b/arch/arm/mach-bcm2708/include/mach/irqs.h
@@ -192,8 +192,9 @@
 #define HARD_IRQS	      (64 + 21)
 #define FIQ_IRQS              (64 + 21)
 #define GPIO_IRQS	      (32*5)
+#define SPARE_IRQS		(64)
 
-#define NR_IRQS		      HARD_IRQS+FIQ_IRQS+GPIO_IRQS
+#define NR_IRQS		      HARD_IRQS+FIQ_IRQS+GPIO_IRQS+SPARE_IRQS
 
 
 #endif /* _BCM2708_IRQS_H_ */


### PR DESCRIPTION
The Raspberry Pi does not support dynamic IRQs.  Some peripherals, such
as the STMPE, add IRQ controllers.  If there aren't any reserved IRQs, then
these peripherals will just fail.

Signed-off-by: Sean Cross xobs@kosagi.com
Signed-off-by: Noralf Tronnes notro@tronnes.org
