### PR TITLE
BCM270x: Add USB controller to Device Tree

### DIFF
--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -121,6 +121,14 @@
 			status = "disabled";
 		};
 
+		usb: usb@7e980000 {
+			compatible = "brcm,bcm2708-usb";
+			reg = <0x7e980000 0x10000>,
+			      <0x7e006000 0x1000>;
+			interrupts = <2 0>,
+				     <1 9>;
+		};
+
 		leds: leds {
 			compatible = "gpio-leds";
 		};

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -955,7 +955,7 @@ void __init bcm2708_init(void)
 #endif
 	bcm_register_device(&bcm2708_systemtimer_device);
 	bcm_register_device_dt(&bcm2708_fb_device);
-	bcm_register_device(&bcm2708_usb_device);
+	bcm_register_device_dt(&bcm2708_usb_device);
 	bcm_register_device(&bcm2708_uart1_device);
 	bcm_register_device(&bcm2708_powerman_device);
 

--- a/arch/arm/mach-bcm2709/bcm2709.c
+++ b/arch/arm/mach-bcm2709/bcm2709.c
@@ -978,7 +978,7 @@ void __init bcm2709_init(void)
 	bcm_register_device(&bcm2708_systemtimer_device);
 #endif
 	bcm_register_device_dt(&bcm2708_fb_device);
-	bcm_register_device(&bcm2708_usb_device);
+	bcm_register_device_dt(&bcm2708_usb_device);
 	bcm_register_device(&bcm2708_uart1_device);
 	bcm_register_device(&bcm2708_powerman_device);
 

--- a/drivers/usb/host/dwc_otg/dwc_otg_driver.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_driver.c
@@ -1043,9 +1043,16 @@ static struct platform_device_id platform_ids[] = {
 };
 MODULE_DEVICE_TABLE(platform, platform_ids);
 
+static const struct of_device_id dwc_otg_of_match_table[] = {
+	{ .compatible = "brcm,bcm2708-usb", },
+	{},
+};
+MODULE_DEVICE_TABLE(of, dwc_otg_of_match_table);
+
 static struct platform_driver dwc_otg_driver = {
 	.driver = {
 		.name = (char *)dwc_driver_name,
+		.of_match_table = dwc_otg_of_match_table,
 		},
         .id_table = platform_ids,
 


### PR DESCRIPTION
Add Device Tree support to dwc_otg driver.
Add device to Device Tree.
Don't add platform devices when booting in DT mode.

Tested on Pi1 and Pi2 with and without DT.

Signed-off-by: Noralf Trønnes noralf@tronnes.org
