### PR TITLE
RFC: QPU user shader support in vc4

### DIFF
--- a/arch/arm/boot/dts/bcm2708_common.dtsi
+++ b/arch/arm/boot/dts/bcm2708_common.dtsi
@@ -375,6 +375,7 @@
 			compatible = "brcm,vc4-v3d";
 			reg = <0x7ec00000 0x1000>;
 			power-domains = <&power RPI_POWER_DOMAIN_V3D>;
+			brcm,firmware = <&firmware>;
 			status = "disabled";
 		};
 

--- a/drivers/gpu/drm/vc4/vc4_regs.h
+++ b/drivers/gpu/drm/vc4/vc4_regs.h
@@ -118,6 +118,16 @@
 #define V3D_SRQUA    0x00434
 #define V3D_SRQUL    0x00438
 #define V3D_SRQCS    0x0043c
+# define V3D_SRQCS_QPURQCC_MASK                        VC4_MASK(23, 16)
+# define V3D_SRQCS_QPURQCC_SHIFT                       16
+# define V3D_SRQCS_QPURQCC_CLEAR                       BIT(16)
+# define V3D_SRQCS_QPURQCM_MASK                        VC4_MASK(15, 8)
+# define V3D_SRQCS_QPURQCM_SHIFT                       8
+# define V3D_SRQCS_QPURQCM_CLEAR                       BIT(8)
+# define V3D_SRQCS_QPURQERR_SHIFT                      BIT(7)
+# define V3D_SRQCS_QPURQL_MASK                         VC4_MASK(5, 0)
+# define V3D_SRQCS_QPURQL_SHIFT                        0
+
 #define V3D_VPACNTL  0x00500
 #define V3D_VPMBASE  0x00504
 #define V3D_PCTRC    0x00670
@@ -154,6 +164,10 @@
 #define V3D_PCTRS14  0x006f4
 #define V3D_PCTR15   0x006f8
 #define V3D_PCTRS15  0x006fc
+#define V3D_DBCFG    0x00e00
+# define V3D_DBCFG_ENABLE                       BIT(0)
+#define V3D_DBQITE   0x00e2c
+#define V3D_DBQITC   0x00e30
 #define V3D_DBGE     0x00f00
 #define V3D_FDBGO    0x00f04
 #define V3D_FDBGB    0x00f08

--- a/include/soc/bcm2835/raspberrypi-firmware.h
+++ b/include/soc/bcm2835/raspberrypi-firmware.h
@@ -133,4 +133,12 @@ int rpi_firmware_property_list(struct rpi_firmware *fw,
 struct rpi_firmware *rpi_firmware_get(struct device_node *firmware_node);
 int rpi_firmware_transaction(struct rpi_firmware *fw, u32 chan, u32 data);
 
+struct vc4_dev;
+void rpi_firmware_register_vc4(struct rpi_firmware *fw, struct vc4_dev *vc4,
+			       int (*qpu_execute)(struct vc4_dev *vc4,
+						  u32 num_qpu,
+						  u32 control,
+						  u32 noflush,
+						  u32 timeout));
+
 #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */


### PR DESCRIPTION
What I took away from my last visit was that the highest priority for being able to switch to vc4-fkms-v3d was having a solution for QPU user shaders like hello_fft.  This merge allows hello_fft to run without even recompiling.

The basic idea here is that we find the mailbox calls that hello_fft makes, and redirect them into vc4 instead.  This is pretty gross, but building a new, clean interface in vc4 would involve pretty major surgery to hello_fft.  Do we want to do that instead?  It would drop the dependency on vc_mem for setting up user shaders, but it would still be root-only, because I'm not planning on writing shader validation for user programs.

Testing status: I'm running hello_fft in a loop while piglit runs, and things seem fine (~50% through the piglit run).

I still need to do some research into the VPM setup to see if I need to dynamically change VPMBASE either for functionality of QPU programs or for performance of 3D, or if it's fine like this.  But before I go too much farther down polishing this path, are there general comments on the architecture here?
