### PR TITLE
Swap X Y axis of ads7846 touchscreen controller for PiScreen TFT

### DIFF
--- a/arch/arm/boot/dts/piscreen-overlay.dts
+++ b/arch/arm/boot/dts/piscreen-overlay.dts
@@ -80,6 +80,7 @@
 				interrupts = <17 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
 				pendown-gpio = <&gpio 17 0>;
+				ti,swap-xy;
 				ti,x-plate-ohms = /bits/ 16 <100>;
 				ti,pressure-max = /bits/ 16 <255>;
 			};


### PR DESCRIPTION
as discussed in pull request #917 

this swaps the axis X and Y axis of the touchscreen.
without it, 
-complicated calibration and configuration is needed to have the X and Y axis appear the correct way around in X.

-current insufficient support to correct the calibration outside of X.

This will also match up the 0,0 coordinates with the raw framebuffer when it is being mapped via ioctl().

I am the creator of PiScreen display and this will make it easier for end users to use PiScreen
