### PR TITLE
Revert "BCM270X_DT: mz61581: Revert to spi-bcm2708"

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -368,6 +368,8 @@ Params: speed                    Display SPI bus speed
 
         fps                      Delay between frame updates
 
+        txbuflen                 Transmit buffer length (default 32768)
+
         debug                    Debug output level {0-7}
 
         xohms                    Touchpanel sensitivity (X-plate resistance)

--- a/arch/arm/boot/dts/overlays/mz61581-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mz61581-overlay.dts
@@ -12,8 +12,6 @@
 	fragment@0 {
 		target = <&spi0>;
 		__overlay__ {
-			/* does not work with spi-bcm2835 using software chip selects */
-			compatible = "brcm,bcm2708-spi";
 			status = "okay";
 
 			spidev@0{

--- a/arch/arm/boot/dts/overlays/mz61581-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mz61581-overlay.dts
@@ -57,6 +57,7 @@
 				bgr;
 				fps = <30>;
 				buswidth = <8>;
+				txbuflen = <32768>;
 
 				reset-gpios = <&gpio 15 0>;
 				dc-gpios = <&gpio 25 0>;
@@ -103,6 +104,7 @@
 		speed =   <&mz61581>, "spi-max-frequency:0";
 		rotate =  <&mz61581>, "rotate:0";
 		fps =     <&mz61581>, "fps:0";
+		txbuflen = <&mz61581>, "txbuflen:0";
 		debug =   <&mz61581>, "debug:0";
 		xohms =   <&mz61581_ts>,"ti,x-plate-ohms;0";
 	};


### PR DESCRIPTION
This reverts commit 1820cd05d93b2d465d1616202772efe5bf0d11fe.

The spi-bcm2835 driver has been fixed, so now we can use it again.

Signed-off-by: Noralf Trønnes noralf@tronnes.org
