### PR TITLE
Enable vchiq on ARCH_BCM2835

### DIFF
--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -114,6 +114,12 @@
 			compatible = "brcm,bcm2708-fb";
 			status = "disabled";
 		};
+
+		vchiq: vchiq {
+			compatible = "brcm,bcm2835-vchiq";
+			reg = <0x7e00b840 0xf>;
+			interrupts = <0 2>;
+		};
 	};
 
 	clocks {

--- a/arch/arm/boot/dts/bcm2835.dtsi
+++ b/arch/arm/boot/dts/bcm2835.dtsi
@@ -164,6 +164,12 @@
 			compatible = "brcm,bcm2708-fb";
 			status = "disabled";
 		};
+
+		vchiq: vchiq {
+			compatible = "brcm,bcm2835-vchiq";
+			reg = <0x7e00b840 0xf>;
+			interrupts = <0 2>;
+		};
 	};
 
 	clocks {

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -437,6 +437,31 @@ static struct platform_device bcm2708_vcio_device = {
 		},
 };
 
+static struct resource bcm2708_vchiq_resources[] = {
+	{
+		.start = ARMCTRL_0_BELL_BASE,
+		.end = ARMCTRL_0_BELL_BASE + 16,
+		.flags = IORESOURCE_MEM,
+	}, {
+		.start = IRQ_ARM_DOORBELL_0,
+		.end = IRQ_ARM_DOORBELL_0,
+		.flags = IORESOURCE_IRQ,
+	},
+};
+
+static u64 vchiq_dmamask = DMA_BIT_MASK(DMA_MASK_BITS_COMMON);
+
+static struct platform_device bcm2708_vchiq_device = {
+	.name = "bcm2835_vchiq",
+	.id = -1,
+	.resource = bcm2708_vchiq_resources,
+	.num_resources = ARRAY_SIZE(bcm2708_vchiq_resources),
+	.dev = {
+		.dma_mask = &vchiq_dmamask,
+		.coherent_dma_mask = DMA_BIT_MASK(DMA_MASK_BITS_COMMON),
+		},
+};
+
 #ifdef CONFIG_BCM2708_GPIO
 #define BCM_GPIO_DRIVER_NAME "bcm2708_gpio"
 
@@ -909,6 +934,7 @@ void __init bcm2708_init(void)
 
 	bcm_register_device_dt(&bcm2708_dmaengine_device);
 	bcm_register_device_dt(&bcm2708_vcio_device);
+	bcm_register_device_dt(&bcm2708_vchiq_device);
 #ifdef CONFIG_BCM2708_GPIO
 	bcm_register_device_dt(&bcm2708_gpio_device);
 #endif

--- a/arch/arm/mach-bcm2708/include/mach/platform.h
+++ b/arch/arm/mach-bcm2708/include/mach/platform.h
@@ -81,6 +81,7 @@
 #define ARMCTRL_IC_BASE          (ARM_BASE + 0x200)           /* ARM interrupt controller */
 #define ARMCTRL_TIMER0_1_BASE    (ARM_BASE + 0x400)           /* Timer 0 and 1 */
 #define ARMCTRL_0_SBM_BASE       (ARM_BASE + 0x800)           /* User 0 (ARM)'s Semaphores Doorbells and Mailboxes */
+#define ARMCTRL_0_BELL_BASE      (ARMCTRL_0_SBM_BASE + 0x40)  /* User 0 (ARM)'s Doorbell */
 #define ARMCTRL_0_MAIL0_BASE     (ARMCTRL_0_SBM_BASE + 0x80)  /* User 0 (ARM)'s Mailbox 0 */
 
 

--- a/arch/arm/mach-bcm2709/bcm2709.c
+++ b/arch/arm/mach-bcm2709/bcm2709.c
@@ -456,6 +456,31 @@ static struct platform_device bcm2708_vcio_device = {
 		},
 };
 
+static struct resource bcm2708_vchiq_resources[] = {
+	{
+		.start = ARMCTRL_0_BELL_BASE,
+		.end = ARMCTRL_0_BELL_BASE + 16,
+		.flags = IORESOURCE_MEM,
+	}, {
+		.start = IRQ_ARM_DOORBELL_0,
+		.end = IRQ_ARM_DOORBELL_0,
+		.flags = IORESOURCE_IRQ,
+	},
+};
+
+static u64 vchiq_dmamask = DMA_BIT_MASK(DMA_MASK_BITS_COMMON);
+
+static struct platform_device bcm2708_vchiq_device = {
+	.name = "bcm2835_vchiq",
+	.id = -1,
+	.resource = bcm2708_vchiq_resources,
+	.num_resources = ARRAY_SIZE(bcm2708_vchiq_resources),
+	.dev = {
+		.dma_mask = &vchiq_dmamask,
+		.coherent_dma_mask = DMA_BIT_MASK(DMA_MASK_BITS_COMMON),
+		},
+};
+
 #ifdef CONFIG_BCM2708_GPIO
 #define BCM_GPIO_DRIVER_NAME "bcm2708_gpio"
 
@@ -930,6 +955,7 @@ void __init bcm2709_init(void)
 
 	bcm_register_device_dt(&bcm2708_dmaengine_device);
 	bcm_register_device_dt(&bcm2708_vcio_device);
+	bcm_register_device_dt(&bcm2708_vchiq_device);
 #ifdef CONFIG_BCM2708_GPIO
 	bcm_register_device_dt(&bcm2708_gpio_device);
 #endif

--- a/arch/arm/mach-bcm2709/include/mach/platform.h
+++ b/arch/arm/mach-bcm2709/include/mach/platform.h
@@ -81,6 +81,7 @@
 #define ARMCTRL_IC_BASE          (ARM_BASE + 0x200)           /* ARM interrupt controller */
 #define ARMCTRL_TIMER0_1_BASE    (ARM_BASE + 0x400)           /* Timer 0 and 1 */
 #define ARMCTRL_0_SBM_BASE       (ARM_BASE + 0x800)           /* User 0 (ARM)'s Semaphores Doorbells and Mailboxes */
+#define ARMCTRL_0_BELL_BASE      (ARMCTRL_0_SBM_BASE + 0x40)  /* User 0 (ARM)'s Doorbell */
 #define ARMCTRL_0_MAIL0_BASE     (ARMCTRL_0_SBM_BASE + 0x80)  /* User 0 (ARM)'s Mailbox 0 */
 
 

--- a/drivers/misc/vc04_services/Kconfig
+++ b/drivers/misc/vc04_services/Kconfig
@@ -1,6 +1,6 @@
 config BCM2708_VCHIQ
 	tristate "Videocore VCHIQ"
-	depends on MACH_BCM2708 || MACH_BCM2709
+	depends on MACH_BCM2708 || MACH_BCM2709 || ARCH_BCM2835
 	default y
 	help
 		Kernel to VideoCore communication interface for the

--- a/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_arm.h
+++ b/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_arm.h
@@ -36,6 +36,7 @@
 #define VCHIQ_ARM_H
 
 #include <linux/mutex.h>
+#include <linux/platform_device.h>
 #include <linux/semaphore.h>
 #include <linux/atomic.h>
 #include "vchiq_core.h"
@@ -128,11 +129,7 @@ typedef struct vchiq_arm_state_struct {
 extern int vchiq_arm_log_level;
 extern int vchiq_susp_log_level;
 
-extern int __init
-vchiq_platform_init(VCHIQ_STATE_T *state);
-
-extern void __exit
-vchiq_platform_exit(VCHIQ_STATE_T *state);
+int vchiq_platform_init(struct platform_device *pdev, VCHIQ_STATE_T *state);
 
 extern VCHIQ_STATE_T *
 vchiq_get_state(void);


### PR DESCRIPTION
Tested on Pi1 and Pi2 regular kernel with and without DT + ARCH_BCM2835.

Tested from userspace:

```
$ vcgencmd measure_temp
temp=34.7'C
```
