### PR TITLE
Rpi 3.19.y

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -64,6 +64,7 @@ endif
 dtb-$(CONFIG_BCM2708_DT) += bcm2708-rpi-b.dtb
 dtb-$(CONFIG_BCM2708_DT) += bcm2708-rpi-b-plus.dtb
 dtb-$(CONFIG_BCM2709_DT) += bcm2709-rpi-2-b.dtb
+dtb-$(RPI_DT_OVERLAYS) += bmp085_i2c-sensor-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += ds1307-rtc-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += hifiberry-dac-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += hifiberry-dacplus-overlay.dtb

--- a/arch/arm/boot/dts/bmp085_i2c-sensor-overlay.dts
+++ b/arch/arm/boot/dts/bmp085_i2c-sensor-overlay.dts
@@ -1,0 +1,23 @@
+// Definitions for BMP085/BMP180 digital barometric pressure and temperature sensors from Bosch Sensortec
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "brcm,bcm2708";
+
+        fragment@0 {
+                target = <&i2c1>;
+                __overlay__ {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+                        status = "okay";
+
+                        bmp085@77 {
+                                compatible = "bosch,bmp085";
+                                reg = <0x77>;
+                                default-oversampling = <3>;
+                                status = "okay";
+                        };
+                };
+        };
+};


### PR DESCRIPTION
Add device-tree overlay for bmp085 sensor.
For use with the bmp085_i2c driver.
