### PR TITLE
[media]: bcm2835-camera: fix compilation error

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-camera.c
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.c
@@ -236,7 +236,7 @@ static struct mmal_fmt *get_format(struct v4l2_format *f)
 	Videobuf queue operations
    ------------------------------------------------------------------*/
 
-static int queue_setup(struct vb2_queue *vq, const void *parg,
+static int queue_setup(struct vb2_queue *vq,
 		       unsigned int *nbuffers, unsigned int *nplanes,
 		       unsigned int sizes[], void *alloc_ctxs[])
 {


### PR DESCRIPTION
There is an error when compiling rpi-4.6.y branch:
  CC [M]  drivers/media/platform/bcm2835/bcm2835-camera.o
drivers/media/platform/bcm2835/bcm2835-camera.c:639:17: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
  .queue_setup = queue_setup,
                 ^
drivers/media/platform/bcm2835/bcm2835-camera.c:639:17: note: (near initialization for 'bm2835_mmal_video_qops.queue_setup')

The const void *parg in setup_queue callback is not needed since commit:
df9ecb0cad14b952a2865f8b3af86b2bbadfab45.
This commit removes it.

Signed-off-by: Slawomir Stepien sst@poczta.fm
