### PR TITLE
spi: bcm2708: add device tree support

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -5,4 +5,36 @@
 / {
 	compatible = "brcm,bcm2708";
 	model = "Raspberry Pi";
+
+	aliases {
+		spi0 = &spi0;
+	};
+};
+
+&gpio {
+	spi0_pins: spi0_pins {
+		brcm,pins = <7 8 9 10 11>;
+		brcm,function = <4>; /* alt0 */
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_pins>;
+
+	spidev@0{
+		compatible = "spidev";
+		reg = <0>;	/* CE0 */
+		#address-cells = <1>;
+		#size-cells = <0>;
+		spi-max-frequency = <500000>;
+	};
+
+	spidev@1{
+		compatible = "spidev";
+		reg = <1>;	/* CE1 */
+		#address-cells = <1>;
+		#size-cells = <0>;
+		spi-max-frequency = <500000>;
+	};
 };

--- a/arch/arm/boot/dts/bcm2708.dtsi
+++ b/arch/arm/boot/dts/bcm2708.dtsi
@@ -33,11 +33,29 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
+
+		spi0: spi@7e204000 {
+			compatible = "brcm,bcm2708-spi";
+			reg = <0x7e204000 0x1000>;
+			interrupts = <2 22>;
+			clocks = <&clk_spi>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
 	};
 
 	clocks {
 		compatible = "simple-bus";
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		clk_spi: clock@2 {
+			compatible = "fixed-clock";
+			reg = <2>;
+			#clock-cells = <0>;
+			clock-output-names = "spi";
+			clock-frequency = <250000000>;
+		};
 	};
 };

--- a/arch/arm/mach-bcm2708/Kconfig
+++ b/arch/arm/mach-bcm2708/Kconfig
@@ -44,7 +44,7 @@ config BCM2708_NOL2CACHE
 
 config BCM2708_SPIDEV
 	bool "Bind spidev to SPI0 master"
-	depends on MACH_BCM2708
+	depends on MACH_BCM2708 && !USE_OF
 	depends on SPI
 	default y
 	help

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -514,6 +514,7 @@ static struct platform_device bcm2708_alsa_devices[] = {
 	       },
 };
 
+#ifndef CONFIG_OF
 static struct resource bcm2708_spi_resources[] = {
 	{
 		.start = SPI0_BASE,
@@ -537,6 +538,7 @@ static struct platform_device bcm2708_spi_device = {
 		.dma_mask = &bcm2708_spi_dmamask,
 		.coherent_dma_mask = DMA_BIT_MASK(DMA_MASK_BITS_COMMON)},
 };
+#endif
 
 #ifdef CONFIG_BCM2708_SPIDEV
 static struct spi_board_info bcm2708_spi_devices[] = {
@@ -698,6 +700,16 @@ int __init bcm_register_device(struct platform_device *pdev)
 	return ret;
 }
 
+/*
+ * Use this macro for platform devices that are present in the Device Tree.
+ * This way the device is only added on non-DT builds.
+ */
+#ifdef CONFIG_OF
+#define bcm_register_device_dt(pdev)
+#else
+#define bcm_register_device_dt(pdev) bcm_register_device(pdev)
+#endif
+
 int calc_rsts(int partition)
 {
 	return PM_PASSWORD |
@@ -815,7 +827,7 @@ void __init bcm2708_init(void)
 	for (i = 0; i < ARRAY_SIZE(bcm2708_alsa_devices); i++)
 		bcm_register_device(&bcm2708_alsa_devices[i]);
 
-	bcm_register_device(&bcm2708_spi_device);
+	bcm_register_device_dt(&bcm2708_spi_device);
 	bcm_register_device(&bcm2708_bsc0_device);
 	bcm_register_device(&bcm2708_bsc1_device);
 

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -76,7 +76,7 @@ config SPI_ATMEL
 
 config SPI_BCM2835
 	tristate "BCM2835 SPI controller"
-	depends on ARCH_BCM2835 || COMPILE_TEST
+	depends on ARCH_BCM2835 || ARCH_BCM2708 || COMPILE_TEST
 	help
 	  This selects a driver for the Broadcom BCM2835 SPI master.
 

--- a/drivers/spi/spi-bcm2708.c
+++ b/drivers/spi/spi-bcm2708.c
@@ -512,6 +512,7 @@ static int bcm2708_spi_probe(struct platform_device *pdev)
 	master->setup = bcm2708_spi_setup;
 	master->transfer = bcm2708_spi_transfer;
 	master->cleanup = bcm2708_spi_cleanup;
+	master->dev.of_node = pdev->dev.of_node;
 	platform_set_drvdata(pdev, master);
 
 	bs = spi_master_get_devdata(master);
@@ -596,10 +597,17 @@ static int bcm2708_spi_remove(struct platform_device *pdev)
 	return 0;
 }
 
+static const struct of_device_id bcm2708_spi_match[] = {
+	{ .compatible = "brcm,bcm2708-spi", },
+	{}
+};
+MODULE_DEVICE_TABLE(of, bcm2708_spi_match);
+
 static struct platform_driver bcm2708_spi_driver = {
 	.driver		= {
 		.name	= DRV_NAME,
 		.owner	= THIS_MODULE,
+		.of_match_table = bcm2708_spi_match,
 	},
 	.probe		= bcm2708_spi_probe,
 	.remove		= bcm2708_spi_remove,


### PR DESCRIPTION
kconfig

```
ARCH=arm make bcmrpi_defconfig
scripts/config --enable BCM2708_DT
scripts/config --module SPI_BCM2835
yes "" | ARCH=arm make oldconfig
```

Enable SPI

```
$ fdtget /boot/bcm2708-rpi-b.dtb /soc/spi@7e204000 status
disabled
$ sudo fdtput --type s /boot/bcm2708-rpi-b.dtb /soc/spi@7e204000 status "okay"
$ sudo reboot
$ lsmod
spi_bcm2708
```

Use the spi-bcm2835 driver

```
$ fdtget /boot/bcm2708-rpi-b.dtb /soc/spi@7e204000 compatible
brcm,bcm2708-spi
$ sudo fdtput --type s /boot/bcm2708-rpi-b.dtb /soc/spi@7e204000 compatible "brcm,bcm2835-spi"
$ fdtget /boot/bcm2708-rpi-b.dtb /soc/spi@7e204000 compatible
brcm,bcm2835-spi
$ sudo reboot
$ lsmod
spi_bcm2835
```

Howto install latest dtc: https://github.com/notro/rpi-firmware/wiki/Device-Tree

**Test**

I have tested both SPI drivers with an ADS7846 touch controller. Worked fine.
This also verifies that GPIO interrupts in DT works.
