### PR TITLE
Make gpio pullup configurable for lirc driver

### DIFF
--- a/drivers/staging/media/lirc/lirc_rpi.c
+++ b/drivers/staging/media/lirc/lirc_rpi.c
@@ -40,6 +40,8 @@
 #include <media/lirc_dev.h>
 #include <linux/gpio.h>
 
+#include <linux/platform_data/bcm2708.h>
+
 #define LIRC_DRIVER_NAME "lirc_rpi"
 #define RBUF_LEN 256
 #define LIRC_TRANSMITTER_LATENCY 50
@@ -61,6 +63,8 @@
 
 /* set the default GPIO input pin */
 static int gpio_in_pin = 18;
+/* set the default pull behaviour for input pin */
+static int gpio_in_pull = BCM2708_PULL_DOWN;
 /* set the default GPIO output pin */
 static int gpio_out_pin = 17;
 /* enable debugging messages */
@@ -320,6 +324,7 @@ static int init_port(void)
 		goto exit_gpio_free_out_pin;
 	}
 
+	bcm2708_gpio_setpull(gpiochip, gpio_in_pin, gpio_in_pull);
 	gpiochip->direction_input(gpiochip, gpio_in_pin);
 	gpiochip->direction_output(gpiochip, gpio_out_pin, 1);
 	gpiochip->set(gpiochip, gpio_out_pin, invert);
@@ -680,6 +685,10 @@ module_param(gpio_in_pin, int, S_IRUGO);
 MODULE_PARM_DESC(gpio_in_pin, "GPIO input pin number of the BCM processor."
 		 " Valid pin numbers are: 0, 1, 4, 8, 7, 9, 10, 11, 14, 15,"
 		 " 17, 18, 21, 22, 23, 24, 25, default 18");
+
+module_param(gpio_in_pull, int, S_IRUGO);
+MODULE_PARM_DESC(gpio_in_pull, "GPIO input pin pull configuration."
+		 " (0 = off, 1 = up, 2 = down, default down)");
 
 module_param(sense, int, S_IRUGO);
 MODULE_PARM_DESC(sense, "Override autodetection of IR receiver circuit"

--- a/include/linux/platform_data/bcm2708.h
+++ b/include/linux/platform_data/bcm2708.h
@@ -1,0 +1,23 @@
+/*
+ * include/linux/platform_data/bcm2708.h
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * (C) 2014 Julian Scheel <julian@jusst.de>
+ *
+ */
+#ifndef __BCM2708_H_
+#define __BCM2708_H_
+
+typedef enum {
+	BCM2708_PULL_OFF,
+	BCM2708_PULL_UP,
+	BCM2708_PULL_DOWN
+} bcm2708_gpio_pull_t;
+
+extern int bcm2708_gpio_setpull(struct gpio_chip *gc, unsigned offset,
+		bcm2708_gpio_pull_t value)
+
+#endif


### PR DESCRIPTION
This patch series allows users of the lirc_rpi driver to specify the pull behaviour of the gpio_in_pin, which can be very helpful depending on the external IR circuitry.

Please comment on creating `include/linux/platform_data/bcm2708.h` to specify function header and enum. I am a bit unsure if there isn't some better suited place already existing...
