### PR TITLE
Add fixed voltage regulators to audio overlays using pcm512x, wm8804 and adau1977 codecs

### DIFF
--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -36,6 +36,7 @@
 		vchiq = &vchiq;
 		thermal = &thermal;
 		clocks = &clocks;
+		regulators = &regulators;
 	};
 
 	soc: soc {
@@ -482,6 +483,29 @@
 			#clock-cells = <0>;
 			clock-output-names = "osc";
 			clock-frequency = <19200000>;
+		};
+	};
+
+	regulators: regulators {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reg_3v3: reg3v3@0 {
+			compatible = "regulator-fixed";
+			reg = <0>;
+			regulator-name = "DC_3V3";
+			regulator-min-microvolt = <3300000>;
+			regulator-max-microvolt = <3300000>;
+			regulator-always-on;
+		};
+		reg_5v0: reg5v0@1 {
+			compatible = "regulator-fixed";
+			reg = <1>;
+			regulator-name = "DC_5V0";
+			regulator-min-microvolt = <5000000>;
+			regulator-max-microvolt = <5000000>;
+			regulator-always-on;
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/adau1977-adc-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adau1977-adc-overlay.dts
@@ -4,45 +4,31 @@
 
 / {
 	compatible = "brcm,bcm2708";
-    
-	fragment@0 {
-		target = <&soc>;
-		
-		__overlay__ {
-			codec_supply: fixedregulator@0 {
-				compatible = "regulator-fixed";
-				regulator-name = "AVDD";
-				regulator-min-microvolt = <3300000>;
-				regulator-max-microvolt = <3300000>;
-			};
-		};
-	};
-	
-	fragment@1 {
-        	target = <&i2c>;
-        	
-		__overlay__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
-			status = "okay";
-			
-			adau1977: codec@11 {
-                        	compatible = "adi,adau1977";
-                        	reg = <0x11>;
-                        	reset-gpios = <&gpio 5 0>;
-                        	AVDD-supply = <&codec_supply>;
-                	};
-        	};
-	};
 
-	fragment@2 {
+	fragment@0 {
 		target = <&i2s>;
 		__overlay__ {
 			status = "okay";
 		};
 	};
 
-	fragment@3 {
+	fragment@1 {
+		target = <&i2c>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adau1977: codec@11 {
+				compatible = "adi,adau1977";
+				reg = <0x11>;
+				reset-gpios = <&gpio 5 0>;
+				AVDD-supply = <&reg_3v3>;
+			};
+		};
+	};
+
+	fragment@2 {
 		target = <&sound>;
 		__overlay__ {
 			compatible = "adi,adau1977-adc";

--- a/arch/arm/boot/dts/overlays/akkordion-iqdacplus-overlay.dts
+++ b/arch/arm/boot/dts/overlays/akkordion-iqdacplus-overlay.dts
@@ -24,6 +24,9 @@
 				compatible = "ti,pcm5122";
 				reg = <0x4c>;
 				status = "okay";
+				AVDD-supply = <&reg_3v3>;
+				DVDD-supply = <&reg_3v3>;
+				CPVDD-supply = <&reg_3v3>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/hifiberry-dacplus-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dacplus-overlay.dts
@@ -35,6 +35,9 @@
 				reg = <0x4d>;
 				clocks = <&dacpro_osc>;
 				status = "okay";
+				AVDD-supply = <&reg_3v3>;
+				DVDD-supply = <&reg_3v3>;
+				CPVDD-supply = <&reg_3v3>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/hifiberry-digi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-digi-overlay.dts
@@ -24,6 +24,8 @@
 				compatible = "wlf,wm8804";
 				reg = <0x3b>;
 				status = "okay";
+				DVDD-supply = <&reg_3v3>;
+				PVDD-supply = <&reg_3v3>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/hifiberry-digi-pro-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-digi-pro-overlay.dts
@@ -24,6 +24,8 @@
 				compatible = "wlf,wm8804";
 				reg = <0x3b>;
 				status = "okay";
+				DVDD-supply = <&reg_3v3>;
+				PVDD-supply = <&reg_3v3>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/iqaudio-dac-overlay.dts
+++ b/arch/arm/boot/dts/overlays/iqaudio-dac-overlay.dts
@@ -24,6 +24,9 @@
 				compatible = "ti,pcm5122";
 				reg = <0x4c>;
 				status = "okay";
+				AVDD-supply = <&reg_3v3>;
+				DVDD-supply = <&reg_3v3>;
+				CPVDD-supply = <&reg_3v3>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/iqaudio-dacplus-overlay.dts
+++ b/arch/arm/boot/dts/overlays/iqaudio-dacplus-overlay.dts
@@ -24,6 +24,9 @@
 				compatible = "ti,pcm5122";
 				reg = <0x4c>;
 				status = "okay";
+				AVDD-supply = <&reg_3v3>;
+				DVDD-supply = <&reg_3v3>;
+				CPVDD-supply = <&reg_3v3>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/iqaudio-digi-wm8804-audio-overlay.dts
+++ b/arch/arm/boot/dts/overlays/iqaudio-digi-wm8804-audio-overlay.dts
@@ -24,8 +24,8 @@
 				compatible = "wlf,wm8804";
 				reg = <0x3b>;
 				status = "okay";
-				// DVDD-supply = <&reg_3v3>;
-				// PVDD-supply = <&reg_3v3>;
+				DVDD-supply = <&reg_3v3>;
+				PVDD-supply = <&reg_3v3>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/justboom-dac-overlay.dts
+++ b/arch/arm/boot/dts/overlays/justboom-dac-overlay.dts
@@ -24,6 +24,9 @@
 				compatible = "ti,pcm5122";
 				reg = <0x4d>;
 				status = "okay";
+				AVDD-supply = <&reg_3v3>;
+				DVDD-supply = <&reg_3v3>;
+				CPVDD-supply = <&reg_3v3>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/justboom-digi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/justboom-digi-overlay.dts
@@ -24,6 +24,8 @@
 				compatible = "wlf,wm8804";
 				reg = <0x3b>;
 				status = "okay";
+				DVDD-supply = <&reg_3v3>;
+				PVDD-supply = <&reg_3v3>;
 			};
 		};
 	};


### PR DESCRIPTION
Phil/Dom, feel free to close straight away if you want without pulling. But if you ever do enable REGULATOR, you might want to have these reg defs already in the overlays affected.

```
CONFIG_REGULATOR=y
CONFIG_REGULATOR_FIXED_VOLTAGE=m
```

This stops the codecs using regs, (specifically pcm512x and wm8804), from refusing to load because they cant find the necessary regs.
