### PR TITLE
vmcs: Remove unused sm_cache_map_vector definition

### DIFF
--- a/drivers/char/broadcom/vc_sm/vmcs_sm.c
+++ b/drivers/char/broadcom/vc_sm/vmcs_sm.c
@@ -197,12 +197,14 @@ struct SM_STATE_T {
 static struct SM_STATE_T *sm_state;
 static int sm_inited;
 
+#if 0
 static const char *const sm_cache_map_vector[] = {
 	"(null)",
 	"host",
 	"videocore",
 	"host+videocore",
 };
+#endif
 
 /* ---- Private Function Prototypes -------------------------------------- */
 


### PR DESCRIPTION
The code using it also ifdef'ed with 0, anyyd gcc 6
complains

error: 'sm_cache_map_vector' defined but not used

The code using it also ifdef'ed out

Signed-off-by: Khem Raj raj.khem@gmail.com
