### PR TITLE
V4L2: Extend range for V4L2_CID_MPEG_VIDEO_H264_I_PERIOD

### DIFF
--- a/drivers/media/platform/bcm2835/controls.c
+++ b/drivers/media/platform/bcm2835/controls.c
@@ -1151,7 +1151,7 @@ static const struct bm2835_mmal_v4l2_ctrl v4l2_ctrls[V4L2_CTRL_COUNT] = {
 	},
 	{
 		V4L2_CID_MPEG_VIDEO_H264_I_PERIOD, MMAL_CONTROL_TYPE_STD,
-		1, 1000, 60, 1, NULL,
+		0, 0x7FFFFFFF, 60, 1, NULL,
 		MMAL_PARAMETER_INTRAPERIOD,
 		&ctrl_set_video_encode_param_output,
 		false


### PR DESCRIPTION
From https://github.com/raspberrypi/linux/issues/593

Request to extend the range from the fairly arbitrary
1000 frames (33 seconds at 30fps). Extend out to the
max range supported (int32 value).
Also allow 0, which is handled by the codec as only
send an I-frame on the first frame and never again.
There may be an exception if it detects a significant
scene change, but there's no easy way around that.

Signed-off-by: Dave Stevenson dsteve@broadcom.com
