### PR TITLE
bcm2708: fix print_debug misstake

### DIFF
--- a/drivers/video/fbdev/bcm2708_fb.c
+++ b/drivers/video/fbdev/bcm2708_fb.c
@@ -679,7 +679,7 @@ static int bcm2708_fb_register(struct bcm2708_fb *fb)
 	fb_set_var(&fb->fb, &fb->fb.var);
 	bcm2708_fb_set_par(&fb->fb);
 
-	print_debug("BCM2708FB: registering framebuffer (%dx%d@%d) (%d)\n", fbwidth
+	print_debug("BCM2708FB: registering framebuffer (%dx%d@%d) (%d)\n", fbwidth,
 		fbheight, fbdepth, fbswap);
 
 	ret = register_framebuffer(&fb->fb);


### PR DESCRIPTION
A call to print_debug() inside bcm2708 is missing a comma and it causes
build fail when debug mode is turned on. Fix the issue by adding a comma
in it.

Signed-off-by: SeongJae Park sj38.park@gmail.com
