### PR TITLE
rpi-4.1.y: Allow up to 24dB digital gain to be applied when using IQAudIO DAC+

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -341,8 +341,21 @@ Params: <None>
 
 Name:   iqaudio-dacplus
 Info:   Configures the IQaudio DAC+ audio card
-Load:   dtoverlay=iqaudio-dacplus
-Params: <None>
+Load:   dtoverlay=iqaudio-dacplus,<param>=<val>
+Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
+                                Digital volume control. Enable with
+                                "dtoverlay=iqaudio-dacplus,24db_digital_gain"
+                                (The default behaviour is that the Digital
+                                volume control is limited to a maximum of
+                                0dB. ie. it can attenuate but not provide
+                                gain. For most users, this will be desired
+                                as it will prevent clipping. By appending
+                                the 24db_digital_gain parameter, the Digital
+                                volume control will allow up to 24dB of
+                                gain. If this parameter is enabled, it is the
+                                responsibility of the user to ensure that
+                                the Digital volume control is set to a value
+                                that does not result in clipping/distortion!)
 
 
 Name:   lirc-rpi

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -252,8 +252,21 @@ Params: <None>
 
 Name:   hifiberry-dacplus
 Info:   Configures the HifiBerry DAC+ audio card
-Load:   dtoverlay=hifiberry-dacplus
-Params: <None>
+Load:   dtoverlay=hifiberry-dacplus,<param>=<val>
+Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
+                                Digital volume control. Enable with
+                                "dtoverlay=hifiberry-dacplus,24db_digital_gain"
+                                (The default behaviour is that the Digital
+                                volume control is limited to a maximum of
+                                0dB. ie. it can attenuate but not provide
+                                gain. For most users, this will be desired
+                                as it will prevent clipping. By appending
+                                the 24dB_digital_gain parameter, the Digital
+                                volume control will allow up to 24dB of
+                                gain. If this parameter is enabled, it is the
+                                responsibility of the user to ensure that
+                                the Digital volume control is set to a value
+                                that does not result in clipping/distortion!)
 
 
 Name:   hifiberry-digi

--- a/arch/arm/boot/dts/overlays/hifiberry-dacplus-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dacplus-overlay.dts
@@ -17,7 +17,7 @@
 
 	fragment@1 {
 		target = <&sound>;
-		__overlay__ {
+		frag1: __overlay__ {
 			compatible = "hifiberry,hifiberry-dacplus";
 			i2s-controller = <&i2s>;
 			status = "okay";
@@ -46,5 +46,9 @@
 				status = "okay";
 			};
 		};
+	};
+
+	__overrides__ {
+		24db_digital_gain = <&frag1>,"hifiberry,24db_digital_gain?";
 	};
 };

--- a/arch/arm/boot/dts/overlays/iqaudio-dacplus-overlay.dts
+++ b/arch/arm/boot/dts/overlays/iqaudio-dacplus-overlay.dts
@@ -7,7 +7,7 @@
 
 	fragment@0 {
 		target = <&sound>;
-		__overlay__ {
+		frag0: __overlay__ {
 			compatible = "iqaudio,iqaudio-dac";
 			i2s-controller = <&i2s>;
 			status = "okay";
@@ -35,5 +35,9 @@
 				status = "okay";
 			};
 		};
+	};
+
+	__overrides__ {
+		24db_digital_gain = <&frag0>,"iqaudio,24db_digital_gain?";
 	};
 };

--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -48,6 +48,7 @@ struct pcm512x_priv {
 #define CLK_48EN_RATE 24576000UL
 
 static bool snd_rpi_hifiberry_is_dacpro;
+static bool digital_gain_0db_limit = true;
 
 static void snd_rpi_hifiberry_dacplus_select_clk(struct snd_soc_codec *codec,
 	int clk_id)
@@ -166,6 +167,17 @@ static int snd_rpi_hifiberry_dacplus_init(struct snd_soc_pcm_runtime *rtd)
 	snd_soc_update_bits(codec, PCM512x_GPIO_EN, 0x08, 0x08);
 	snd_soc_update_bits(codec, PCM512x_GPIO_OUTPUT_4, 0x0f, 0x02);
 	snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x08, 0x08);
+
+	if (digital_gain_0db_limit)
+	{
+		int ret;
+		struct snd_soc_card *card = rtd->card;
+		struct snd_soc_codec *codec = rtd->codec;
+
+		ret = snd_soc_limit_volume(codec, "Digital Playback Volume", 207);
+		if (ret < 0)
+			dev_warn(card->dev, "Failed to set volume limit: %d\n", ret);
+	}
 
 	return 0;
 }
@@ -299,6 +311,9 @@ static int snd_rpi_hifiberry_dacplus_probe(struct platform_device *pdev)
 			dai->platform_name = NULL;
 			dai->platform_of_node = i2s_node;
 		}
+
+		digital_gain_0db_limit = !of_property_read_bool(
+			pdev->dev.of_node, "hifiberry,24db_digital_gain");
 	}
 
 	ret = snd_soc_register_card(&snd_rpi_hifiberry_dacplus);

--- a/sound/soc/bcm/iqaudio-dac.c
+++ b/sound/soc/bcm/iqaudio-dac.c
@@ -23,15 +23,20 @@
 #include <sound/soc.h>
 #include <sound/jack.h>
 
+static bool digital_gain_0db_limit = true;
+
 static int snd_rpi_iqaudio_dac_init(struct snd_soc_pcm_runtime *rtd)
 {
-	int ret;
-	struct snd_soc_card *card = rtd->card;
-	struct snd_soc_codec *codec = rtd->codec;
+	if (digital_gain_0db_limit)
+	{
+		int ret;
+		struct snd_soc_card *card = rtd->card;
+		struct snd_soc_codec *codec = rtd->codec;
 
-	ret = snd_soc_limit_volume(codec, "Digital Playback Volume", 207);
-	if (ret < 0)
-		dev_warn(card->dev, "Failed to set volume limit: %d\n", ret);
+		ret = snd_soc_limit_volume(codec, "Digital Playback Volume", 207);
+		if (ret < 0)
+			dev_warn(card->dev, "Failed to set volume limit: %d\n", ret);
+	}
 
 	return 0;
 }
@@ -95,6 +100,9 @@ static int snd_rpi_iqaudio_dac_probe(struct platform_device *pdev)
 		dai->platform_name = NULL;
 		dai->platform_of_node = i2s_node;
 	    }
+
+	    digital_gain_0db_limit = !of_property_read_bool(pdev->dev.of_node,
+					"iqaudio,24db_digital_gain");
 	}
 
 	ret = snd_soc_register_card(&snd_rpi_iqaudio_dac);


### PR DESCRIPTION
@pelwell Phil, feel free to close immediately without pulling....... 

No trouble, I originally tested on 4.1.y before I submitted for rpi-4.4.y.
