### PR TITLE
bcm2835-mmc/sdhost: of_dma_request_slave_channel isn't exported

### DIFF
--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -1493,8 +1493,8 @@ static int bcm2835_mmc_probe(struct platform_device *pdev)
 
 if (!(mmc_debug & (1<<12))) {
 	if (node) {
-		host->dma_chan_tx = of_dma_request_slave_channel(node, "tx");
-		host->dma_chan_rx = of_dma_request_slave_channel(node, "rx");
+		host->dma_chan_tx = dma_request_slave_channel(dev, "tx");
+		host->dma_chan_rx = dma_request_slave_channel(dev, "rx");
 	} else {
 		dma_cap_mask_t mask;
 

--- a/drivers/mmc/host/bcm2835-sdhost.c
+++ b/drivers/mmc/host/bcm2835-sdhost.c
@@ -1578,9 +1578,9 @@ static int bcm2835_sdhost_probe(struct platform_device *pdev)
 	if (host->allow_dma) {
 		if (node) {
 			host->dma_chan_tx =
-				of_dma_request_slave_channel(node, "tx");
+				dma_request_slave_channel(dev, "tx");
 			host->dma_chan_rx =
-				of_dma_request_slave_channel(node, "rx");
+				dma_request_slave_channel(dev, "rx");
 		} else {
 			dma_cap_mask_t mask;
 


### PR DESCRIPTION
of_dma_request_slave_channel isn't an exported function, so can't be
used from within a module. Replace with dma_request_slave_channel,
which calls the of_ variant but IS exported.

See: https://github.com/raspberrypi/linux/issues/952

Signed-off-by: Phil Elwell phil@raspberrypi.org
