### PR TITLE
ASoC: bcm: add missing .owner fields in sound card drivers

### DIFF
--- a/sound/soc/bcm/hifiberry_amp.c
+++ b/sound/soc/bcm/hifiberry_amp.c
@@ -61,6 +61,7 @@ static struct snd_soc_dai_link snd_rpi_hifiberry_amp_dai[] = {
 
 static struct snd_soc_card snd_rpi_hifiberry_amp = {
 	.name         = "snd_rpi_hifiberry_amp",
+	.owner        = THIS_MODULE,
 	.dai_link     = snd_rpi_hifiberry_amp_dai,
 	.num_links    = ARRAY_SIZE(snd_rpi_hifiberry_amp_dai),
 };

--- a/sound/soc/bcm/hifiberry_dac.c
+++ b/sound/soc/bcm/hifiberry_dac.c
@@ -63,6 +63,7 @@ static struct snd_soc_dai_link snd_rpi_hifiberry_dac_dai[] = {
 /* audio machine driver */
 static struct snd_soc_card snd_rpi_hifiberry_dac = {
 	.name         = "snd_rpi_hifiberry_dac",
+	.owner        = THIS_MODULE,
 	.dai_link     = snd_rpi_hifiberry_dac_dai,
 	.num_links    = ARRAY_SIZE(snd_rpi_hifiberry_dac_dai),
 };

--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -287,6 +287,7 @@ static struct snd_soc_dai_link snd_rpi_hifiberry_dacplus_dai[] = {
 /* audio machine driver */
 static struct snd_soc_card snd_rpi_hifiberry_dacplus = {
 	.name         = "snd_rpi_hifiberry_dacplus",
+	.owner        = THIS_MODULE,
 	.dai_link     = snd_rpi_hifiberry_dacplus_dai,
 	.num_links    = ARRAY_SIZE(snd_rpi_hifiberry_dacplus_dai),
 };

--- a/sound/soc/bcm/hifiberry_digi.c
+++ b/sound/soc/bcm/hifiberry_digi.c
@@ -164,6 +164,7 @@ static struct snd_soc_dai_link snd_rpi_hifiberry_digi_dai[] = {
 /* audio machine driver */
 static struct snd_soc_card snd_rpi_hifiberry_digi = {
 	.name         = "snd_rpi_hifiberry_digi",
+	.owner        = THIS_MODULE,
 	.dai_link     = snd_rpi_hifiberry_digi_dai,
 	.num_links    = ARRAY_SIZE(snd_rpi_hifiberry_digi_dai),
 };

--- a/sound/soc/bcm/iqaudio-dac.c
+++ b/sound/soc/bcm/iqaudio-dac.c
@@ -77,6 +77,7 @@ static struct snd_soc_dai_link snd_rpi_iqaudio_dac_dai[] = {
 /* audio machine driver */
 static struct snd_soc_card snd_rpi_iqaudio_dac = {
 	.name         = "IQaudIODAC",
+	.owner        = THIS_MODULE,
 	.dai_link     = snd_rpi_iqaudio_dac_dai,
 	.num_links    = ARRAY_SIZE(snd_rpi_iqaudio_dac_dai),
 };

--- a/sound/soc/bcm/raspidac3.c
+++ b/sound/soc/bcm/raspidac3.c
@@ -128,6 +128,7 @@ static struct snd_soc_dai_link snd_rpi_raspidac3_dai[] = {
 /* audio machine driver */
 static struct snd_soc_card snd_rpi_raspidac3 = {
 	.name         = "RaspiDAC Rev.3x HiFi Audio Card",
+	.owner        = THIS_MODULE,
 	.dai_link     = snd_rpi_raspidac3_dai,
 	.num_links    = ARRAY_SIZE(snd_rpi_raspidac3_dai),
 };

--- a/sound/soc/bcm/rpi-dac.c
+++ b/sound/soc/bcm/rpi-dac.c
@@ -60,6 +60,7 @@ static struct snd_soc_dai_link snd_rpi_rpi_dac_dai[] = {
 /* audio machine driver */
 static struct snd_soc_card snd_rpi_rpi_dac = {
 	.name         = "snd_rpi_rpi_dac",
+	.owner        = THIS_MODULE,
 	.dai_link     = snd_rpi_rpi_dac_dai,
 	.num_links    = ARRAY_SIZE(snd_rpi_rpi_dac_dai),
 };

--- a/sound/soc/bcm/rpi-proto.c
+++ b/sound/soc/bcm/rpi-proto.c
@@ -91,6 +91,7 @@ static struct snd_soc_dai_link snd_rpi_proto_dai[] = {
 /* audio machine driver */
 static struct snd_soc_card snd_rpi_proto = {
 	.name		= "snd_rpi_proto",
+	.owner		= THIS_MODULE,
 	.dai_link	= snd_rpi_proto_dai,
 	.num_links	= ARRAY_SIZE(snd_rpi_proto_dai),
 };


### PR DESCRIPTION
If snd_soc_card.owner is not set the kernel won't do usage refcounting
and one can remove the card driver module while it's in use (eg playback
active) - which leads to a kernel crash.

The missing owner field also prevents ALSA slot ordering
(options snd slots=module-name1,module-name-2,...) from working with
the I2S cards as it has no module name to match against.

Fix these issues by setting the .owner field in the snd_soc_card structs.

@popcornmix @pelwell if you merge this please also cherry-pick this commit into the 4.1 and 4.5 trees
