### PR TITLE
bcm2708_fb : Implement blanking support using the mailbox property inter...

### DIFF
--- a/arch/arm/mach-bcm2708/include/mach/vcio.h
+++ b/arch/arm/mach-bcm2708/include/mach/vcio.h
@@ -33,6 +33,13 @@
 #define MBOX_CHAN_PROPERTY 8 /* for use by the property channel */
 #define MBOX_CHAN_COUNT    9
 
+enum {
+	VCMSG_PROCESS_REQUEST 		= 0x00000000
+};
+enum {
+	VCMSG_REQUEST_SUCCESSFUL 	= 0x80000000,
+	VCMSG_REQUEST_FAILED 		= 0x80000001
+};
 /* Mailbox property tags */
 enum {
 	VCMSG_PROPERTY_END               = 0x00000000,
@@ -136,6 +143,6 @@ extern int /*rc*/ bcm_mailbox_property(void *data, int size);
 /*
  * The name of the device file
  */
-#define DEVICE_FILE_NAME "char_dev"
+#define DEVICE_FILE_NAME "vcio"
 
 #endif

--- a/drivers/video/fbdev/bcm2708_fb.c
+++ b/drivers/video/fbdev/bcm2708_fb.c
@@ -375,13 +375,36 @@ static int bcm2708_fb_setcolreg(unsigned int regno, unsigned int red,
 	}
 	return regno > 255;
 }
-
 static int bcm2708_fb_blank(int blank_mode, struct fb_info *info)
 {
-	/*print_debug("bcm2708_fb_blank\n"); */
-	return -1;
-}
+	s32 result = -1 ; 
+	u32 p[7];
+	if ( 	(blank_mode == FB_BLANK_NORMAL) || 
+		(blank_mode == FB_BLANK_UNBLANK)) {
+		
+		pr_info("bcm2708_fb_blank blank_mode=%d\n",blank_mode);
+		
+		
+		p[0] = 28; //  size = sizeof u32 * length of p
+		p[1] = VCMSG_PROCESS_REQUEST; // process request
+		p[2] = VCMSG_SET_BLANK_SCREEN; // (the tag id)
+		p[3] = 4; // (size of the response buffer)
+		p[4] = 4; // (size of the request data)
+		p[5] = blank_mode;
+		p[6] = VCMSG_PROPERTY_END; // end tag
+	
+		bcm_mailbox_property(&p, p[0]);
+	
+		pr_info("bcm2708_fb_blank returns=%d p[1]=0x%x\n",p[5],p[1]);
+	
+		if ( p[1] == VCMSG_REQUEST_SUCCESSFUL )
+			result = 0 ; 
+	    
+	}
+	return result;
 
+
+}
 static void bcm2708_fb_fillrect(struct fb_info *info,
 				const struct fb_fillrect *rect)
 {


### PR DESCRIPTION
...face

This implementation uses the userspace request style of an array of unsigned
32bit ints rather the vc_msg/vc_msg_tag which is more confusing to work with.

vcio.h : Added some extra enums to the vcio.h to improve readability
vcio.h : Renamed DEVICE_FILE_NAME to something more appropriate. users of the
vcio api will be unaffected  by this change as the device node as the device node
is created manually in userspace
