### PR TITLE
i2c: bcm2708: add device tree support

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -8,6 +8,8 @@
 
 	aliases {
 		spi0 = &spi0;
+		i2c0 = &i2c0;
+		i2c1 = &i2c1;
 	};
 };
 
@@ -15,6 +17,16 @@
 	spi0_pins: spi0_pins {
 		brcm,pins = <7 8 9 10 11>;
 		brcm,function = <4>; /* alt0 */
+	};
+
+	i2c0_pins: i2c0 {
+		brcm,pins = <0 1>;
+		brcm,function = <4>;
+	};
+
+	i2c1_pins: i2c1 {
+		brcm,pins = <2 3>;
+		brcm,function = <4>;
 	};
 };
 
@@ -37,4 +49,16 @@
 		#size-cells = <0>;
 		spi-max-frequency = <500000>;
 	};
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	clock-frequency = <100000>;
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c1_pins>;
+	clock-frequency = <100000>;
 };

--- a/arch/arm/boot/dts/bcm2708.dtsi
+++ b/arch/arm/boot/dts/bcm2708.dtsi
@@ -43,12 +43,39 @@
 			#size-cells = <0>;
 			status = "disabled";
 		};
+
+		i2c0: i2c@7e205000 {
+			compatible = "brcm,bcm2708-i2c";
+			reg = <0x7e205000 0x1000>;
+			interrupts = <2 21>;
+			clocks = <&clk_i2c>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		i2c1: i2c@7e804000 {
+			compatible = "brcm,bcm2708-i2c";
+			reg = <0x7e804000 0x1000>;
+			interrupts = <2 21>;
+			clocks = <&clk_i2c>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
 	};
 
 	clocks {
 		compatible = "simple-bus";
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		clk_i2c: i2c {
+			compatible = "fixed-clock";
+			reg = <1>;
+			#clock-cells = <0>;
+			clock-frequency = <250000000>;
+		};
 
 		clk_spi: clock@2 {
 			compatible = "fixed-clock";

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -560,6 +560,7 @@ static struct spi_board_info bcm2708_spi_devices[] = {
 };
 #endif
 
+#ifndef CONFIG_OF
 static struct resource bcm2708_bsc0_resources[] = {
 	{
 		.start = BSC0_BASE,
@@ -598,6 +599,7 @@ static struct platform_device bcm2708_bsc1_device = {
 	.num_resources = ARRAY_SIZE(bcm2708_bsc1_resources),
 	.resource = bcm2708_bsc1_resources,
 };
+#endif
 
 static struct platform_device bcm2835_hwmon_device = {
 	.name = "bcm2835_hwmon",
@@ -828,8 +830,8 @@ void __init bcm2708_init(void)
 		bcm_register_device(&bcm2708_alsa_devices[i]);
 
 	bcm_register_device_dt(&bcm2708_spi_device);
-	bcm_register_device(&bcm2708_bsc0_device);
-	bcm_register_device(&bcm2708_bsc1_device);
+	bcm_register_device_dt(&bcm2708_bsc0_device);
+	bcm_register_device_dt(&bcm2708_bsc1_device);
 
 	bcm_register_device(&bcm2835_hwmon_device);
 	bcm_register_device(&bcm2835_thermal_device);

--- a/drivers/i2c/busses/Kconfig
+++ b/drivers/i2c/busses/Kconfig
@@ -338,7 +338,7 @@ config I2C_AU1550
 
 config I2C_BCM2835
 	tristate "Broadcom BCM2835 I2C controller"
-	depends on ARCH_BCM2835
+	depends on ARCH_BCM2835 || ARCH_BCM2708
 	help
 	  If you say yes to this option, support will be included for the
 	  BCM2835 I2C controller.


### PR DESCRIPTION
kconfig

```
ARCH=arm make bcmrpi_defconfig
scripts/config --enable BCM2708_DT
scripts/config --module I2C_BCM2835
yes "" | ARCH=arm make oldconfig
```

Enable i2c-1

```
$ fdtget /boot/bcm2708-rpi-b.dtb /soc/i2c@7e804000 status
disabled
$ sudo fdtput --type s /boot/bcm2708-rpi-b.dtb /soc/i2c@7e804000 status "okay"
$ sudo reboot
$ dmesg
[    6.613730] bcm2708_i2c_init_pinmode(1,2)
[    6.811634] bcm2708_i2c_init_pinmode(1,3)
[    6.964823] bcm2708_i2c 20804000.i2c: BSC1 Controller at 0x20804000 (irq 79) (baudrate 100000)
[    8.090310] pcm512x 1-004c: Failed to reset device: -5
[    8.107153] pcm512x: probe of 1-004c failed with error -5
$ ls -l /dev/i2c*
crw-rw---T 1 root i2c 89, 1 Jul 28 20:47 /dev/i2c-1
```

Use the i2c-bcm2835 driver

```
$ fdtget /boot/bcm2708-rpi-b.dtb /soc/i2c@7e804000 compatible
brcm,bcm2708-i2c
$ sudo fdtput --type s /boot/bcm2708-rpi-b.dtb /soc/i2c@7e804000 compatible "brcm,bcm2835-i2c"
$ fdtget /boot/bcm2708-rpi-b.dtb /soc/i2c@7e804000 compatible
brcm,bcm2835-i2c
$ sudo reboot
$ dmesg
[    8.020037] i2c-bcm2835 20804000.i2c: i2c transfer failed: 100
[    8.028457] pcm512x 1-004c: Failed to reset device: -121
[    8.036192] pcm512x: probe of 1-004c failed with error -121
$ ls -l /dev/i2c*
crw-rw---T 1 root i2c 89, 1 Jul 28 20:47 /dev/i2c-1
```

The transfer error seem to be related to the failed pcm512x probing.

Howto install latest dtc: https://github.com/notro/rpi-firmware/wiki/Device-Tree

**Test**

Using a ds1307 rtc chip.

Add to dts

```
&i2c1 {
    status = "okay";

    rtc@68 {
        compatible = "dallas,ds1307";
        reg = <0x68>;
    };
};
```

Verify

```
$ dmesg
[    6.895287] rtc-ds1307 1-0068: rtc core: registered ds1307 as rtc0
[    6.903734] rtc-ds1307 1-0068: 56 bytes nvram
[    7.242081] bcm2708_i2c 20804000.i2c: BSC1 Controller at 0x20804000 (irq 79) (baudrate 100000)
$ sudo hwclock -r
Mon 28 Jul 2014 20:26:15 UTC  -0.905546 seconds
```

Works with both drivers.
