### PR TITLE
Add ifdef to make kernel compile without CONFIG_BCM2708_DT=y

### DIFF
--- a/arch/arm/mach-bcm2708/bcm2708_gpio.c
+++ b/arch/arm/mach-bcm2708/bcm2708_gpio.c
@@ -90,6 +90,7 @@ static int bcm2708_set_function(struct gpio_chip *gc, unsigned offset,
 	return 0;
 }
 
+#ifdef CONFIG_BCM2708_DT
 static int bcm2708_gpio_request(struct gpio_chip *chip, unsigned offset)
 {
 	return pinctrl_request_gpio(chip->base + offset);
@@ -99,6 +100,7 @@ static void bcm2708_gpio_free(struct gpio_chip *chip, unsigned offset)
 {
 	pinctrl_free_gpio(chip->base + offset);
 }
+#endif
 
 static int bcm2708_gpio_dir_in(struct gpio_chip *gc, unsigned offset)
 {
@@ -355,8 +357,10 @@ static int bcm2708_gpio_probe(struct platform_device *dev)
 	ucb->gc.ngpio = BCM2708_NR_GPIOS;
 	ucb->gc.owner = THIS_MODULE;
 
+#ifdef CONFIG_BCM2708_DT
 	ucb->gc.request = bcm2708_gpio_request;
 	ucb->gc.free = bcm2708_gpio_free;
+#endif
 	ucb->gc.direction_input = bcm2708_gpio_dir_in;
 	ucb->gc.direction_output = bcm2708_gpio_dir_out;
 	ucb->gc.get = bcm2708_gpio_get;

--- a/arch/arm/mach-bcm2708/bcm2708_gpio.c
+++ b/arch/arm/mach-bcm2708/bcm2708_gpio.c
@@ -21,7 +21,9 @@
 #include <linux/gpio.h>
 #include <linux/platform_device.h>
 #include <mach/platform.h>
-
+#ifdef CONFIG_BCM2708_DT
+#include <linux/pinctrl/consumer.h>
+#endif
 #include <linux/platform_data/bcm2708.h>
 
 #define BCM_GPIO_DRIVER_NAME "bcm2708_gpio"

--- a/arch/arm/mach-bcm2708/bcm2708_gpio.c
+++ b/arch/arm/mach-bcm2708/bcm2708_gpio.c
@@ -21,9 +21,8 @@
 #include <linux/gpio.h>
 #include <linux/platform_device.h>
 #include <mach/platform.h>
-#ifdef CONFIG_BCM2708_DT
 #include <linux/pinctrl/consumer.h>
-#endif
+
 #include <linux/platform_data/bcm2708.h>
 
 #define BCM_GPIO_DRIVER_NAME "bcm2708_gpio"
@@ -92,7 +91,6 @@ static int bcm2708_set_function(struct gpio_chip *gc, unsigned offset,
 	return 0;
 }
 
-#ifdef CONFIG_BCM2708_DT
 static int bcm2708_gpio_request(struct gpio_chip *chip, unsigned offset)
 {
 	return pinctrl_request_gpio(chip->base + offset);
@@ -102,7 +100,6 @@ static void bcm2708_gpio_free(struct gpio_chip *chip, unsigned offset)
 {
 	pinctrl_free_gpio(chip->base + offset);
 }
-#endif
 
 static int bcm2708_gpio_dir_in(struct gpio_chip *gc, unsigned offset)
 {
@@ -359,10 +356,8 @@ static int bcm2708_gpio_probe(struct platform_device *dev)
 	ucb->gc.ngpio = BCM2708_NR_GPIOS;
 	ucb->gc.owner = THIS_MODULE;
 
-#ifdef CONFIG_BCM2708_DT
 	ucb->gc.request = bcm2708_gpio_request;
 	ucb->gc.free = bcm2708_gpio_free;
-#endif
 	ucb->gc.direction_input = bcm2708_gpio_dir_in;
 	ucb->gc.direction_output = bcm2708_gpio_dir_out;
 	ucb->gc.get = bcm2708_gpio_get;


### PR DESCRIPTION
GCC throws `implicit declaration of function 'pinctrl_request_gpio'` and `implicit declaration of function 'pinctrl_free_gpio'` when `CONFIG_BCM2708_DT` is not defined

This change removes this issue

EDIT: Changed "not defined" to actual error, write it at late night, sorry
