### PR TITLE
IQAudIO: Add auto-mute for amp to dac driver

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -524,6 +524,12 @@ Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
                                 responsibility of the user to ensure that
                                 the Digital volume control is set to a value
                                 that does not result in clipping/distortion!)
+        auto_mute_amp           If specified, unmute/mute the IQAudIO amp when
+                                starting/stopping audio playback. eg.
+                                dtoverlay=iqaudio-dacplus,auto_mute_amp
+        auto_mute_amp_gpio      Allow a user-specified GPIO for amp
+                                unmute/mute. (default is GPIO22.) eg.
+                                dtoverlay=iqaudio-dacplus,auto_mute_amp_gpio=22
 
 
 Name:   lirc-rpi

--- a/arch/arm/boot/dts/overlays/iqaudio-dacplus-overlay.dts
+++ b/arch/arm/boot/dts/overlays/iqaudio-dacplus-overlay.dts
@@ -30,14 +30,29 @@
 
 	fragment@2 {
 		target = <&sound>;
-		frag2: __overlay__ {
+		iqaudio_dac: __overlay__ {
 			compatible = "iqaudio,iqaudio-dac";
+			pinctrl-names = "default";
+			pinctrl-0 = <&iqaudio_dac_mute_amp_pins>;
 			i2s-controller = <&i2s>;
 			status = "okay";
 		};
 	};
 
+	fragment@3 {
+		target = <&gpio>;
+		__overlay__ {
+			iqaudio_dac_mute_amp_pins: iqaudio_dac_mute_amp_pins {
+				brcm,pins = <22>;
+				brcm,function = <1>; // out
+				brcm,pull = <0>; // off
+			};
+		};
+	};
+
 	__overrides__ {
-		24db_digital_gain = <&frag2>,"iqaudio,24db_digital_gain?";
+		24db_digital_gain = <&iqaudio_dac>,"iqaudio,24db_digital_gain?";
+		auto_mute_amp = <&iqaudio_dac>,"iqaudio,auto_mute_amp?";
+		auto_mute_amp_gpio = <&iqaudio_dac_mute_amp_pins>,"brcm,pins:0";
 	};
 };


### PR DESCRIPTION
Phil/Dom, this is another PR that needs third-party input rather than actually pulling.

@iqaudio Gordon, this was about to slip through the cracks. I'm not sure whether I ever sent you the 3rd generation patch, which rather than a "oneshot" to unmute amp at startup when driver module loads, is unmuting when audio device opens and muting when audio device closed. It achieves what you wanted, while accommodating those who already modified userspace software to mute/unmute the amp when the playback software opens/closes the audio device. Thoughts?

"dtoverlay=iqaudio-dacplus,auto_mute_amp"
