### PR TITLE
[4.1] fix cyclic dma setup and i2s parameters

### DIFF
--- a/drivers/dma/bcm2708-dmaengine.c
+++ b/drivers/dma/bcm2708-dmaengine.c
@@ -710,7 +710,7 @@ static struct dma_async_tx_descriptor *bcm2835_dma_prep_dma_cyclic(
 		max_size = MAX_NORMAL_TRANSFER;
 	period_len = min(period_len, max_size);
 
-	d->frames = (buf_len-1) / period_len + 1;
+	d->frames = DIV_ROUND_UP(buf_len, period_len);
 
 	/* Allocate memory for control blocks */
 	d->control_block_size = d->frames * sizeof(struct bcm2835_dma_cb);

--- a/sound/soc/bcm/bcm2708-i2s.c
+++ b/sound/soc/bcm/bcm2708-i2s.c
@@ -881,7 +881,7 @@ static struct snd_pcm_hardware bcm2708_pcm_hardware = {
 				  SNDRV_PCM_FMTBIT_S24_LE |
 				  SNDRV_PCM_FMTBIT_S32_LE,
 	.period_bytes_min	= 32,
-	.period_bytes_max	= 64 * PAGE_SIZE,
+	.period_bytes_max	= SZ_32K,
 	.periods_min		= 2,
 	.periods_max		= 255,
 	.buffer_bytes_max	= 128 * PAGE_SIZE,


### PR DESCRIPTION
Backport bcm2835 fixes in #1193 to bcm2708
