### PR TITLE
Align pcm512x driver with upstream

### DIFF
--- a/sound/soc/bcm/iqaudio-dac.c
+++ b/sound/soc/bcm/iqaudio-dac.c
@@ -25,7 +25,13 @@
 
 static int snd_rpi_iqaudio_dac_init(struct snd_soc_pcm_runtime *rtd)
 {
-// NOT USED	struct snd_soc_codec *codec = rtd->codec;
+	int ret;
+	struct snd_soc_card *card = rtd->card;
+	struct snd_soc_codec *codec = rtd->codec;
+
+	ret = snd_soc_limit_volume(codec, "Digital Playback Volume", 207);
+	if (ret < 0)
+		dev_warn(card->dev, "Failed to set volume limit: %d\n", ret);
 
 	return 0;
 }

--- a/sound/soc/codecs/pcm512x.c
+++ b/sound/soc/codecs/pcm512x.c
@@ -259,8 +259,8 @@ static const struct soc_enum pcm512x_veds =
 			pcm512x_ramp_step_text);
 
 static const struct snd_kcontrol_new pcm512x_controls[] = {
-SOC_DOUBLE_R_RANGE_TLV("PCM", PCM512x_DIGITAL_VOLUME_2,
-		 PCM512x_DIGITAL_VOLUME_3, 0, 40, 255, 1, digital_tlv),
+SOC_DOUBLE_R_TLV("Digital Playback Volume", PCM512x_DIGITAL_VOLUME_2,
+		 PCM512x_DIGITAL_VOLUME_3, 0, 255, 1, digital_tlv),
 SOC_DOUBLE_TLV("Playback Volume", PCM512x_ANALOG_GAIN_CTRL,
 	       PCM512x_LAGN_SHIFT, PCM512x_RAGN_SHIFT, 1, 1, analog_tlv),
 SOC_DOUBLE_TLV("Playback Boost Volume", PCM512x_ANALOG_GAIN_BOOST,


### PR DESCRIPTION
The first commit in this PR reverts a previous commit that I made to the pcm512x driver that retricted the maximum volume range. I submitted this upstream but it was rejected as it was felt that a device driver should allow access to the full functionality of a device.

The second commit acheives the same limiting of the volume but from the iqaudio-dac driver instead. 
