### PR TITLE
BCM270X_DT: mz61581: Revert to spi-bcm2708

### DIFF
--- a/arch/arm/boot/dts/overlays/mz61581-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mz61581-overlay.dts
@@ -12,6 +12,8 @@
 	fragment@0 {
 		target = <&spi0>;
 		__overlay__ {
+			/* does not work with spi-bcm2835 using software chip selects */
+			compatible = "brcm,bcm2708-spi";
 			status = "okay";
 
 			spidev@0{

--- a/drivers/staging/fbtft/fbtft-core.c
+++ b/drivers/staging/fbtft/fbtft-core.c
@@ -1086,6 +1086,11 @@ static int fbtft_init_display_dt(struct fbtft_par *par)
 	p = of_prop_next_u32(prop, NULL, &val);
 	if (!p)
 		return -EINVAL;
+
+	par->fbtftops.reset(par);
+	if (par->gpio.cs != -1)
+		gpio_set_value(par->gpio.cs, 0);  /* Activate chip */
+
 	while (p) {
 		if (val & FBTFT_OF_INIT_CMD) {
 			val &= 0xFFFF;


### PR DESCRIPTION
The MZ61581 display does not work with spi-bcm2835 and software chip selects. It works before the commit: spi: bcm2835: transform native-cs to gpio-cs on first spi_setup

Revert to spi-bcm2708 until the cause has been detected and the issue resolved.

Also increase reliability by adding a patch for missing display controller reset.
This fbtft patch is now in linux-next and will probably land in 4.3.
