### PR TITLE
Use Device Tree to add the bcm2835-mmc device

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
@@ -44,6 +44,11 @@
 	};
 };
 
+&mmc {
+	status = "okay";
+	bus-width = <4>;
+};
+
 &spi0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi0_pins>;

--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -44,6 +44,11 @@
 	};
 };
 
+&mmc {
+	status = "okay";
+	bus-width = <4>;
+};
+
 &spi0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi0_pins>;

--- a/arch/arm/boot/dts/bcm2708.dtsi
+++ b/arch/arm/boot/dts/bcm2708.dtsi
@@ -41,6 +41,17 @@
 			#interrupt-cells = <2>;
 		};
 
+		mmc: mmc@7e300000 {
+			compatible = "brcm,bcm2835-mmc";
+			reg = <0x7e300000 0x100>;
+			interrupts = <2 30>;
+			clocks = <&clk_mmc>;
+			dmas = <&dma 11>,
+			       <&dma 11>;
+			dma-names = "tx", "rx";
+			status = "disabled";
+		};
+
 		i2s: i2s@7e203000 {
 			compatible = "brcm,bcm2708-i2s";
 			reg = <0x7e203000 0x20>,
@@ -95,6 +106,14 @@
 		compatible = "simple-bus";
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		clk_mmc: clock@0 {
+			compatible = "fixed-clock";
+			reg = <0>;
+			#clock-cells = <0>;
+			clock-output-names = "mmc";
+			clock-frequency = <250000000>;
+		};
 
 		clk_i2c: i2c {
 			compatible = "fixed-clock";

--- a/arch/arm/boot/dts/bcm2708.dtsi
+++ b/arch/arm/boot/dts/bcm2708.dtsi
@@ -17,6 +17,11 @@
 		#size-cells = <1>;
 		ranges = <0x7e000000 0x20000000 0x01000000>;
 
+		dma: dma@7e007000 {
+			compatible = "brcm,bcm2835-dma";
+			#dma-cells = <1>;
+		};
+
 		intc: interrupt-controller {
 			compatible = "brcm,bcm2708-armctrl-ic";
 			reg = <0x7e00b200 0x200>;

--- a/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
@@ -44,6 +44,11 @@
 	};
 };
 
+&mmc {
+	status = "okay";
+	bus-width = <4>;
+};
+
 &spi0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi0_pins>;

--- a/arch/arm/boot/dts/bcm2709.dtsi
+++ b/arch/arm/boot/dts/bcm2709.dtsi
@@ -17,6 +17,11 @@
 		#size-cells = <1>;
 		ranges = <0x7e000000 0x3f000000 0x01000000>;
 
+		dma: dma@7e007000 {
+			compatible = "brcm,bcm2835-dma";
+			#dma-cells = <1>;
+		};
+
 		intc: interrupt-controller {
 			compatible = "brcm,bcm2708-armctrl-ic";
 			reg = <0x7e00b200 0x200>;

--- a/arch/arm/boot/dts/bcm2709.dtsi
+++ b/arch/arm/boot/dts/bcm2709.dtsi
@@ -41,6 +41,17 @@
 			#interrupt-cells = <2>;
 		};
 
+		mmc: mmc@7e300000 {
+			compatible = "brcm,bcm2835-mmc";
+			reg = <0x7e300000 0x100>;
+			interrupts = <2 30>;
+			clocks = <&clk_mmc>;
+			dmas = <&dma 11>,
+			       <&dma 11>;
+			dma-names = "tx", "rx";
+			status = "disabled";
+		};
+
 		i2s: i2s@7e203000 {
 			compatible = "brcm,bcm2708-i2s";
 			reg = <0x7e203000 0x20>,
@@ -96,6 +107,14 @@
 		compatible = "simple-bus";
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		clk_mmc: clock@0 {
+			compatible = "fixed-clock";
+			reg = <0>;
+			#clock-cells = <0>;
+			clock-output-names = "mmc";
+			clock-frequency = <250000000>;
+		};
 
 		clk_i2c: i2c {
 			compatible = "fixed-clock";

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -885,7 +885,7 @@ void __init bcm2708_init(void)
 	bcm_register_device(&bcm2708_powerman_device);
 
 #ifdef CONFIG_MMC_BCM2835
-	bcm_register_device(&bcm2835_emmc_device);
+	bcm_register_device_dt(&bcm2835_emmc_device);
 #endif
 	bcm2708_init_led();
 	for (i = 0; i < ARRAY_SIZE(bcm2708_alsa_devices); i++)

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -233,6 +233,7 @@ void __init bcm2708_init_clocks(void)
 	bcm2708_register_clkdev(clk, "dev:f1");
 
 	clk = bcm2708_clk_register("sdhost_clk", 250000000);
+	bcm2708_register_clkdev(clk, "mmc-bcm2835.0");
 	bcm2708_register_clkdev(clk, "bcm2708_spi.0");
 	bcm2708_register_clkdev(clk, "bcm2708_i2c.0");
 	bcm2708_register_clkdev(clk, "bcm2708_i2c.1");

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -857,7 +857,7 @@ void __init bcm2708_init(void)
 	bcm2708_dt_init();
 
 	bcm_register_device(&bcm2708_dmaman_device);
-	bcm_register_device(&bcm2708_dmaengine_device);
+	bcm_register_device_dt(&bcm2708_dmaengine_device);
 	bcm_register_device(&bcm2708_vcio_device);
 #ifdef CONFIG_BCM2708_GPIO
 	bcm_register_device_dt(&bcm2708_gpio_device);

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -262,6 +262,11 @@ static struct platform_device bcm2708_dmaman_device = {
 	.num_resources = ARRAY_SIZE(bcm2708_dmaman_resources),
 };
 
+static struct platform_device bcm2708_dmaengine_device = {
+	.name = "bcm2708-dmaengine",
+	.id = -1,
+};
+
 #if defined(CONFIG_W1_MASTER_GPIO) || defined(CONFIG_W1_MASTER_GPIO_MODULE)
 static struct w1_gpio_platform_data w1_gpio_pdata = {
 	.pin = W1_GPIO,
@@ -852,6 +857,7 @@ void __init bcm2708_init(void)
 	bcm2708_dt_init();
 
 	bcm_register_device(&bcm2708_dmaman_device);
+	bcm_register_device(&bcm2708_dmaengine_device);
 	bcm_register_device(&bcm2708_vcio_device);
 #ifdef CONFIG_BCM2708_GPIO
 	bcm_register_device_dt(&bcm2708_gpio_device);

--- a/arch/arm/mach-bcm2709/bcm2709.c
+++ b/arch/arm/mach-bcm2709/bcm2709.c
@@ -909,7 +909,7 @@ void __init bcm2709_init(void)
 	bcm_register_device(&bcm2708_powerman_device);
 
 #ifdef CONFIG_MMC_BCM2835
-	bcm_register_device(&bcm2835_emmc_device);
+	bcm_register_device_dt(&bcm2835_emmc_device);
 #endif
 	bcm2709_init_led();
 	for (i = 0; i < ARRAY_SIZE(bcm2708_alsa_devices); i++)

--- a/arch/arm/mach-bcm2709/bcm2709.c
+++ b/arch/arm/mach-bcm2709/bcm2709.c
@@ -243,6 +243,7 @@ void __init bcm2709_init_clocks(void)
 	bcm2709_register_clkdev(clk, "dev:f1");
 
 	clk = bcm2709_clk_register("sdhost_clk", 250000000);
+	bcm2709_register_clkdev(clk, "mmc-bcm2835.0");
 	bcm2709_register_clkdev(clk, "bcm2708_spi.0");
 	bcm2709_register_clkdev(clk, "bcm2708_i2c.0");
 	bcm2709_register_clkdev(clk, "bcm2708_i2c.1");

--- a/arch/arm/mach-bcm2709/bcm2709.c
+++ b/arch/arm/mach-bcm2709/bcm2709.c
@@ -879,7 +879,7 @@ void __init bcm2709_init(void)
 	bcm2709_dt_init();
 
 	bcm_register_device(&bcm2708_dmaman_device);
-	bcm_register_device(&bcm2708_dmaengine_device);
+	bcm_register_device_dt(&bcm2708_dmaengine_device);
 	bcm_register_device(&bcm2708_vcio_device);
 #ifdef CONFIG_BCM2708_GPIO
 	bcm_register_device_dt(&bcm2708_gpio_device);

--- a/arch/arm/mach-bcm2709/bcm2709.c
+++ b/arch/arm/mach-bcm2709/bcm2709.c
@@ -272,6 +272,11 @@ static struct platform_device bcm2708_dmaman_device = {
 	.num_resources = ARRAY_SIZE(bcm2708_dmaman_resources),
 };
 
+static struct platform_device bcm2708_dmaengine_device = {
+	.name = "bcm2708-dmaengine",
+	.id = -1,
+};
+
 #if defined(CONFIG_W1_MASTER_GPIO) || defined(CONFIG_W1_MASTER_GPIO_MODULE)
 static struct w1_gpio_platform_data w1_gpio_pdata = {
 	.pin = W1_GPIO,
@@ -874,6 +879,7 @@ void __init bcm2709_init(void)
 	bcm2709_dt_init();
 
 	bcm_register_device(&bcm2708_dmaman_device);
+	bcm_register_device(&bcm2708_dmaengine_device);
 	bcm_register_device(&bcm2708_vcio_device);
 #ifdef CONFIG_BCM2708_GPIO
 	bcm_register_device_dt(&bcm2708_gpio_device);

--- a/drivers/dma/bcm2708-dmaengine.c
+++ b/drivers/dma/bcm2708-dmaengine.c
@@ -995,35 +995,7 @@ static struct platform_driver bcm2835_dma_driver = {
 	},
 };
 
-static struct platform_device *pdev;
-
-static const struct platform_device_info bcm2835_dma_dev_info = {
-	.name = "bcm2708-dmaengine",
-	.id = -1,
-};
-
-static int bcm2835_dma_init(void)
-{
-	int rc = platform_driver_register(&bcm2835_dma_driver);
-
-	if (rc == 0) {
-		pdev = platform_device_register_full(&bcm2835_dma_dev_info);
-		if (IS_ERR(pdev)) {
-			platform_driver_unregister(&bcm2835_dma_driver);
-			rc = PTR_ERR(pdev);
-		}
-	}
-
-	return rc;
-}
-module_init(bcm2835_dma_init); /* preferable to subsys_initcall */
-
-static void __exit bcm2835_dma_exit(void)
-{
-	platform_device_unregister(pdev);
-	platform_driver_unregister(&bcm2835_dma_driver);
-}
-module_exit(bcm2835_dma_exit);
+module_platform_driver(bcm2835_dma_driver);
 
 #else
 

--- a/drivers/dma/bcm2708-dmaengine.c
+++ b/drivers/dma/bcm2708-dmaengine.c
@@ -612,8 +612,6 @@ static struct dma_async_tx_descriptor *bcm2835_dma_prep_slave_sg(
 				control_block->info |= sync_type;
 
 			/* Setup DREQ channel */
-			c->dreq = c->cfg.slave_id; /* DREQ loaded from config */
-
 			if (c->dreq != 0)
 				control_block->info |=
 					BCM2835_DMA_PER_MAP(c->dreq);
@@ -656,6 +654,8 @@ static int bcm2835_dma_slave_config(struct bcm2835_chan *c,
 	}
 
 	c->cfg = *cfg;
+	if (!c->dreq)
+		c->dreq = cfg->slave_id;
 
 	return 0;
 }

--- a/drivers/dma/bcm2708-dmaengine.c
+++ b/drivers/dma/bcm2708-dmaengine.c
@@ -734,8 +734,6 @@ static int bcm2835_dma_chan_init(struct bcm2835_dmadev *d, int chan_id, int irq)
 	vchan_init(&c->vc, &d->ddev);
 	INIT_LIST_HEAD(&c->node);
 
-	d->ddev.chancnt++;
-
 	c->chan_base = BCM2835_DMA_CHANIO(d->base, chan_id);
 	c->ch = chan_id;
 	c->irq_number = irq;
@@ -756,8 +754,6 @@ static int bcm2708_dma_chan_init(struct bcm2835_dmadev *d,
 	c->vc.desc_free = bcm2835_dma_desc_free;
 	vchan_init(&c->vc, &d->ddev);
 	INIT_LIST_HEAD(&c->node);
-
-	d->ddev.chancnt++;
 
 	c->chan_base = chan_base;
 	c->ch = chan_id;

--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -1261,19 +1261,17 @@ static void bcm2835_mmc_tasklet_finish(unsigned long param)
 
 int bcm2835_mmc_add_host(struct bcm2835_host *host)
 {
-	struct mmc_host *mmc;
+	struct mmc_host *mmc = host->mmc;
+	struct device *dev = mmc->parent;
 #ifndef FORCE_PIO
 	struct dma_slave_config cfg;
 #endif
 	int ret;
 
-	mmc = host->mmc;
-
 	bcm2835_mmc_reset(host, SDHCI_RESET_ALL);
 
 	host->clk_mul = 0;
 
-	mmc->ops = &bcm2835_ops;
 	mmc->f_max = host->max_clk;
 	mmc->f_max = host->max_clk;
 	mmc->f_min = host->max_clk / SDHCI_MAX_DIV_SPEC_300;
@@ -1291,17 +1289,17 @@ int bcm2835_mmc_add_host(struct bcm2835_host *host)
 
 	spin_lock_init(&host->lock);
 
-
 #ifdef FORCE_PIO
-	pr_info("Forcing PIO mode\n");
+	dev_info(dev, "Forcing PIO mode\n");
 	host->have_dma = false;
 #else
-	if (!host->dma_chan_tx || !host->dma_chan_rx ||
-	IS_ERR(host->dma_chan_tx) || IS_ERR(host->dma_chan_rx)) {
-		pr_err("%s: Unable to initialise DMA channels. Falling back to PIO\n", DRIVER_NAME);
+	if (IS_ERR_OR_NULL(host->dma_chan_tx) ||
+	    IS_ERR_OR_NULL(host->dma_chan_rx)) {
+		dev_err(dev, "%s: Unable to initialise DMA channels. Falling back to PIO\n",
+			DRIVER_NAME);
 		host->have_dma = false;
 	} else {
-		pr_info("DMA channels allocated for the MMC driver");
+		dev_info(dev, "DMA channels allocated");
 		host->have_dma = true;
 
 		cfg.src_addr_width = DMA_SLAVE_BUSWIDTH_4_BYTES;
@@ -1319,8 +1317,6 @@ int bcm2835_mmc_add_host(struct bcm2835_host *host)
 		ret = dmaengine_slave_config(host->dma_chan_rx, &cfg);
 	}
 #endif
-
-
 	mmc->max_segs = 128;
 	mmc->max_req_size = 524288;
 	mmc->max_seg_size = mmc->max_req_size;
@@ -1338,22 +1334,20 @@ int bcm2835_mmc_add_host(struct bcm2835_host *host)
 
 	bcm2835_mmc_init(host, 0);
 #ifndef CONFIG_ARCH_BCM2835
-	ret = request_irq(host->irq, bcm2835_mmc_irq, 0 /*IRQF_SHARED*/,
-				  mmc_hostname(mmc), host);
+	ret = devm_request_irq(dev, host->irq, bcm2835_mmc_irq, 0,
+			       mmc_hostname(mmc), host);
 #else
-	ret = request_threaded_irq(host->irq, bcm2835_mmc_irq, bcm2835_mmc_thread_irq,
-				   IRQF_SHARED,	mmc_hostname(mmc), host);
+	ret = devm_request_threaded_irq(dev, host->irq, bcm2835_mmc_irq,
+					bcm2835_mmc_thread_irq, IRQF_SHARED,
+					mmc_hostname(mmc), host);
 #endif
 	if (ret) {
-		pr_err("%s: Failed to request IRQ %d: %d\n",
-		       mmc_hostname(mmc), host->irq, ret);
+		dev_err(dev, "Failed to request IRQ %d: %d\n", host->irq, ret);
 		goto untasklet;
 	}
 
 	mmiowb();
 	mmc_add_host(mmc);
-
-	pr_info("Load BCM2835 MMC driver\n");
 
 	return 0;
 
@@ -1369,26 +1363,24 @@ static int bcm2835_mmc_probe(struct platform_device *pdev)
 	struct device_node *node = dev->of_node;
 	struct clk *clk;
 	struct resource *iomem;
-	struct bcm2835_host *host = NULL;
-	int ret;
+	struct bcm2835_host *host;
 	struct mmc_host *mmc;
+	int ret;
 
-	iomem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-	if (!iomem) {
-		ret = -ENOMEM;
-		goto err;
-	}
+	mmc = mmc_alloc_host(sizeof(*host), dev);
+	if (!mmc)
+		return -ENOMEM;
 
-	if (resource_size(iomem) < 0x100)
-		dev_err(&pdev->dev, "Invalid iomem size!\n");
-
-	mmc = mmc_alloc_host(sizeof(struct bcm2835_host), dev);
+	mmc->ops = &bcm2835_ops;
 	host = mmc_priv(mmc);
 	host->mmc = mmc;
+	host->timeout = msecs_to_jiffies(1000);
+	spin_lock_init(&host->lock);
 
-
-	if (IS_ERR(host)) {
-		ret = PTR_ERR(host);
+	iomem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	host->ioaddr = devm_ioremap_resource(dev, iomem);
+	if (IS_ERR(host->ioaddr)) {
+		ret = PTR_ERR(host->ioaddr);
 		goto err;
 	}
 
@@ -1412,63 +1404,39 @@ static int bcm2835_mmc_probe(struct platform_device *pdev)
 	if (IS_ERR(clk)) {
 		dev_err(dev, "could not get clk\n");
 		ret = PTR_ERR(clk);
-		goto out;
+		goto err;
 	}
 
 	host->max_clk = clk_get_rate(clk);
 
 	host->irq = platform_get_irq(pdev, 0);
-
-	if (!request_mem_region(iomem->start, resource_size(iomem),
-		mmc_hostname(host->mmc))) {
-		dev_err(&pdev->dev, "cannot request region\n");
-		ret = -EBUSY;
-		goto err_request;
-	}
-
-	host->ioaddr = ioremap(iomem->start, resource_size(iomem));
-	if (!host->ioaddr) {
-		dev_err(&pdev->dev, "failed to remap registers\n");
-		ret = -ENOMEM;
-		goto err_remap;
-	}
-
-	platform_set_drvdata(pdev, host);
-
-
 	if (host->irq <= 0) {
 		dev_err(dev, "get IRQ failed\n");
 		ret = -EINVAL;
-		goto out;
+		goto err;
 	}
 
 	if (node)
 		mmc_of_parse(mmc);
 	else
 		mmc->caps |= MMC_CAP_4_BIT_DATA;
-	host->timeout = msecs_to_jiffies(1000);
-	spin_lock_init(&host->lock);
-	mmc->ops = &bcm2835_ops;
-	return bcm2835_mmc_add_host(host);
 
+	ret = bcm2835_mmc_add_host(host);
+	if (ret)
+		goto err;
 
-err_remap:
-	release_mem_region(iomem->start, resource_size(iomem));
-err_request:
-	mmc_free_host(host->mmc);
+	platform_set_drvdata(pdev, host);
+
+	return 0;
 err:
-	dev_err(&pdev->dev, "%s failed %d\n", __func__, ret);
-	return ret;
-out:
-	if (mmc)
-		mmc_free_host(mmc);
+	mmc_free_host(mmc);
+
 	return ret;
 }
 
 static int bcm2835_mmc_remove(struct platform_device *pdev)
 {
 	struct bcm2835_host *host = platform_get_drvdata(pdev);
-	struct resource *iomem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	unsigned long flags;
 	int dead;
 	u32 scratch;
@@ -1506,8 +1474,6 @@ static int bcm2835_mmc_remove(struct platform_device *pdev)
 
 	tasklet_kill(&host->finish_tasklet);
 
-	iounmap(host->ioaddr);
-	release_mem_region(iomem->start, resource_size(iomem));
 	mmc_free_host(host->mmc);
 	platform_set_drvdata(pdev, NULL);
 


### PR DESCRIPTION
Move the dma and mmc devices to Device Tree.
This enables drivers to get DMA channels using Device Tree.

Tested on Pi1 B+ and Pi2 in both DT and non-DT mode.
