### PR TITLE
drm/vc4: Fix memory leak of the CRTC state.

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -862,7 +862,7 @@ static void vc4_crtc_destroy_state(struct drm_crtc *crtc,
 
 	}
 
-	__drm_atomic_helper_crtc_destroy_state(crtc, state);
+	drm_atomic_helper_crtc_destroy_state(crtc, state);
 }
 
 static const struct drm_crtc_funcs vc4_crtc_funcs = {


### PR DESCRIPTION
The underscores variant frees the pointers inside, while the
no-underscores variant calls underscores and then frees the struct.

Signed-off-by: Eric Anholt eric@anholt.net
Fixes: d8dbf44f13b9 ("drm/vc4: Make the CRTCs cooperate on allocating display lists.")
Cc: stable@vger.kernel.org
