### PR TITLE
Use dtb-dirs feature for overlays.

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -15,6 +15,9 @@ endif
 ifeq ($(CONFIG_ARCH_BCM2835),y)
    RPI_DT_OVERLAYS=y
 endif
+ifeq ($(RPI_DT_OVERLAYS),y)
+    dts-dirs += overlays
+endif
 
 dtb-$(CONFIG_ARCH_ALPINE) += \
 	alpine-db.dtb
@@ -683,11 +686,10 @@ targets += $(dtb-y)
 endif
 
 always		:= $(dtb-y)
+subdir-y	:= $(dts-dirs)
 clean-files	:= *.dtb
 
 # Enable fixups to support overlays on BCM2708 platforms
 ifeq ($(RPI_DT_OVERLAYS),y)
 	DTC_FLAGS ?= -@
 endif
-
-subdir-y  += overlays


### PR DESCRIPTION
The kernel makefiles have a dtb-dirs target that is for vendor subdirectories.

Using this fixes install_dtbs, which previously did not install the overlays.
