### PR TITLE
add support for rpi-proto driver

### DIFF
--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -754,6 +754,19 @@ static struct i2c_board_info __initdata snd_pcm512x_i2c_devices[] = {
 };
 #endif
 
+#ifdef CONFIG_SND_BCM2708_SOC_RPI_CODEC_PROTO_MODULE
+static struct platform_device snd_rpi_proto_device = {
+        .name = "snd-rpi-proto",
+        .id = 0,
+        .num_resources = 0,
+};
+static struct i2c_board_info __initdata snd_rpi_proto_i2c_devices[] = {
+        {
+                I2C_BOARD_INFO("wm8731", 0x1a)
+        },
+};
+#endif
+
 int __init bcm_register_device(struct platform_device *pdev)
 {
 	int ret;
@@ -922,6 +935,10 @@ void __init bcm2708_init(void)
 #if defined(CONFIG_SND_BCM2708_SOC_IQAUDIO_DAC) || defined(CONFIG_SND_BCM2708_SOC_IQAUDIO_DAC_MODULE)
         bcm_register_device(&snd_rpi_iqaudio_dac_device);
         i2c_register_board_info(1, snd_pcm512x_i2c_devices, ARRAY_SIZE(snd_pcm512x_i2c_devices));
+#endif
+#if defined(CONFIG_SND_BCM2708_SOC_RPI_CODEC_PROTO_MODULE)
+	bcm_register_device(&snd_rpi_proto_device);
+	i2c_register_board_info(1, snd_rpi_proto_i2c_devices, ARRAY_SIZE(snd_rpi_proto_i2c_devices));
 #endif
 
 

--- a/sound/soc/bcm/Kconfig
+++ b/sound/soc/bcm/Kconfig
@@ -50,3 +50,11 @@ config SND_BCM2708_SOC_IQAUDIO_DAC
 	select SND_SOC_PCM512x
 	help
 	  Say Y or M if you want to add support for IQaudIO-DAC.
+
+config SND_BCM2708_SOC_RPI_CODEC_PROTO
+	tristate "Support for Audio Codec Board - PROTO (WM8731)"
+	depends on SND_BCM2708_SOC_I2S
+	select SND_SOC_WM8731
+	help
+	  Say Y if you want to add support for Audio Codec Board -
+	  PROTO (WM8731)

--- a/sound/soc/bcm/Makefile
+++ b/sound/soc/bcm/Makefile
@@ -10,6 +10,7 @@ snd-soc-hifiberry-digi-objs := hifiberry_digi.o
 snd-soc-hifiberry-amp-objs := hifiberry_amp.o
 snd-soc-rpi-dac-objs := rpi-dac.o
 snd-soc-iqaudio-dac-objs := iqaudio-dac.o
+snd-soc-rpi-proto-objs := rpi-proto.o
 
 obj-$(CONFIG_SND_BCM2708_SOC_HIFIBERRY_DAC) += snd-soc-hifiberry-dac.o
 obj-$(CONFIG_SND_BCM2708_SOC_HIFIBERRY_DACPLUS) += snd-soc-hifiberry-dacplus.o
@@ -17,3 +18,4 @@ obj-$(CONFIG_SND_BCM2708_SOC_HIFIBERRY_DIGI) += snd-soc-hifiberry-digi.o
 obj-$(CONFIG_SND_BCM2708_SOC_HIFIBERRY_AMP) += snd-soc-hifiberry-amp.o
 obj-$(CONFIG_SND_BCM2708_SOC_RPI_DAC) += snd-soc-rpi-dac.o
 obj-$(CONFIG_SND_BCM2708_SOC_IQAUDIO_DAC) += snd-soc-iqaudio-dac.o
+obj-$(CONFIG_SND_BCM2708_SOC_RPI_CODEC_PROTO) += snd-soc-rpi-proto.o

--- a/sound/soc/bcm/bcm2708-i2s.c
+++ b/sound/soc/bcm/bcm2708-i2s.c
@@ -171,6 +171,11 @@ static const unsigned int bcm2708_clk_freq[BCM2708_CLK_SRC_HDMI+1] = {
 /* I2S pin configuration */
 static int bcm2708_i2s_gpio=BCM2708_I2S_GPIO_AUTO;
 
+static bool use_mmap = 1;
+module_param(use_mmap, bool, S_IRUGO);
+MODULE_PARM_DESC(use_mmap, "Use MMAP");
+
+
 /* General device struct */
 struct bcm2708_i2s_dev {
 	struct device				*dev;
@@ -870,7 +875,7 @@ static const struct snd_soc_component_driver bcm2708_i2s_component = {
 	.name		= "bcm2708-i2s-comp",
 };
 
-static const struct snd_pcm_hardware bcm2708_pcm_hardware = {
+static struct snd_pcm_hardware bcm2708_pcm_hardware = {
 	.info			= SNDRV_PCM_INFO_INTERLEAVED |
 				  SNDRV_PCM_INFO_JOINT_DUPLEX,
 	.formats		= SNDRV_PCM_FMTBIT_S16_LE |
@@ -960,6 +965,11 @@ static int bcm2708_i2s_probe(struct platform_device *pdev)
 		dev_err(&pdev->dev, "Could not register DAI: %d\n", ret);
 		ret = -ENOMEM;
 		return ret;
+	}
+
+	if (use_mmap) {
+		bcm2708_pcm_hardware.info |= SNDRV_PCM_INFO_MMAP;
+		bcm2708_pcm_hardware.info |= SNDRV_PCM_INFO_MMAP_VALID;
 	}
 
 	ret = snd_dmaengine_pcm_register(&pdev->dev,

--- a/sound/soc/bcm/rpi-proto.c
+++ b/sound/soc/bcm/rpi-proto.c
@@ -1,0 +1,130 @@
+/*
+ * ASoC driver for PROTO AudioCODEC (with a WM8731)
+ * connected to a Raspberry Pi
+ *
+ * Author:      Florian Meier, <koalo@koalo.de>
+ *	      Copyright 2013
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+
+#include <sound/core.h>
+#include <sound/pcm.h>
+#include <sound/soc.h>
+#include <sound/jack.h>
+
+#include "../codecs/wm8731.h"
+
+static const unsigned int wm8731_rates_12288000[] = {
+	8000, 32000, 48000, 96000,
+};
+
+static struct snd_pcm_hw_constraint_list wm8731_constraints_12288000 = {
+	.list = wm8731_rates_12288000,
+	.count = ARRAY_SIZE(wm8731_rates_12288000),
+};
+
+static int snd_rpi_proto_startup(struct snd_pcm_substream *substream)
+{
+	/* Setup constraints, because there is a 12.288 MHz XTAL on the board */
+	snd_pcm_hw_constraint_list(substream->runtime, 0,
+				SNDRV_PCM_HW_PARAM_RATE,
+				&wm8731_constraints_12288000);
+	return 0;
+}
+
+static int snd_rpi_proto_hw_params(struct snd_pcm_substream *substream,
+				       struct snd_pcm_hw_params *params)
+{
+	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_dai *codec_dai = rtd->codec_dai;
+	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
+	int sysclk = 12288000; /* This is fixed on this board */
+
+	/* Set proto bclk */
+	int ret = snd_soc_dai_set_bclk_ratio(cpu_dai,32*2);
+	if (ret < 0){
+		dev_err(substream->pcm->dev,
+				"Failed to set BCLK ratio %d\n", ret);
+		return ret;
+	}
+
+	/* Set proto sysclk */
+	ret = snd_soc_dai_set_sysclk(codec_dai, WM8731_SYSCLK_XTAL,
+			sysclk, SND_SOC_CLOCK_IN);
+	if (ret < 0) {
+		dev_err(substream->pcm->dev,
+				"Failed to set WM8731 SYSCLK: %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/* machine stream operations */
+static struct snd_soc_ops snd_rpi_proto_ops = {
+	.startup = snd_rpi_proto_startup,
+	.hw_params = snd_rpi_proto_hw_params,
+};
+
+static struct snd_soc_dai_link snd_rpi_proto_dai[] = {
+{
+	.name		= "WM8731",
+	.stream_name	= "WM8731 HiFi",
+	.cpu_dai_name	= "bcm2708-i2s.0",
+	.codec_dai_name	= "wm8731-hifi",
+	.platform_name	= "bcm2708-i2s.0",
+	.codec_name	= "wm8731.1-001a",
+	.dai_fmt	= SND_SOC_DAIFMT_I2S
+				| SND_SOC_DAIFMT_NB_NF
+				| SND_SOC_DAIFMT_CBM_CFM,
+	.ops		= &snd_rpi_proto_ops,
+},
+};
+
+/* audio machine driver */
+static struct snd_soc_card snd_rpi_proto = {
+	.name		= "snd_rpi_proto",
+	.dai_link	= snd_rpi_proto_dai,
+	.num_links	= ARRAY_SIZE(snd_rpi_proto_dai),
+};
+
+static int snd_rpi_proto_probe(struct platform_device *pdev)
+{
+	int ret = 0;
+
+	snd_rpi_proto.dev = &pdev->dev;
+	ret = snd_soc_register_card(&snd_rpi_proto);
+	if (ret) {
+		dev_err(&pdev->dev,
+				"snd_soc_register_card() failed: %d\n", ret);
+	}
+
+	return ret;
+}
+
+
+static int snd_rpi_proto_remove(struct platform_device *pdev)
+{
+	return snd_soc_unregister_card(&snd_rpi_proto);
+}
+
+static struct platform_driver snd_rpi_proto_driver = {
+	.driver = {
+		.name   = "snd-rpi-proto",
+		.owner  = THIS_MODULE,
+	},
+	.probe	  = snd_rpi_proto_probe,
+	.remove	 = snd_rpi_proto_remove,
+};
+
+module_platform_driver(snd_rpi_proto_driver);
+
+MODULE_AUTHOR("Florian Meier");
+MODULE_DESCRIPTION("ASoC Driver for Raspberry Pi connected to PROTO board (WM8731)");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Forward port of 3.10.x driver from https://github.com/koalo
We are using a custom board and would like to use rpi 3.12.x
kernel. Patch works fine for our embedded system.

Signed-off-by: Waldemar Brodkorb wbrodkorb@conet.de
