### PR TITLE
vcsm: Use boolean as it cannot be built as module

### DIFF
--- a/drivers/char/broadcom/Kconfig
+++ b/drivers/char/broadcom/Kconfig
@@ -15,7 +15,7 @@ config BCM_VC_CMA
           Helper for videocore CMA access.
 
 config BCM_VC_SM
-	tristate "VMCS Shared Memory"
+	bool "VMCS Shared Memory"
 	default n
 	help
 	Support for the VC shared memory on the Broadcom reference


### PR DESCRIPTION
On building the bcm_vc_sm as a module we get the following error:

v7_dma_flush_range and do_munmap are undefined in vc-sm.ko.

Fix by making it not an option to build as module
