### PR TITLE
lirc_rpi: Lower IR reception error to debug

### DIFF
--- a/drivers/staging/media/lirc/lirc_rpi.c
+++ b/drivers/staging/media/lirc/lirc_rpi.c
@@ -273,7 +273,7 @@ static irqreturn_t irq_handler(int i, void *blah, struct pt_regs *regs)
 			data = PULSE_MASK; /* really long time */
 			if (!(signal^sense)) {
 				/* sanity check */
-				printk(KERN_WARNING LIRC_DRIVER_NAME
+				printk(KERN_DEBUG LIRC_DRIVER_NAME
 				       ": AIEEEE: %d %d %lx %lx %lx %lx\n",
 				       signal, sense, tv.tv_sec, lasttv.tv_sec,
 				       tv.tv_usec, lasttv.tv_usec);


### PR DESCRIPTION
Sometimes the IR receiver does not understands a IR pulse and will throw lots of printks:

```
Mar 21 21:47:02 pi-quarto kernel: [190313.352993] lirc_rpi: AIEEEE: 1 1 56f06bd6 56f06b53 3d963 2e722
Mar 21 21:49:27 pi-quarto kernel: [190458.485894] lirc_rpi: AIEEEE: 0 0 56f06c67 56f06c39 5e08a 67f04
Mar 21 22:20:57 pi-quarto kernel: [192348.232130] lirc_rpi: AIEEEE: 1 1 56f073c9 56f07389 20147 bbca1
Mar 21 22:22:30 pi-quarto kernel: [192441.471321] lirc_rpi: AIEEEE: 0 0 56f07426 56f073ec 5a79e cb6f4
Mar 21 22:30:52 pi-quarto kernel: [192943.810652] lirc_rpi: AIEEEE: 1 1 56f0761c 56f075f4 ad520 231c0
Mar 21 22:35:14 pi-quarto kernel: [193205.705152] lirc_rpi: AIEEEE: 0 0 56f07722 56f07709 93904 ce464
Mar 22 08:42:38 pi-quarto kernel: [229649.228031] lirc_rpi: AIEEEE: 1 1 56f1057e 56f104cb 1f144 70e72
Mar 22 08:43:02 pi-quarto kernel: [229673.395809] lirc_rpi: AIEEEE: 0 0 56f10596 56f1057e 480a7 1f666
```

This will cause a disk/SD card wake up and a write of the `printk()` in `/var/log/{messages,syslog,kern.log}`

This commit lowers a IR reception error condition message to KERNEL_DEBUG.
