### PR TITLE
DT configfs: fix build error

### DIFF
--- a/drivers/of/configfs.c
+++ b/drivers/of/configfs.c
@@ -277,18 +277,12 @@ static struct config_item_type of_cfs_type = {
 
 struct config_group of_cfs_overlay_group;
 
-struct config_group *of_cfs_def_groups[] = {
-	&of_cfs_overlay_group,
-	NULL
-};
-
 static struct configfs_subsystem of_cfs_subsys = {
 	.su_group = {
 		.cg_item = {
 			.ci_namebuf = "device-tree",
 			.ci_type = &of_cfs_type,
 		},
-		.default_groups = of_cfs_def_groups,
 	},
 	.su_mutex = __MUTEX_INITIALIZER(of_cfs_subsys.su_mutex),
 };
@@ -302,6 +296,8 @@ static int __init of_cfs_init(void)
 	config_group_init(&of_cfs_subsys.su_group);
 	config_group_init_type_name(&of_cfs_overlay_group, "overlays",
 			&overlays_type);
+	configfs_add_default_group(&of_cfs_overlay_group,
+			&of_cfs_subsys.su_group);
 
 	ret = configfs_register_subsystem(&of_cfs_subsys);
 	if (ret != 0) {


### PR DESCRIPTION
There is an error when compiling rpi-4.6.y branch:
  CC      drivers/of/configfs.o
drivers/of/configfs.c:291:21: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
   .default_groups = of_cfs_def_groups,
                     ^
drivers/of/configfs.c:291:21: note: (near initialization for 'of_cfs_subsys.su_group.default_groups.next')

The .default_groups is linked list since commit
1ae1602de028acaa42a0f6ff18d19756f8e825c6.
This commit uses configfs_add_default_group to fix this problem.

Signed-off-by: Slawomir Stepien sst@poczta.fm
