### PR TITLE
Create generic i2c-rtc overlay supporting multiple devices

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -65,6 +65,7 @@ dtb-$(CONFIG_BCM2708_DT) += bcm2708-rpi-b.dtb
 dtb-$(CONFIG_BCM2708_DT) += bcm2708-rpi-b-plus.dtb
 dtb-$(CONFIG_BCM2709_DT) += bcm2709-rpi-2-b.dtb
 dtb-$(RPI_DT_OVERLAYS) += ds1307-rtc-overlay.dtb
+dtb-$(RPI_DT_OVERLAYS) += i2c-rtc-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += hifiberry-dac-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += hifiberry-dacplus-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += hifiberry-digi-overlay.dtb

--- a/arch/arm/boot/dts/i2c-rtc-overlay.dts
+++ b/arch/arm/boot/dts/i2c-rtc-overlay.dts
@@ -1,0 +1,43 @@
+// Definitions for several I2C based Real Time Clocks
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ds1307: ds1307@68 {
+				compatible = "maxim,ds1307";
+				reg = <0x68>;
+				status = "disable";
+			};
+			ds3231: ds3231@68 {
+				compatible = "maxim,ds3231";
+				reg = <0x68>;
+				status = "disable";
+			};
+			pcf2127: pcf2127@51 {
+				compatible = "nxp,pcf2127";
+				reg = <0x51>;
+				status = "disable";
+			};
+			pcf8523: pcf8523@68 {
+				compatible = "nxp,pcf8523";
+				reg = <0x68>;
+				status = "disable";
+			};
+		};
+	};
+	__overrides__ {
+		ds1307 = <&ds1307>,"status";
+		ds3231 = <&ds3231>,"status";
+		pcf2127 = <&pcf2127>,"status";
+		pcf8523 = <&pcf8523>,"status";
+	};
+};


### PR DESCRIPTION
Supports ds1307, ds3231, pcf2127 and pcf8523. Tested with a single board using both ds1307 & ds3231 driver modes. The PCF entries are taken from other existing overlay files but are not tested. 

Example config.txt entries and dmesg output:

```
dtoverlay=i2c-rtc,ds1307
[    3.432544] rtc-ds1307 1-0068: rtc core: registered ds1307 as rtc0
[    3.435725] rtc-ds1307 1-0068: 56 bytes nvram
```

```
dtoverlay=i2c-rtc,ds3231
[    3.496913] rtc-ds1307 1-0068: rtc core: registered ds3231 as rtc0
```

Signed-off-by: Jon Burgess jburgess777@gmail.com
