### PR TITLE
Update i2c-bcm2708.c

### DIFF
--- a/drivers/i2c/busses/i2c-bcm2708.c
+++ b/drivers/i2c/busses/i2c-bcm2708.c
@@ -265,9 +265,10 @@ static int bcm2708_i2c_master_xfer(struct i2c_adapter *adap,
 	bi->nmsgs = num;
 	bi->error = false;
 
-	spin_unlock_irqrestore(&bi->lock, flags);
-
 	bcm2708_bsc_setup(bi);
+
+	/* unlockig _after_ the setup to avoid races with the interrupt routine */
+	spin_unlock_irqrestore(&bi->lock, flags);
 
 	ret = wait_for_completion_timeout(&bi->done,
 			msecs_to_jiffies(I2C_TIMEOUT_MS));


### PR DESCRIPTION
Using combined transactions and heavy i2c traffic causes kernel panics and bus errors because the bcm2708_bsc_setup(bi) is not protected by the spin lock while the interrupt routine uses the bus.
This patch fixes the issue and makes combined transactions work again.
