### PR TITLE
Add thermal sensor support to ARCH_BCM2835

### DIFF
--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -143,6 +143,10 @@
 			reg = <0x7e00b840 0xf>;
 			interrupts = <0 2>;
 		};
+
+		thermal: thermal {
+			compatible = "brcm,bcm2835-thermal";
+		};
 	};
 
 	clocks {

--- a/arch/arm/boot/dts/bcm2835.dtsi
+++ b/arch/arm/boot/dts/bcm2835.dtsi
@@ -170,6 +170,10 @@
 			reg = <0x7e00b840 0xf>;
 			interrupts = <0 2>;
 		};
+
+		thermal: thermal {
+			compatible = "brcm,bcm2835-thermal";
+		};
 	};
 
 	clocks {

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -984,7 +984,7 @@ void __init bcm2708_init(void)
 	}
 
 	bcm_register_device(&bcm2835_hwmon_device);
-	bcm_register_device(&bcm2835_thermal_device);
+	bcm_register_device_dt(&bcm2835_thermal_device);
 
 #if defined(CONFIG_SND_BCM2708_SOC_I2S) || defined(CONFIG_SND_BCM2708_SOC_I2S_MODULE)
 	bcm_register_device_dt(&bcm2708_i2s_device);

--- a/arch/arm/mach-bcm2709/bcm2709.c
+++ b/arch/arm/mach-bcm2709/bcm2709.c
@@ -1007,7 +1007,7 @@ void __init bcm2709_init(void)
 	}
 
 	bcm_register_device(&bcm2835_hwmon_device);
-	bcm_register_device(&bcm2835_thermal_device);
+	bcm_register_device_dt(&bcm2835_thermal_device);
 
 #if defined(CONFIG_SND_BCM2708_SOC_I2S) || defined(CONFIG_SND_BCM2708_SOC_I2S_MODULE)
 	bcm_register_device_dt(&bcm2708_i2s_device);

--- a/drivers/thermal/bcm2835-thermal.c
+++ b/drivers/thermal/bcm2835-thermal.c
@@ -167,13 +167,19 @@ static struct thermal_zone_device_ops ops  = {
 	.get_mode = bcm2835_get_mode,
 };
 
-/* Thermal Driver */
+static const struct of_device_id bcm2835_thermal_of_match_table[] = {
+	{ .compatible = "brcm,bcm2835-thermal", },
+	{},
+};
+MODULE_DEVICE_TABLE(of, bcm2835_thermal_of_match_table);
+
 static struct platform_driver bcm2835_thermal_driver = {
 	.probe = bcm2835_thermal_probe,
 	.remove = bcm2835_thermal_remove,
 	.driver = {
 				.name = "bcm2835_thermal",
 				.owner = THIS_MODULE,
+				.of_match_table = bcm2835_thermal_of_match_table,
 			},
 };
 


### PR DESCRIPTION
Tested on Pi1 and Pi2 with and without DT + ARCH_BCM2835.

```
$ cat /sys/class/thermal/thermal_zone0/temp
35780
```
