### PR TITLE
Implement a "wakeup-source" option for the i2c-rtc DeviceTree overlay.

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -445,6 +445,8 @@ Params: ds1307                  Select the DS1307 device
 
         trickle-resistor-ohms   Resistor value for trickle charge (DS1339-only)
 
+        wakeup-source           Specify that the RTC can be used as a wakeup source
+
 
 Name:   i2c0-bcm2708
 Info:   Enable the i2c_bcm2708 driver for the i2c0 bus. Not all pin combinations

--- a/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
@@ -65,5 +65,9 @@
 		pcf8523 = <&pcf8523>,"status";
 		pcf8563 = <&pcf8563>,"status";
 		trickle-resistor-ohms = <&ds1339>,"trickle-resistor-ohms:0";
+		wakeup-source = <&ds1339>,"wakeup-source?",
+				<&ds3231>,"wakeup-source?",
+				<&mcp7940x>,"wakeup-source?",
+				<&mcp7941x>,"wakeup-source?";
 	};
 };


### PR DESCRIPTION
This patch was already discussed at [https://github.com/raspberrypi/linux/pull/1260#issuecomment-204966308].
Unfortunately, I have not had the opportunity yet to test it myself with the latest firmware.
