### PR TITLE
BCM2835-V4L2: Return buffers to videobuf2 on shutdown

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-camera.c
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.c
@@ -390,6 +390,7 @@ static void buffer_cb(struct vchiq_mmal_instance *instance,
 			}
 		} else {
 			/* signal frame completion */
+			vb2_buffer_done(&buf->vb, VB2_BUF_STATE_ERROR);
 			complete(&dev->capture.frame_cmplt);
 		}
 	}


### PR DESCRIPTION
https://github.com/raspberrypi/linux/issues/817
Fixes the kernel warning from videobuf2 as buffers
are now returned as they are being flushed on
stop_streaming.

Signed-off-by: Dave Stevenson 6by9@users.noreply.github.com
