### PR TITLE
bcm2708-dmaengine: Fix memory leak when stopping a running transfer

### DIFF
--- a/drivers/dma/bcm2708-dmaengine.c
+++ b/drivers/dma/bcm2708-dmaengine.c
@@ -964,6 +964,7 @@ static int bcm2835_dma_terminate_all(struct dma_chan *chan)
 	 * c->desc is NULL and exit.)
 	 */
 	if (c->desc) {
+		bcm2835_dma_desc_free(&c->desc->vd);
 		c->desc = NULL;
 		bcm2835_dma_abort(c->chan_base);
 


### PR DESCRIPTION
This patch fixes a memory leak already fixed in upstream drivers (see f93178291712772983845700b12fc1c8b32f2eb1 for the fix and 0a4812798fae4f6bfcaab51e31b3898ff5ea3108 for the merge).
