### PR TITLE
bcm270x: add dtparam to enable onboard sound device

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
@@ -126,5 +126,7 @@
 		pwr_led_gpio = <&pwr_led>,"gpios:4";
 		pwr_led_activelow = <&pwr_led>,"gpios:8";
 		pwr_led_trigger = <&pwr_led>,"linux,default-trigger";
+
+		audio = <&audio>,"status";
 	};
 };

--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -116,5 +116,7 @@
 		act_led_gpio = <&act_led>,"gpios:4";
 		act_led_activelow = <&act_led>,"gpios:8";
 		act_led_trigger = <&act_led>,"linux,default-trigger";
+
+		audio = <&audio>,"status";
 	};
 };

--- a/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
@@ -126,5 +126,7 @@
 		pwr_led_gpio = <&pwr_led>,"gpios:4";
 		pwr_led_activelow = <&pwr_led>,"gpios:8";
 		pwr_led_trigger = <&pwr_led>,"linux,default-trigger";
+
+		audio = <&audio>,"status";
 	};
 };


### PR DESCRIPTION
PR977 has the sideeffect of snd-bcm2835 being enabled by default.

This PR changes this back to the previous default and adds a device tree parameter
so snd-bcm2835 can be enabled like the other devices with "dtparam=audio=on".
