### PR TITLE
Initial patches to prepare the ground for Element-14 Wolfson audio support

### DIFF
--- a/drivers/mfd/arizona-irq.c
+++ b/drivers/mfd/arizona-irq.c
@@ -28,13 +28,17 @@
 
 static int arizona_map_irq(struct arizona *arizona, int irq)
 {
-	int ret;
-
-	ret = regmap_irq_get_virq(arizona->aod_irq_chip, irq);
-	if (ret < 0)
-		ret = regmap_irq_get_virq(arizona->irq_chip, irq);
-
-	return ret;
+	switch (irq) {
+	case ARIZONA_IRQ_GP5_FALL:
+	case ARIZONA_IRQ_GP5_RISE:
+	case ARIZONA_IRQ_JD_FALL:
+	case ARIZONA_IRQ_JD_RISE:
+	case ARIZONA_IRQ_MICD_CLAMP_FALL:
+	case ARIZONA_IRQ_MICD_CLAMP_RISE:
+		return arizona->pdata.irq_base + 2 + irq;
+	default:
+		return arizona->pdata.irq_base + 2 + ARIZONA_NUM_IRQ + irq;
+	}
 }
 
 int arizona_request_irq(struct arizona *arizona, int irq, char *name,
@@ -61,11 +65,49 @@ EXPORT_SYMBOL_GPL(arizona_free_irq);
 
 int arizona_set_irq_wake(struct arizona *arizona, int irq, int on)
 {
-	irq = arizona_map_irq(arizona, irq);
-	if (irq < 0)
-		return irq;
+	int val = 0;
 
-	return irq_set_irq_wake(irq, on);
+	if (on) {
+		val = 0xffff;
+		irq_set_irq_wake(arizona->irq, 1);
+	} else {
+		irq_set_irq_wake(arizona->irq, 0);
+	}
+
+	switch (irq) {
+	case ARIZONA_IRQ_MICD_CLAMP_RISE:
+		return regmap_update_bits(arizona->regmap,
+					  ARIZONA_WAKE_CONTROL,
+					  val & ARIZONA_WKUP_MICD_CLAMP_RISE,
+					  val & ARIZONA_WKUP_MICD_CLAMP_RISE);
+	case ARIZONA_IRQ_MICD_CLAMP_FALL:
+		return regmap_update_bits(arizona->regmap,
+					  ARIZONA_WAKE_CONTROL,
+					  val & ARIZONA_WKUP_MICD_CLAMP_FALL,
+					  val & ARIZONA_WKUP_MICD_CLAMP_FALL);
+	case ARIZONA_IRQ_GP5_FALL:
+		return regmap_update_bits(arizona->regmap,
+					  ARIZONA_WAKE_CONTROL,
+					  val & ARIZONA_WKUP_GP5_RISE,
+					  val & ARIZONA_WKUP_GP5_RISE);
+	case ARIZONA_IRQ_GP5_RISE:
+		return regmap_update_bits(arizona->regmap,
+					  ARIZONA_WAKE_CONTROL,
+					  val & ARIZONA_WKUP_GP5_FALL,
+					  val & ARIZONA_WKUP_GP5_FALL);
+	case ARIZONA_IRQ_JD_RISE:
+		return regmap_update_bits(arizona->regmap,
+					  ARIZONA_WAKE_CONTROL,
+					  val & ARIZONA_WKUP_JD1_RISE,
+					  val & ARIZONA_WKUP_JD1_RISE);
+	case ARIZONA_IRQ_JD_FALL:
+		return regmap_update_bits(arizona->regmap,
+					  ARIZONA_WAKE_CONTROL,
+					  val & ARIZONA_WKUP_JD1_FALL,
+					  val & ARIZONA_WKUP_JD1_FALL);
+	default:
+		return -ENXIO;
+	}
 }
 EXPORT_SYMBOL_GPL(arizona_set_irq_wake);
 
@@ -108,7 +150,8 @@ static irqreturn_t arizona_irq_thread(int irq, void *data)
 		poll = false;
 
 		/* Always handle the AoD domain */
-		handle_nested_irq(irq_find_mapping(arizona->virq, 0));
+		handle_nested_irq(arizona->virq[0]);
+
 
 		/*
 		 * Check if one of the main interrupts is asserted and only
@@ -117,7 +160,7 @@ static irqreturn_t arizona_irq_thread(int irq, void *data)
 		ret = regmap_read(arizona->regmap, ARIZONA_IRQ_PIN_STATUS,
 				  &val);
 		if (ret == 0 && val & ARIZONA_IRQ1_STS) {
-			handle_nested_irq(irq_find_mapping(arizona->virq, 1));
+			handle_nested_irq(arizona->virq[1]);
 		} else if (ret != 0) {
 			dev_err(arizona->dev,
 				"Failed to read main IRQ status: %d\n", ret);
@@ -158,31 +201,6 @@ static struct irq_chip arizona_irq_chip = {
 	.irq_enable		= arizona_irq_enable,
 };
 
-static int arizona_irq_map(struct irq_domain *h, unsigned int virq,
-			      irq_hw_number_t hw)
-{
-	struct regmap_irq_chip_data *data = h->host_data;
-
-	irq_set_chip_data(virq, data);
-	irq_set_chip_and_handler(virq, &arizona_irq_chip, handle_edge_irq);
-	irq_set_nested_thread(virq, 1);
-
-	/* ARM needs us to explicitly flag the IRQ as valid
-	 * and will set them noprobe when we do so. */
-#ifdef CONFIG_ARM
-	set_irq_flags(virq, IRQF_VALID);
-#else
-	irq_set_noprobe(virq);
-#endif
-
-	return 0;
-}
-
-static struct irq_domain_ops arizona_domain_ops = {
-	.map	= arizona_irq_map,
-	.xlate	= irq_domain_xlate_twocell,
-};
-
 int arizona_irq_init(struct arizona *arizona)
 {
 	int flags = IRQF_ONESHOT;
@@ -190,6 +208,7 @@ int arizona_irq_init(struct arizona *arizona)
 	const struct regmap_irq_chip *aod, *irq;
 	bool ctrlif_error = true;
 	struct irq_data *irq_data;
+	int irq_base;
 
 	switch (arizona->type) {
 #ifdef CONFIG_MFD_WM5102
@@ -262,27 +281,45 @@ int arizona_irq_init(struct arizona *arizona)
 
 	flags |= arizona->pdata.irq_flags;
 
-	/* Allocate a virtual IRQ domain to distribute to the regmap domains */
-	arizona->virq = irq_domain_add_linear(NULL, 2, &arizona_domain_ops,
-					      arizona);
-	if (!arizona->virq) {
-		dev_err(arizona->dev, "Failed to add core IRQ domain\n");
-		ret = -EINVAL;
-		goto err;
+        /* set up virtual IRQs */
+	irq_base = irq_alloc_descs(arizona->pdata.irq_base, 0,
+				   ARRAY_SIZE(arizona->virq), 0);
+	if (irq_base < 0) {
+		dev_warn(arizona->dev, "Failed to allocate IRQs: %d\n",
+			 irq_base);
+		return irq_base;
+	}
+
+	arizona->virq[0] = irq_base;
+	arizona->virq[1] = irq_base + 1;
+	irq_base += 2;
+
+	for (i = 0; i < ARRAY_SIZE(arizona->virq); i++) {
+		irq_set_chip_and_handler(arizona->virq[i], &arizona_irq_chip,
+		handle_edge_irq);
+		irq_set_nested_thread(arizona->virq[i], 1);
+
+		/* ARM needs us to explicitly flag the IRQ as valid
+		* and will set them noprobe when we do so. */
+#ifdef CONFIG_ARM
+		set_irq_flags(arizona->virq[i], IRQF_VALID);
+#else
+		irq_set_noprobe(arizona->virq[i]);
+#endif
 	}
 
 	ret = regmap_add_irq_chip(arizona->regmap,
-				  irq_create_mapping(arizona->virq, 0),
-				  IRQF_ONESHOT, -1, aod,
-				  &arizona->aod_irq_chip);
+					arizona->virq[0],
+					IRQF_ONESHOT, irq_base, aod,
+					&arizona->aod_irq_chip);
 	if (ret != 0) {
 		dev_err(arizona->dev, "Failed to add AOD IRQs: %d\n", ret);
 		goto err_domain;
 	}
 
 	ret = regmap_add_irq_chip(arizona->regmap,
-				  irq_create_mapping(arizona->virq, 1),
-				  IRQF_ONESHOT, -1, irq,
+				  arizona->virq[1],
+				  IRQF_ONESHOT, irq_base + ARIZONA_NUM_IRQ, irq,
 				  &arizona->irq_chip);
 	if (ret != 0) {
 		dev_err(arizona->dev, "Failed to add AOD IRQs: %d\n", ret);
@@ -349,10 +386,10 @@ err_main_irq:
 err_ctrlif:
 	free_irq(arizona_map_irq(arizona, ARIZONA_IRQ_BOOT_DONE), arizona);
 err_boot_done:
-	regmap_del_irq_chip(irq_create_mapping(arizona->virq, 1),
+	regmap_del_irq_chip(arizona->virq[1],
 			    arizona->irq_chip);
 err_aod:
-	regmap_del_irq_chip(irq_create_mapping(arizona->virq, 0),
+	regmap_del_irq_chip(arizona->virq[0],
 			    arizona->aod_irq_chip);
 err_domain:
 err:
@@ -363,9 +400,9 @@ int arizona_irq_exit(struct arizona *arizona)
 {
 	free_irq(arizona_map_irq(arizona, ARIZONA_IRQ_CTRLIF_ERR), arizona);
 	free_irq(arizona_map_irq(arizona, ARIZONA_IRQ_BOOT_DONE), arizona);
-	regmap_del_irq_chip(irq_create_mapping(arizona->virq, 1),
+	regmap_del_irq_chip(arizona->irq,
 			    arizona->irq_chip);
-	regmap_del_irq_chip(irq_create_mapping(arizona->virq, 0),
+	regmap_del_irq_chip(arizona->irq,
 			    arizona->aod_irq_chip);
 	free_irq(arizona->irq, arizona);
 

--- a/include/linux/mfd/arizona/core.h
+++ b/include/linux/mfd/arizona/core.h
@@ -99,7 +99,7 @@ struct arizona {
 	unsigned int external_dcvdd:1;
 
 	int irq;
-	struct irq_domain *virq;
+	int virq[2];
 	struct regmap_irq_chip_data *aod_irq_chip;
 	struct regmap_irq_chip_data *irq_chip;
 

--- a/include/linux/mfd/arizona/pdata.h
+++ b/include/linux/mfd/arizona/pdata.h
@@ -188,6 +188,9 @@ struct arizona_pdata {
 
 	/** GPIO for primary IRQ (used for edge triggered emulation) */
 	int irq_gpio;
+
+	/** IRQ base */
+	int irq_base;
 };
 
 #endif

--- a/include/sound/soc-dapm.h
+++ b/include/sound/soc-dapm.h
@@ -409,9 +409,9 @@ int snd_soc_dapm_new_dai_widgets(struct snd_soc_dapm_context *dapm,
 				 struct snd_soc_dai *dai);
 int snd_soc_dapm_link_dai_widgets(struct snd_soc_card *card);
 int snd_soc_dapm_new_pcm(struct snd_soc_card *card,
-			 const struct snd_soc_pcm_stream *params,
+			 struct snd_soc_pcm_stream *params,
 			 struct snd_soc_dapm_widget *source,
-			 struct snd_soc_dapm_widget *sink);
+			 struct snd_soc_dapm_widget *sink, void *priv);
 
 /* dapm path setup */
 int snd_soc_dapm_new_widgets(struct snd_soc_card *card);
@@ -556,7 +556,7 @@ struct snd_soc_dapm_widget {
 
 	void *priv;				/* widget specific data */
 	struct regulator *regulator;		/* attached regulator */
-	const struct snd_soc_pcm_stream *params; /* params for dai links */
+	struct snd_soc_pcm_stream *params; /* params for dai links */
 
 	/* dapm control */
 	int reg;				/* negative reg = no direct dapm */

--- a/include/sound/soc.h
+++ b/include/sound/soc.h
@@ -899,7 +899,9 @@ struct snd_soc_dai_link {
 	const struct device_node *platform_of_node;
 	int be_id;	/* optional ID for machine driver BE identification */
 
-	const struct snd_soc_pcm_stream *params;
+	struct snd_soc_pcm_stream *params;
+	/* optional params re-writing for dai links */
+	int (*params_fixup)(struct snd_soc_dapm_widget *w, int event);
 
 	unsigned int dai_fmt;           /* format to set on init */
 

--- a/sound/soc/codecs/arizona.c
+++ b/sound/soc/codecs/arizona.c
@@ -1026,39 +1026,6 @@ static int arizona_sr_vals[] = {
 	512000,
 };
 
-static int arizona_startup(struct snd_pcm_substream *substream,
-			   struct snd_soc_dai *dai)
-{
-	struct snd_soc_codec *codec = dai->codec;
-	struct arizona_priv *priv = snd_soc_codec_get_drvdata(codec);
-	struct arizona_dai_priv *dai_priv = &priv->dai[dai->id - 1];
-	const struct snd_pcm_hw_constraint_list *constraint;
-	unsigned int base_rate;
-
-	switch (dai_priv->clk) {
-	case ARIZONA_CLK_SYSCLK:
-		base_rate = priv->sysclk;
-		break;
-	case ARIZONA_CLK_ASYNCCLK:
-		base_rate = priv->asyncclk;
-		break;
-	default:
-		return 0;
-	}
-
-	if (base_rate == 0)
-		return 0;
-
-	if (base_rate % 8000)
-		constraint = &arizona_44k1_constraint;
-	else
-		constraint = &arizona_48k_constraint;
-
-	return snd_pcm_hw_constraint_list(substream->runtime, 0,
-					  SNDRV_PCM_HW_PARAM_RATE,
-					  constraint);
-}
-
 static int arizona_hw_params_rate(struct snd_pcm_substream *substream,
 				  struct snd_pcm_hw_params *params,
 				  struct snd_soc_dai *dai)
@@ -1113,12 +1080,33 @@ static int arizona_hw_params(struct snd_pcm_substream *substream,
 {
 	struct snd_soc_codec *codec = dai->codec;
 	struct arizona_priv *priv = snd_soc_codec_get_drvdata(codec);
+	struct arizona_dai_priv *dai_priv = &priv->dai[dai->id - 1];
 	struct arizona *arizona = priv->arizona;
 	int base = dai->driver->base;
 	const int *rates;
 	int i, ret, val;
 	int chan_limit = arizona->pdata.max_channels_clocked[dai->id - 1];
 	int bclk, lrclk, wl, frame, bclk_target;
+	unsigned int base_rate;
+
+	switch (dai_priv->clk) {
+	case ARIZONA_CLK_SYSCLK:
+		base_rate = priv->sysclk;
+		break;
+	case ARIZONA_CLK_ASYNCCLK:
+		base_rate = priv->asyncclk;
+		break;
+	default:
+		arizona_aif_err(dai, "Unknown clock: %d\n", dai_priv->clk);
+		return -EINVAL;
+	}
+
+	if (!!(base_rate % 8000) != !!(params_rate(params) % 8000)) {
+		arizona_aif_err(dai,
+				"Rate %dHz not supported off %dHz clock\n",
+				params_rate(params), base_rate);
+		return -EINVAL;
+	}
 
 	if (params_rate(params) % 8000)
 		rates = &arizona_44k1_bclk_rates[0];
@@ -1253,7 +1241,6 @@ static int arizona_set_tristate(struct snd_soc_dai *dai, int tristate)
 }
 
 const struct snd_soc_dai_ops arizona_dai_ops = {
-	.startup = arizona_startup,
 	.set_fmt = arizona_set_fmt,
 	.hw_params = arizona_hw_params,
 	.set_sysclk = arizona_dai_set_sysclk,
@@ -1262,7 +1249,6 @@ const struct snd_soc_dai_ops arizona_dai_ops = {
 EXPORT_SYMBOL_GPL(arizona_dai_ops);
 
 const struct snd_soc_dai_ops arizona_simple_dai_ops = {
-	.startup = arizona_startup,
 	.hw_params = arizona_hw_params_rate,
 	.set_sysclk = arizona_dai_set_sysclk,
 };

--- a/sound/soc/codecs/arizona.c
+++ b/sound/soc/codecs/arizona.c
@@ -1337,7 +1337,7 @@ static int arizona_calc_fll(struct arizona_fll *fll,
 	Fref /= div;
 
 	/* Fvco should be over the targt; don't check the upper bound */
-	div = 1;
+	div = 2;
 	while (Fout * div < 90000000 * fll->vco_mult) {
 		div++;
 		if (div > 7) {

--- a/sound/soc/codecs/wm8804.c
+++ b/sound/soc/codecs/wm8804.c
@@ -98,7 +98,8 @@ static const SOC_ENUM_SINGLE_EXT_DECL(txsrc, txsrc_text);
 static const struct snd_kcontrol_new wm8804_snd_controls[] = {
 	SOC_ENUM_EXT("Input Source", txsrc, txsrc_get, txsrc_put),
 	SOC_SINGLE("TX Playback Switch", WM8804_PWRDN, 2, 1, 1),
-	SOC_SINGLE("AIF Playback Switch", WM8804_PWRDN, 4, 1, 1)
+	SOC_SINGLE("AIF Playback Switch", WM8804_PWRDN, 4, 1, 1),
+	SOC_SINGLE("RX Playback Switch", WM8804_PWRDN, 1, 1, 1),
 };
 
 static int txsrc_get(struct snd_kcontrol *kcontrol,
@@ -121,7 +122,7 @@ static int txsrc_put(struct snd_kcontrol *kcontrol,
 		     struct snd_ctl_elem_value *ucontrol)
 {
 	struct snd_soc_codec *codec;
-	unsigned int src, txpwr;
+	unsigned int src, txpwr, rxpwr;
 
 	codec = snd_kcontrol_chip(kcontrol);
 
@@ -143,15 +144,18 @@ static int txsrc_put(struct snd_kcontrol *kcontrol,
 
 	/* save the current power state of the transmitter */
 	txpwr = snd_soc_read(codec, WM8804_PWRDN) & 0x4;
+	/* save the current power state of the receiver */
+	rxpwr = snd_soc_read(codec, WM8804_PWRDN) & 0x2;
 	/* power down the transmitter */
 	snd_soc_update_bits(codec, WM8804_PWRDN, 0x4, 0x4);
+	/* power down the receiver */
+	snd_soc_update_bits(codec, WM8804_PWRDN, 0x2, 0x2);
+
 	/* set the tx source */
 	snd_soc_update_bits(codec, WM8804_SPDTX4, 0x40,
 			    ucontrol->value.integer.value[0] << 6);
 
 	if (ucontrol->value.integer.value[0]) {
-		/* power down the receiver */
-		snd_soc_update_bits(codec, WM8804_PWRDN, 0x2, 0x2);
 		/* power up the AIF */
 		snd_soc_update_bits(codec, WM8804_PWRDN, 0x10, 0);
 	} else {
@@ -162,6 +166,8 @@ static int txsrc_put(struct snd_kcontrol *kcontrol,
 
 	/* restore the transmitter's configuration */
 	snd_soc_update_bits(codec, WM8804_PWRDN, 0x4, txpwr);
+	/* restore the receiver's configuration */
+	snd_soc_update_bits(codec, WM8804_PWRDN, 0x2, rxpwr);
 
 	return 0;
 }

--- a/sound/soc/soc-core.c
+++ b/sound/soc/soc-core.c
@@ -1454,7 +1454,7 @@ static int soc_probe_link_dais(struct snd_soc_card *card, int num, int order)
 			capture_w = cpu_dai->capture_widget;
 			if (play_w && capture_w) {
 				ret = snd_soc_dapm_new_pcm(card, dai_link->params,
-						   capture_w, play_w);
+						   capture_w, play_w, dai_link);
 				if (ret != 0) {
 					dev_err(card->dev, "ASoC: Can't link %s to %s: %d\n",
 						play_w->name, capture_w->name, ret);
@@ -1466,7 +1466,7 @@ static int soc_probe_link_dais(struct snd_soc_card *card, int num, int order)
 			capture_w = codec_dai->capture_widget;
 			if (play_w && capture_w) {
 				ret = snd_soc_dapm_new_pcm(card, dai_link->params,
-						   capture_w, play_w);
+						   capture_w, play_w, dai_link);
 				if (ret != 0) {
 					dev_err(card->dev, "ASoC: Can't link %s to %s: %d\n",
 						play_w->name, capture_w->name, ret);


### PR DESCRIPTION
Hi all,

Wolfson would like to add support for the Element 14 Wolfson audio card.

I will be the main point of contact at Wolfson for the upstreaming of the patches to your kernel. Any support regarding the audio card should still be routed through to Element 14.

I will be pushing more patches over the next few weeks but I wanted to start pushing these particular patches to minimize the differences between the out of tree kernel and the rpi kernel.
The current patches extend the WM8804 and WM5102 drivers in order to have full audio support.

For your reference, the following link takes you to the official product page.

http://www.element14.com/community/community/raspberry-pi/raspberry-pi-accessories/wolfson_pi?CMP=KNC-EU-RPI-ACC-Wolfson

Manish Gupta
