### PR TITLE
BCM2835_V4L2: Add support for V4L2_EXPOSURE_METERING_MATRIX

### DIFF
--- a/drivers/media/platform/bcm2835/controls.c
+++ b/drivers/media/platform/bcm2835/controls.c
@@ -384,11 +384,9 @@ static int ctrl_set_metering_mode(struct bm2835_mmal_dev *dev,
 		dev->metering_mode = MMAL_PARAM_EXPOSUREMETERINGMODE_SPOT;
 		break;
 
-	/* todo matrix weighting not added to Linux API till 3.9
 	case V4L2_EXPOSURE_METERING_MATRIX:
 		dev->metering_mode = MMAL_PARAM_EXPOSUREMETERINGMODE_MATRIX;
 		break;
-	*/
 
 	}
 
@@ -1006,7 +1004,7 @@ static const struct bm2835_mmal_v4l2_ctrl v4l2_ctrls[V4L2_CTRL_COUNT] = {
 	{
 		V4L2_CID_EXPOSURE_METERING,
 		MMAL_CONTROL_TYPE_STD_MENU,
-		~0x7, 2, V4L2_EXPOSURE_METERING_AVERAGE, 0, NULL,
+		~0xF, 3, V4L2_EXPOSURE_METERING_AVERAGE, 0, NULL,
 		MMAL_PARAMETER_EXP_METERING_MODE,
 		&ctrl_set_metering_mode,
 		false


### PR DESCRIPTION
It wasn't added originally as the enum was only added in
kernel 3.9. Enable it.

Signed-off-by: Dave Stevenson 6by9@users.noreply.github.com
