### PR TITLE
bugfix for 32kHz sample rate, was missing

### DIFF
--- a/sound/soc/bcm/hifiberry_digi.c
+++ b/sound/soc/bcm/hifiberry_digi.c
@@ -80,6 +80,7 @@ static int snd_rpi_hifiberry_digi_hw_params(struct snd_pcm_substream *substream,
 	samplerate = params_rate(params);
 
 	switch (samplerate) {
+		case 32000:
 		case 44100:
 		case 48000:
 		case 88200:


### PR DESCRIPTION
Easy one-line fix: the hifiberry_digi driver is not going down to 32 kHz audio sample rate (the lowest for S/PDIF), however the underlying WM8804 codec driver supports and advertises 32 kHz. This was inconsistant, resulted in out-of-pitch playback with 44.1 kHz because the application was thinking it's playing 32 kHz.
With this fix, such problems are gone, tested with aplay and mplayer, 32 kHz plays well. Below, mplayer does correct upsampling, before it was mislead.
