### PR TITLE
Revert "bcm2835-dma: Fix dreq not set for slave transfers"

### DIFF
--- a/drivers/dma/bcm2835-dma.c
+++ b/drivers/dma/bcm2835-dma.c
@@ -679,8 +679,6 @@ static int bcm2835_dma_slave_config(struct dma_chan *chan,
 	}
 
 	c->cfg = *cfg;
-	if (!c->dreq)
-		c->dreq = cfg->slave_id;
 
 	return 0;
 }


### PR DESCRIPTION
We added the dreq setup at a time when the I2S dma channels were not defined in the devicetree. DMA channels are defined in DT since 96e6962324390cdfd58913f921da196d0291da80 and this code doesn't seem to be needed anymore - I2S cards work fine with the code reverted.

ping @notro @pelwell could you verify if this is correct?
