### PR TITLE
Add onboard sound device to Device Tree

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
@@ -53,6 +53,10 @@
 	status = "okay";
 };
 
+&audio {
+	status = "okay";
+};
+
 &spi0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi0_pins>;

--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -53,6 +53,10 @@
 	status = "okay";
 };
 
+&audio {
+	status = "okay";
+};
+
 &spi0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi0_pins>;

--- a/arch/arm/boot/dts/bcm2708-rpi-cm.dtsi
+++ b/arch/arm/boot/dts/bcm2708-rpi-cm.dtsi
@@ -34,6 +34,10 @@
 	status = "okay";
 };
 
+&audio {
+	status = "okay";
+};
+
 / {
 	__overrides__ {
 		act_led_gpio = <&act_led>,"gpios:4";

--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -3,6 +3,13 @@
 / {
 	interrupt-parent = <&intc>;
 
+	/* Onboard audio */
+	audio: audio {
+		compatible = "brcm,bcm2835-audio";
+		brcm,pwm-channels = <8>;
+		status = "disabled";
+	};
+
 	soc: soc {
 		compatible = "simple-bus";
 		#address-cells = <1>;

--- a/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
@@ -53,6 +53,10 @@
 	status = "okay";
 };
 
+&audio {
+	status = "okay";
+};
+
 &spi0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi0_pins>;

--- a/arch/arm/boot/dts/bcm2835-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2835-rpi.dtsi
@@ -14,6 +14,12 @@
 			linux,default-trigger = "heartbeat";
 		};
 	};
+
+	/* Onboard audio */
+	audio: audio {
+		compatible = "brcm,bcm2835-audio";
+		brcm,pwm-channels = <8>;
+	};
 };
 
 &gpio {

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -964,7 +964,7 @@ void __init bcm2708_init(void)
 #endif
 	bcm2708_init_led();
 	for (i = 0; i < ARRAY_SIZE(bcm2708_alsa_devices); i++)
-		bcm_register_device(&bcm2708_alsa_devices[i]);
+		bcm_register_device_dt(&bcm2708_alsa_devices[i]);
 
 	bcm_register_device_dt(&bcm2708_spi_device);
 

--- a/arch/arm/mach-bcm2709/bcm2709.c
+++ b/arch/arm/mach-bcm2709/bcm2709.c
@@ -987,7 +987,7 @@ void __init bcm2709_init(void)
 #endif
 	bcm2709_init_led();
 	for (i = 0; i < ARRAY_SIZE(bcm2708_alsa_devices); i++)
-		bcm_register_device(&bcm2708_alsa_devices[i]);
+		bcm_register_device_dt(&bcm2708_alsa_devices[i]);
 
 	bcm_register_device_dt(&bcm2708_spi_device);
 

--- a/sound/arm/Kconfig
+++ b/sound/arm/Kconfig
@@ -41,7 +41,8 @@ config SND_PXA2XX_AC97
 
 config SND_BCM2835
 	tristate "BCM2835 ALSA driver"
-	depends on (ARCH_BCM2708 || ARCH_BCM2709) && BCM2708_VCHIQ && SND
+	depends on (ARCH_BCM2708 || ARCH_BCM2709 || ARCH_BCM2835) \
+		   && BCM2708_VCHIQ && SND
 	select SND_PCM
 	help
 	  Say Y or M if you want to support BCM2835 Alsa pcm card driver


### PR DESCRIPTION
Tested on Pi1 and Pi2 regular kernel with and without DT + ARCH_BCM2835.

Tested from userspace:

```
$ speaker-test -c2 -t wav
$ omxplayer /usr/share/scratch/Media/Sounds/Vocals/Singer2.wav
```

omxplayer hangs with no sound on ARCH_BCM2835, reason unknown.

I will enable the driver on ARCH_BCM2835 later when I merge bcm2835_defconfig with bcmrpi_config.
