### PR TITLE
bcm2835-sdhost: wait at least 150us between read retries

### DIFF
--- a/drivers/mmc/host/bcm2835-sdhost.c
+++ b/drivers/mmc/host/bcm2835-sdhost.c
@@ -1202,7 +1202,7 @@ static void bcm2835_sdhost_finish_command(struct bcm2835_host *host,
 		wait_max = jiffies + msecs_to_jiffies(100);
 		while (time_before(jiffies, wait_max)) {
 			spin_unlock_irqrestore(&host->lock, *irq_flags);
-			usleep_range(1, 10);
+			usleep_range(150, 200);
 			spin_lock_irqsave(&host->lock, *irq_flags);
 			sdcmd = bcm2835_sdhost_read(host, SDCMD);
 			if (!(sdcmd & SDCMD_NEW_FLAG) ||


### PR DESCRIPTION
With the Compute Module I get timeout's while initializing the eMMC:

mmc0: command never completed.

And the system won't boot properly.
With this patch it boots every single time successfully and won't ever show the above error.
Also I don't see any performance regressions whatsoever.
150us seems to be a magic number, as wait times below doesn't always make the eMMC initialize successfully on first retry.
So use 150us to 200us as usleep range for between read retries.

Signed-off-by: Ahmet Inan xdsopl@googlemail.com
