### PR TITLE
SDIO-overlay: add poll_once-boolean parameter

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -562,6 +562,9 @@ Params: overclock_50             Clock (in MHz) to use when the MMC framework
 
         debug                    Enable debug output (default off)
 
+        poll_once                Disable SDIO-device polling every second
+                                 (default on: polling once at boot-time)
+
 
 Name:   smi
 Info:   Enables the Secondary Memory Interface peripheral. Uses GPIOs 2-25!

--- a/arch/arm/boot/dts/overlays/sdio-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sdio-overlay.dts
@@ -7,7 +7,7 @@
 
 	fragment@3 {
 		target = <&mmc>;
-		__overlay__ {
+		sdio_mmc: __overlay__ {
 			compatible = "brcm,bcm2835-mmc";
 			pinctrl-names = "default";
 			pinctrl-0 = <&sdio_pins>;
@@ -25,5 +25,9 @@
 				brcm,pull = <0 2 2 2 2 2>;
 			};
 		};
+	};
+
+	__overrides__ {
+		poll_once = <&sdio_mmc>,"non-removable?";
 	};
 };


### PR DESCRIPTION
Add paramter to toggle sdio-device-polling done every second or once at boot-time in the sdio-overlay.dts .

Can also be applied to other branches of more recent versions.
