### PR TITLE
Allow up to 24db digital gain to be applied when using IQAudIO DAC+

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -362,8 +362,21 @@ Params: <None>
 
 Name:   iqaudio-dacplus
 Info:   Configures the IQaudio DAC+ audio card
-Load:   dtoverlay=iqaudio-dacplus
-Params: <None>
+Load:   dtoverlay=iqaudio-dacplus,<param>=<val>
+Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
+                                Digital volume control. Enable with
+                                "dtoverlay=iqaudio-dacplus,24db_digital_gain"
+                                (The default behaviour is that the Digital
+                                volume control is limited to a maximum of
+                                0dB. ie. it can attenuate but not provide
+                                gain. For most users, this will be desired
+                                as it will prevent clipping. By appending
+                                the 24db_digital_gain parameter, the Digital
+                                volume control will allow up to 24dB of
+                                gain. If this parameter is enabled, it is the
+                                responsibility of the user to ensure that
+                                the Digital volume control is set to a value
+                                that does not result in clipping/distortion!)
 
 
 Name:   lirc-rpi

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -273,8 +273,21 @@ Params: <None>
 
 Name:   hifiberry-dacplus
 Info:   Configures the HifiBerry DAC+ audio card
-Load:   dtoverlay=hifiberry-dacplus
-Params: <None>
+Load:   dtoverlay=hifiberry-dacplus,<param>=<val>
+Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
+                                Digital volume control. Enable with
+                                "dtoverlay=hifiberry-dacplus,24db_digital_gain"
+                                (The default behaviour is that the Digital
+                                volume control is limited to a maximum of
+                                0dB. ie. it can attenuate but not provide
+                                gain. For most users, this will be desired
+                                as it will prevent clipping. By appending
+                                the 24dB_digital_gain parameter, the Digital
+                                volume control will allow up to 24dB of
+                                gain. If this parameter is enabled, it is the
+                                responsibility of the user to ensure that
+                                the Digital volume control is set to a value
+                                that does not result in clipping/distortion!)
 
 
 Name:   hifiberry-digi

--- a/arch/arm/boot/dts/overlays/hifiberry-dacplus-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dacplus-overlay.dts
@@ -17,7 +17,7 @@
 
 	fragment@1 {
 		target = <&sound>;
-		__overlay__ {
+		frag1: __overlay__ {
 			compatible = "hifiberry,hifiberry-dacplus";
 			i2s-controller = <&i2s>;
 			status = "okay";
@@ -46,5 +46,9 @@
 				status = "okay";
 			};
 		};
+	};
+
+	__overrides__ {
+		24db_digital_gain = <&frag1>,"hifiberry,24db_digital_gain?";
 	};
 };

--- a/arch/arm/boot/dts/overlays/iqaudio-dacplus-overlay.dts
+++ b/arch/arm/boot/dts/overlays/iqaudio-dacplus-overlay.dts
@@ -7,7 +7,7 @@
 
 	fragment@0 {
 		target = <&sound>;
-		__overlay__ {
+		frag0: __overlay__ {
 			compatible = "iqaudio,iqaudio-dac";
 			i2s-controller = <&i2s>;
 			status = "okay";
@@ -35,5 +35,9 @@
 				status = "okay";
 			};
 		};
+	};
+
+	__overrides__ {
+		24db_digital_gain = <&frag0>,"iqaudio,24db_digital_gain?";
 	};
 };

--- a/sound/soc/bcm/iqaudio-dac.c
+++ b/sound/soc/bcm/iqaudio-dac.c
@@ -23,14 +23,19 @@
 #include <sound/soc.h>
 #include <sound/jack.h>
 
+static bool digital_gain_0db_limit = true;
+
 static int snd_rpi_iqaudio_dac_init(struct snd_soc_pcm_runtime *rtd)
 {
-	int ret;
-	struct snd_soc_card *card = rtd->card;
+	if (digital_gain_0db_limit)
+	{
+		int ret;
+		struct snd_soc_card *card = rtd->card;
 
-	ret = snd_soc_limit_volume(card, "Digital Playback Volume", 207);
-	if (ret < 0)
-		dev_warn(card->dev, "Failed to set volume limit: %d\n", ret);
+		ret = snd_soc_limit_volume(card, "Digital Playback Volume", 207);
+		if (ret < 0)
+			dev_warn(card->dev, "Failed to set volume limit: %d\n", ret);
+	}
 
 	return 0;
 }
@@ -94,6 +99,9 @@ static int snd_rpi_iqaudio_dac_probe(struct platform_device *pdev)
 		dai->platform_name = NULL;
 		dai->platform_of_node = i2s_node;
 	    }
+
+	    digital_gain_0db_limit = !of_property_read_bool(pdev->dev.of_node,
+					"iqaudio,24db_digital_gain");
 	}
 
 	ret = snd_soc_register_card(&snd_rpi_iqaudio_dac);


### PR DESCRIPTION
24db_digital_gain DT param can be used to specify that PCM512x
codec "Digital" volume control should not be limited to 0db gain,
and if specified will allow the full 24db gain.
