### PR TITLE
Updated smsc95xx driver to check for a valid MAC address in eeprom first

### DIFF
--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -821,10 +821,6 @@ static int smsc95xx_is_macaddr_param(struct usbnet *dev, u8 *dev_mac)
 
 static void smsc95xx_init_mac_address(struct usbnet *dev)
 {
-       /* Check module parameters */
-       if (smsc95xx_is_macaddr_param(dev, dev->net->dev_addr))
-               return;
-
 	/* try reading mac address from EEPROM */
 	if (smsc95xx_read_eeprom(dev, EEPROM_MAC_OFFSET, ETH_ALEN,
 			dev->net->dev_addr) == 0) {
@@ -835,7 +831,11 @@ static void smsc95xx_init_mac_address(struct usbnet *dev)
 		}
 	}
 
-	/* no eeprom, or eeprom values are invalid. generate random MAC */
+	/* Check module parameters */
+	if (smsc95xx_is_macaddr_param(dev, dev->net->dev_addr))
+		return;
+
+	/* no eeprom, or eeprom values are invalid, and no module parameter specified to set MAC. Generate random MAC */
 	eth_hw_addr_random(dev->net);
 	netif_dbg(dev, ifup, dev->net, "MAC address set to eth_random_addr\n");
 }


### PR DESCRIPTION
I'm using multiple USB->Ethernet Adaptors based on the same chip as the RPi has. I've found they all show up with the same MAC address on boot. This Pull Request solves this by checking for a valid MAC on eeprom before setting the MAC address based on the smsc95xx.macaddr parameter. It's a re-order of existing code, not additional code.
