### PR TITLE
bcm2708-dmaengine: Use more DMA channels (but not 12)

### DIFF
--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -59,11 +59,10 @@
 				     <1 24>,
 				     <1 25>,
 				     <1 26>,
-				     <1 27>,
-				     <1 28>;
+				     <1 27>;
 
 			#dma-cells = <1>;
-			brcm,dma-channel-mask = <0x7f35>;
+			brcm,dma-channel-mask = <0x0f35>;
 		};
 
 		intc: interrupt-controller {


### PR DESCRIPTION
1) Only the bcm2708_fb drivers uses the legacy DMA API, and
it requires a BULK-capable channel, so all other types
(FAST, NORMAL and LITE) can be made available to the regular
DMA API.

2) DMA channels 11-14 share an interrupt. The driver can't
handle this, so don't use channels 12-14 (12 was used, probably
because it appears to have an interrupt, but in reality that
interrupt is for activity on ANY channel). This may explain
a lockup encountered when running out of DMA channels.

The combined effect of this patch is to leave 7 DMA channels
available + channel 0 for bcm2708_fb via the legacy API.

See: https://github.com/raspberrypi/linux/issues/1110
     https://github.com/raspberrypi/linux/issues/1108
