### PR TITLE
[4.2] fix cyclic dma setup and i2s parameters

### DIFF
--- a/drivers/dma/bcm2835-dma.c
+++ b/drivers/dma/bcm2835-dma.c
@@ -407,7 +407,7 @@ static struct dma_async_tx_descriptor *bcm2835_dma_prep_dma_cyclic(
 	else
 		max_size = MAX_NORMAL_TRANSFER;
 	period_len = min(period_len, max_size);
-	d->frames = (buf_len - 1) / (period_len + 1);
+	d->frames = DIV_ROUND_UP(buf_len, period_len);
 
 	/* Allocate memory for control blocks */
 	d->control_block_size = d->frames * sizeof(struct bcm2835_dma_cb);

--- a/drivers/dma/bcm2835-dma.c
+++ b/drivers/dma/bcm2835-dma.c
@@ -141,12 +141,6 @@ struct bcm2835_desc {
  */
 #define MAX_LITE_TRANSFER	(SZ_64K - 4)
 
-/*
- * Transfers larger than 32k cause issues with the bcm2708-i2s driver,
- * so limit transfer size to 32k as bcm2708-dmaengine did.
- */
-#define MAX_CYCLIC_LITE_TRANSFER	SZ_32K
-
 static inline struct bcm2835_dmadev *to_bcm2835_dma_dev(struct dma_device *d)
 {
 	return container_of(d, struct bcm2835_dmadev, ddev);
@@ -403,7 +397,7 @@ static struct dma_async_tx_descriptor *bcm2835_dma_prep_dma_cyclic(
 
 	d->dir = direction;
 	if (c->ch >= 8) /* LITE channel */
-		max_size = MAX_CYCLIC_LITE_TRANSFER;
+		max_size = MAX_LITE_TRANSFER;
 	else
 		max_size = MAX_NORMAL_TRANSFER;
 	period_len = min(period_len, max_size);

--- a/sound/soc/bcm/bcm2835-i2s.c
+++ b/sound/soc/bcm/bcm2835-i2s.c
@@ -806,16 +806,16 @@ static struct snd_pcm_hardware bcm2835_pcm_hardware = {
 				  SNDRV_PCM_FMTBIT_S24_LE |
 				  SNDRV_PCM_FMTBIT_S32_LE,
 	.period_bytes_min	= 32,
-	.period_bytes_max	= 64 * PAGE_SIZE,
+	.period_bytes_max	= SZ_64K - 4,
 	.periods_min		= 2,
 	.periods_max		= 255,
-	.buffer_bytes_max	= 128 * PAGE_SIZE,
+	.buffer_bytes_max	= SZ_512K,
 };
 
 static const struct snd_dmaengine_pcm_config bcm2835_dmaengine_pcm_config = {
 	.prepare_slave_config = snd_dmaengine_pcm_prepare_slave_config,
 	.pcm_hardware = &bcm2835_pcm_hardware,
-	.prealloc_buffer_size = 256 * PAGE_SIZE,
+	.prealloc_buffer_size = SZ_1M,
 };
 
 static int bcm2835_i2s_probe(struct platform_device *pdev)


### PR DESCRIPTION
I found out why I got clicks with I2S soundcards after the lite DMA channel transfer size limit was bumped from 32k to 64k-4 bytes:

The frame number calculation in the cyclic DMA setup code was wrong, so fewer frames than needed were allocated and the last frame was larger than it should be.

With the old limit this bug went unnoticed as the frame length was still below the maximum size the DMA controller could handle. But with the larger limit we exceeded what the DMA controller could do.

I've also adjusted the maximum period size in the i2s driver to match the capabilities of the DMA controller. This ensures that the actual DMA frames will match the requested buffer/period layout.

This fix should go in 4.3 as well, after (or with) the huge atags PR.

I'll create a separate PR for 4.1 with backported fixes for the 2708 drivers.
