### PR TITLE
bcm2708-i2s sign-extend 24-bit capture

### DIFF
--- a/sound/soc/bcm/bcm2708-i2s.c
+++ b/sound/soc/bcm/bcm2708-i2s.c
@@ -629,6 +629,8 @@ static int bcm2708_i2s_hw_params(struct snd_pcm_substream *substream,
 	regmap_update_bits(dev->i2s_regmap, BCM2708_I2S_CS_A_REG,
 			BCM2708_I2S_RXTHR(1)
 			| BCM2708_I2S_TXTHR(1)
+			//FIXME if driver adds U24_LE PCM format support
+			| BCM2708_I2S_RXSEX  //sign-extend received data
 			| BCM2708_I2S_DMAEN, 0xffffffff);
 
 	regmap_update_bits(dev->i2s_regmap, BCM2708_I2S_DREQ_A_REG,


### PR DESCRIPTION
Enable hardware 'receive sign extension' (RXSEX) flag. Has no effect for tx, or on 16/32 bit rx, thus only affects S24_LE capture. If driver ever adds support for U24_LE PCM format this will need to be 'fixed'.
