### PR TITLE
vchiq: Fix wrong condition check

### DIFF
--- a/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
+++ b/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
@@ -322,7 +322,7 @@ vchiq_platform_use_suspend_timer(void)
 void
 vchiq_dump_platform_use_state(VCHIQ_STATE_T *state)
 {
-	vchiq_log_info((vchiq_arm_log_level>=VCHIQ_LOG_INFO),"Suspend timer not in use");
+	vchiq_log_info(vchiq_arm_log_level, "Suspend timer not in use");
 }
 void
 vchiq_platform_handle_timeout(VCHIQ_STATE_T *state)


### PR DESCRIPTION
The log level is checked from within the log call. Remove the check in the call.

Signed-off-by: Pranith Kumar bobby.prani@gmail.com
