### PR TITLE
Add FBUNSUPPORTED ioctl for bcm2708_fb

### DIFF
--- a/drivers/video/fbdev/bcm2708_fb.c
+++ b/drivers/video/fbdev/bcm2708_fb.c
@@ -442,8 +442,8 @@ static int bcm2708_ioctl(struct fb_info *info, unsigned int cmd, unsigned long a
 					    &dummy, sizeof(dummy));
 		break;
 	default:
-		dev_err(info->device, "Unknown ioctl 0x%x\n", cmd);
-		return -EINVAL;
+		dev_dbg(info->device, "Unknown ioctl 0x%x\n", cmd);
+		return -ENOTTY;
 	}
 
 	if (ret)


### PR DESCRIPTION
since fbturbo introduces and use it on copyarea operations for
unsupported dummy ioctl which is expected to return failure.
In order not to confuse user in kernel log, we should filter it out.

> 240 Nov 16 02:53:15 raspberrypi kernel: [    7.522998] smsc95xx 1-1.1:1.0 eth0: link up, 100Mbps, full-duplex, lpa 0x43E1
>     241 Nov 16 02:53:15 raspberrypi kernel: [    8.343603] Adding 102396k swap on /var/swap.  Priority:-1 extents:5 across:573436k SSFS
>     242 Nov 16 02:53:16 raspberrypi kernel: [    9.572984] bcm2708_fb soc:fb: Unknown ioctl 0x40187a22
>     243 Nov 16 02:53:17 raspberrypi kernel: [   10.465163] cfg80211: Calling CRDA to update world regulatory domain
>     244 Nov 16 02:53:20 raspberrypi kernel: [   13.615097] cfg80211: Calling CRDA to update world regulatory domain
>     245 Nov 16 02:53:23 raspberrypi kernel: [   16.765045] cfg80211: Calling CRDA to update world regulatory domain

related fbturbo copyarea src code at: https://github.com/ssvb/xf86-video-fbturbo/blob/master/src/fb_copyarea.c#L76
