### PR TITLE
BCM270x: Make uart1 work with Device Tree

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
@@ -18,6 +18,7 @@
 		audio = &audio;
 		sound = &sound;
 		uart0 = &uart0;
+		uart1 = &uart1;
 		clocks = &clocks;
 	};
 

--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -18,6 +18,7 @@
 		audio = &audio;
 		sound = &sound;
 		uart0 = &uart0;
+		uart1 = &uart1;
 		clocks = &clocks;
 	};
 

--- a/arch/arm/boot/dts/bcm2708-rpi-cm.dtsi
+++ b/arch/arm/boot/dts/bcm2708-rpi-cm.dtsi
@@ -13,6 +13,7 @@
 		audio = &audio;
 		sound = &sound;
 		uart0 = &uart0;
+		uart1 = &uart1;
 		clocks = &clocks;
 	};
 

--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -134,6 +134,16 @@
 			status = "disabled";
 		};
 
+		uart1: uart@7e215040 {
+			compatible = "brcm,bcm2835-aux-uart", "ns16550";
+			reg = <0x7e215040 0x40>;
+			interrupts = <1 29>;
+			clock-frequency = <500000000>;
+			reg-shift = <2>;
+			no-loopback-test;
+			status = "disabled";
+	        };
+
 		i2c1: i2c@7e804000 {
 			compatible = "brcm,bcm2708-i2c";
 			reg = <0x7e804000 0x1000>;

--- a/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
@@ -18,6 +18,7 @@
 		audio = &audio;
 		sound = &sound;
 		uart0 = &uart0;
+		uart1 = &uart1;
 		clocks = &clocks;
 	};
 

--- a/arch/arm/mach-bcm2709/bcm2709.c
+++ b/arch/arm/mach-bcm2709/bcm2709.c
@@ -363,27 +363,6 @@ static struct platform_device bcm2708_fb_device = {
 		},
 };
 
-static struct plat_serial8250_port bcm2708_uart1_platform_data[] = {
-	{
-	 .mapbase = UART1_BASE + 0x40,
-	 .irq = IRQ_AUX,
-	 .uartclk = 125000000,
-	 .regshift = 2,
-	 .iotype = UPIO_MEM,
-	 .flags = UPF_FIXED_TYPE | UPF_IOREMAP | UPF_SKIP_TEST,
-	 .type = PORT_8250,
-	 },
-	{},
-};
-
-static struct platform_device bcm2708_uart1_device = {
-	.name = "serial8250",
-	.id = PLAT8250_DEV_PLATFORM,
-	.dev = {
-		.platform_data = bcm2708_uart1_platform_data,
-		},
-};
-
 static struct resource bcm2708_usb_resources[] = {
 	[0] = {
 	       .start = USB_BASE,
@@ -922,6 +901,17 @@ static void bcm2709_power_off(void)
 	}
 }
 
+static void __init bcm2709_init_uart1(void)
+{
+	struct device_node *np;
+
+	np = of_find_compatible_node(NULL, NULL, "brcm,bcm2835-aux-uart");
+	if (of_device_is_available(np)) {
+		pr_info("bcm2709: Mini UART enabled\n");
+		writel(1, __io_address(UART1_BASE + 0x4));
+	}
+}
+
 #ifdef CONFIG_OF
 static void __init bcm2709_dt_init(void)
 {
@@ -979,13 +969,13 @@ void __init bcm2709_init(void)
 #endif
 	bcm_register_device_dt(&bcm2708_fb_device);
 	bcm_register_device_dt(&bcm2708_usb_device);
-	bcm_register_device(&bcm2708_uart1_device);
 	bcm_register_device(&bcm2708_powerman_device);
 
 #ifdef CONFIG_MMC_BCM2835
 	bcm_register_device_dt(&bcm2835_emmc_device);
 #endif
 	bcm2709_init_led();
+	bcm2709_init_uart1();
 
 	/* Only create the platform devices for the ALSA driver in the
 	   absence of an enabled "audio" DT node */


### PR DESCRIPTION
Add uart1 to Device Tree. Enable it in AUXENB when it's used.
Remove old platform device.

This is how I have tested this on Pi1 and Pi2:

config

```
CONFIG_SERIAL_8250=y
CONFIG_SERIAL_8250_CONSOLE=y
CONFIG_SERIAL_OF_PLATFORM=y
```

DT overlay

```
/dts-v1/;
/plugin/;

/ {
    compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";

    fragment@0 {
        target = <&gpio>;
        __overlay__ {
            uart1_pins: uart1_pins {
                brcm,pins = <14 15>;
                brcm,function = <2>; /* alt5 */
            };
        };
    };

    fragment@1 {
        target = <&uart1>;
        __overlay__ {
            pinctrl-names = "default";
            pinctrl-0 = <&uart1_pins>;
            status = "okay";
        };
    };
};

```

Add to /boot/cmdline.txt

```
console=ttyS0,115200
```

dmesg

```
[    0.260750] bcm2708: Mini UART enabled
[...]
[    0.278795] Serial: AMBA PL011 UART driver
[    0.283324] 20201000.uart: ttyAMA0 at MMIO 0x20201000 (irq = 83, base_baud = 0) is a PL011 rev2
[    0.292376] console [ttyAMA0] enabled
[...]
[    1.191862] Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
[    1.201851] uart-pl011 20201000.uart: no DMA platform data
[    1.209983] console [ttyS0] disabled
[    1.215464] 20215040.uart: ttyS0 at MMIO 0x20215040 (irq = 29, base_baud = 31250000) is a 16550
[    1.901232] console [ttyS0] enabled
```

To get a login prompt on ttyS0, /etc/inittab would need some attention.
