### PR TITLE
dts: Added overlay for gpio_ir_recv driver

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -17,6 +17,7 @@ dtb-$(RPI_DT_OVERLAYS) += at86rf233-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += bmp085_i2c-sensor-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += dht11-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += enc28j60-overlay.dtb
+dtb-$(RPI_DT_OVERLAYS) += gpio-ir-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += gpio-poweroff-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += hifiberry-amp-overlay.dtb
 dtb-$(RPI_DT_OVERLAYS) += hifiberry-dac-overlay.dtb

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -209,6 +209,22 @@ Params: int_pin                  GPIO used for INT (default 25)
         speed                    SPI bus speed (default 12000000)
 
 
+Name:   gpio-ir
+Info:   Use GPIO pin as rc-core style infrared receiver input. The rc-core-
+        based gpio_ir_recv driver maps received keys directly to a
+        /dev/input/event* device, all decoding is done by the kernel - LIRC is
+        not required! The key mapping and other decoding parameters can be
+        configured by "ir-keytable" tool.
+Load:   gpio-ir,<param>=<val>
+Params: gpio_pin                 Input pin number. Default is 18.
+
+        gpio_pull                Desired pull-up/down state (off, down, up)
+                                 Default is "down".
+
+        linux,rc-map-name        Default rc keymap (can also be changed by
+                                 ir-keytable), defaults to "rc-rc6-mce"
+
+
 Name:   gpio-poweroff
 Info:   Drives a GPIO high or low on reboot
 Load:   gpio-poweroff,<param>=<val>

--- a/arch/arm/boot/dts/overlays/gpio-ir-overlay.dts
+++ b/arch/arm/boot/dts/overlays/gpio-ir-overlay.dts
@@ -1,0 +1,45 @@
+// Definitions for ir-gpio module
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "brcm,bcm2708";
+
+        fragment@0 {
+                target-path = "/";
+                __overlay__ {
+                        gpio_ir: ir-receiver {
+                                compatible = "gpio-ir-receiver";
+
+                                // pin number, high or low
+                                gpios = <&gpio 18 1>;
+
+                                // parameter for keymap name
+                                linux,rc-map-name = "rc-rc6-mce";
+
+                                status = "okay";
+                        };
+                };
+        };
+
+        fragment@1 {
+                target = <&gpio>;
+                __overlay__ {
+                        gpio_ir_pins: gpio_ir_pins {
+                                brcm,pins = <18>;                       // pin 18
+                                brcm,function = <0>;                    // in
+                                brcm,pull = <1>;                        // down
+                        };
+                };
+        };
+
+        __overrides__ {
+                // parameters
+                gpio_pin =      <&gpio_ir>,"gpios:4",
+                                        <&gpio_ir_pins>,"brcm,pins:0",
+                                        <&gpio_ir_pins>,"brcm,pull:0";  // pin number
+                gpio_pull = <&gpio_ir_pins>,"brcm,pull:0";              // pull-up/down state
+
+                rc-map-name = <&gpio_ir>,"linux,rc-map-name";           // default rc map
+        };
+};


### PR DESCRIPTION
This PR adds a DTS that allows the use of the gpio_ir_recv kernel driver.

The gpio_ir_recv  driver is a rc-core based driver for TSOP-style IR receivers connected to a GPIO pin and is part of the Linux kernel. In contrast to lirc_rpi, no LIRC is needed for IR signal decoding or RC key mapping. These tasks are done by proven kernel infrastructure instead.

In contrast to the LIRC/lirc_rpi approach, the gpio_ir_recv driver brings a better RC responsiveness and a more consistent timing between RC button pressed and and key event and does not suffer from the typical double-key problems often reported from the lirc_rpi/LIRCd approach.
