### PR TITLE
dmaengine: bcm2708: add missing residue_granularity field

### DIFF
--- a/drivers/dma/bcm2708-dmaengine.c
+++ b/drivers/dma/bcm2708-dmaengine.c
@@ -812,6 +812,7 @@ static int bcm2835_dma_device_slave_caps(struct dma_chan *dchan,
 	caps->src_addr_widths = BIT(DMA_SLAVE_BUSWIDTH_4_BYTES);
 	caps->dstn_addr_widths = BIT(DMA_SLAVE_BUSWIDTH_4_BYTES);
 	caps->directions = BIT(DMA_DEV_TO_MEM) | BIT(DMA_MEM_TO_DEV);
+	caps->residue_granularity = DMA_RESIDUE_GRANULARITY_BURST;
 	caps->cmd_pause = false;
 	caps->cmd_terminate = true;
 


### PR DESCRIPTION
The dma_slave_caps callback didn't set residue_granularity which
led to UMRs in soc-generic-dmaengine-pcm.

Most of the time the UMR had no consequences, but if the stack memory happened to be 0 snd_pcm_dmaengine would use the unreliable "no-residue" path.

The dmaengine driver supports reporting transfer status at burst level, so setting residue_granularity to DMA_RESIDUE_GRANULARITY_BURST seems to be the correct fix.
