### PR TITLE
V4L2 driver updates

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-camera.c
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.c
@@ -1825,7 +1825,7 @@ void bcm2835_cleanup_instance(struct bm2835_mmal_dev *dev)
 static struct v4l2_format default_v4l2_format = {
 	.fmt.pix.pixelformat = V4L2_PIX_FMT_JPEG,
 	.fmt.pix.width = 1024,
-	.fmt.pix.bytesperline = 1024,
+	.fmt.pix.bytesperline = 0,
 	.fmt.pix.height = 768,
 	.fmt.pix.sizeimage = 1024*768,
 };

--- a/drivers/media/platform/bcm2835/bcm2835-camera.c
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.c
@@ -54,6 +54,10 @@ int bcm2835_v4l2_debug;
 module_param_named(debug, bcm2835_v4l2_debug, int, 0644);
 MODULE_PARM_DESC(bcm2835_v4l2_debug, "Debug level 0-2");
 
+static int video_nr = -1;
+module_param_named(video_nr, video_nr, int, 0644);
+MODULE_PARM_DESC(video_nr, "videoX start number, -1 is autodetect");
+
 int max_video_width = MAX_VIDEO_MODE_WIDTH;
 int max_video_height = MAX_VIDEO_MODE_HEIGHT;
 module_param(max_video_width, int, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
@@ -1685,7 +1689,7 @@ static int __init bm2835_mmal_init_device(struct bm2835_mmal_dev *dev,
 	/* video device needs to be able to access instance data */
 	video_set_drvdata(vfd, dev);
 
-	ret = video_register_device(vfd, VFL_TYPE_GRABBER, -1);
+	ret = video_register_device(vfd, VFL_TYPE_GRABBER, video_nr);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/media/platform/bcm2835/bcm2835-camera.c
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.c
@@ -61,8 +61,8 @@ static int video_nr[] = {[0 ... (MAX_BCM2835_CAMERAS - 1)] = UNSET };
 module_param_array(video_nr, int, NULL, 0644);
 MODULE_PARM_DESC(video_nr, "videoX start numbers, -1 is autodetect");
 
-int max_video_width = MAX_VIDEO_MODE_WIDTH;
-int max_video_height = MAX_VIDEO_MODE_HEIGHT;
+static int max_video_width = MAX_VIDEO_MODE_WIDTH;
+static int max_video_height = MAX_VIDEO_MODE_HEIGHT;
 module_param(max_video_width, int, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(max_video_width, "Threshold for video mode");
 module_param(max_video_height, int, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
@@ -77,7 +77,7 @@ MODULE_PARM_DESC(max_video_height, "Threshold for video mode");
  * our function table list (actually switch to an alternate set, but same
  * result).
  */
-int gst_v4l2src_is_broken = 0;
+static int gst_v4l2src_is_broken;
 module_param(gst_v4l2src_is_broken, int, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 MODULE_PARM_DESC(gst_v4l2src_is_broken, "If non-zero, enable workaround for Gstreamer");
 

--- a/drivers/media/platform/bcm2835/bcm2835-camera.h
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.h
@@ -128,3 +128,16 @@ int set_framerate_params(struct bm2835_mmal_dev *dev);
 		(pix_fmt)->pixelformat, (pix_fmt)->bytesperline,	\
 		(pix_fmt)->sizeimage, (pix_fmt)->colorspace, (pix_fmt)->priv); \
 }
+#define v4l2_dump_win_format(level, debug, dev, win_fmt, desc)	\
+{	\
+	v4l2_dbg(level, debug, dev,	\
+"%s: w %u h %u l %u t %u  field %u chromakey %06X clip %p " \
+"clipcount %u bitmap %p\n", \
+		desc == NULL ? "" : desc,	\
+		(win_fmt)->w.width, (win_fmt)->w.height, \
+		(win_fmt)->w.left, (win_fmt)->w.top, \
+		(win_fmt)->field,	\
+		(win_fmt)->chromakey,	\
+		(win_fmt)->clips, (win_fmt)->clipcount,	\
+		(win_fmt)->bitmap); \
+}

--- a/drivers/media/platform/bcm2835/bcm2835-camera.h
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.h
@@ -106,6 +106,8 @@ struct bm2835_mmal_dev {
 
 	} capture;
 
+	unsigned int camera_num;
+
 };
 
 int bm2835_mmal_init_controls(

--- a/drivers/media/platform/bcm2835/bcm2835-camera.h
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.h
@@ -15,7 +15,7 @@
  * core driver device
  */
 
-#define V4L2_CTRL_COUNT 28 /* number of v4l controls */
+#define V4L2_CTRL_COUNT 29 /* number of v4l controls */
 
 enum {
 	MMAL_COMPONENT_CAMERA = 0,
@@ -58,6 +58,8 @@ struct bm2835_mmal_dev {
 	enum mmal_parameter_exposuremeteringmode metering_mode;
 	unsigned int		  manual_shutter_speed;
 	bool			  exp_auto_priority;
+	bool manual_iso_enabled;
+	uint32_t iso;
 
 	/* allocated mmal instance and components */
 	struct vchiq_mmal_instance   *instance;

--- a/drivers/media/platform/bcm2835/mmal-parameters.h
+++ b/drivers/media/platform/bcm2835/mmal-parameters.h
@@ -654,3 +654,36 @@ struct mmal_parameter_imagefx_parameters {
 	u32 num_effect_params;
 	u32 effect_parameter[MMAL_MAX_IMAGEFX_PARAMETERS];
 };
+
+#define MMAL_PARAMETER_CAMERA_INFO_MAX_CAMERAS 4
+#define MMAL_PARAMETER_CAMERA_INFO_MAX_FLASHES 2
+#define MMAL_PARAMETER_CAMERA_INFO_MAX_STR_LEN 16
+
+struct mmal_parameter_camera_info_camera_t {
+	u32    port_id;
+	u32    max_width;
+	u32    max_height;
+	u32    lens_present;
+	u8     camera_name[MMAL_PARAMETER_CAMERA_INFO_MAX_STR_LEN];
+};
+
+enum mmal_parameter_camera_info_flash_type_t {
+	/* Make values explicit to ensure they match values in config ini */
+	MMAL_PARAMETER_CAMERA_INFO_FLASH_TYPE_XENON = 0,
+	MMAL_PARAMETER_CAMERA_INFO_FLASH_TYPE_LED   = 1,
+	MMAL_PARAMETER_CAMERA_INFO_FLASH_TYPE_OTHER = 2,
+	MMAL_PARAMETER_CAMERA_INFO_FLASH_TYPE_MAX = 0x7FFFFFFF
+};
+
+struct mmal_parameter_camera_info_flash_t {
+	enum mmal_parameter_camera_info_flash_type_t flash_type;
+};
+
+struct mmal_parameter_camera_info_t {
+	u32                            num_cameras;
+	u32                            num_flashes;
+	struct mmal_parameter_camera_info_camera_t
+				cameras[MMAL_PARAMETER_CAMERA_INFO_MAX_CAMERAS];
+	struct mmal_parameter_camera_info_flash_t
+				flashes[MMAL_PARAMETER_CAMERA_INFO_MAX_FLASHES];
+};


### PR DESCRIPTION
A few updates to the V4L2 driver for the Pi Camera.
- Correct the support for ISO control.
- Add option to specify the /dev/videoN node number.
- Support for multiple cameras on the CM.
- Support for specifying where the overlay is on the screen.
- Compliance test failure.

A quick review by others would be appreciated, just to make sure I haven't missed something silly in the init/exit loops. (I'm afraid I haven't done as much testing of that as I perhaps ought to have done)
