### PR TITLE
Fix reduced volume issue for users of PCM5122 DAC

### DIFF
--- a/Documentation/sound/alsa/ControlNames.txt
+++ b/Documentation/sound/alsa/ControlNames.txt
@@ -49,11 +49,11 @@ SOURCE:
   IEC958
 
 Exceptions:
-  [Digital] Capture Source
-  [Digital] Capture Switch	(aka input gain switch)
-  [Digital] Capture Volume	(aka input gain volume)
-  [Digital] Playback Switch	(aka output gain switch)
-  [Digital] Playback Volume	(aka output gain volume)
+  [Analogue|Digital] Capture Source
+  [Analogue|Digital] Capture Switch	(aka input gain switch)
+  [Analogue|Digital] Capture Volume	(aka input gain volume)
+  [Analogue|Digital] Playback Switch	(aka output gain switch)
+  [Analogue|Digital] Playback Volume	(aka output gain volume)
   Tone Control - Switch
   Tone Control - Bass
   Tone Control - Treble

--- a/sound/soc/codecs/pcm512x.c
+++ b/sound/soc/codecs/pcm512x.c
@@ -261,9 +261,9 @@ static const struct soc_enum pcm512x_veds =
 static const struct snd_kcontrol_new pcm512x_controls[] = {
 SOC_DOUBLE_R_TLV("Digital Playback Volume", PCM512x_DIGITAL_VOLUME_2,
 		 PCM512x_DIGITAL_VOLUME_3, 0, 255, 1, digital_tlv),
-SOC_DOUBLE_TLV("Playback Volume", PCM512x_ANALOG_GAIN_CTRL,
+SOC_DOUBLE_TLV("Analogue Playback Volume", PCM512x_ANALOG_GAIN_CTRL,
 	       PCM512x_LAGN_SHIFT, PCM512x_RAGN_SHIFT, 1, 1, analog_tlv),
-SOC_DOUBLE_TLV("Playback Boost Volume", PCM512x_ANALOG_GAIN_BOOST,
+SOC_DOUBLE_TLV("Analogue Playback Boost Volume", PCM512x_ANALOG_GAIN_BOOST,
 	       PCM512x_AGBL_SHIFT, PCM512x_AGBR_SHIFT, 1, 0, boost_tlv),
 SOC_DOUBLE("Digital Playback Switch", PCM512x_MUTE, PCM512x_RQML_SHIFT,
 	   PCM512x_RQMR_SHIFT, 1, 1),


### PR DESCRIPTION
Since the recent upgrade to the 3.18 kernel users of the PCM5122 DAC have found that there output volume has been significantly reduced. The issue is related to commit id 5be2fc2 which added support for a couple of analogue gain selections. One of these (Playback Volume) sets a gain of either 0db or -6dB and is intended to set the full scale output at 2Vrms or 1Vrms respectively. The reset state is 0db (so 2Vrms) but unfortunately "alsactl restore" applies a default of -20dB to a control named "Playback Volume" if '/var/lib/alsa/asound.state' doesn't exist or there is no saved state for a particular control. So the control ends up at -6dB and the volume is halved. I have reported this issue upstream here: http://thread.gmane.org/gmane.linux.alsa.devel/135504 but in the meantime I think the best course of action is to revert to the 3.12 situation and simply remove these controls. Therefore this pull request simply reverts commit 5be2fc20b101b5138c4f54a584dc11790ef16598.
