### PR TITLE
Added optional parameter to set resistance of touch plate(x-plate-ohms)

### DIFF
--- a/arch/arm/boot/dts/piscreen-overlay.dts
+++ b/arch/arm/boot/dts/piscreen-overlay.dts
@@ -72,7 +72,7 @@
 					0x1000029>;
 			};
 
-			piscreen-ts@1 {
+			piscreen_ts: piscreen-ts@1 {
 				compatible = "ti,ads7846";
 				reg = <1>;
 
@@ -91,5 +91,6 @@
 		rotate =	<&piscreen>,"rotate:0";
 		fps =		<&piscreen>,"fps:0";
 		debug =		<&piscreen>,"debug:0";
+		xohms =		<&piscreen_ts>,"ti,x-plate-ohms;0";
 	};
 };


### PR DESCRIPTION
I am the creator of PiScreen.
Users have asked for an easy option to change the touch resistance of on the PiScreen display.
This optional parameter gives the user the option to change the default value of Ohms resistance of the touchscreen.
