### PR TITLE
SDIO-overlay: Add parameter to change the SDIO bus width

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -613,6 +613,8 @@ Params: overclock_50             Clock (in MHz) to use when the MMC framework
         poll_once                Disable SDIO-device polling every second
                                  (default on: polling once at boot-time)
 
+        bus_width                Set the SDIO host bus width (default 4 bits)
+
 
 Name:   smi
 Info:   Enables the Secondary Memory Interface peripheral. Uses GPIOs 2-25!

--- a/arch/arm/boot/dts/overlays/sdio-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sdio-overlay.dts
@@ -11,6 +11,7 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&sdio_pins>;
 			non-removable;
+			bus-width = <4>;
 			status = "okay";
 		};
 	};
@@ -28,5 +29,6 @@
 
 	__overrides__ {
 		poll_once = <&sdio_mmc>,"non-removable?";
+		bus_width = <&sdio_mmc>,"bus-width:0";
 	};
 };

--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -1329,7 +1329,7 @@ static int bcm2835_mmc_add_host(struct bcm2835_host *host)
 	/* host controller capabilities */
 	mmc->caps |= MMC_CAP_CMD23 | MMC_CAP_ERASE | MMC_CAP_NEEDS_POLL |
 		MMC_CAP_SDIO_IRQ | MMC_CAP_SD_HIGHSPEED |
-		MMC_CAP_MMC_HIGHSPEED | MMC_CAP_4_BIT_DATA;
+		MMC_CAP_MMC_HIGHSPEED;
 
 	host->flags = SDHCI_AUTO_CMD23;
 


### PR DESCRIPTION
Adds a parameter to the SDIO overlay, bus_width=, that can be used to limit the SDIO bus to 1 bit mode.  It is necessary to limit the driver to 1 bit mode when the bus is wired for 1 bit mode but the device advertises 4 bit mode.

Tested that this doesn't affect the bus width on the remapped SDIO bus or on the bcm2835-sdhost bus when not defined and when the SDIO overlay is not loaded.
