### PR TITLE
some kzalloc fix and use bcm2835_hw params in preallocate

### DIFF
--- a/drivers/usb/host/dwc_otg/dummy_audio.c
+++ b/drivers/usb/host/dwc_otg/dummy_audio.c
@@ -1377,10 +1377,9 @@ zero_bind (struct usb_gadget *gadget)
 
 
 	/* ok, we made sense of the hardware ... */
-	dev = kmalloc (sizeof *dev, SLAB_KERNEL);
+	dev = kzalloc (sizeof *dev, SLAB_KERNEL);
 	if (!dev)
 		return -ENOMEM;
-	memset (dev, 0, sizeof *dev);
 	spin_lock_init (&dev->lock);
 	dev->gadget = gadget;
 	set_gadget_data (gadget, dev);

--- a/drivers/usb/host/dwc_otg/dwc_otg_pcd_linux.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_pcd_linux.c
@@ -212,12 +212,11 @@ static struct usb_request *dwc_otg_pcd_alloc_request(struct usb_ep *ep,
 		DWC_WARN("%s() %s\n", __func__, "Invalid EP!\n");
 		return 0;
 	}
-	usb_req = kmalloc(sizeof(*usb_req), gfp_flags);
+	usb_req = kzalloc(sizeof(*usb_req), gfp_flags);
 	if (0 == usb_req) {
 		DWC_WARN("%s() %s\n", __func__, "request allocation failed!\n");
 		return 0;
 	}
-	memset(usb_req, 0, sizeof(*usb_req));
 	usb_req->dma = DWC_DMA_ADDR_INVALID;
 
 	return usb_req;

--- a/sound/arm/bcm2835-pcm.c
+++ b/sound/arm/bcm2835-pcm.c
@@ -504,11 +504,11 @@ int snd_bcm2835_new_pcm(bcm2835_chip_t * chip)
 			&snd_bcm2835_playback_ops);
 
 	/* pre-allocation of buffers */
-	/* NOTE: this may fail */
+	/* NOTE: this may fail      size_t size = snd_bcm2835_playback_hw.buffer_bytes_max;  */
 	snd_pcm_lib_preallocate_pages_for_all(pcm, SNDRV_DMA_TYPE_CONTINUOUS,
 					      snd_dma_continuous_data
-					      (GFP_KERNEL), 64 * 1024,
-					      64 * 1024);
+					      (GFP_KERNEL), snd_bcm2835_playback_hw.buffer_bytes_max, snd_bcm2835_playback_hw.buffer_bytes_max);
+
 
 	mutex_unlock(&chip->audio_mutex);
 	audio_info(" .. OUT\n");
@@ -537,9 +537,11 @@ int snd_bcm2835_new_spdif_pcm(bcm2835_chip_t * chip)
 	snd_pcm_set_ops(pcm, SNDRV_PCM_STREAM_PLAYBACK,
 			&snd_bcm2835_playback_spdif_ops);
 
+	/* pre-allocation of buffers */
+	/* NOTE: this may fail - size_t size = snd_bcm2835_playback_spdif_hw.buffer_bytes_max;  */*/
 	snd_pcm_lib_preallocate_pages_for_all(pcm, SNDRV_DMA_TYPE_CONTINUOUS,
 					      snd_dma_continuous_data (GFP_KERNEL),
-					      64 * 1024, 64 * 1024);
+					      snd_bcm2835_playback_spdif_hw.buffer_bytes_max, snd_bcm2835_playback_spdif_hw.buffer_bytes_max);
 	mutex_unlock(&chip->audio_mutex);
 	audio_info(" .. OUT\n");
 


### PR DESCRIPTION
Well testing ffplay with some TrueHD files gave me:
ALSA lib pcm.c:7843:(snd_pcm_recover) underrun occurred  0B f=0/0
 cat /proc/asound/_/pcm_p/sub*/prealloc and prealloc_max == 64

So its not possible to set or test bigger prealloc but  i found this:
bcm2708-i2s.c:    .period_bytes_max    = 64 \* PAGE_SIZE,
bcm2708-i2s.c:    .buffer_bytes_max    = 128 \* PAGE_SIZE,
bcm2708-i2s.c:    .prealloc_buffer_size = 256 \* PAGE_SIZE,

Then compared with  bcm2835-pcm.c: snd_pcm_lib_preallocate_pages_for_all(pcm,SNDRV_DMA_TYPE_CONTINUOUS,                                           snd_dma_continuous_data(GFP_KERNEL), 64 \* 1024, 64 \* 1024);

First in this commit i set the prealloc and prealloc_max to bcm2835_hw_defs. 
But the values in bcm2708-i2s module are bigger, maybe increase the prealloc_max size to 256k ? 
