### PR TITLE
device-tree: spi: make spi-bcm2835 the default spi driver and prepare…

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -41,6 +41,7 @@ dtb-$(RPI_DT_OVERLAYS) += sdhost-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += w1-gpio-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += w1-gpio-pullup-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += spi-bcm2835-overlay.dtb
+dtb-$(RPI_DT_OVERLAYS) += spi-bcm2708-overlay.dtb
 
 dtb-$(CONFIG_MACH_ASM9260) += \
 	alphascale-asm9260-devkit.dtb

--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -84,13 +84,21 @@
 		};
 
 		spi0: spi@7e204000 {
-			compatible = "brcm,bcm2708-spi";
+			compatible = "brcm,bcm2835-spi";
 			reg = <0x7e204000 0x1000>;
 			interrupts = <2 22>;
 			clocks = <&clk_spi>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
+			/* the dma channels */
+			dmas = <&dma 6>, <&dma 7>;
+			dma-names = "tx", "rx";
+			/* the chipselects used - <0> means native GPIO
+			 * add more gpios if necessary as <&gpio 6 1>
+			 * (but do not forget to make them output!)
+			 */
+			cs-gpios = <0>, <0>;
 		};
 
 		i2c0: i2c@7e205000 {

--- a/arch/arm/boot/dts/spi-bcm2708-overlay.dts
+++ b/arch/arm/boot/dts/spi-bcm2708-overlay.dts
@@ -1,0 +1,18 @@
+/*
+ * Device tree overlay for spi-bcm2835
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2836", "brcm,bcm2708", "brcm,bcm2709";
+	/* setting up compatiblity to allow loading the spi-bcm2835 driver */
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+			compatible = "brcm,bcm2708-spi";
+		};
+	};
+};


### PR DESCRIPTION
… for dma
- make spi-bcm2835 the default driver for spi
- add a fallback spi-bcm2708 overlay
- add dma entries to device tree for future updates
- add default cs-gpios entry showing how to extend the number of chip-selects.

Signed-off-by: Martin Sperl kernel@martin.sperl.org
