### PR TITLE
dts: Added overlay for Adafruit PiTFT 2.8" capacitive touch screen

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -436,6 +436,28 @@ Params: speed                    Display SPI bus speed
         xohms                    Touchpanel sensitivity (X-plate resistance)
 
 
+Name:   pitft28-capacitive
+Info:   Adafruit PiTFT 2.8" capacitive touch screen
+Load:   dtoverlay=pitft28-capacitive,<param>=<val>
+Params: speed                    Display SPI bus speed
+
+        rotate                   Display rotation {0,90,180,270}
+
+        fps                      Delay between frame updates
+
+        debug                    Debug output level {0-7}
+        
+        touch-sizex              Touchscreen size x (default 240)
+        
+        touch-sizey              Touchscreen size y (default 320)
+        
+        touch-invx               Touchscreen inverted x axis
+        
+        touch-invy               Touchscreen inverted y axis
+        
+        touch-swapxy             Touchscreen swapped x y axis
+
+       
 Name:   pitft28-resistive
 Info:   Adafruit PiTFT 2.8" resistive touch screen
 Load:   dtoverlay=pitft28-resistive,<param>=<val>

--- a/arch/arm/boot/dts/overlays/pitft28-capacitive-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pitft28-capacitive-overlay.dts
@@ -1,0 +1,88 @@
+/*
+ * Device Tree overlay for Adafruit PiTFT 2.8" capavitive touch screen
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+        fragment@0 {
+                target = <&spi0>;
+                __overlay__ {
+                        status = "okay";
+
+                        spidev@0{
+                                status = "disabled";
+                        };
+                };
+        };
+
+        fragment@1 {
+                target = <&gpio>;
+                __overlay__ {
+                        pitft_pins: pitft_pins {
+                                brcm,pins = <24 25>;
+                                brcm,function = <0 1>; /* in out */
+                                brcm,pull = <2 0>; /* pullup none */
+                        };
+                };
+        };
+
+        fragment@2 {
+                target = <&spi0>;
+                __overlay__ {
+                        /* needed to avoid dtc warning */
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        pitft: pitft@0{
+                                compatible = "ilitek,ili9340";
+                                reg = <0>;
+                                pinctrl-names = "default";
+                                pinctrl-0 = <&pitft_pins>;
+
+                                spi-max-frequency = <32000000>;
+                                rotate = <90>;
+                                fps = <25>;
+                                bgr;
+                                buswidth = <8>;
+                                dc-gpios = <&gpio 25 0>;
+                                debug = <0>;
+                        };
+                };
+        };
+
+        fragment@3 {
+                target = <&i2c1>;
+                __overlay__ {
+                        /* needed to avoid dtc warning */
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        ft6236: ft6236@38 {
+                                compatible = "focaltech,ft6236";
+                                reg = <0x38>;
+
+                                interrupt-parent = <&gpio>;
+                                interrupts = <24 2>;
+                                touchscreen-size-x = <240>;
+                                touchscreen-size-y = <320>;
+                        };
+                };
+        };
+
+        __overrides__ {
+                speed =   <&pitft>,"spi-max-frequency:0";
+                rotate =  <&pitft>,"rotate:0";
+                fps =     <&pitft>,"fps:0";
+                debug =   <&pitft>,"debug:0";
+                touch-sizex = <&ft6236>,"touchscreen-size-x?";
+                touch-sizey = <&ft6236>,"touchscreen-size-y?";
+                touch-invx  = <&ft6236>,"touchscreen-inverted-x?";
+                touch-invy  = <&ft6236>,"touchscreen-inverted-y?";
+                touch-swapxy = <&ft6236>,"touchscreen-swapped-x-y?";
+        };
+};


### PR DESCRIPTION
This adds the device tree overlay for Adafruit PiTFT 2.8" capacitive touch screen.
See issue #1050. Please merge.
