### PR TITLE
Fix for PCM register ranges in device trees

### DIFF
--- a/arch/arm/boot/dts/bcm2708.dtsi
+++ b/arch/arm/boot/dts/bcm2708.dtsi
@@ -49,8 +49,8 @@
 
 		i2s: i2s@7e203000 {
 			compatible = "brcm,bcm2708-i2s";
-			reg = <0x7e203000 0x20>,
-			      <0x7e101098 0x02>;
+			reg = <0x7e203000 0x24>,
+			      <0x7e101098 0x08>;
 
 			//dmas = <&dma 2>,
 			//       <&dma 3>;

--- a/arch/arm/boot/dts/bcm2709.dtsi
+++ b/arch/arm/boot/dts/bcm2709.dtsi
@@ -49,8 +49,8 @@
 
 		i2s: i2s@7e203000 {
 			compatible = "brcm,bcm2708-i2s";
-			reg = <0x7e203000 0x20>,
-			      <0x7e101098 0x02>;
+			reg = <0x7e203000 0x24>,
+			      <0x7e101098 0x08>;
 
 			//dmas = <&dma 2>,
 			//       <&dma 3>;

--- a/arch/arm/boot/dts/bcm2835.dtsi
+++ b/arch/arm/boot/dts/bcm2835.dtsi
@@ -93,8 +93,8 @@
 
 		i2s: i2s@7e203000 {
 			compatible = "brcm,bcm2835-i2s";
-			reg = <0x7e203000 0x20>,
-			      <0x7e101098 0x02>;
+			reg = <0x7e203000 0x24>,
+			      <0x7e101098 0x08>;
 
 			dmas = <&dma 2>,
 			       <&dma 3>;


### PR DESCRIPTION
There are two minor issues with the current device trees:
1. the `PCM_GRAY` register is not included in the 0x7e203000 range; and
2. the range starting at 0x7e101098 should probably be 8 bytes long, not 2 bytes (I couldn't find any documentation for this memory area, but the code suggests so).

Excerpt of `/proc/iomem` in current version (tested with `bcm2708.dtsi`):

```
20101098-20101099 : /soc/i2s@7e203000
20203000-2020301f : /soc/i2s@7e203000
```

Excerpt of `/proc/iomem` with this change applied:

```
20101098-2010109f : /soc/i2s@7e203000
20203000-20203023 : /soc/i2s@7e203000
```

This is probably not causing any problems at all, but I just noticed it while reading the RPi I2S driver.

Please let me know if I should submit these patches on some other branch.
