### PR TITLE
[4.4] scripts/dtc: Fix UMR causing corrupt dtbo overlay files

### DIFF
--- a/scripts/dtc/checks.c
+++ b/scripts/dtc/checks.c
@@ -523,6 +523,7 @@ static void fixup_phandle_references(struct check *c, struct node *dt,
 			fe->prop = prop;
 			fe->offset = m->offset;
 			fe->next = NULL;
+			fe->local_fixup_generated = false;
 
 			/* append it to the local fixups */
 			fep = &dt->local_fixups;


### PR DESCRIPTION
I've tracked down some mysterious devicetree issues (phandle not found in vcdbg log) and kernel crashes with local builds to be caused by an uninitialized memory read in dtc.

Depending on command line parameters and the phase of the moon I got different dtbo files than the ones from https://github.com/raspberrypi/firmware/tree/next - the md5sums didn't match although the source trees were identical.

One way to reproduce here was calling "make dtbs V=1" to get the excact dtc command to generate lirc-rpi.dtbo or dht11.dtbo and then remove the '-d ...'  part to generate the dependency info.

Using valgrind then gave the final clue and confirmation.

BTW: with the UMR fixed I still get some md5 mismatches to the dtbos from your official firmware release. Please double-check these files, they could be faulty:

```
dht11.dtbo: FAILED
i2c0-bcm2708.dtbo: FAILED
i2c1-bcm2708.dtbo: FAILED
iqaudio-dacplus.dtbo: FAILED
sdhost.dtbo: FAILED
smi-nand.dtbo: FAILED
```

I've attached the md5sums of the dtbos generated locally with the fixed dtc so you can compare them.

[dtbo-md5sums.txt](https://github.com/raspberrypi/linux/files/174852/dtbo-md5sums.txt)
