### PR TITLE
Enable 352k8 and 384k sample rates for I2S connected boards/HATs that support those rates

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -360,8 +360,9 @@ Params: <None>
 
 Name:   hifiberry-dac
 Info:   Configures the HifiBerry DAC audio card
-Load:   dtoverlay=hifiberry-dac
-Params: <None>
+Load:   dtoverlay=hifiberry-dac,<param>
+Params: 384k                    Instructs the pcm5102a codec driver to support
+                                352k8 and 384k sample rates.
 
 
 Name:   hifiberry-dacplus

--- a/arch/arm/boot/dts/overlays/dionaudio-loco-overlay.dts
+++ b/arch/arm/boot/dts/overlays/dionaudio-loco-overlay.dts
@@ -24,6 +24,7 @@
 				#sound-dai-cells = <0>;
 				compatible = "ti,pcm5102a";
 				status = "okay";
+				pcm5102a,384k;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/hifiberry-dac-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dac-overlay.dts
@@ -15,7 +15,7 @@
 	fragment@1 {
 		target-path = "/";
 		__overlay__ {
-			pcm5102a-codec {
+			pcm5102a_codec: pcm5102a-codec {
 				#sound-dai-cells = <0>;
 				compatible = "ti,pcm5102a";
 				status = "okay";
@@ -30,5 +30,9 @@
 			i2s-controller = <&i2s>;
 			status = "okay";
 		};
+	};
+
+	__overrides__ {
+		384k = <&pcm5102a_codec>,"pcm5102a,384k?";
 	};
 };

--- a/sound/soc/bcm/bcm2835-i2s.c
+++ b/sound/soc/bcm/bcm2835-i2s.c
@@ -730,7 +730,9 @@ static struct snd_soc_dai_driver bcm2835_i2s_dai = {
 	.playback = {
 		.channels_min = 2,
 		.channels_max = 2,
-		.rates =	SNDRV_PCM_RATE_8000_192000,
+		.rates =	SNDRV_PCM_RATE_CONTINUOUS,
+		.rate_min =	8000,
+		.rate_max =	384000,
 		.formats =	SNDRV_PCM_FMTBIT_S16_LE
 				| SNDRV_PCM_FMTBIT_S24_LE
 				| SNDRV_PCM_FMTBIT_S32_LE
@@ -738,7 +740,9 @@ static struct snd_soc_dai_driver bcm2835_i2s_dai = {
 	.capture = {
 		.channels_min = 2,
 		.channels_max = 2,
-		.rates =	SNDRV_PCM_RATE_8000_192000,
+		.rates =	SNDRV_PCM_RATE_CONTINUOUS,
+		.rate_min =	8000,
+		.rate_max =	384000,
 		.formats =	SNDRV_PCM_FMTBIT_S16_LE
 				| SNDRV_PCM_FMTBIT_S24_LE
 				| SNDRV_PCM_FMTBIT_S32_LE

--- a/sound/soc/codecs/pcm5102a.c
+++ b/sound/soc/codecs/pcm5102a.c
@@ -21,16 +21,51 @@
 
 #include <sound/soc.h>
 
+static const u32 pcm5102a_rates[] = {
+	8000, 16000, 32000, 44100, 48000, 88200, 96000, 176400, 192000,
+	352800, 384000,
+};
+
+static const struct snd_pcm_hw_constraint_list pcm5102a_constraint_rates = {
+	.count = ARRAY_SIZE(pcm5102a_rates),
+	.list = pcm5102a_rates,
+};
+
+static int pcm5102a_dai_startup(struct snd_pcm_substream *substream,
+	struct snd_soc_dai *dai)
+{
+	struct snd_soc_codec *codec = dai->codec;
+	int ret;
+
+	dev_dbg(codec->dev, "%s: set rates (8k-384k) constraint\n", __func__);
+
+	ret = snd_pcm_hw_constraint_list(substream->runtime, 0,
+					 SNDRV_PCM_HW_PARAM_RATE,
+					 &pcm5102a_constraint_rates);
+	if (ret != 0) {
+		dev_err(codec->dev, "%s: Failed to set rates constraint: %d\n",
+			__func__, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static const struct snd_soc_dai_ops pcm5102a_dai_ops = {
+	.startup = pcm5102a_dai_startup,
+};
+
 static struct snd_soc_dai_driver pcm5102a_dai = {
 	.name = "pcm5102a-hifi",
 	.playback = {
 		.channels_min = 2,
 		.channels_max = 2,
-		.rates = SNDRV_PCM_RATE_8000_192000,
+		.rates = SNDRV_PCM_RATE_KNOT,
 		.formats = SNDRV_PCM_FMTBIT_S16_LE |
 			   SNDRV_PCM_FMTBIT_S24_LE |
 			   SNDRV_PCM_FMTBIT_S32_LE
 	},
+	.ops = &pcm5102a_dai_ops,
 };
 
 static struct snd_soc_codec_driver soc_codec_dev_pcm5102a;

--- a/sound/soc/codecs/pcm512x.c
+++ b/sound/soc/codecs/pcm512x.c
@@ -480,7 +480,7 @@ static unsigned long pcm512x_ncp_target(struct pcm512x_priv *pcm512x,
 
 static const u32 pcm512x_dai_rates[] = {
 	8000, 11025, 16000, 22050, 32000, 44100, 48000, 64000,
-	88200, 96000, 176400, 192000, 384000,
+	88200, 96000, 176400, 192000, 352800, 384000,
 };
 
 static const struct snd_pcm_hw_constraint_list constraints_slave = {


### PR DESCRIPTION
This is another RFC, please do not pull!

I have tested original HiFiBerry DAC (PCM5102) on a PiB and HiFiBerry DAC+ (PCM5122 slave) on a Pi2B @ 352k8 and 384k.
I have tested first gen IQAudio DAC on a PiB, IQAudio DAC+ on a Pi3B, IQAudio Zero DAC on a PIZero @ 352k8/384k.

What I cannot test right now is HB DAC+ Pro (BCLK master / LRCK master) audio playback at 352k8 and 384k. (I lent my DAC+Pro to someone who doesn't appear to comprehend there is a difference between "loan" and "gift"!) @bonezuk @hifiberry don't know if you need to modify your driver for master mode (MCLK divider for BCLK?????), but it might be worth your while testing now rather than later. As I already said, your slave mode, works "out of the box" with this patch set.

Their is still chatter going on in DIY circles about over/upsampling (externally) to 8x on the TI PCM5 series, to bypass the TI OSF. (Can't switch it off, but by up/oversampling to 8x data rates in software and sending to the DAC, internal OS filter is bypass or 1x mode.) Me thinks that if 384k support isn't added via downstream first, at some point it will trickle down from upstream.......
