### PR TITLE
ARM: bcm2708: add generic fbtft overlay with reset and dc gpios

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -23,6 +23,7 @@ dtbo-$(RPI_DT_OVERLAYS) += dwc2.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += dwc-otg.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += dht11.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += enc28j60.dtbo
+dtbo-$(RPI_DT_OVERLAYS) += fbtft.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += gpio-ir.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += gpio-poweroff.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += hifiberry-amp.dtbo

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -299,6 +299,28 @@ Params: int_pin                 GPIO used for INT (default 25)
         speed                   SPI bus speed (default 12000000)
 
 
+Name:   fbtft
+Info:   Overlay for a generic fbtft device with dc and reset lines
+Load:   dtoverlay=fbtft,<param>=<val>
+Params: cs                      SPI bus Chip Select (default 1)
+
+        speed                   SPI bus speed (default 8MHz)
+
+	txbuflen		transmit buffer length
+
+	compatible		the compatible string for selection of the driver
+
+        rotate                  Display rotation {0,90,180,270}
+
+        fps                     Delay between frame updates
+
+        debug                   Debug output level {0-7}
+
+        resetgpio               GPIO used to reset controller
+
+        dcgpio                  GPIO used to signal data/command
+
+
 Name:   gpio-ir
 Info:   Use GPIO pin as rc-core style infrared receiver input. The rc-core-
         based gpio_ir_recv driver maps received keys directly to a

--- a/arch/arm/boot/dts/overlays/fbtft-overlay.dts
+++ b/arch/arm/boot/dts/overlays/fbtft-overlay.dts
@@ -1,0 +1,61 @@
+/*
+ * fbtft-overlay.dts
+ *
+ * generic overlay
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target = <&gpio>;
+		__overlay__ {
+			fbtft_pins: fbtft_pins {
+				brcm,pins = <255 255>;
+				brcm,function = <1>; /* out */
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			fbtft: fbtft@0 {
+				reg = <0>;
+				status = "okay";
+				compatible = "fb_tft"; /* dummy - tbd */
+				pinctrl-names = "default";
+				pinctrl-0 = <&fbtft_pins>;
+				spi-max-frequency = <8000000>;
+				reset-gpios = <&gpio 255 1>;
+				dc-gpios = <&gpio 255 0>;
+				buswidth = <8>;
+				txbuflen = <32768>;
+				fps = <25>;
+				rotate = <0>;
+				debug = <0>;
+			};
+		};
+	};
+
+	__overrides__ {
+		cs =         <&fbtft>,"reg:0";
+		speed =      <&fbtft>,"spi-max-frequency:0";
+		txbuflen =   <&fbtft>,"txbuflen:0";
+		compatible = <&fbtft>,"compatible"; /* REQUIRED */
+		rotate =     <&fbtft>,"rotate:0";
+		fps =        <&fbtft>,"fps:0";
+		debug =      <&fbtft>,"debug:0";
+		dcgpio =     <&fbtft>,"dc-gpios:4", /* REQUIRED */
+			     <&fbtft_pins>,"brcm,pins:0";
+		resetgpio =  <&fbtft>,"reset-gpios:4", /* REQUIRED */
+			     <&fbtft_pins>,"brcm,pins:4";
+	};
+};


### PR DESCRIPTION
add a generic fbtft overlay with reset and dc-gpios.

Signed-off-by: Martin Sperl kernel@martin.sperl.org
