### PR TITLE
Dwc lockdep fixes rpi 3.16.y

### DIFF
--- a/drivers/usb/host/dwc_common_port/dwc_common_linux.c
+++ b/drivers/usb/host/dwc_common_port/dwc_common_linux.c
@@ -766,7 +766,11 @@ dwc_timer_t *DWC_TIMER_ALLOC(char *name, dwc_timer_callback_t cb, void *data)
 		goto no_name;
 	}
 
+#if (defined(DWC_LINUX) && defined(CONFIG_DEBUG_SPINLOCK))
+	DWC_SPINLOCK_ALLOC_LINUX_DEBUG(t->lock);
+#else
 	t->lock = DWC_SPINLOCK_ALLOC();
+#endif
 	if (!t->lock) {
 		DWC_ERROR("Cannot allocate memory for lock");
 		goto no_lock;
@@ -1083,7 +1087,11 @@ dwc_workq_t *DWC_WORKQ_ALLOC(char *name)
 
 	wq->pending = 0;
 
+#if (defined(DWC_LINUX) && defined(CONFIG_DEBUG_SPINLOCK))
+	DWC_SPINLOCK_ALLOC_LINUX_DEBUG(wq->lock);
+#else
 	wq->lock = DWC_SPINLOCK_ALLOC();
+#endif
 	if (!wq->lock) {
 		goto no_lock;
 	}

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
@@ -951,8 +951,13 @@ int dwc_otg_hcd_init(dwc_otg_hcd_t * hcd, dwc_otg_core_if_t * core_if)
 	int i;
 	dwc_hc_t *channel;
 
+#if (defined(DWC_LINUX) && defined(CONFIG_DEBUG_SPINLOCK))
+	DWC_SPINLOCK_ALLOC_LINUX_DEBUG(hcd->lock);
+	DWC_SPINLOCK_ALLOC_LINUX_DEBUG(hcd->channel_lock);
+#else
 	hcd->lock = DWC_SPINLOCK_ALLOC();
 	hcd->channel_lock = DWC_SPINLOCK_ALLOC();
+#endif
         DWC_DEBUGPL(DBG_HCDV, "init of HCD %p given core_if %p\n",
                     hcd, core_if);
 	if (!hcd->lock) {

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_queue.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_queue.c
@@ -55,9 +55,10 @@ extern bool microframe_schedule;
 void dwc_otg_hcd_qh_free(dwc_otg_hcd_t * hcd, dwc_otg_qh_t * qh)
 {
 	dwc_otg_qtd_t *qtd, *qtd_tmp;
+	dwc_irqflags_t flags;
 
 	/* Free each QTD in the QTD list */
-	DWC_SPINLOCK(hcd->lock);
+	DWC_SPINLOCK_IRQSAVE(hcd->lock, &flags);
 	DWC_CIRCLEQ_FOREACH_SAFE(qtd, qtd_tmp, &qh->qtd_list, qtd_list_entry) {
 		DWC_CIRCLEQ_REMOVE(&qh->qtd_list, qtd, qtd_list_entry);
 		dwc_otg_hcd_qtd_free(qtd);
@@ -76,7 +77,7 @@ void dwc_otg_hcd_qh_free(dwc_otg_hcd_t * hcd, dwc_otg_qh_t * qh)
 	}
 
 	DWC_FREE(qh);
-	DWC_SPINUNLOCK(hcd->lock);
+	DWC_SPINUNLOCK_IRQRESTORE(hcd->lock, flags);
 	return;
 }
 

--- a/drivers/usb/host/dwc_otg/dwc_otg_pcd.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_pcd.c
@@ -1120,7 +1120,11 @@ dwc_otg_pcd_t *dwc_otg_pcd_init(dwc_otg_core_if_t * core_if)
 		return NULL;
 	}
 
+#if (defined(DWC_LINUX) && defined(CONFIG_DEBUG_SPINLOCK))
+	DWC_SPINLOCK_ALLOC_LINUX_DEBUG(pcd->lock);
+#else
 	pcd->lock = DWC_SPINLOCK_ALLOC();
+#endif
         DWC_DEBUGPL(DBG_HCDV, "Init of PCD %p given core_if %p\n",
                     pcd, core_if);//GRAYG
 	if (!pcd->lock) {


### PR DESCRIPTION
2 separate lockdep fixes to dwc. First one fixing false positive due to os wrapper function and second one fixing inconsistent lock state in hcd lock. 
