### PR TITLE
bcm2835-camera: fix a bug in computation of frame timestamp

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-camera.c
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.c
@@ -360,8 +360,7 @@ static void buffer_cb(struct vchiq_mmal_instance *instance,
 				div =
 				    div_u64_rem(runtime_us, USEC_PER_SEC, &rem);
 				buf->vb.v4l2_buf.timestamp.tv_sec =
-				    dev->capture.kernel_start_ts.tv_sec - 1 +
-				    div;
+				    dev->capture.kernel_start_ts.tv_sec + div;
 				buf->vb.v4l2_buf.timestamp.tv_usec =
 				    dev->capture.kernel_start_ts.tv_usec + rem;
 


### PR DESCRIPTION
Fixes #1318
