### PR TITLE
ARM: bcm2708: overlay to set cma to 128M@128M

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -18,6 +18,7 @@ dtbo-$(RPI_DT_OVERLAYS) += at86rf233.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += bmp085_i2c-sensor.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += boomberry-dac.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += boomberry-digi.dtbo
+dtbo-$(RPI_DT_OVERLAYS) += cma-128m@128m.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += dpi24.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += dwc2.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += dwc-otg.dtbo

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -251,6 +251,12 @@ Load:   dtoverlay=boomberry-digi
 Params: <None>
 
 
+Name:   cma-128m@128m
+Info:   set cma to 128m@128m - typically used in conjunction with
+	vc4-kms-v3d on a machine with 512MB or less.
+Load:   dtoverlay=cma-128m@128m
+
+
 Name:   dht11
 Info:   Overlay for the DHT11/DHT21/DHT22 humidity/temperature sensors
         Also sometimes found with the part number(s) AM230x.

--- a/arch/arm/boot/dts/overlays/cma-128m@128m-overlay.dts
+++ b/arch/arm/boot/dts/overlays/cma-128m@128m-overlay.dts
@@ -1,0 +1,17 @@
+/*
+ * cma-128m@128m-overlay.dts
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+	fragment@0 {
+		target-path = "/chosen";
+		__overlay__ {
+			bootargs = "cma=128M@128M";
+		};
+	};
+
+};


### PR DESCRIPTION
Added overlay to set cma-boot parameter to 128M@128M.

This may be most helpful for system with 512MB when running vc4-kms

Signed-off-by: Martin Sperl kernel@martin.sperl.org
