### PR TITLE
[8192cu] Fixes

### DIFF
--- a/drivers/net/wireless/realtek/rtl8192cu/Makefile
+++ b/drivers/net/wireless/realtek/rtl8192cu/Makefile
@@ -1,11 +1,19 @@
 EXTRA_CFLAGS += $(USER_EXTRA_CFLAGS)
 EXTRA_CFLAGS += -O1
 #EXTRA_CFLAGS += -O3
-#EXTRA_CFLAGS += -Wall
-#EXTRA_CFLAGS += -Wextra
+EXTRA_CFLAGS += -Wall
+EXTRA_CFLAGS += -Wextra
 #EXTRA_CFLAGS += -Werror
 #EXTRA_CFLAGS += -pedantic
 #EXTRA_CFLAGS += -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes
+
+# The "$(call cc-option,-Wxxx)" macro only includes that option when it's
+# supported by the compiler used. It may only work on Debian systems.
+
+# Wdate-time was added in gcc-4.9
+EXTRA_CFLAGS += $(call cc-option,-Werror=date-time)
+# Wincompatible-pointer-types was added in gcc-5.0
+EXTRA_CFLAGS += $(call cc-option,-Werror=incompatible-pointer-types)
 
 EXTRA_CFLAGS += -Wno-unused-variable
 EXTRA_CFLAGS += -Wno-unused-value
@@ -14,9 +22,15 @@ EXTRA_CFLAGS += -Wno-unused-parameter
 EXTRA_CFLAGS += -Wno-unused-function
 EXTRA_CFLAGS += -Wno-unused
 
-EXTRA_CFLAGS += -Wno-uninitialized
+# Relax some warnings from '-Wextra' so we won't get flooded with warnings
+EXTRA_CFLAGS += -Wno-sign-compare
+EXTRA_CFLAGS += -Wno-missing-field-initializers
+
+#EXTRA_CFLAGS += -Wno-uninitialized
 
 EXTRA_CFLAGS += -I$(src)/include
+
+EXTRA_LDFLAGS += --strip-debug
 
 CONFIG_AUTOCFG_CP = n
 

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_ap.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_ap.c
@@ -210,7 +210,7 @@ void rtw_add_bcn_ie(_adapter *padapter, WLAN_BSSID_EX *pnetwork, u8 index, u8 *d
 	PNDIS_802_11_VARIABLE_IEs	pIE;
 	u8	bmatch = _FALSE;
 	u8	*pie = pnetwork->IEs;
-	u8	*p, *dst_ie, *premainder_ie=NULL, *pbackup_remainder_ie=NULL;
+	u8	*p=NULL, *dst_ie=NULL, *premainder_ie=NULL, *pbackup_remainder_ie=NULL;
 	u32	i, offset, ielen, ie_offset, remainder_ielen = 0;
 
 	for (i = sizeof(NDIS_802_11_FIXED_IEs); i < pnetwork->IELength;)
@@ -249,6 +249,9 @@ void rtw_add_bcn_ie(_adapter *padapter, WLAN_BSSID_EX *pnetwork, u8 index, u8 *d
 		else
 			dst_ie = (p+ielen);
 	}
+
+	if(dst_ie == NULL)
+		return;
 
 	if(remainder_ielen>0)
 	{
@@ -357,7 +360,7 @@ void	expire_timeout_chk(_adapter *padapter)
 {
 	_irqL irqL;
 	_list	*phead, *plist;
-	u8 updated;
+	u8 updated = _FALSE;
 	struct sta_info *psta=NULL;
 	struct sta_priv *pstapriv = &padapter->stapriv;
 	u8 chk_alive_num = 0;

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_ieee80211.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_ieee80211.c
@@ -1859,7 +1859,8 @@ int rtw_action_frame_parse(const u8 *frame, u32 frame_len, u8* category, u8 *act
 {
 	const u8 *frame_body = frame + sizeof(struct rtw_ieee80211_hdr_3addr);
 	u16 fc;
-	u8 c, a;
+	u8 c;
+	u8 a = ACT_PUBLIC_MAX;
 
 	fc = le16_to_cpu(((struct rtw_ieee80211_hdr_3addr *)frame)->frame_ctl);
 

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_mlme_ext.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_mlme_ext.c
@@ -2454,7 +2454,7 @@ unsigned int OnDeAuth(_adapter *padapter, union recv_frame *precv_frame)
 		psta = rtw_get_stainfo(pstapriv, GetAddr2Ptr(pframe));
 		if(psta)
 		{
-			u8 updated;
+			u8 updated = _FALSE;
 
 			_enter_critical_bh(&pstapriv->asoc_list_lock, &irqL);
 			if(rtw_is_list_empty(&psta->asoc_list)==_FALSE)
@@ -2548,7 +2548,7 @@ unsigned int OnDisassoc(_adapter *padapter, union recv_frame *precv_frame)
 		psta = rtw_get_stainfo(pstapriv, GetAddr2Ptr(pframe));
 		if(psta)
 		{
-			u8 updated;
+			u8 updated = _FALSE;
 
 			_enter_critical_bh(&pstapriv->asoc_list_lock, &irqL);
 			if(rtw_is_list_empty(&psta->asoc_list)==_FALSE)
@@ -5663,7 +5663,7 @@ unsigned int on_action_public_p2p(union recv_frame *precv_frame)
 
 				//	Commented by Kurt 20120113
 				//	Get peer_dev_addr here if peer doesn't issue prov_disc frame.
-				if( _rtw_memcmp(pwdinfo->rx_prov_disc_info.peerDevAddr, empty_addr, ETH_ALEN) );
+				if( _rtw_memcmp(pwdinfo->rx_prov_disc_info.peerDevAddr, empty_addr, ETH_ALEN) )
 					_rtw_memcpy(pwdinfo->rx_prov_disc_info.peerDevAddr, GetAddr2Ptr(pframe), ETH_ALEN);
 
 				result = process_p2p_group_negotation_req( pwdinfo, frame_body, len );
@@ -11932,7 +11932,7 @@ u8 setkey_hdl(_adapter *padapter, u8 *pbuf)
 u8 set_stakey_hdl(_adapter *padapter, u8 *pbuf)
 {
 	u16 ctrl=0;
-	u8 cam_id;//cam_entry
+	u8 cam_id=0;//cam_entry
 	struct mlme_ext_priv	*pmlmeext = &padapter->mlmeextpriv;
 	struct mlme_ext_info	*pmlmeinfo = &(pmlmeext->mlmext_info);
 	struct set_stakey_parm	*pparm = (struct set_stakey_parm *)pbuf;

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_p2p.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_p2p.c
@@ -4896,9 +4896,9 @@ void init_wifidirect_info( _adapter* padapter, enum P2P_ROLE role)
 #endif
 #ifdef CONFIG_CONCURRENT_MODE
 	_adapter				*pbuddy_adapter = padapter->pbuddy_adapter;
-	struct wifidirect_info	*pbuddy_wdinfo;
-	struct mlme_priv		*pbuddy_mlmepriv;
-	struct mlme_ext_priv	*pbuddy_mlmeext;
+	struct wifidirect_info	*pbuddy_wdinfo = NULL;
+	struct mlme_priv		*pbuddy_mlmepriv = NULL;
+	struct mlme_ext_priv	*pbuddy_mlmeext = NULL;
 #endif
 
 	pwdinfo = &padapter->wdinfo;

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_wlan_util.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_wlan_util.c
@@ -853,7 +853,7 @@ void flush_all_cam_entry(_adapter *padapter)
 		{
 			struct sta_priv	*pstapriv = &padapter->stapriv;
 			struct sta_info	*psta;
-			u8 cam_id;//cam_entry
+			u8 cam_id=0;//cam_entry
 
 			psta = rtw_get_stainfo(pstapriv, pmlmeinfo->network.MacAddress);
 			if(psta) {

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_xmit.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_xmit.c
@@ -2590,7 +2590,7 @@ exit:
 s32 rtw_free_xmitframe(struct xmit_priv *pxmitpriv, struct xmit_frame *pxmitframe)
 {
 	_irqL irqL;
-	_queue *queue;
+	_queue *queue = NULL;
 	_adapter *padapter = pxmitpriv->adapter;
 	_pkt *pndis_pkt = NULL;
 

--- a/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/rtl8192c_rf6052.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/rtl8192c_rf6052.c
@@ -373,7 +373,7 @@ static void getTxPowerWriteValByRegulatory(
 {
 	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(Adapter);
 	struct dm_priv	*pdmpriv = &pHalData->dmpriv;
-	u8	i, chnlGroup, pwr_diff_limit[4];
+	u8	i, chnlGroup = 0, pwr_diff_limit[4];
 	u32 	writeVal, customer_limit, rf;
 
 	//
@@ -615,7 +615,7 @@ phy_RF6052_Config_ParaFile(
 	IN	PADAPTER		Adapter
 	)
 {
-	u32					u4RegValue;
+	u32					u4RegValue=0;
 	u8					eRFPath;
 	BB_REGISTER_DEFINITION_T	*pPhyReg;
 

--- a/drivers/net/wireless/realtek/rtl8192cu/include/rtw_debug.h
+++ b/drivers/net/wireless/realtek/rtl8192cu/include/rtw_debug.h
@@ -313,15 +313,15 @@ extern u32 GlobalDebugLevel;
 #if     defined (_dbgdump)
         #undef DBG_871X
 //      #define DBG_871X _dbgdump
-        #define DBG_871X(...) LOG_LEVEL(_drv_emerg_ , __VA_ARGS__)
+        #define DBG_871X(...) LOG_LEVEL(_drv_debug_ , __VA_ARGS__)
 
         #undef MSG_8192C
 //      #define MSG_8192C _dbgdump
-        #define MSG_8192C(...) LOG_LEVEL(_drv_emerg_ , __VA_ARGS__)
+        #define MSG_8192C(...) LOG_LEVEL(_drv_info_ , __VA_ARGS__)
 
         #undef DBG_8192C
 //      #define DBG_8192C _dbgdump
-        #define DBG_8192C(...) LOG_LEVEL(_drv_emerg_ ,  __VA_ARGS__)
+        #define DBG_8192C(...) LOG_LEVEL(_drv_debug_ ,  __VA_ARGS__)
 
 
 	#undef WRN_8192C

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_cfg80211.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_cfg80211.c
@@ -221,7 +221,7 @@ exit:
 
 void rtw_spt_band_free(struct ieee80211_supported_band *spt_band)
 {
-	u32 size;
+	u32 size = 0;
 
 	if(!spt_band)
 		return;
@@ -3773,7 +3773,7 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 	int ret=0;
 	_irqL irqL;
 	_list	*phead, *plist;
-	u8 updated;
+	u8 updated = _FALSE;
 	struct sta_info *psta = NULL;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct mlme_priv *pmlmepriv = &(padapter->mlmepriv);

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_cfg80211.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_cfg80211.c
@@ -5402,8 +5402,11 @@ int rtw_wdev_alloc(_adapter *padapter, struct device *dev)
 	}
 	wdev->wiphy = wiphy;
 	wdev->netdev = pnetdev;
-	//wdev->iftype = NL80211_IFTYPE_STATION;
-	wdev->iftype = NL80211_IFTYPE_MONITOR; // for rtw_setopmode_cmd() in cfg80211_rtw_change_iface()
+
+	wdev->iftype = NL80211_IFTYPE_STATION; // will be init in rtw_hal_init()
+	                                       // Must sync with _rtw_init_mlme_priv()
+	                                       // pmlmepriv->fw_state = WIFI_STATION_STATE
+	//wdev->iftype = NL80211_IFTYPE_MONITOR; // for rtw_setopmode_cmd() in cfg80211_rtw_change_iface()
 	padapter->rtw_wdev = wdev;
 	pnetdev->ieee80211_ptr = wdev;
 

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_linux.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_linux.c
@@ -6584,7 +6584,6 @@ static int rtw_dbg_port(struct net_device *dev,
 				case 0x01: //dbg mode
 					padapter->recvpriv.is_signal_dbg = 1;
 					extra_arg = extra_arg>100?100:extra_arg;
-					extra_arg = extra_arg<0?0:extra_arg;
 					padapter->recvpriv.signal_strength_dbg=extra_arg;
 					break;
 			}
@@ -6956,7 +6955,7 @@ static int rtw_dbg_port(struct net_device *dev,
 				{
 					struct registry_priv	*pregpriv = &padapter->registrypriv;
 					// 0: disable, 0x1:enable (but wifi_spec should be 0), 0x2: force enable (don't care wifi_spec)
-					if( pregpriv && extra_arg >= 0 && extra_arg < 3 )
+					if( pregpriv && extra_arg < 3 )
 					{
 						pregpriv->ampdu_enable= extra_arg;
 						DBG_871X("set ampdu_enable=%d\n",pregpriv->ampdu_enable);

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/os_intfs.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/os_intfs.c
@@ -945,7 +945,13 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 	return dscp >> 5;
 }
 
+#if (LINUX_VERSION_CODE>=KERNEL_VERSION(3,14,0))
+static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb,
+			    void *accel_priv,
+			    select_queue_fallback_t fallback)
+#else
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb)
+#endif
 {
 	_adapter	*padapter = rtw_netdev_priv(dev);
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/os_intfs.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/os_intfs.c
@@ -1062,6 +1062,10 @@ int rtw_init_netdev_name(struct net_device *pnetdev, const char *ifname)
 	return 0;
 }
 
+static const struct device_type wlan_type = {
+	.name = "wlan",
+};
+
 struct net_device *rtw_init_netdev(_adapter *old_padapter)
 {
 	_adapter *padapter;
@@ -1077,6 +1081,7 @@ struct net_device *rtw_init_netdev(_adapter *old_padapter)
 	if (!pnetdev)
 		return NULL;
 
+	pnetdev->dev.type = &wlan_type;
 	padapter = rtw_netdev_priv(pnetdev);
 	padapter->pnetdev = pnetdev;
 

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/os_intfs.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/os_intfs.c
@@ -1691,9 +1691,6 @@ int _netdev_vir_if_open(struct net_device *pnetdev)
 
 		padapter->bup = _TRUE;
 		padapter->hw_init_completed = _TRUE;
-
-		rtw_start_mbssid_cam(padapter);//start mbssid_cam after bup = _TRUE & hw_init_completed = _TRUE
-
 	}
 
 	padapter->net_closed = _FALSE;

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/os_intfs.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/os_intfs.c
@@ -945,13 +945,14 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 	return dscp >> 5;
 }
 
-#if (LINUX_VERSION_CODE>=KERNEL_VERSION(3,14,0))
-static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb,
-			    void *accel_priv,
-			    select_queue_fallback_t fallback)
-#else
-static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb)
+static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
+				, void *accel_priv
 #endif
+#if (LINUX_VERSION_CODE>=KERNEL_VERSION(3,14,0))
+			    , select_queue_fallback_t fallback
+#endif
+)
 {
 	_adapter	*padapter = rtw_netdev_priv(dev);
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/recv_linux.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/recv_linux.c
@@ -136,7 +136,7 @@ int rtw_os_recvbuf_resource_free(_adapter *padapter, struct recv_buf *precvbuf)
 void rtw_handle_tkip_mic_err(_adapter *padapter,u8 bgroup)
 {
 #ifdef CONFIG_IOCTL_CFG80211
-	enum nl80211_key_type key_type;
+	enum nl80211_key_type key_type = 0;
 #endif
 	union iwreq_data wrqu;
 	struct iw_michaelmicfailure    ev;

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/usb_intf.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/usb_intf.c
@@ -995,7 +995,7 @@ static int rtw_resume(struct usb_interface *pusb_intf)
 int rtw_resume_process(_adapter *padapter)
 {
 	struct net_device *pnetdev;
-	struct pwrctrl_priv *pwrpriv;
+	struct pwrctrl_priv *pwrpriv=NULL;
 	int ret = -1;
 	u32 start_time = rtw_get_current_time();
 	_func_enter_;
@@ -1058,7 +1058,8 @@ exit:
 	rtw_unlock_suspend();
 	#endif //CONFIG_RESUME_IN_WORKQUEUE
 
-	pwrpriv->bInSuspend = _FALSE;
+	if (pwrpriv)
+		pwrpriv->bInSuspend = _FALSE;
 	DBG_871X("<===  %s return %d.............. in %dms\n", __FUNCTION__
 		, ret, rtw_get_passing_time_ms(start_time));
 

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/usb_intf.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/usb_intf.c
@@ -117,6 +117,7 @@ static void rtw_dev_remove(struct usb_interface *pusb_intf);
 	{USB_DEVICE(0x0B05, 0x17BA)}, /* ASUS - Edimax */ \
 	{USB_DEVICE(0x0BDA, 0x1E1E)}, /* Intel - - */ \
 	{USB_DEVICE(0x04BB, 0x094c)}, /* I-O DATA - Edimax */ \
+	{USB_DEVICE(0X0BDA, 0x8176)}, /* TP-Link TL-WN723N */ \
 	/****** 8188CTV ********/ \
 	{USB_DEVICE(0xCDAB, 0x8011)}, /* - - compare */ \
 	{USB_DEVICE(0x0BDA, 0x0A8A)}, /* Sony - Foxconn */ \

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/usb_intf.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/usb_intf.c
@@ -102,6 +102,7 @@ static void rtw_dev_remove(struct usb_interface *pusb_intf);
 	{USB_DEVICE(0x103C, 0x1629)},/* HP - Lite-On ,8188CUS Slim Combo */ \
 	{USB_DEVICE(0x2001, 0x3308)},/* D-Link - Alpha */ \
 	{USB_DEVICE(0x050D, 0x1102)},/* Belkin - Edimax */ \
+	{USB_DEVICE(0x050D, 0x11F2)},/* ISY - Edimax */ \
 	{USB_DEVICE(0x2019, 0xAB2A)},/* Planex - Abocom */ \
 	{USB_DEVICE(0x20F4, 0x648B)},/* TRENDnet - Cameo */ \
 	{USB_DEVICE(0x4855, 0x0090)},/*  - Feixun */ \
@@ -110,6 +111,7 @@ static void rtw_dev_remove(struct usb_interface *pusb_intf);
 	{USB_DEVICE(0x0BDA, 0x5088)},/* Thinkware - CC&C */ \
 	{USB_DEVICE(0x4856, 0x0091)},/* NetweeN - Feixun */ \
 	{USB_DEVICE(0x0846, 0x9041)}, /* Netgear - Cameo */ \
+	{USB_DEVICE(0x0846, 0x9042)}, /* On Networks - N150MA */ \
 	{USB_DEVICE(0x2019, 0x4902)},/* Planex - Etop */ \
 	{USB_DEVICE(0x2019, 0xAB2E)},/* SW-WF02-AD15 -Abocom */ \
 	{USB_DEVICE(0x2001, 0x330B)}, /* D-LINK - T&W */ \

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/usb_intf.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/usb_intf.c
@@ -112,6 +112,7 @@ static void rtw_dev_remove(struct usb_interface *pusb_intf);
 	{USB_DEVICE(0x4856, 0x0091)},/* NetweeN - Feixun */ \
 	{USB_DEVICE(0x0846, 0x9041)}, /* Netgear - Cameo */ \
 	{USB_DEVICE(0x0846, 0x9042)}, /* On Networks - N150MA */ \
+	{USB_DEVICE(0x0846, 0x9043)}, /* Netgear N150 -WNA1000M */ \
 	{USB_DEVICE(0x2019, 0x4902)},/* Planex - Etop */ \
 	{USB_DEVICE(0x2019, 0xAB2E)},/* SW-WF02-AD15 -Abocom */ \
 	{USB_DEVICE(0x2001, 0x330B)}, /* D-LINK - T&W */ \


### PR DESCRIPTION
(https://github.com/raspberrypi/linux/pull/1487) Summary of changes:
- Adds support for ISY - Edimax
- Adds support for On Networks - N150MA
- Adds support for Netgear N150 -WNA1000M
- Adds support for TP-Link TL-WN723N
- Suppress spurious messages
- Fixes https://github.com/pvaret/rtl8192cu-fixes/issues/23
- Fixes CONFIG_MULTI_VIR_IFACES
- Fixes compatiblity with 3.13
- Enables compiler warnings and general fixes
- Fixes NetworkManager not finding the device (https://github.com/raspberrypi/linux/pull/1525, https://github.com/raspberrypi/linux/pull/1489#issuecomment-224958014)

Reference repositories:
- https://github.com/pvaret/rtl8192cu-fixes
- https://github.com/diederikdehaas/rtl8812AU (realtek drivers share a common base, that's the latest I could find)
