### PR TITLE
v4l2 - ioctl 2 times bugfix on still mode

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-camera.c
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.c
@@ -333,7 +333,8 @@ static void buffer_cb(struct vchiq_mmal_instance *instance,
 			pr_debug("Empty buffer");
 		} else if (dev->capture.frame_count) {
 			/* grab another frame */
-			if (is_capturing(dev)) {
+			if (is_capturing(dev) &&
+			    !vchiq_mmal_port_buffer_empty(dev->capture.port)) {
 				pr_debug("Grab another frame");
 				vchiq_mmal_port_parameter_set(
 					instance,
@@ -389,7 +390,8 @@ static void buffer_cb(struct vchiq_mmal_instance *instance,
 			vb2_buffer_done(&buf->vb, VB2_BUF_STATE_DONE);
 
 			if (mmal_flags & MMAL_BUFFER_HEADER_FLAG_EOS &&
-			    is_capturing(dev)) {
+			    is_capturing(dev) &&
+			    !vchiq_mmal_port_buffer_empty(dev->capture.port)) {
 				v4l2_dbg(1, bcm2835_v4l2_debug, &dev->v4l2_dev,
 					 "Grab another frame as buffer has EOS");
 				vchiq_mmal_port_parameter_set(
@@ -466,6 +468,7 @@ static void buffer_queue(struct vb2_buffer *vb)
 {
 	struct bm2835_mmal_dev *dev = vb2_get_drv_priv(vb->vb2_queue);
 	struct mmal_buffer *buf = container_of(vb, struct mmal_buffer, vb);
+	bool empty = vchiq_mmal_port_buffer_empty(dev->capture.port);
 	int ret;
 
 	v4l2_dbg(1, bcm2835_v4l2_debug, &dev->v4l2_dev,
@@ -478,6 +481,19 @@ static void buffer_queue(struct vb2_buffer *vb)
 	if (ret < 0)
 		v4l2_err(&dev->v4l2_dev, "%s: error submitting buffer\n",
 			 __func__);
+
+	if (dev->capture.frame_count && is_capturing(dev) && empty) {
+		v4l2_dbg(1, bcm2835_v4l2_debug, &dev->v4l2_dev,
+				 "Grab a frame on buffer queued\n");
+		vchiq_mmal_port_parameter_set(
+			dev->instance,
+			dev->capture.
+			camera_port,
+			MMAL_PARAMETER_CAPTURE,
+			&dev->capture.
+			frame_count,
+			sizeof(dev->capture.frame_count));
+	}
 }
 
 static int start_streaming(struct vb2_queue *vq, unsigned int count)
@@ -558,6 +574,10 @@ static int start_streaming(struct vb2_queue *vq, unsigned int count)
 		}
 		return -1;
 	}
+
+	if (is_capturing(dev) &&
+	    vchiq_mmal_port_buffer_empty(dev->capture.port))
+		return 0;
 
 	/* capture the first frame */
 	vchiq_mmal_port_parameter_set(dev->instance,

--- a/drivers/media/platform/bcm2835/mmal-vchiq.c
+++ b/drivers/media/platform/bcm2835/mmal-vchiq.c
@@ -1643,6 +1643,11 @@ int vchiq_mmal_submit_buffer(struct vchiq_mmal_instance *instance,
 	return 0;
 }
 
+bool vchiq_mmal_port_buffer_empty(struct vchiq_mmal_port *port)
+{
+	return list_empty(&port->buffers);
+}
+
 /* Initialise a mmal component and its ports
  *
  */

--- a/drivers/media/platform/bcm2835/mmal-vchiq.h
+++ b/drivers/media/platform/bcm2835/mmal-vchiq.h
@@ -175,4 +175,6 @@ int vchiq_mmal_submit_buffer(struct vchiq_mmal_instance *instance,
 			     struct vchiq_mmal_port *port,
 			     struct mmal_buffer *buf);
 
+bool vchiq_mmal_port_buffer_empty(struct vchiq_mmal_port *port);
+
 #endif /* MMAL_VCHIQ_H */


### PR DESCRIPTION
Avoid 2 times VIDIOC_QBUF, VIDIOC_DQBUF call on JPEG format capture.
#1297
