### PR TITLE
Add device-tree overlay for ds3231 RTC.

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -65,6 +65,7 @@ dtb-$(CONFIG_BCM2708_DT) += bcm2708-rpi-b.dtb
 dtb-$(CONFIG_BCM2708_DT) += bcm2708-rpi-b-plus.dtb
 dtb-$(CONFIG_BCM2709_DT) += bcm2709-rpi-2-b.dtb
 dtb-$(RPI_DT_OVERLAYS) += ds1307-rtc-overlay.dtb
+dtb-$(RPI_DT_OVERLAYS) += ds3231-rtc-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += hifiberry-dac-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += hifiberry-dacplus-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += hifiberry-digi-overlay.dtb

--- a/arch/arm/boot/dts/ds3231-rtc-overlay.dts
+++ b/arch/arm/boot/dts/ds3231-rtc-overlay.dts
@@ -1,0 +1,22 @@
+// Definitions for DS3231 Real Time Clock
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ds3231@68 {
+				compatible = "maxim,ds3231";
+				reg = <0x68>;
+				status = "okay";
+			};
+		};
+	};
+};


### PR DESCRIPTION
pi@raspberrypi ~ $ dmesg | grep rtc
[    3.402855] rtc-ds1307 1-0068: rtc core: registered ds3231 as rtc0

pi@raspberrypi ~ $ sudo hwclock
Mon 16 Feb 2015 03:15:51 UTC  -0.585763 seconds

Signed-off-by: Jon Burgess jburgess777@gmail.com
