### PR TITLE
Use label so overrides can apply.

### DIFF
--- a/arch/arm/boot/dts/overlays/dwc2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/dwc2-overlay.dts
@@ -8,7 +8,7 @@
 		target = <&usb>;
 		#address-cells = <1>;
 		#size-cells = <1>;
-		__overlay__ {
+		dwc2_usb: __overlay__ {
 			compatible = "brcm,bcm2835-usb";
 			reg = <0x7e980000 0x10000>;
 			interrupts = <1 9>;
@@ -21,9 +21,9 @@
 	};
 
 	__overrides__ {
-		dr_mode = <&usb>, "dr_mode";
-		g-np-tx-fifo-size = <&usb>,"g-np-tx-fifo-size:0";
-		g-rx-fifo-size = <&usb>,"g-rx-fifo-size:0";
-		g-tx-fifo-size = <&usb>,"g-tx-fifo-size:0";
+		dr_mode = <&dwc2_usb>, "dr_mode";
+		g-np-tx-fifo-size = <&dwc2_usb>,"g-np-tx-fifo-size:0";
+		g-rx-fifo-size = <&dwc2_usb>,"g-rx-fifo-size:0";
+		g-tx-fifo-size = <&dwc2_usb>,"g-tx-fifo-size:0";
 	};
 };


### PR DESCRIPTION
Without this overlay parameters are ignored during startup.
