### PR TITLE
Fix I2S issues with bcm2835-dma

### DIFF
--- a/drivers/dma/bcm2835-dma.c
+++ b/drivers/dma/bcm2835-dma.c
@@ -141,6 +141,12 @@ struct bcm2835_desc {
  */
 #define MAX_LITE_TRANSFER	(SZ_64K - 4)
 
+/*
+ * Transfers larger than 32k cause issues with the bcm2708-i2s driver,
+ * so limit transfer size to 32k as bcm2708-dmaengine did.
+ */
+#define MAX_CYCLIC_LITE_TRANSFER	SZ_32K
+
 static inline struct bcm2835_dmadev *to_bcm2835_dma_dev(struct dma_device *d)
 {
 	return container_of(d, struct bcm2835_dmadev, ddev);
@@ -397,7 +403,7 @@ static struct dma_async_tx_descriptor *bcm2835_dma_prep_dma_cyclic(
 
 	d->dir = direction;
 	if (c->ch >= 8) /* LITE channel */
-		max_size = MAX_LITE_TRANSFER;
+		max_size = MAX_CYCLIC_LITE_TRANSFER;
 	else
 		max_size = MAX_NORMAL_TRANSFER;
 	period_len = min(period_len, max_size);

--- a/drivers/dma/bcm2835-dma.c
+++ b/drivers/dma/bcm2835-dma.c
@@ -633,6 +633,8 @@ static int bcm2835_dma_slave_config(struct dma_chan *chan,
 	}
 
 	c->cfg = *cfg;
+	if (!c->dreq)
+		c->dreq = cfg->slave_id;
 
 	return 0;
 }


### PR DESCRIPTION
dreq setup was missing for slave transfers and for some (yet unknown) reason transfer sizes larger than 32k cause repated clicking on I2S soundcards.

These changes bring bcm2835-dma in line with bcm2708-dmaengine, but only limit cyclic lite transfers to 32k - other lite transfers can still use 64k-4.

See also discussion in #1153

ping  @notro
