### PR TITLE
Correct typos in spi-gpio35-39-overlay.dts

### DIFF
--- a/arch/arm/boot/dts/overlays/spi-gpio35-39-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi-gpio35-39-overlay.dts
@@ -18,14 +18,14 @@
 	fragment@1 {
 		target = <&spi0_cs_pins>;
 		__overlay__ {
-			bcrm,pins = <36 35>;
+			brcm,pins = <36 35>;
 		};
 	};
 
 	fragment@2 {
 		target = <&spi0_pins>;
 		__overlay__ {
-			bcrm,pins = <37 38 39>;
+			brcm,pins = <37 38 39>;
 		};
 	};
 };


### PR DESCRIPTION
bcrm,pins corrected to brcm,pins
