### PR TITLE
vchiq, fbdev, thermal, cpufreq: Use the new firmware API

### DIFF
--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -225,6 +225,7 @@
 			reg = <0x7e00b840 0xf>;
 			interrupts = <0 2>;
 			cache-line-size = <32>;
+			firmware = <&firmware>;
 		};
 
 		thermal: thermal {

--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -230,6 +230,7 @@
 
 		thermal: thermal {
 			compatible = "brcm,bcm2835-thermal";
+			firmware = <&firmware>;
 		};
 	};
 

--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -217,6 +217,7 @@
 
 		fb: fb {
 			compatible = "brcm,bcm2708-fb";
+			firmware = <&firmware>;
 			status = "disabled";
 		};
 

--- a/arch/arm/boot/dts/bcm2835-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2835-rpi.dtsi
@@ -32,6 +32,24 @@
 			compatible = "raspberrypi,bcm2835-firmware";
 			mboxes = <&mailbox>;
 		};
+
+		fb: fb {
+			compatible = "brcm,bcm2708-fb";
+			firmware = <&firmware>;
+		};
+
+		thermal: thermal {
+			compatible = "brcm,bcm2835-thermal";
+			firmware = <&firmware>;
+		};
+
+		vchiq: vchiq {
+			compatible = "brcm,bcm2835-vchiq";
+			reg = <0x7e00b840 0xf>;
+			interrupts = <0 2>;
+			cache-line-size = <32>;
+			firmware = <&firmware>;
+		};
 	};
 
 	/* Onboard audio */
@@ -99,10 +117,6 @@
 &mmc {
 	status = "okay";
 	bus-width = <4>;
-};
-
-&fb {
-	status = "okay";
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2835.dtsi
+++ b/arch/arm/boot/dts/bcm2835.dtsi
@@ -160,21 +160,6 @@
 		arm-pmu {
 			compatible = "arm,arm1176-pmu";
 		};
-
-		fb: fb {
-			compatible = "brcm,bcm2708-fb";
-			status = "disabled";
-		};
-
-		vchiq: vchiq {
-			compatible = "brcm,bcm2835-vchiq";
-			reg = <0x7e00b840 0xf>;
-			interrupts = <0 2>;
-		};
-
-		thermal: thermal {
-			compatible = "brcm,bcm2835-thermal";
-		};
 	};
 
 	clocks {

--- a/drivers/cpufreq/bcm2835-cpufreq.c
+++ b/drivers/cpufreq/bcm2835-cpufreq.c
@@ -26,7 +26,7 @@
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/cpufreq.h>
-#include <linux/platform_data/mailbox-bcm2708.h>
+#include <soc/bcm2835/raspberrypi-firmware.h>
 
 /* ---------- DEFINES ---------- */
 /*#define CPUFREQ_DEBUG_ENABLE*/		/* enable debugging */
@@ -43,23 +43,6 @@
 #define print_err(fmt,...) pr_err("%s:%s:%d: "fmt, MODULE_NAME, __func__,__LINE__, ##__VA_ARGS__)
 #define print_info(fmt,...) pr_info("%s: "fmt, MODULE_NAME, ##__VA_ARGS__)
 
-/* tag part of the message */
-struct vc_msg_tag {
-	uint32_t tag_id;		/* the message id */
-	uint32_t buffer_size;		/* size of the buffer (which in this case is always 8 bytes) */
-	uint32_t data_size;		/* amount of data being sent or received */
-	uint32_t dev_id;		/* the ID of the clock/voltage to get or set */
-	uint32_t val;			/* the value (e.g. rate (in Hz)) to set */
-};
-
-/* message structure to be sent to videocore */
-struct vc_msg {
-	uint32_t msg_size;		/* simply, sizeof(struct vc_msg) */
-	uint32_t request_code;		/* holds various information like the success and number of bytes returned (refer to mailboxes wiki) */
-	struct vc_msg_tag tag;		/* the tag structure above to make */
-	uint32_t end_tag;		/* an end identifier, should be set to NULL */
-};
-
 /* ---------- GLOBALS ---------- */
 static struct cpufreq_driver bcm2835_cpufreq_driver;	/* the cpufreq driver global */
 
@@ -74,62 +57,63 @@ static struct cpufreq_frequency_table bcm2835_freq_table[] = {
   clk_rate either gets or sets the clock rates.
  ===============================================
 */
+
+static int bcm2835_cpufreq_clock_property(u32 tag, u32 id, u32 *val)
+{
+	struct rpi_firmware *fw = rpi_firmware_get(NULL);
+	struct {
+		u32 id;
+		u32 val;
+	} packet;
+	int ret;
+
+	packet.id = id;
+	packet.val = *val;
+	ret = rpi_firmware_property(fw, tag, &packet, sizeof(packet));
+	if (ret)
+		return ret;
+
+	*val = packet.val;
+
+	return 0;
+}
+
 static uint32_t bcm2835_cpufreq_set_clock(int cur_rate, int arm_rate)
 {
-	int s, actual_rate=0;
-	struct vc_msg msg;
+	u32 rate = arm_rate * 1000;
+	int ret;
 
-	/* wipe all previous message data */
-	memset(&msg, 0, sizeof msg);
+	ret = bcm2835_cpufreq_clock_property(RPI_FIRMWARE_SET_CLOCK_RATE, VCMSG_ID_ARM_CLOCK, &rate);
+	if (ret) {
+		print_err("Failed to set clock: %d (%d)\n", arm_rate, ret);
+		return 0;
+	}
 
-	msg.msg_size = sizeof msg;
+	rate /= 1000;
+	print_debug("Setting new frequency = %d -> %d (actual %d)\n", cur_rate, arm_rate, rate);
 
-	msg.tag.tag_id = VCMSG_SET_CLOCK_RATE;
-	msg.tag.buffer_size = 8;
-	msg.tag.data_size = 8;   /* we're sending the clock ID and the new rates which is a total of 2 words */
-	msg.tag.dev_id = VCMSG_ID_ARM_CLOCK;
-	msg.tag.val = arm_rate * 1000;
-
-	/* send the message */
-	s = bcm_mailbox_property(&msg, sizeof msg);
-
-	/* check if it was all ok and return the rate in KHz */
-	if (s == 0 && (msg.request_code & 0x80000000))
-		actual_rate = msg.tag.val/1000;
-
-	print_debug("Setting new frequency = %d -> %d (actual %d)\n", cur_rate, arm_rate, actual_rate);
-	return actual_rate;
+	return rate;
 }
 
 static uint32_t bcm2835_cpufreq_get_clock(int tag)
 {
-	int s;
-	int arm_rate = 0;
-	struct vc_msg msg;
+	u32 rate;
+	int ret;
 
-	/* wipe all previous message data */
-	memset(&msg, 0, sizeof msg);
+	ret = bcm2835_cpufreq_clock_property(tag, VCMSG_ID_ARM_CLOCK, &rate);
+	if (ret) {
+		print_err("Failed to get clock (%d)\n", ret);
+		return 0;
+	}
 
-	msg.msg_size = sizeof msg;
-	msg.tag.tag_id = tag;
-	msg.tag.buffer_size = 8;
-	msg.tag.data_size = 4; /* we're just sending the clock ID which is one word long */
-	msg.tag.dev_id = VCMSG_ID_ARM_CLOCK;
+	rate /= 1000;
+	print_debug("%s frequency = %u\n",
+		tag == RPI_FIRMWARE_GET_CLOCK_RATE ? "Current":
+		tag == RPI_FIRMWARE_GET_MIN_CLOCK_RATE ? "Min":
+		tag == RPI_FIRMWARE_GET_MAX_CLOCK_RATE ? "Max":
+		"Unexpected", rate);
 
-	/* send the message */
-	s = bcm_mailbox_property(&msg, sizeof msg);
-
-	/* check if it was all ok and return the rate in KHz */
-	if (s == 0 && (msg.request_code & 0x80000000))
-		arm_rate = msg.tag.val/1000;
-
-	print_debug("%s frequency = %d\n",
-		tag == VCMSG_GET_CLOCK_RATE ? "Current":
-		tag == VCMSG_GET_MIN_CLOCK ? "Min":
-		tag == VCMSG_GET_MAX_CLOCK ? "Max":
-		"Unexpected", arm_rate);
-
-	return arm_rate;
+	return rate;
 }
 
 /*
@@ -165,9 +149,14 @@ static int bcm2835_cpufreq_driver_init(struct cpufreq_policy *policy)
 	/* measured value of how long it takes to change frequency */
 	const unsigned int transition_latency = 355000; /* ns */
 
+	if (!rpi_firmware_get(NULL)) {
+		print_err("Firmware is not available\n");
+		return -ENODEV;
+	}
+
 	/* now find out what the maximum and minimum frequencies are */
-	bcm2835_freq_table[0].frequency = bcm2835_cpufreq_get_clock(VCMSG_GET_MIN_CLOCK);
-	bcm2835_freq_table[1].frequency = bcm2835_cpufreq_get_clock(VCMSG_GET_MAX_CLOCK);
+	bcm2835_freq_table[0].frequency = bcm2835_cpufreq_get_clock(RPI_FIRMWARE_GET_MIN_CLOCK_RATE);
+	bcm2835_freq_table[1].frequency = bcm2835_cpufreq_get_clock(RPI_FIRMWARE_GET_MAX_CLOCK_RATE);
 
 	print_info("min=%d max=%d\n", bcm2835_freq_table[0].frequency, bcm2835_freq_table[1].frequency);
 	return cpufreq_generic_init(policy, bcm2835_freq_table, transition_latency);
@@ -201,8 +190,8 @@ static int bcm2835_cpufreq_driver_target_index(struct cpufreq_policy *policy, un
 
 static unsigned int bcm2835_cpufreq_driver_get(unsigned int cpu)
 {
-	unsigned int actual_rate = bcm2835_cpufreq_get_clock(VCMSG_GET_CLOCK_RATE);
-	print_debug("%d: freq=%d\n", cpu, actual_rate);
+	unsigned int actual_rate = bcm2835_cpufreq_get_clock(RPI_FIRMWARE_GET_CLOCK_RATE);
+	print_debug("cpu%d: freq=%d\n", cpu, actual_rate);
 	return actual_rate <= bcm2835_freq_table[0].frequency ? bcm2835_freq_table[0].frequency : bcm2835_freq_table[1].frequency;
 }
 

--- a/drivers/thermal/bcm2835-thermal.c
+++ b/drivers/thermal/bcm2835-thermal.c
@@ -12,160 +12,112 @@
 * consent.
 *****************************************************************************/
 
-#include <linux/kernel.h>
 #include <linux/module.h>
-#include <linux/init.h>
-#include <linux/platform_data/mailbox-bcm2708.h>
 #include <linux/platform_device.h>
-#include <linux/slab.h>
-#include <linux/sysfs.h>
 #include <linux/thermal.h>
+#include <soc/bcm2835/raspberrypi-firmware.h>
 
-
-/* --- DEFINITIONS --- */
-#define MODULE_NAME "bcm2835_thermal"
-
-/*#define THERMAL_DEBUG_ENABLE*/
-
-#ifdef THERMAL_DEBUG_ENABLE
-#define print_debug(fmt,...) printk(KERN_INFO "%s:%s:%d: "fmt"\n", MODULE_NAME, __func__, __LINE__, ##__VA_ARGS__)
-#else
-#define print_debug(fmt,...)
-#endif
-#define print_err(fmt,...) printk(KERN_ERR "%s:%s:%d: "fmt"\n", MODULE_NAME, __func__,__LINE__, ##__VA_ARGS__)
-
-#define VC_TAG_GET_TEMP 0x00030006
-#define VC_TAG_GET_MAX_TEMP 0x0003000A
-
-typedef enum {
-	TEMP,
-	MAX_TEMP,
-} temp_type;
-
-/* --- STRUCTS --- */
-/* tag part of the message */
-struct vc_msg_tag {
-	uint32_t tag_id;		/* the tag ID for the temperature */
-	uint32_t buffer_size;	/* size of the buffer (should be 8) */
-	uint32_t request_code;	/* identifies message as a request (should be 0) */
-	uint32_t id;			/* extra ID field (should be 0) */
-	uint32_t val;			/* returned value of the temperature */
-};
-
-/* message structure to be sent to videocore */
-struct vc_msg {
-	uint32_t msg_size;		/* simply, sizeof(struct vc_msg) */
-	uint32_t request_code;		/* holds various information like the success and number of bytes returned (refer to mailboxes wiki) */
-	struct vc_msg_tag tag;		/* the tag structure above to make */
-	uint32_t end_tag;		/* an end identifier, should be set to NULL */
-};
-
-struct bcm2835_thermal_data {
-	struct thermal_zone_device *thermal_dev;
-	struct vc_msg msg;
-};
-
-/* --- GLOBALS --- */
-static struct bcm2835_thermal_data bcm2835_data;
-
-/* Thermal Device Operations */
-static struct thermal_zone_device_ops ops;
-
-/* --- FUNCTIONS --- */
-
-static int bcm2835_get_temp_or_max(struct thermal_zone_device *thermal_dev, unsigned long *temp, unsigned tag_id)
+static int bcm2835_thermal_get_property(struct thermal_zone_device *tz,
+					unsigned long *temp, u32 tag)
 {
-	int result = -1, retry = 3;
-	print_debug("IN");
+	struct rpi_firmware *fw = tz->devdata;
+	struct {
+		u32 id;
+		u32 val;
+	} packet;
+	int ret;
 
 	*temp = 0;
-	while (result != 0 && retry-- > 0) {
-		/* wipe all previous message data */
-		memset(&bcm2835_data.msg, 0, sizeof bcm2835_data.msg);
-
-		/* prepare message */
-		bcm2835_data.msg.msg_size = sizeof bcm2835_data.msg;
-		bcm2835_data.msg.tag.buffer_size = 8;
-		bcm2835_data.msg.tag.tag_id = tag_id;
-
-		/* send the message */
-		result = bcm_mailbox_property(&bcm2835_data.msg, sizeof bcm2835_data.msg);
-		print_debug("Got %stemperature as %u (%d,%x)\n", tag_id==VC_TAG_GET_MAX_TEMP ? "max ":"", (uint)bcm2835_data.msg.tag.val, result, bcm2835_data.msg.request_code);
-		if (!(bcm2835_data.msg.request_code & 0x80000000))
-			result = -1;
+	packet.id = 0;
+	ret = rpi_firmware_property(fw, tag, &packet, sizeof(packet));
+	if (ret) {
+		dev_err(&tz->device, "Failed to get temperature\n");
+		return ret;
 	}
 
-	/* check if it was all ok and return the rate in milli degrees C */
-	if (result == 0)
-		*temp = (uint)bcm2835_data.msg.tag.val;
-	else
-		print_err("Failed to get temperature! (%x:%d)\n", tag_id, result);
-	print_debug("OUT");
-	return result;
-}
+	*temp = packet.val;
+	dev_dbg(&tz->device, "%stemp=%lu\n",
+		tag == RPI_FIRMWARE_GET_MAX_TEMPERATURE ? "max" : "", *temp);
 
-static int bcm2835_get_temp(struct thermal_zone_device *thermal_dev, unsigned long *temp)
-{
-	return bcm2835_get_temp_or_max(thermal_dev, temp, VC_TAG_GET_TEMP);
-}
-
-static int bcm2835_get_max_temp(struct thermal_zone_device *thermal_dev, int trip_num, unsigned long *temp)
-{
-	return bcm2835_get_temp_or_max(thermal_dev, temp, VC_TAG_GET_MAX_TEMP);
-}
-
-static int bcm2835_get_trip_type(struct thermal_zone_device * thermal_dev, int trip_num, enum thermal_trip_type *trip_type)
-{
-	*trip_type = THERMAL_TRIP_HOT;
 	return 0;
 }
 
-
-static int bcm2835_get_mode(struct thermal_zone_device *thermal_dev, enum thermal_device_mode *dev_mode)
+static int bcm2835_thermal_get_temp(struct thermal_zone_device *tz,
+				    unsigned long *temp)
 {
-	*dev_mode = THERMAL_DEVICE_ENABLED;
+	return bcm2835_thermal_get_property(tz, temp,
+					    RPI_FIRMWARE_GET_TEMPERATURE);
+}
+
+static int bcm2835_thermal_get_max_temp(struct thermal_zone_device *tz,
+					int trip, unsigned long *temp)
+{
+	/*
+	 * The maximum safe temperature of the SoC.
+	 * Overclock may be disabled above this temperature.
+	 */
+	return bcm2835_thermal_get_property(tz, temp,
+					    RPI_FIRMWARE_GET_MAX_TEMPERATURE);
+}
+
+static int bcm2835_thermal_get_trip_type(struct thermal_zone_device *tz,
+					 int trip, enum thermal_trip_type *type)
+{
+	*type = THERMAL_TRIP_HOT;
+
 	return 0;
 }
 
-
-static int bcm2835_thermal_probe(struct platform_device *pdev)
+static int bcm2835_thermal_get_mode(struct thermal_zone_device *tz,
+				    enum thermal_device_mode *mode)
 {
-	print_debug("IN");
-	print_debug("THERMAL Driver has been probed!");
-
-	/* check that the device isn't null!*/
-	if(pdev == NULL)
-	{
-		print_debug("Platform device is empty!");
-		return -ENODEV;
-	}
-
-	if(!(bcm2835_data.thermal_dev = thermal_zone_device_register("bcm2835_thermal",  1, 0, NULL, &ops, NULL, 0, 0)))
-	{
-		print_debug("Unable to register the thermal device!");
-		return -EFAULT;
-	}
-	return 0;
-}
-
-
-static int bcm2835_thermal_remove(struct platform_device *pdev)
-{
-	print_debug("IN");
-
-	thermal_zone_device_unregister(bcm2835_data.thermal_dev);
-
-	print_debug("OUT");
+	*mode = THERMAL_DEVICE_ENABLED;
 
 	return 0;
 }
 
 static struct thermal_zone_device_ops ops  = {
-	.get_temp = bcm2835_get_temp,
-	.get_trip_temp = bcm2835_get_max_temp,
-	.get_trip_type = bcm2835_get_trip_type,
-	.get_mode = bcm2835_get_mode,
+	.get_temp = bcm2835_thermal_get_temp,
+	.get_trip_temp = bcm2835_thermal_get_max_temp,
+	.get_trip_type = bcm2835_thermal_get_trip_type,
+	.get_mode = bcm2835_thermal_get_mode,
 };
+
+static int bcm2835_thermal_probe(struct platform_device *pdev)
+{
+	struct device_node *fw_np;
+	struct rpi_firmware *fw;
+	struct thermal_zone_device *tz;
+
+	fw_np = of_parse_phandle(pdev->dev.of_node, "firmware", 0);
+/* Remove comment when booting without Device Tree is no longer supported
+	if (!fw_np) {
+		dev_err(&pdev->dev, "Missing firmware node\n");
+		return -ENOENT;
+	}
+*/
+	fw = rpi_firmware_get(fw_np);
+	if (!fw)
+		return -EPROBE_DEFER;
+
+	tz = thermal_zone_device_register("bcm2835_thermal", 1, 0, fw, &ops,
+					  NULL, 0, 0);
+	if (IS_ERR(tz)) {
+		dev_err(&pdev->dev, "Failed to register the thermal device\n");
+		return PTR_ERR(tz);
+	}
+
+	platform_set_drvdata(pdev, tz);
+
+	return 0;
+}
+
+static int bcm2835_thermal_remove(struct platform_device *pdev)
+{
+	thermal_zone_device_unregister(platform_get_drvdata(pdev));
+
+	return 0;
+}
 
 static const struct of_device_id bcm2835_thermal_of_match_table[] = {
 	{ .compatible = "brcm,bcm2835-thermal", },
@@ -177,14 +129,13 @@ static struct platform_driver bcm2835_thermal_driver = {
 	.probe = bcm2835_thermal_probe,
 	.remove = bcm2835_thermal_remove,
 	.driver = {
-				.name = "bcm2835_thermal",
-				.owner = THIS_MODULE,
-				.of_match_table = bcm2835_thermal_of_match_table,
-			},
+		.name = "bcm2835_thermal",
+		.of_match_table = bcm2835_thermal_of_match_table,
+	},
 };
-
-MODULE_LICENSE("GPL");
-MODULE_AUTHOR("Dorian Peake");
-MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
-
 module_platform_driver(bcm2835_thermal_driver);
+
+MODULE_AUTHOR("Dorian Peake");
+MODULE_AUTHOR("Noralf Trønnes");
+MODULE_DESCRIPTION("Thermal driver for bcm2835 chip");
+MODULE_LICENSE("GPL");

--- a/drivers/video/fbdev/bcm2708_fb.c
+++ b/drivers/video/fbdev/bcm2708_fb.c
@@ -25,7 +25,6 @@
 #include <linux/ioport.h>
 #include <linux/list.h>
 #include <linux/platform_data/dma-bcm2708.h>
-#include <linux/platform_data/mailbox-bcm2708.h>
 #include <linux/platform_device.h>
 #include <linux/clk.h>
 #include <linux/printk.h>
@@ -34,6 +33,7 @@
 #include <asm/sizes.h>
 #include <linux/io.h>
 #include <linux/dma-mapping.h>
+#include <soc/bcm2835/raspberrypi-firmware.h>
 
 //#define BCM2708_FB_DEBUG
 #define MODULE_NAME "bcm2708_fb"
@@ -58,15 +58,19 @@ static u32 dma_busy_wait_threshold = 1<<15;
 module_param(dma_busy_wait_threshold, int, 0644);
 MODULE_PARM_DESC(dma_busy_wait_threshold, "Busy-wait for DMA completion below this area");
 
-/* this data structure describes each frame buffer device we find */
-
-struct fbinfo_s {
-	u32 xres, yres, xres_virtual, yres_virtual;
-	u32 pitch, bpp;
+struct fb_alloc_tags {
+	struct rpi_firmware_property_tag_header tag1;
+	u32 xres, yres;
+	struct rpi_firmware_property_tag_header tag2;
+	u32 xres_virtual, yres_virtual;
+	struct rpi_firmware_property_tag_header tag3;
+	u32 bpp;
+	struct rpi_firmware_property_tag_header tag4;
 	u32 xoffset, yoffset;
-	u32 base;
-	u32 screen_size;
-	u16 cmap[256];
+	struct rpi_firmware_property_tag_header tag5;
+	u32 base, screen_size;
+	struct rpi_firmware_property_tag_header tag6;
+	u32 pitch;
 };
 
 struct bcm2708_fb_stats {
@@ -78,9 +82,9 @@ struct bcm2708_fb_stats {
 struct bcm2708_fb {
 	struct fb_info fb;
 	struct platform_device *dev;
-	struct fbinfo_s *info;
-	dma_addr_t dma;
+	struct rpi_firmware *fw;
 	u32 cmap[16];
+	u32 gpu_cmap[256];
 	int dma_chan;
 	int dma_irq;
 	void __iomem *dma_chan_base;
@@ -270,69 +274,71 @@ static int bcm2708_fb_check_var(struct fb_var_screeninfo *var,
 
 static int bcm2708_fb_set_par(struct fb_info *info)
 {
-	uint32_t val = 0;
 	struct bcm2708_fb *fb = to_bcm2708(info);
-	volatile struct fbinfo_s *fbinfo = fb->info;
-	fbinfo->xres = info->var.xres;
-	fbinfo->yres = info->var.yres;
-	fbinfo->xres_virtual = info->var.xres_virtual;
-	fbinfo->yres_virtual = info->var.yres_virtual;
-	fbinfo->bpp = info->var.bits_per_pixel;
-	fbinfo->xoffset = info->var.xoffset;
-	fbinfo->yoffset = info->var.yoffset;
-	fbinfo->base = 0;	/* filled in by VC */
-	fbinfo->pitch = 0;	/* filled in by VC */
+	struct fb_alloc_tags fbinfo = {
+		.tag1 = { RPI_FIRMWARE_FRAMEBUFFER_SET_PHYSICAL_WIDTH_HEIGHT,
+			  8, 0, },
+			.xres = info->var.xres,
+			.yres = info->var.yres,
+		.tag2 = { RPI_FIRMWARE_FRAMEBUFFER_SET_VIRTUAL_WIDTH_HEIGHT,
+			  8, 0, },
+			.xres_virtual = info->var.xres_virtual,
+			.yres_virtual = info->var.yres_virtual,
+		.tag3 = { RPI_FIRMWARE_FRAMEBUFFER_SET_DEPTH, 4, 0 },
+			.bpp = info->var.bits_per_pixel,
+		.tag4 = { RPI_FIRMWARE_FRAMEBUFFER_SET_VIRTUAL_OFFSET, 8, 0 },
+			.xoffset = info->var.xoffset,
+			.yoffset = info->var.yoffset,
+		.tag5 = { RPI_FIRMWARE_FRAMEBUFFER_ALLOCATE, 8, 0 },
+			.base = 0,
+			.screen_size = 0,
+		.tag6 = { RPI_FIRMWARE_FRAMEBUFFER_GET_PITCH, 4, 0 },
+			.pitch = 0,
+	};
+	int ret;
 
 	print_debug("bcm2708_fb_set_par info(%p) %dx%d (%dx%d), %d, %d\n", info,
 		info->var.xres, info->var.yres, info->var.xres_virtual,
 		info->var.yres_virtual, (int)info->screen_size,
 		info->var.bits_per_pixel);
 
-	/* ensure last write to fbinfo is visible to GPU */
-	wmb();
-
-	/* inform vc about new framebuffer */
-	bcm_mailbox_write(MBOX_CHAN_FB, fb->dma);
-
-	/* TODO: replace fb driver with vchiq version */
-	/* wait for response */
-	bcm_mailbox_read(MBOX_CHAN_FB, &val);
-
-	/* ensure GPU writes are visible to us */
-	rmb();
-
-        if (val == 0) {
-		fb->fb.fix.line_length = fbinfo->pitch;
-
-		if (info->var.bits_per_pixel <= 8)
-			fb->fb.fix.visual = FB_VISUAL_PSEUDOCOLOR;
-		else
-			fb->fb.fix.visual = FB_VISUAL_TRUECOLOR;
-
-		fb->fb_bus_address = fbinfo->base;
-		fbinfo->base &= ~0xc0000000;
-		fb->fb.fix.smem_start = fbinfo->base;
-		fb->fb.fix.smem_len = fbinfo->pitch * fbinfo->yres_virtual;
-		fb->fb.screen_size = fbinfo->screen_size;
-		if (fb->fb.screen_base)
-			iounmap(fb->fb.screen_base);
-		fb->fb.screen_base =
-			(void *)ioremap_wc(fbinfo->base, fb->fb.screen_size);
-		if (!fb->fb.screen_base) {
-			/* the console may currently be locked */
-			console_trylock();
-			console_unlock();
-			pr_err("bcm2708_fb_set_par: Failed to set screen_base\n");
-			return -EIO;
-		}
+	ret = rpi_firmware_property_list(fb->fw, &fbinfo, sizeof(fbinfo));
+	if (ret) {
+		dev_err(info->device,
+			"Failed to allocate GPU framebuffer (%d)\n", ret);
+		return ret;
 	}
-	print_debug
-	    ("BCM2708FB: start = %p,%p width=%d, height=%d, bpp=%d, pitch=%d size=%d success=%d\n",
-	     (void *)fb->fb.screen_base, (void *)fb->fb_bus_address,
-	     fbinfo->xres, fbinfo->yres, fbinfo->bpp,
-	     fbinfo->pitch, (int)fb->fb.screen_size, val);
 
-	return val;
+	if (info->var.bits_per_pixel <= 8)
+		fb->fb.fix.visual = FB_VISUAL_PSEUDOCOLOR;
+	else
+		fb->fb.fix.visual = FB_VISUAL_TRUECOLOR;
+
+	fb->fb.fix.line_length = fbinfo.pitch;
+	fbinfo.base |= 0x40000000;
+	fb->fb_bus_address = fbinfo.base;
+	fbinfo.base &= ~0xc0000000;
+	fb->fb.fix.smem_start = fbinfo.base;
+	fb->fb.fix.smem_len = fbinfo.pitch * fbinfo.yres_virtual;
+	fb->fb.screen_size = fbinfo.screen_size;
+	if (fb->fb.screen_base)
+		iounmap(fb->fb.screen_base);
+	fb->fb.screen_base = ioremap_wc(fbinfo.base, fb->fb.screen_size);
+	if (!fb->fb.screen_base) {
+		/* the console may currently be locked */
+		console_trylock();
+		console_unlock();
+		dev_err(info->device, "Failed to set screen_base\n");
+		return -ENOMEM;
+	}
+
+	print_debug
+	    ("BCM2708FB: start = %p,%p width=%d, height=%d, bpp=%d, pitch=%d size=%d\n",
+	     (void *)fb->fb.screen_base, (void *)fb->fb_bus_address,
+	     fbinfo.xres, fbinfo.yres, fbinfo.bpp,
+	     fbinfo.pitch, (int)fb->fb.screen_size);
+
+	return 0;
 }
 
 static inline u32 convert_bitfield(int val, struct fb_bitfield *bf)
@@ -352,15 +358,34 @@ static int bcm2708_fb_setcolreg(unsigned int regno, unsigned int red,
 	/*print_debug("BCM2708FB: setcolreg %d:(%02x,%02x,%02x,%02x) %x\n", regno, red, green, blue, transp, fb->fb.fix.visual);*/
 	if (fb->fb.var.bits_per_pixel <= 8) {
 		if (regno < 256) {
-			/* blue [0:4], green [5:10], red [11:15] */
-			fb->info->cmap[regno] = ((red   >> (16-5)) & 0x1f) << 11 |
-						((green >> (16-6)) & 0x3f) << 5 |
-						((blue  >> (16-5)) & 0x1f) << 0;
+			/* blue [23:16], green [15:8], red [7:0] */
+			fb->gpu_cmap[regno] = ((red   >> 8) & 0xff) << 0 |
+					      ((green >> 8) & 0xff) << 8 |
+					      ((blue  >> 8) & 0xff) << 16;
 		}
 		/* Hack: we need to tell GPU the palette has changed, but currently bcm2708_fb_set_par takes noticable time when called for every (256) colour */
 		/* So just call it for what looks like the last colour in a list for now. */
-		if (regno == 15 || regno == 255)
-			bcm2708_fb_set_par(info);
+		if (regno == 15 || regno == 255) {
+			struct packet {
+				u32 offset;
+				u32 length;
+				u32 cmap[256];
+			} *packet;
+			int ret;
+
+			packet = kmalloc(sizeof(*packet), GFP_KERNEL);
+			if (!packet)
+				return -ENOMEM;
+			packet->offset = 0;
+			packet->length = regno + 1;
+			memcpy(packet->cmap, fb->gpu_cmap, sizeof(packet->cmap));
+			ret = rpi_firmware_property(fb->fw, RPI_FIRMWARE_FRAMEBUFFER_SET_PALETTE,
+						    packet, (2 + packet->length) * sizeof(u32));
+			if (ret || packet->offset)
+				dev_err(info->device, "Failed to set palette (%d,%u)\n",
+					ret, packet->offset);
+			kfree(packet);
+		}
         } else if (regno < 16) {
 		fb->cmap[regno] = convert_bitfield(transp, &fb->fb.var.transp) |
 		    convert_bitfield(blue, &fb->fb.var.blue) |
@@ -372,27 +397,31 @@ static int bcm2708_fb_setcolreg(unsigned int regno, unsigned int red,
 
 static int bcm2708_fb_blank(int blank_mode, struct fb_info *info)
 {
-	s32 result = -1;
-	u32 p[7];
-	if ( 	(blank_mode == FB_BLANK_NORMAL) ||
-		(blank_mode == FB_BLANK_UNBLANK)) {
+	struct bcm2708_fb *fb = to_bcm2708(info);
+	u32 value;
+	int ret;
 
-		p[0] = 28; //  size = sizeof u32 * length of p
-		p[1] = VCMSG_PROCESS_REQUEST; // process request
-		p[2] = VCMSG_SET_BLANK_SCREEN; // (the tag id)
-		p[3] = 4; // (size of the response buffer)
-		p[4] = 4; // (size of the request data)
-		p[5] = blank_mode;
-		p[6] = VCMSG_PROPERTY_END; // end tag
-
-		bcm_mailbox_property(&p, p[0]);
-
-		if ( p[1] == VCMSG_REQUEST_SUCCESSFUL )
-			result = 0;
-		else
-			pr_err("bcm2708_fb_blank(%d) returns=%d p[1]=0x%x\n", blank_mode, p[5], p[1]);
+	switch (blank_mode) {
+	case FB_BLANK_UNBLANK:
+		value = 0;
+		break;
+	case FB_BLANK_NORMAL:
+	case FB_BLANK_VSYNC_SUSPEND:
+	case FB_BLANK_HSYNC_SUSPEND:
+	case FB_BLANK_POWERDOWN:
+		value = 1;
+		break;
+	default:
+		return -EINVAL;
 	}
-	return result;
+
+	ret = rpi_firmware_property(fb->fw, RPI_FIRMWARE_FRAMEBUFFER_BLANK,
+				    &value, sizeof(value));
+	if (ret)
+		dev_err(info->device, "bcm2708_fb_blank(%d) failed: %d\n",
+			blank_mode, ret);
+
+	return ret;
 }
 
 static int bcm2708_fb_pan_display(struct fb_var_screeninfo *var, struct fb_info *info)
@@ -408,25 +437,25 @@ static int bcm2708_fb_pan_display(struct fb_var_screeninfo *var, struct fb_info 
 
 static int bcm2708_ioctl(struct fb_info *info, unsigned int cmd, unsigned long arg)
 {
-	s32 result = -1;
-	u32 p[7];
-	if (cmd == FBIO_WAITFORVSYNC) {
-		p[0] = 28; //  size = sizeof u32 * length of p
-		p[1] = VCMSG_PROCESS_REQUEST; // process request
-		p[2] = VCMSG_SET_VSYNC; // (the tag id)
-		p[3] = 4; // (size of the response buffer)
-		p[4] = 4; // (size of the request data)
-		p[5] = 0; // dummy
-		p[6] = VCMSG_PROPERTY_END; // end tag
+	struct bcm2708_fb *fb = to_bcm2708(info);
+	u32 dummy = 0;
+	int ret;
 
-		bcm_mailbox_property(&p, p[0]);
-
-		if ( p[1] == VCMSG_REQUEST_SUCCESSFUL )
-			result = 0;
-		else
-			pr_err("bcm2708_fb_ioctl %x,%lx returns=%d p[1]=0x%x\n", cmd, arg, p[5], p[1]);
+	switch (cmd) {
+	case FBIO_WAITFORVSYNC:
+		ret = rpi_firmware_property(fb->fw,
+					    RPI_FIRMWARE_FRAMEBUFFER_SET_VSYNC,
+					    &dummy, sizeof(dummy));
+		break;
+	default:
+		dev_err(info->device, "Unknown ioctl 0x%x\n", cmd);
+		return -EINVAL;
 	}
-	return result;
+
+	if (ret)
+		dev_err(info->device, "ioctl 0x%x failed (%d)\n", cmd, ret);
+
+	return ret;
 }
 static void bcm2708_fb_fillrect(struct fb_info *info,
 				const struct fb_fillrect *rect)
@@ -621,20 +650,7 @@ static struct fb_ops bcm2708_fb_ops = {
 static int bcm2708_fb_register(struct bcm2708_fb *fb)
 {
 	int ret;
-	dma_addr_t dma;
-	void *mem;
 
-	mem =
-	    dma_alloc_coherent(&fb->dev->dev, PAGE_ALIGN(sizeof(*fb->info)), &dma,
-			       GFP_KERNEL);
-
-	if (NULL == mem) {
-		pr_err(": unable to allocate fbinfo buffer\n");
-		ret = -ENOMEM;
-	} else {
-		fb->info = (struct fbinfo_s *)mem;
-		fb->dma = dma;
-	}
 	fb->fb.fbops = &bcm2708_fb_ops;
 	fb->fb.flags = FBINFO_FLAG_DEFAULT | FBINFO_HWACCEL_COPYAREA;
 	fb->fb.pseudo_palette = fb->cmap;
@@ -693,8 +709,21 @@ out:
 
 static int bcm2708_fb_probe(struct platform_device *dev)
 {
+	struct device_node *fw_np;
+	struct rpi_firmware *fw;
 	struct bcm2708_fb *fb;
 	int ret;
+
+	fw_np = of_parse_phandle(dev->dev.of_node, "firmware", 0);
+/* Remove comment when booting without Device Tree is no longer supported
+	if (!fw_np) {
+		dev_err(&dev->dev, "Missing firmware node\n");
+		return -ENOENT;
+	}
+*/
+	fw = rpi_firmware_get(fw_np);
+	if (!fw)
+		return -EPROBE_DEFER;
 
 	fb = kzalloc(sizeof(struct bcm2708_fb), GFP_KERNEL);
 	if (!fb) {
@@ -704,6 +733,7 @@ static int bcm2708_fb_probe(struct platform_device *dev)
 		goto free_region;
 	}
 
+	fb->fw = fw;
 	bcm2708_fb_debugfs_init(fb);
 
 	fb->cb_base = dma_alloc_writecombine(&dev->dev, SZ_64K,
@@ -737,6 +767,7 @@ static int bcm2708_fb_probe(struct platform_device *dev)
 	       fb->dma_chan, fb->dma_chan_base);
 
 	fb->dev = dev;
+	fb->fb.device = &dev->dev;
 
 	ret = bcm2708_fb_register(fb);
 	if (ret == 0) {
@@ -769,8 +800,6 @@ static int bcm2708_fb_remove(struct platform_device *dev)
 	dma_free_writecombine(&dev->dev, SZ_64K, fb->cb_base, fb->cb_handle);
 	bcm_dma_chan_free(fb->dma_chan);
 
-	dma_free_coherent(NULL, PAGE_ALIGN(sizeof(*fb->info)), (void *)fb->info,
-			  fb->dma);
 	bcm2708_fb_debugfs_deinit(fb);
 
 	free_irq(fb->dma_irq, fb);


### PR DESCRIPTION
Tested on Pi1 and Pi2 with and without Device Tree + ARCH_BCM2835.

Initially I planned to get the thermal and cpufreq drivers upstream, but the process is very slow and I still have a couple of patches that haven't been accepted into mainline yet. My hobby development environment doesn't handle multiple long running tasks very well.

**Test details**

Thermal

```
$ cat /sys/class/thermal/thermal_zone0/temp && vcgencmd measure_temp
39007
temp=39.0'C

```

cpufreq

```
$ head -1 /boot/config.txt
arm_freq=900

# Pi1
$ sudo cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq && vcgencmd measure_clock arm
700000
frequency(45)=700000000
$ sudo cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq
700000

# Pi2
$ sudo cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq && vcgencmd measure_clock arm
600000
frequency(45)=600000000
$ sudo cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq
600000

$ sudo cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq
900000

$ cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
powersave

$ echo performance | sudo tee /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
$ sudo cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq && vcgencmd measure_clock arm
900000
frequency(45)=900000000

$ echo powersave | sudo tee /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor

# Pi1
$ sudo cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq && vcgencmd measure_clock arm
700000
frequency(45)=700000000

# Pi2
$ sudo cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq && vcgencmd measure_clock arm
600000
frequency(45)=600000000

```

bcm2708_fb Colour palette

```
$ wget http://malus.exotica.org.uk/~buzz/pi/sdl/sdl1/deb/rpi1/libsdl1.2debian_1.2.15-8rpi_armhf.deb
$ wget http://malus.exotica.org.uk/~buzz/pi/sdl/sdl1/deb/rpi1/libsdl1.2-dev_1.2.15-8rpi_armhf.deb
$ sudo dpkg -i libsdl1.2debian_1.2.15-8rpi_armhf.deb libsdl1.2-dev_1.2.15-8rpi_armhf.deb
$ sudo apt-get -f install

$ wget http://marklomas.net/ch-egg/downloads/ch-egg-port-sdl-source_v1_1.zip
$ unzip ch-egg-port-sdl-source_v1_1.zip
$ cd ch-egg-port-sdl-source_v1.1/ch-egg/bbcb
$ gcc -Os -I/usr/include/SDL -c sound.c mode2font.c r6502main.c
$ ar cr libbbcb.a sound.o r6502main.o mode2font.o
$ cd ..
$ gcc -Os -I/usr/include/SDL -I../ execute.c library.c main.c -Lbbcb -lbbcb -lSDL -lm
$ mv a.out ../ch-egg.elf

# Audio is necessary: /boot/config.txt
# dtparam=audio=on

$ ./ch-egg-port-sdl-source_v1.1/ch-egg.elf

```

bcm2708_fb Ioctl: FBIOPAN_DISPLAY and FBIO_WAITFORVSYNC

```
$ wget https://raw.githubusercontent.com/rst-/raspberry-compote/master/fb/fbtestXIV.c
$ gcc -O2 -o fbtestXIV fbtestXIV.c
$ ./fbtestXIV

```

bcm2708_fb Blanking

```
$ setterm -blank 1

```
