### PR TITLE
dts: overlay: add generic support for ads7846

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -64,6 +64,7 @@ endif
 dtb-$(CONFIG_BCM2708_DT) += bcm2708-rpi-b.dtb
 dtb-$(CONFIG_BCM2708_DT) += bcm2708-rpi-b-plus.dtb
 dtb-$(CONFIG_BCM2709_DT) += bcm2709-rpi-2-b.dtb
+dtb-$(RPI_DT_OVERLAYS) += ads7846-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += bmp085_i2c-sensor-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += ds1307-rtc-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += enc28j60-overlay.dtb

--- a/arch/arm/boot/dts/ads7846-overlay.dts
+++ b/arch/arm/boot/dts/ads7846-overlay.dts
@@ -1,0 +1,83 @@
+/*
+ * Generic Device Tree overlay for the ADS7846 touch controller
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+
+			spidev@0{
+				status = "disabled";
+			};
+
+			spidev@1{
+				status = "disabled";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			ads7846_pins: ads7846_pins {
+				brcm,pins = <255>; /* illegal default value */
+				brcm,function = <0>; /* in */
+				brcm,pull = <0>; /* none */
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ads7846: ads7846@1 {
+				compatible = "ti,ads7846";
+				reg = <1>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&ads7846_pins>;
+
+				spi-max-frequency = <2000000>;
+				interrupts = <255 2>; /* high-to-low edge triggered */
+				interrupt-parent = <&gpio>;
+				pendown-gpio = <&gpio 255 0>;
+
+				/* driver defaults */
+				ti,x-min = /bits/ 16 <0>;
+				ti,y-min = /bits/ 16 <0>;
+				ti,x-max = /bits/ 16 <0x0FFF>;
+				ti,y-max = /bits/ 16 <0x0FFF>;
+				ti,pressure-min = /bits/ 16 <0>;
+				ti,pressure-max = /bits/ 16 <0xFFFF>;
+				ti,x-plate-ohms = /bits/ 16 <400>;
+			};
+		};
+	};
+	__overrides__ {
+		cs =     <&ads7846>,"reg:0";
+		speed =  <&ads7846>,"spi-max-frequency:0";
+		penirq = <&ads7846_pins>,"brcm,pins:0", /* REQUIRED */
+			 <&ads7846>,"interrupts:0",
+			 <&ads7846>,"pendown-gpio:4";
+		penirq_pull = <&ads7846_pins>,"brcm,pull:0";
+		swapxy = <&ads7846>,"ti,swap-xy?";
+		xmin =   <&ads7846>,"ti,x-min;0";
+		ymin =   <&ads7846>,"ti,y-min;0";
+		xmax =   <&ads7846>,"ti,x-max;0";
+		ymax =   <&ads7846>,"ti,y-max;0";
+		pmin =   <&ads7846>,"ti,pressure-min;0";
+		pmax =   <&ads7846>,"ti,pressure-max;0";
+		xohms =  <&ads7846>,"ti,x-plate-ohms;0";
+	};
+};


### PR DESCRIPTION
Add generic support for the ADS7846 touch controller.

This overlay combined with the (already enabled) [fbtft_device](https://github.com/raspberrypi/linux/blob/rpi-3.18.y/drivers/staging/fbtft/fbtft_device.c) module,
will cover most FBTFT based touch displays.
