### PR TITLE
Fixed MCP23017 overlay description in README

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -595,7 +595,7 @@ Params: gpio_out_pin            GPIO for output (default "17")
 
 
 Name:   mcp23017
-Info:   Configures the MCP23017 I2C port expander
+Info:   Configures the MCP23017 I2C GPIO expander
 Load:   dtoverlay=mcp23017,<param>=<val>
 Params: gpiopin                 Gpio pin connected to the INTA output of the
                                 MCP23017 (default: 4)


### PR DESCRIPTION
Old description could have led to the misunderstanding that it is a i2c port expander, but in fact it is
a gpio expander.
