### PR TITLE
Fixes i2c_bcm2708: Write to FIFO correctly

### DIFF
--- a/drivers/i2c/busses/i2c-bcm2708.c
+++ b/drivers/i2c/busses/i2c-bcm2708.c
@@ -155,6 +155,10 @@ static inline int bcm2708_bsc_setup(struct bcm2708_i2c *bi)
 		if ( (bi->nmsgs > 1) &&
 			!(bi->msg[0].flags & I2C_M_RD) && (bi->msg[1].flags & I2C_M_RD) &&
 			 (bi->msg[0].addr == bi->msg[1].addr) && (bi->msg[0].len <= 16)) {
+
+			/* Clear FIFO */
+			bcm2708_wr(bi, BSC_C, BSC_C_CLEAR_1);
+
 			/* Fill FIFO with entire write message (16 byte FIFO) */
 			while (bi->pos < bi->msg->len) {
 				bcm2708_wr(bi, BSC_FIFO, bi->msg->buf[bi->pos++]);

--- a/drivers/i2c/busses/i2c-bcm2708.c
+++ b/drivers/i2c/busses/i2c-bcm2708.c
@@ -160,7 +160,7 @@ static inline int bcm2708_bsc_setup(struct bcm2708_i2c *bi)
 			bcm2708_wr(bi, BSC_C, BSC_C_CLEAR_1);
 
 			/* Fill FIFO with entire write message (16 byte FIFO) */
-			while (bi->pos < bi->msg->len) {
+			while ((bcm2708_rd(bi, BSC_S) & BSC_S_TXD) && (bi->pos < bi->msg->len)) {
 				bcm2708_wr(bi, BSC_FIFO, bi->msg->buf[bi->pos++]);
 			}
 			/* Start write transfer (no interrupts, don't clear FIFO) */


### PR DESCRIPTION
I encountered issues after receiving NACK's on the rPI's i2c interface. 
When resuming i2c communication after receiving a NACK, the i2c FIFO still contains data from previous i2c send request, clearing this FIFO before trying to send new data is necessary.

Also, add check to verify FIFO is not full before writing new data.
