### PR TITLE
Add support for Digital Dreamtime Akkordion (using OEM IQAudIO DAC module)

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -13,6 +13,7 @@ ifeq ($(CONFIG_ARCH_BCM2835),y)
 endif
 
 dtbo-$(RPI_DT_OVERLAYS) += ads7846.dtbo
+dtbo-$(RPI_DT_OVERLAYS) += akkordion-iqdacplus.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += at86rf233.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += bmp085_i2c-sensor.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += dwc2.dtbo

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -186,6 +186,26 @@ Params: cs                      SPI bus Chip Select (default 1)
         www.kernel.org/doc/Documentation/devicetree/bindings/input/ads7846.txt
 
 
+Name:   akkordion-iqdacplus
+Info:   Configures the Digital Dreamtime Akkordion Music Player (based on the
+        OEM IQAudIO DAC+ or DAC Zero module).
+Load:   dtoverlay=akkordion-iqdacplus,<param>=<val>
+Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
+                                Digital volume control. Enable with
+                                "dtoverlay=akkordion-iqdacplus,24db_digital_gain"
+                                (The default behaviour is that the Digital
+                                volume control is limited to a maximum of
+                                0dB. ie. it can attenuate but not provide
+                                gain. For most users, this will be desired
+                                as it will prevent clipping. By appending
+                                the 24db_digital_gain parameter, the Digital
+                                volume control will allow up to 24dB of
+                                gain. If this parameter is enabled, it is the
+                                responsibility of the user to ensure that
+                                the Digital volume control is set to a value
+                                that does not result in clipping/distortion!)
+
+
 Name:   at86rf233
 Info:   Configures the Atmel AT86RF233 802.15.4 low-power WPAN transceiver,
         connected to spi0.0

--- a/arch/arm/boot/dts/overlays/akkordion-iqdacplus-overlay.dts
+++ b/arch/arm/boot/dts/overlays/akkordion-iqdacplus-overlay.dts
@@ -1,0 +1,46 @@
+// Definitions for Digital Dreamtime Akkordion using IQaudIO DAC+ or DACZero
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&sound>;
+		frag0: __overlay__ {
+			compatible = "iqaudio,iqaudio-dac";
+			card_name = "Akkordion";
+			dai_name = "IQaudIO DAC";
+			dai_stream_name = "IQaudIO DAC HiFi";
+			i2s-controller = <&i2s>;
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&i2s>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			pcm5122@4c {
+				#sound-dai-cells = <0>;
+				compatible = "ti,pcm5122";
+				reg = <0x4c>;
+				status = "okay";
+			};
+		};
+	};
+
+	__overrides__ {
+		24db_digital_gain = <&frag0>,"iqaudio,24db_digital_gain?";
+	};
+};

--- a/sound/soc/bcm/iqaudio-dac.c
+++ b/sound/soc/bcm/iqaudio-dac.c
@@ -61,8 +61,6 @@ static struct snd_soc_ops snd_rpi_iqaudio_dac_ops = {
 
 static struct snd_soc_dai_link snd_rpi_iqaudio_dac_dai[] = {
 {
-	.name		= "IQaudIO DAC",
-	.stream_name	= "IQaudIO DAC HiFi",
 	.cpu_dai_name	= "bcm2708-i2s.0",
 	.codec_dai_name	= "pcm512x-hifi",
 	.platform_name	= "bcm2708-i2s.0",
@@ -76,7 +74,6 @@ static struct snd_soc_dai_link snd_rpi_iqaudio_dac_dai[] = {
 
 /* audio machine driver */
 static struct snd_soc_card snd_rpi_iqaudio_dac = {
-	.name         = "IQaudIODAC",
 	.owner        = THIS_MODULE,
 	.dai_link     = snd_rpi_iqaudio_dac_dai,
 	.num_links    = ARRAY_SIZE(snd_rpi_iqaudio_dac_dai),
@@ -90,6 +87,7 @@ static int snd_rpi_iqaudio_dac_probe(struct platform_device *pdev)
 
 	if (pdev->dev.of_node) {
 	    struct device_node *i2s_node;
+	    struct snd_soc_card *card = &snd_rpi_iqaudio_dac;
 	    struct snd_soc_dai_link *dai = &snd_rpi_iqaudio_dac_dai[0];
 	    i2s_node = of_parse_phandle(pdev->dev.of_node,
 					"i2s-controller", 0);
@@ -103,6 +101,15 @@ static int snd_rpi_iqaudio_dac_probe(struct platform_device *pdev)
 
 	    digital_gain_0db_limit = !of_property_read_bool(pdev->dev.of_node,
 					"iqaudio,24db_digital_gain");
+	    if (of_property_read_string(pdev->dev.of_node, "card_name",
+					&card->name))
+		card->name = "IQaudIODAC";
+	    if (of_property_read_string(pdev->dev.of_node, "dai_name",
+					&dai->name))
+		dai->name = "IQaudIO DAC";
+	    if (of_property_read_string(pdev->dev.of_node, "dai_stream_name",
+					&dai->stream_name))
+		dai->stream_name = "IQaudIO DAC HiFi";
 	}
 
 	ret = snd_soc_register_card(&snd_rpi_iqaudio_dac);


### PR DESCRIPTION
This pull request is to add support for the Digital Dreamtime Akkordion music player, IQAudIO edition, which is "powered" by an OEM IQAudIO DAC module.
