### PR TITLE
Add support for the HiFiBerry DAC+ Pro.

### DIFF
--- a/arch/arm/boot/dts/overlays/hifiberry-dacplus-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dacplus-overlay.dts
@@ -6,6 +6,16 @@
 	compatible = "brcm,bcm2708";
 
 	fragment@0 {
+		target-path = "/clocks";
+		__overlay__ {
+			dacpro_osc: dacpro_osc {
+				compatible = "hifiberry,dacpro-clk";
+				#clock-cells = <0>;
+			};
+		};
+	};
+
+	fragment@1 {
 		target = <&sound>;
 		__overlay__ {
 			compatible = "hifiberry,hifiberry-dacplus";
@@ -14,14 +24,14 @@
 		};
 	};
 
-	fragment@1 {
+	fragment@2 {
 		target = <&i2s>;
 		__overlay__ {
 			status = "okay";
 		};
 	};
 
-	fragment@2 {
+	fragment@3 {
 		target = <&i2c1>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -32,6 +42,7 @@
 				#sound-dai-cells = <0>;
 				compatible = "ti,pcm5122";
 				reg = <0x4d>;
+				clocks = <&dacpro_osc>;
 				status = "okay";
 			};
 		};

--- a/drivers/clk/Makefile
+++ b/drivers/clk/Makefile
@@ -24,6 +24,7 @@ obj-$(CONFIG_COMMON_CLK_CDCE706)	+= clk-cdce706.o
 obj-$(CONFIG_ARCH_CLPS711X)		+= clk-clps711x.o
 obj-$(CONFIG_ARCH_EFM32)		+= clk-efm32gg.o
 obj-$(CONFIG_ARCH_HIGHBANK)		+= clk-highbank.o
+obj-$(CONFIG_SND_BCM2708_SOC_HIFIBERRY_DACPLUS) += clk-hifiberry-dacpro.o
 obj-$(CONFIG_MACH_LOONGSON1)		+= clk-ls1x.o
 obj-$(CONFIG_COMMON_CLK_MAX_GEN)	+= clk-max-gen.o
 obj-$(CONFIG_COMMON_CLK_MAX77686)	+= clk-max77686.o

--- a/drivers/clk/clk-hifiberry-dacpro.c
+++ b/drivers/clk/clk-hifiberry-dacpro.c
@@ -1,0 +1,160 @@
+/*
+ * Clock Driver for HiFiBerry DAC Pro
+ *
+ * Author: Stuart MacLean
+ *         Copyright 2015
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#include <linux/clk-provider.h>
+#include <linux/clkdev.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/slab.h>
+#include <linux/platform_device.h>
+
+/* Clock rate of CLK44EN attached to GPIO6 pin */
+#define CLK_44EN_RATE 22579200UL
+/* Clock rate of CLK48EN attached to GPIO3 pin */
+#define CLK_48EN_RATE 24576000UL
+
+/**
+ * struct hifiberry_dacpro_clk - Common struct to the HiFiBerry DAC Pro
+ * @hw: clk_hw for the common clk framework
+ * @mode: 0 => CLK44EN, 1 => CLK48EN
+ */
+struct clk_hifiberry_hw {
+	struct clk_hw hw;
+	uint8_t mode;
+};
+
+#define to_hifiberry_clk(_hw) container_of(_hw, struct clk_hifiberry_hw, hw)
+
+static const struct of_device_id clk_hifiberry_dacpro_dt_ids[] = {
+	{ .compatible = "hifiberry,dacpro-clk",},
+	{ }
+};
+MODULE_DEVICE_TABLE(of, clk_hifiberry_dacpro_dt_ids);
+
+static unsigned long clk_hifiberry_dacpro_recalc_rate(struct clk_hw *hw,
+	unsigned long parent_rate)
+{
+	return (to_hifiberry_clk(hw)->mode == 0) ? CLK_44EN_RATE :
+		CLK_48EN_RATE;
+}
+
+static long clk_hifiberry_dacpro_round_rate(struct clk_hw *hw,
+	unsigned long rate, unsigned long *parent_rate)
+{
+	long actual_rate;
+
+	if (rate <= CLK_44EN_RATE) {
+		actual_rate = (long)CLK_44EN_RATE;
+	} else if (rate >= CLK_48EN_RATE) {
+		actual_rate = (long)CLK_48EN_RATE;
+	} else {
+		long diff44Rate = (long)(rate - CLK_44EN_RATE);
+		long diff48Rate = (long)(CLK_48EN_RATE - rate);
+
+		if (diff44Rate < diff48Rate)
+			actual_rate = (long)CLK_44EN_RATE;
+		else
+			actual_rate = (long)CLK_48EN_RATE;
+	}
+	return actual_rate;
+}
+
+
+static int clk_hifiberry_dacpro_set_rate(struct clk_hw *hw,
+	unsigned long rate, unsigned long parent_rate)
+{
+	unsigned long actual_rate;
+	struct clk_hifiberry_hw *clk = to_hifiberry_clk(hw);
+
+	actual_rate = (unsigned long)clk_hifiberry_dacpro_round_rate(hw, rate,
+		&parent_rate);
+	clk->mode = (actual_rate == CLK_44EN_RATE) ? 0 : 1;
+	return 0;
+}
+
+
+const struct clk_ops clk_hifiberry_dacpro_rate_ops = {
+	.recalc_rate = clk_hifiberry_dacpro_recalc_rate,
+	.round_rate = clk_hifiberry_dacpro_round_rate,
+	.set_rate = clk_hifiberry_dacpro_set_rate,
+};
+
+static int clk_hifiberry_dacpro_probe(struct platform_device *pdev)
+{
+	int ret;
+	struct clk_hifiberry_hw *proclk;
+	struct clk *clk;
+	struct device *dev;
+	struct clk_init_data init;
+
+	dev = &pdev->dev;
+
+	proclk = kzalloc(sizeof(struct clk_hifiberry_hw), GFP_KERNEL);
+	if (!proclk)
+		return -ENOMEM;
+
+	init.name = "clk-hifiberry-dacpro";
+	init.ops = &clk_hifiberry_dacpro_rate_ops;
+	init.flags = CLK_IS_ROOT | CLK_IS_BASIC;
+	init.parent_names = NULL;
+	init.num_parents = 0;
+
+	proclk->mode = 0;
+	proclk->hw.init = &init;
+
+	clk = devm_clk_register(dev, &proclk->hw);
+	if (!IS_ERR(clk)) {
+		ret = of_clk_add_provider(dev->of_node, of_clk_src_simple_get,
+			clk);
+	} else {
+		dev_err(dev, "Fail to register clock driver\n");
+		kfree(proclk);
+		ret = PTR_ERR(clk);
+	}
+	return ret;
+}
+
+static int clk_hifiberry_dacpro_remove(struct platform_device *pdev)
+{
+	of_clk_del_provider(pdev->dev.of_node);
+	return 0;
+}
+
+static struct platform_driver clk_hifiberry_dacpro_driver = {
+	.probe = clk_hifiberry_dacpro_probe,
+	.remove = clk_hifiberry_dacpro_remove,
+	.driver = {
+		.name = "clk-hifiberry-dacpro",
+		.of_match_table = clk_hifiberry_dacpro_dt_ids,
+	},
+};
+
+static int __init clk_hifiberry_dacpro_init(void)
+{
+	return platform_driver_register(&clk_hifiberry_dacpro_driver);
+}
+core_initcall(clk_hifiberry_dacpro_init);
+
+static void __exit clk_hifiberry_dacpro_exit(void)
+{
+	platform_driver_unregister(&clk_hifiberry_dacpro_driver);
+}
+module_exit(clk_hifiberry_dacpro_exit);
+
+MODULE_DESCRIPTION("HiFiBerry DAC Pro clock driver");
+MODULE_LICENSE("GPL v2");
+MODULE_ALIAS("platform:clk-hifiberry-dacpro");

--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -1,8 +1,8 @@
 /*
- * ASoC Driver for HiFiBerry DAC+
+ * ASoC Driver for HiFiBerry DAC+ / DAC Pro
  *
- * Author:	Daniel Matuschek
- *		Copyright 2014
+ * Author:	Daniel Matuschek, Stuart MacLean <stuart@hifiberry.com>
+ *		Copyright 2014-2015
  *		based on code by Florian Meier <florian.meier@koalo.de>
  *
  * This program is free software; you can redistribute it and/or
@@ -17,6 +17,13 @@
 
 #include <linux/module.h>
 #include <linux/platform_device.h>
+#include <linux/kernel.h>
+#include <linux/clk.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/slab.h>
+#include <linux/delay.h>
 
 #include <sound/core.h>
 #include <sound/pcm.h>
@@ -26,34 +33,222 @@
 
 #include "../codecs/pcm512x.h"
 
+#define HIFIBERRY_DACPRO_NOCLOCK 0
+#define HIFIBERRY_DACPRO_CLK44EN 1
+#define HIFIBERRY_DACPRO_CLK48EN 2
+
+struct pcm512x_priv {
+	struct regmap *regmap;
+	struct clk *sclk;
+};
+
+/* Clock rate of CLK44EN attached to GPIO6 pin */
+#define CLK_44EN_RATE 22579200UL
+/* Clock rate of CLK48EN attached to GPIO3 pin */
+#define CLK_48EN_RATE 24576000UL
+
+static bool snd_rpi_hifiberry_is_dacpro;
+
+static void snd_rpi_hifiberry_dacplus_select_clk(struct snd_soc_codec *codec,
+	int clk_id)
+{
+	switch (clk_id) {
+	case HIFIBERRY_DACPRO_NOCLOCK:
+		snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x24, 0x00);
+		break;
+	case HIFIBERRY_DACPRO_CLK44EN:
+		snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x24, 0x20);
+		break;
+	case HIFIBERRY_DACPRO_CLK48EN:
+		snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x24, 0x04);
+		break;
+	}
+}
+
+static void snd_rpi_hifiberry_dacplus_clk_gpio(struct snd_soc_codec *codec)
+{
+	snd_soc_update_bits(codec, PCM512x_GPIO_EN, 0x24, 0x24);
+	snd_soc_update_bits(codec, PCM512x_GPIO_OUTPUT_3, 0x0f, 0x02);
+	snd_soc_update_bits(codec, PCM512x_GPIO_OUTPUT_6, 0x0f, 0x02);
+}
+
+static bool snd_rpi_hifiberry_dacplus_is_sclk(struct snd_soc_codec *codec)
+{
+	int sck;
+
+	sck = snd_soc_read(codec, PCM512x_RATE_DET_4);
+	return (!(sck & 0x40));
+}
+
+static bool snd_rpi_hifiberry_dacplus_is_sclk_sleep(
+	struct snd_soc_codec *codec)
+{
+	msleep(2);
+	return snd_rpi_hifiberry_dacplus_is_sclk(codec);
+}
+
+static bool snd_rpi_hifiberry_dacplus_is_pro_card(struct snd_soc_codec *codec)
+{
+	bool isClk44EN, isClk48En, isNoClk;
+
+	snd_rpi_hifiberry_dacplus_clk_gpio(codec);
+
+	snd_rpi_hifiberry_dacplus_select_clk(codec, HIFIBERRY_DACPRO_CLK44EN);
+	isClk44EN = snd_rpi_hifiberry_dacplus_is_sclk_sleep(codec);
+
+	snd_rpi_hifiberry_dacplus_select_clk(codec, HIFIBERRY_DACPRO_NOCLOCK);
+	isNoClk = snd_rpi_hifiberry_dacplus_is_sclk_sleep(codec);
+
+	snd_rpi_hifiberry_dacplus_select_clk(codec, HIFIBERRY_DACPRO_CLK48EN);
+	isClk48En = snd_rpi_hifiberry_dacplus_is_sclk_sleep(codec);
+
+	return (isClk44EN && isClk48En && !isNoClk);
+}
+
+static int snd_rpi_hifiberry_dacplus_clk_for_rate(int sample_rate)
+{
+	int type;
+
+	switch (sample_rate) {
+	case 11025:
+	case 22050:
+	case 44100:
+	case 88200:
+	case 176400:
+		type = HIFIBERRY_DACPRO_CLK44EN;
+		break;
+	default:
+		type = HIFIBERRY_DACPRO_CLK48EN;
+		break;
+	}
+	return type;
+}
+
+static void snd_rpi_hifiberry_dacplus_set_sclk(struct snd_soc_codec *codec,
+	int sample_rate)
+{
+	struct pcm512x_priv *pcm512x = snd_soc_codec_get_drvdata(codec);
+
+	if (!IS_ERR(pcm512x->sclk)) {
+		int ctype;
+
+		ctype = snd_rpi_hifiberry_dacplus_clk_for_rate(sample_rate);
+		clk_set_rate(pcm512x->sclk, (ctype == HIFIBERRY_DACPRO_CLK44EN)
+			? CLK_44EN_RATE : CLK_48EN_RATE);
+		snd_rpi_hifiberry_dacplus_select_clk(codec, ctype);
+	}
+}
+
 static int snd_rpi_hifiberry_dacplus_init(struct snd_soc_pcm_runtime *rtd)
 {
 	struct snd_soc_codec *codec = rtd->codec;
+	struct pcm512x_priv *priv;
+
+	snd_rpi_hifiberry_is_dacpro
+		= snd_rpi_hifiberry_dacplus_is_pro_card(codec);
+
+	if (snd_rpi_hifiberry_is_dacpro) {
+		struct snd_soc_dai_link *dai = rtd->dai_link;
+
+		dai->name = "HiFiBerry DAC+ Pro";
+		dai->stream_name = "HiFiBerry DAC+ Pro HiFi";
+		dai->dai_fmt = SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF
+			| SND_SOC_DAIFMT_CBM_CFM;
+
+		snd_soc_update_bits(codec, PCM512x_BCLK_LRCLK_CFG, 0x31, 0x11);
+		snd_soc_update_bits(codec, PCM512x_MASTER_MODE, 0x03, 0x03);
+		snd_soc_update_bits(codec, PCM512x_MASTER_CLKDIV_2, 0x7f, 63);
+	} else {
+		priv = snd_soc_codec_get_drvdata(codec);
+		priv->sclk = ERR_PTR(-ENOENT);
+	}
+
 	snd_soc_update_bits(codec, PCM512x_GPIO_EN, 0x08, 0x08);
-	snd_soc_update_bits(codec, PCM512x_GPIO_OUTPUT_4, 0xf, 0x02);
-	snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x08,0x08);
+	snd_soc_update_bits(codec, PCM512x_GPIO_OUTPUT_4, 0x0f, 0x02);
+	snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x08, 0x08);
+
 	return 0;
 }
 
-static int snd_rpi_hifiberry_dacplus_hw_params(struct snd_pcm_substream *substream,
-				       struct snd_pcm_hw_params *params)
+static int snd_rpi_hifiberry_dacplus_update_rate_den(
+	struct snd_pcm_substream *substream, struct snd_pcm_hw_params *params)
 {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
-	return snd_soc_dai_set_bclk_ratio(cpu_dai, 64);
-}
-
-static int snd_rpi_hifiberry_dacplus_startup(struct snd_pcm_substream *substream) {
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	struct snd_soc_codec *codec = rtd->codec;
-	snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x08,0x08);
+	struct pcm512x_priv *pcm512x = snd_soc_codec_get_drvdata(codec);
+	struct snd_ratnum *rats_no_pll;
+	unsigned int num = 0, den = 0;
+	int err;
+
+	rats_no_pll = devm_kzalloc(rtd->dev, sizeof(*rats_no_pll), GFP_KERNEL);
+	if (!rats_no_pll)
+		return -ENOMEM;
+
+	rats_no_pll->num = clk_get_rate(pcm512x->sclk) / 64;
+	rats_no_pll->den_min = 1;
+	rats_no_pll->den_max = 128;
+	rats_no_pll->den_step = 1;
+
+	err = snd_interval_ratnum(hw_param_interval(params,
+		SNDRV_PCM_HW_PARAM_RATE), 1, rats_no_pll, &num, &den);
+	if (err >= 0 && den) {
+		params->rate_num = num;
+		params->rate_den = den;
+	}
+
+	devm_kfree(rtd->dev, rats_no_pll);
 	return 0;
 }
 
-static void snd_rpi_hifiberry_dacplus_shutdown(struct snd_pcm_substream *substream) {
+static int snd_rpi_hifiberry_dacplus_set_bclk_ratio_pro(
+	struct snd_soc_dai *cpu_dai, struct snd_pcm_hw_params *params)
+{
+	int bratio = snd_pcm_format_physical_width(params_format(params))
+		* params_channels(params);
+	return snd_soc_dai_set_bclk_ratio(cpu_dai, bratio);
+}
+
+static int snd_rpi_hifiberry_dacplus_hw_params(
+	struct snd_pcm_substream *substream, struct snd_pcm_hw_params *params)
+{
+	int ret;
+	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
+
+	if (snd_rpi_hifiberry_is_dacpro) {
+		struct snd_soc_codec *codec = rtd->codec;
+
+		snd_rpi_hifiberry_dacplus_set_sclk(codec,
+			params_rate(params));
+
+		ret = snd_rpi_hifiberry_dacplus_set_bclk_ratio_pro(cpu_dai,
+			params);
+		if (!ret)
+			ret = snd_rpi_hifiberry_dacplus_update_rate_den(
+				substream, params);
+	} else {
+		ret = snd_soc_dai_set_bclk_ratio(cpu_dai, 64);
+	}
+	return ret;
+}
+
+static int snd_rpi_hifiberry_dacplus_startup(
+	struct snd_pcm_substream *substream)
+{
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	struct snd_soc_codec *codec = rtd->codec;
-	snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x08,0x00);
+
+	snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x08, 0x08);
+	return 0;
+}
+
+static void snd_rpi_hifiberry_dacplus_shutdown(
+	struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_codec *codec = rtd->codec;
+
+	snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x08, 0x00);
 }
 
 /* machine stream operations */
@@ -90,19 +285,20 @@ static int snd_rpi_hifiberry_dacplus_probe(struct platform_device *pdev)
 	int ret = 0;
 
 	snd_rpi_hifiberry_dacplus.dev = &pdev->dev;
-
 	if (pdev->dev.of_node) {
-	    struct device_node *i2s_node;
-	    struct snd_soc_dai_link *dai = &snd_rpi_hifiberry_dacplus_dai[0];
-	    i2s_node = of_parse_phandle(pdev->dev.of_node,
-					"i2s-controller", 0);
+		struct device_node *i2s_node;
+		struct snd_soc_dai_link *dai;
 
-	    if (i2s_node) {
-		dai->cpu_dai_name = NULL;
-		dai->cpu_of_node = i2s_node;
-		dai->platform_name = NULL;
-		dai->platform_of_node = i2s_node;
-	    }
+		dai = &snd_rpi_hifiberry_dacplus_dai[0];
+		i2s_node = of_parse_phandle(pdev->dev.of_node,
+			"i2s-controller", 0);
+
+		if (i2s_node) {
+			dai->cpu_dai_name = NULL;
+			dai->cpu_of_node = i2s_node;
+			dai->platform_name = NULL;
+			dai->platform_of_node = i2s_node;
+		}
 	}
 
 	ret = snd_soc_register_card(&snd_rpi_hifiberry_dacplus);

--- a/sound/soc/codecs/pcm512x.c
+++ b/sound/soc/codecs/pcm512x.c
@@ -856,7 +856,8 @@ static int pcm512x_set_dividers(struct snd_soc_dai *dai,
 	int fssp;
 	int gpio;
 
-	lrclk_div = snd_soc_params_to_frame_size(params);
+	lrclk_div = snd_pcm_format_physical_width(params_format(params))
+		* params_channels(params);
 	if (lrclk_div == 0) {
 		dev_err(dev, "No LRCLK?\n");
 		return -EINVAL;


### PR DESCRIPTION
The HiFiBerry DAC+ and DAC+ Pro products both use the existing bcm sound driver with the DAC+ Pro having a special clock device driver representing the two high precision oscillators.

An addition bug fix is included for the PCM512x codec where by the physical size of the sample frame is used in the calculation of the LRCK divisor as it was found to be wrong when using 24-bit depth sample contained in a little endian 4-byte sample frame.
