### PR TITLE
Fix I2S soundcard issues with kernel 4.0

### DIFF
--- a/drivers/dma/bcm2708-dmaengine.c
+++ b/drivers/dma/bcm2708-dmaengine.c
@@ -1112,6 +1112,7 @@ static int bcm2835_dma_probe(struct platform_device *pdev)
 	od->ddev.src_addr_widths = BIT(DMA_SLAVE_BUSWIDTH_4_BYTES);
 	od->ddev.dst_addr_widths = BIT(DMA_SLAVE_BUSWIDTH_4_BYTES);
 	od->ddev.directions = BIT(DMA_DEV_TO_MEM) | BIT(DMA_MEM_TO_DEV);
+	od->ddev.residue_granularity = DMA_RESIDUE_GRANULARITY_BURST;
 	od->ddev.dev = &pdev->dev;
 	INIT_LIST_HEAD(&od->ddev.channels);
 	spin_lock_init(&od->lock);
@@ -1180,6 +1181,7 @@ static int bcm2835_dma_probe(struct platform_device *pdev)
 	od->ddev.src_addr_widths = BIT(DMA_SLAVE_BUSWIDTH_4_BYTES);
 	od->ddev.dst_addr_widths = BIT(DMA_SLAVE_BUSWIDTH_4_BYTES);
 	od->ddev.directions = BIT(DMA_DEV_TO_MEM) | BIT(DMA_MEM_TO_DEV);
+	od->ddev.residue_granularity = DMA_RESIDUE_GRANULARITY_BURST;
 	od->ddev.dev = &pdev->dev;
 	INIT_LIST_HEAD(&od->ddev.channels);
 	spin_lock_init(&od->lock);


### PR DESCRIPTION
Using I2S soundcards with kernel 4.0 has various issues like repeated crackling, especially noticable when playing back high samplerate (96 or 192kHz) audio files with kodi.

These issues are caused by bcm2708-dmaengine not setting the residue_granularity field (it's by default initialized to 0) which then causes snd_pcm_dmaengine to fall back to the unreliable "no-residue" path.

The dmaengine driver supports residue reporting at burst level and setting residue_granularity to BURST fixes the sound issues.

On kernel 3.18 and 3.19 this issue was hidden by an uninitialized stack memory read - I'll create another PR for that.
