### PR TITLE
vchiq_arm: do not use page_cache_release(page) macro

### DIFF
--- a/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
+++ b/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
@@ -439,7 +439,7 @@ create_pagelist(char __user *buf, size_t count, unsigned short type,
 			while (actual_pages > 0)
 			{
 				actual_pages--;
-				page_cache_release(pages[actual_pages]);
+				put_page(pages[actual_pages]);
 			}
 			kfree(pagelist);
 			if (actual_pages == 0)
@@ -578,7 +578,7 @@ free_pagelist(PAGELIST_T *pagelist, int actual)
 				offset = 0;
 				set_page_dirty(pg);
 			}
-			page_cache_release(pg);
+			put_page(pg);
 		}
 	}
 

--- a/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -1520,7 +1520,7 @@ dump_phys_mem(void *virt_addr, uint32_t num_bytes)
 		kunmap(page);
 
 	for (page_idx = 0; page_idx < num_pages; page_idx++)
-		page_cache_release(pages[page_idx]);
+		put_page(pages[page_idx]);
 
 	kfree(pages);
 }


### PR DESCRIPTION
This macro is gone since 1fa64f198b9f8d6ec0f7aec7c18dc94684391140.

Signed-off-by: Slawomir Stepien sst@poczta.fm
