### PR TITLE
gpio-ir-receiver: fix overlay and add upstream patches

### DIFF
--- a/arch/arm/boot/dts/overlays/gpio-ir-overlay.dts
+++ b/arch/arm/boot/dts/overlays/gpio-ir-overlay.dts
@@ -36,8 +36,7 @@
         __overrides__ {
                 // parameters
                 gpio_pin =      <&gpio_ir>,"gpios:4",
-                                        <&gpio_ir_pins>,"brcm,pins:0",
-                                        <&gpio_ir_pins>,"brcm,pull:0";  // pin number
+                                        <&gpio_ir_pins>,"brcm,pins:0";  // pin number
                 gpio_pull = <&gpio_ir_pins>,"brcm,pull:0";              // pull-up/down state
 
                 rc-map-name = <&gpio_ir>,"linux,rc-map-name";           // default rc map

--- a/drivers/media/rc/gpio-ir-recv.c
+++ b/drivers/media/rc/gpio-ir-recv.c
@@ -30,6 +30,7 @@ struct gpio_rc_dev {
 	struct rc_dev *rcdev;
 	int gpio_nr;
 	bool active_low;
+	struct timer_list flush_timer;
 };
 
 #ifdef CONFIG_OF
@@ -93,10 +94,24 @@ static irqreturn_t gpio_ir_recv_irq(int irq, void *dev_id)
 	if (rc < 0)
 		goto err_get_value;
 
+	mod_timer(&gpio_dev->flush_timer,
+		  jiffies + nsecs_to_jiffies(gpio_dev->rcdev->timeout));
+
 	ir_raw_event_handle(gpio_dev->rcdev);
 
 err_get_value:
 	return IRQ_HANDLED;
+}
+
+static void flush_timer(unsigned long arg)
+{
+	struct gpio_rc_dev *gpio_dev = (struct gpio_rc_dev *)arg;
+	DEFINE_IR_RAW_EVENT(ev);
+
+	ev.timeout = true;
+	ev.duration = gpio_dev->rcdev->timeout;
+	ir_raw_event_store(gpio_dev->rcdev, &ev);
+	ir_raw_event_handle(gpio_dev->rcdev);
 }
 
 static int gpio_ir_recv_probe(struct platform_device *pdev)
@@ -144,6 +159,9 @@ static int gpio_ir_recv_probe(struct platform_device *pdev)
 	rcdev->input_id.version = 0x0100;
 	rcdev->dev.parent = &pdev->dev;
 	rcdev->driver_name = GPIO_IR_DRIVER_NAME;
+	rcdev->min_timeout = 0;
+	rcdev->timeout = IR_DEFAULT_TIMEOUT;
+	rcdev->max_timeout = 10 * IR_DEFAULT_TIMEOUT;
 	if (pdata->allowed_protos)
 		rcdev->allowed_protocols = pdata->allowed_protos;
 	else
@@ -153,6 +171,9 @@ static int gpio_ir_recv_probe(struct platform_device *pdev)
 	gpio_dev->rcdev = rcdev;
 	gpio_dev->gpio_nr = pdata->gpio_nr;
 	gpio_dev->active_low = pdata->active_low;
+
+	setup_timer(&gpio_dev->flush_timer, flush_timer,
+		    (unsigned long)gpio_dev);
 
 	rc = gpio_request(pdata->gpio_nr, "gpio-ir-recv");
 	if (rc < 0)
@@ -196,6 +217,7 @@ static int gpio_ir_recv_remove(struct platform_device *pdev)
 	struct gpio_rc_dev *gpio_dev = platform_get_drvdata(pdev);
 
 	free_irq(gpio_to_irq(gpio_dev->gpio_nr), gpio_dev);
+	del_timer_sync(&gpio_dev->flush_timer);
 	rc_unregister_device(gpio_dev->rcdev);
 	gpio_free(gpio_dev->gpio_nr);
 	kfree(gpio_dev);

--- a/include/media/rc-core.h
+++ b/include/media/rc-core.h
@@ -239,6 +239,7 @@ static inline void init_ir_raw_event(struct ir_raw_event *ev)
 	memset(ev, 0, sizeof(*ev));
 }
 
+#define IR_DEFAULT_TIMEOUT	MS_TO_NS(125)
 #define IR_MAX_DURATION         500000000	/* 500 ms */
 #define US_TO_NS(usec)		((usec) * 1000)
 #define MS_TO_US(msec)		((msec) * 1000)


### PR DESCRIPTION
There is a small bug in the gpio-ir overlay, setting gpio_pin also changed the pin pull setting. That fix should also be applied to the 4.6 and 4.7 trees.

A minor nit: the gpio-ir overlay uses a mixture of "-" and  underscore in it's parameters (gpio_pin, gpio_pull but rc-map-name), I wonder if we should straighten that up and use either "-" or underscore consistently.

I've also included the gpio-ir-recv timeout fix from kernel 4.5 and up (these are straight cherry-picks). In my tests with a RC5 hauppauge remote they also seemed to help dealing with dropouts (remote not pointing straight to IR receiver).
