### PR TITLE
spi: bcm270x: dt: move to cs-gpio and add an overlay for GPIO 35-39

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
@@ -9,8 +9,13 @@
 
 &gpio {
 	spi0_pins: spi0_pins {
-		brcm,pins = <7 8 9 10 11>;
+		brcm,pins = <9 10 11>;
 		brcm,function = <4>; /* alt0 */
+	};
+
+	spi0_cs_pins: spi0_cs_pins {
+		brcm,pins = <8 7>;
+		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {
@@ -44,7 +49,8 @@
 
 &spi0 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&spi0_pins>;
+	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
+	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
 
 	spidev@0{
 		compatible = "spidev";

--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -9,8 +9,13 @@
 
 &gpio {
 	spi0_pins: spi0_pins {
-		brcm,pins = <7 8 9 10 11>;
+		brcm,pins = <9 10 11>;
 		brcm,function = <4>; /* alt0 */
+	};
+
+	spi0_cs_pins: spi0_cs_pins {
+		brcm,pins = <8 7>;
+		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {
@@ -44,7 +49,8 @@
 
 &spi0 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&spi0_pins>;
+	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
+	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
 
 	spidev@0{
 		compatible = "spidev";

--- a/arch/arm/boot/dts/bcm2708-rpi-cm.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-cm.dts
@@ -12,8 +12,13 @@
 
 &gpio {
 	spi0_pins: spi0_pins {
-		brcm,pins = <7 8 9 10 11>;
+		brcm,pins = <9 10 11>;
 		brcm,function = <4>; /* alt0 */
+	};
+
+	spi0_cs_pins: spi0_cs_pins {
+		brcm,pins = <8 7>;
+		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {
@@ -34,7 +39,8 @@
 
 &spi0 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&spi0_pins>;
+	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
+	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
 
 	spidev@0{
 		compatible = "spidev";

--- a/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
@@ -9,8 +9,13 @@
 
 &gpio {
 	spi0_pins: spi0_pins {
-		brcm,pins = <7 8 9 10 11>;
+		brcm,pins = <9 10 11>;
 		brcm,function = <4>; /* alt0 */
+	};
+
+	spi0_cs_pins: spi0_cs_pins {
+		brcm,pins = <8 7>;
+		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {
@@ -44,7 +49,8 @@
 
 &spi0 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&spi0_pins>;
+	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
+	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
 
 	spidev@0{
 		compatible = "spidev";

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -43,6 +43,7 @@ dtb-$(RPI_DT_OVERLAYS) += rpi-sense-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += sdhost-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += spi-bcm2708-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += spi-bcm2835-overlay.dtb
+dtb-$(RPI_DT_OVERLAYS) += spi-gpio35-39-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += tinylcd35-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += uart1-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += vga666-overlay.dtb

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -474,6 +474,12 @@ Load:   dtoverlay=spi-bcm2835
 Params: <None>
 
 
+Name:	spi-gpio35-39
+Info:	move SPI function block to GPIO 35 to 39
+Load:	dtoverlay=spi-gpio35-39
+Params: <None>
+
+
 Name:   tinylcd35
 Info:   3.5" Color TFT Display by www.tinylcd.com
         Options: Touch, RTC, keypad

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -474,9 +474,9 @@ Load:   dtoverlay=spi-bcm2835
 Params: <None>
 
 
-Name:	spi-gpio35-39
-Info:	move SPI function block to GPIO 35 to 39
-Load:	dtoverlay=spi-gpio35-39
+Name:   spi-gpio35-39
+Info:   move SPI function block to GPIO 35 to 39
+Load:   dtoverlay=spi-gpio35-39
 Params: <None>
 
 

--- a/arch/arm/boot/dts/overlays/spi-gpio35-39-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi-gpio35-39-overlay.dts
@@ -11,7 +11,7 @@
 	fragment@0 {
 		target = <&spi0>;
 		__overlay__ {
-			cs-gpios = <&gpio 36>, <&gpio 35>;
+			cs-gpios = <&gpio 36 1>, <&gpio 35 1>;
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/spi-gpio35-39-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi-gpio35-39-overlay.dts
@@ -1,5 +1,5 @@
 /*
- * Device tree overlay to use spi-bcm2708
+ * Device tree overlay to move spi0 to gpio 35 to 39 on CM
  */
 
 /dts-v1/;
@@ -7,19 +7,25 @@
 
 / {
 	compatible = "brcm,bcm2835", "brcm,bcm2836", "brcm,bcm2708", "brcm,bcm2709";
-	/* setting up compatiblity to allow loading the spi-bcm2835 driver */
+
 	fragment@0 {
 		target = <&spi0>;
 		__overlay__ {
-			status = "okay";
-			compatible = "brcm,bcm2708-spi";
+			cs-gpios = <&gpio 36>, <&gpio 35>;
 		};
 	};
 
 	fragment@1 {
 		target = <&spi0_cs_pins>;
 		__overlay__ {
-			brcm,function = <4>; /* alt0 */
+			bcrm,pins = <36 35>;
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0_pins>;
+		__overlay__ {
+			bcrm,pins = <37 38 39>;
 		};
 	};
 };


### PR DESCRIPTION
Moves SPI settings for chip-selects to framework managed GPIOs.
And also adds an overlay to move GPIOs used for SPI to GPIO35-39
