### PR TITLE
BCM270X_DT: Enable 'make clean' on overlays directory

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -16,8 +16,6 @@ ifeq ($(CONFIG_ARCH_BCM2835),y)
    RPI_DT_OVERLAYS=y
 endif
 
-subdir-$(RPI_DT_OVERLAYS)  += overlays
-
 dtb-$(CONFIG_MACH_ASM9260) += \
 	alphascale-asm9260-devkit.dtb
 # Keep at91 dtb files sorted alphabetically for each SoC
@@ -676,3 +674,5 @@ clean-files	:= *.dtb
 ifeq ($(RPI_DT_OVERLAYS),y)
 	DTC_FLAGS ?= -@
 endif
+
+subdir-y  += overlays


### PR DESCRIPTION
Always add the overlays directory to subdir so it can be cleaned with 'make clean'.

Currently the overlays directory is not cleaned:

```
$ ARCH=arm CROSS_COMPILE=[...] make dtbs

$ ARCH=arm make clean
  CLEAN   .
  CLEAN   arch/arm/boot/dts
  CLEAN   .tmp_versions
```

Workaround:

```
$ ARCH=arm RPI_DT_OVERLAYS=y CONFIG_OF=y make clean
  CLEAN   .
  CLEAN   arch/arm/boot/dts/overlays
  CLEAN   arch/arm/boot/dts
  CLEAN   .tmp_versions
```

With this PR it behaves as expected:

```
$ ARCH=arm CROSS_COMPILE=[...] make dtbs
[...]
  DTC     arch/arm/boot/dts/overlays/ads7846-overlay.dtb
[...]
  DTC     arch/arm/boot/dts/overlays/w1-gpio-pullup-overlay.dtb
  DTC     arch/arm/boot/dts/bcm2708-rpi-b.dtb
  DTC     arch/arm/boot/dts/bcm2708-rpi-b-plus.dtb
  DTC     arch/arm/boot/dts/bcm2708-rpi-cm.dtb

$ ARCH=arm make clean
  CLEAN   .
  CLEAN   arch/arm/boot/dts/overlays
  CLEAN   arch/arm/boot/dts
  CLEAN   .tmp_versions
```
