### PR TITLE
dts: update overlay to override the correct value with the correct type

### DIFF
--- a/arch/arm/boot/dts/mcp2515-can0-overlay.dts
+++ b/arch/arm/boot/dts/mcp2515-can0-overlay.dts
@@ -62,7 +62,7 @@
         };
     };
     __overrides__ {
-        oscillator = <&can0_osc>,"oscillator-frequency";
+        oscillator = <&can0_osc>,"clock-frequency:0";
         spimaxfrequency = <&can0>,"spi-max-frequency:0";
         interrupt = <&can0_pins>,"brcm,pins:0",<&can0>,"interrupts:0";
     };


### PR DESCRIPTION
Unfortunately the device-tree-overlay so far was only working correctly
with a 16MHz oscillator - the overlay parameter was introducing a new
device-tree key instead of overwriting the default value.

In addition to that the value vas set as string and not as an integer.

Signed-off-by: Martin Sperl kernel@martin.sperl.org
