### PR TITLE
Added support for non-GNU AWK

### DIFF
--- a/lib/raid6/Makefile
+++ b/lib/raid6/Makefile
@@ -11,7 +11,7 @@ raid6_pq-$(CONFIG_TILEGX) += tilegx8.o
 hostprogs-y	+= mktables
 
 quiet_cmd_unroll = UNROLL  $@
-      cmd_unroll = $(AWK) -f$(srctree)/$(src)/unroll.awk -vN=$(UNROLL) \
+      cmd_unroll = $(AWK) -f $(srctree)/$(src)/unroll.awk -v N=$(UNROLL) \
                    < $< > $@ || ( rm -f $@ && exit 1 )
 
 ifeq ($(CONFIG_ALTIVEC),y)


### PR DESCRIPTION
Without this fix cross compiling from mac osX doesn't work
