### PR TITLE
Add device tree overlay for HiFiBerry Amp/Amp+

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -58,6 +58,7 @@ dtb-$(CONFIG_BCM2708_DT) += bcm2708-rpi-b-plus.dtb
 dtb-$(CONFIG_BCM2708_DT) += hifiberry-dac-overlay.dtb
 dtb-$(CONFIG_BCM2708_DT) += hifiberry-dacplus-overlay.dtb
 dtb-$(CONFIG_BCM2708_DT) += hifiberry-digi-overlay.dtb
+dtb-$(CONFIG_BCM2708_DT) += hifiberry-amp-overlay.dtb
 dtb-$(CONFIG_BCM2708_DT) += iqaudio-dac-overlay.dtb
 dtb-$(CONFIG_BCM2708_DT) += iqaudio-dacplus-overlay.dtb
 dtb-$(CONFIG_BCM2708_DT) += lirc-rpi-overlay.dtb

--- a/arch/arm/boot/dts/hifiberry-amp-overlay.dts
+++ b/arch/arm/boot/dts/hifiberry-amp-overlay.dts
@@ -1,0 +1,39 @@
+// Definitions for HiFiBerry Amp/Amp+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&sound>;
+		__overlay__ {
+			compatible = "hifiberry,hifiberry-amp";
+			i2s-controller = <&i2s>;
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&i2s>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			tas5713@1b {
+				#sound-dai-cells = <0>;
+				compatible = "ti,tas5713";
+				reg = <0x1b>;
+				status = "okay";
+			};
+		};
+	};
+};


### PR DESCRIPTION
This patch add the missing device tree file for the HiFiBerry Amp and Amp+ boards.
