### PR TITLE
dwc_otg: fiq_fsm: Make high-speed isochronous strided transfers work properly

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h
+++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h
@@ -260,12 +260,13 @@ struct fiq_dma_blob {
  * @iso_frame:	Pointer to the array of OTG URB iso_frame_descs.
  * @nrframes:	Total length of iso_frame_desc array
  * @index:	Current index (FIQ-maintained)
- *
+ * @stride:	Interval in uframes between HS isoc transactions
  */
 struct fiq_hs_isoc_info {
 	struct dwc_otg_hcd_iso_packet_desc *iso_desc;
 	unsigned int nrframes;
 	unsigned int index;
+	unsigned int stride;
 };
 
 /**
@@ -296,6 +297,8 @@ struct fiq_channel_state {
 	/* Hardware bug workaround: sometimes channel halt interrupts are
 	 * delayed until the next SOF. Keep track of when we expected to get interrupted. */
 	unsigned int expected_uframe;
+	/* number of uframes remaining (for interval > 1 HS isoc transfers) before next transfer */
+	unsigned int uframe_sleeps;
 	/* in/out for communicating number of dma buffers used, or number of ISOC to do */
 	unsigned int nrpackets;
 	struct fiq_dma_info dma_info;

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
@@ -2297,10 +2297,10 @@ void dwc_otg_fiq_unmangle_isoc(dwc_otg_hcd_t *hcd, dwc_otg_qh_t *qh, dwc_otg_qtd
 			dwc_urb->error_count++;
 		}
 	}
+	qh->sched_frame = dwc_frame_num_inc(qh->sched_frame, qh->interval * (nr_frames - 1));
+
 	//printk_ratelimited(KERN_INFO "%s: HS isochronous of %d/%d frames with %d errors complete\n",
 	//			__FUNCTION__, i, dwc_urb->packet_count, dwc_urb->error_count);
-	hcd->fops->complete(hcd, dwc_urb->priv, dwc_urb, 0);
-	release_channel(hcd, qh->channel, qtd, DWC_OTG_HC_XFER_URB_COMPLETE);
 }
 
 /**
@@ -2543,6 +2543,8 @@ void dwc_otg_hcd_handle_hc_fsm(dwc_otg_hcd_t *hcd, uint32_t num)
 		 * fail.
 		 */
 		dwc_otg_fiq_unmangle_isoc(hcd, qh, qtd, num);
+		hcd->fops->complete(hcd, qtd->urb->priv, qtd->urb, 0);
+		release_channel(hcd, hc, qtd, DWC_OTG_HC_XFER_URB_COMPLETE);
 		break;
 
 	case FIQ_PER_SPLIT_LS_ABORTED:


### PR DESCRIPTION
Fixes playback on my Schitt Modi 2 audio box.

Should fix the root cause identified in #888.
