### PR TITLE
bcm2708: fix uart1 parameters

### DIFF
--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -312,11 +312,12 @@ static struct plat_serial8250_port bcm2708_uart1_platform_data[] = {
 	{
 	 .mapbase = UART1_BASE + 0x40,
 	 .irq = IRQ_AUX,
-	 .uartclk = 125000000,
+	 .uartclk = 500000000,
 	 .regshift = 2,
 	 .iotype = UPIO_MEM,
-	 .flags = UPF_FIXED_TYPE | UPF_IOREMAP | UPF_SKIP_TEST,
-	 .type = PORT_8250,
+	 .flags = UPF_SHARE_IRQ | UPF_FIXED_TYPE | UPF_FIXED_PORT |
+		UPF_IOREMAP | UPF_SKIP_TEST,
+	 .type = PORT_16550,
 	 },
 	{},
 };


### PR DESCRIPTION
System clock is 250MHz, but the device uses a non-standard
oversampling rate (8 instead of 16) hence the clock rate
has to be multiplied by 16/8 = 2.  Currently the clock
rate seems to be divided by 2.

Also correct the .type and .flags.

Signed-off-by: Jakub Kicinski kubakici@wp.pl
