### PR TITLE
Use raspberrypi-power to turn on USB power

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2708-rpi.dtsi
@@ -103,3 +103,7 @@
 &hdmi {
 	power-domains = <&power RPI_POWER_DOMAIN_HDMI>;
 };
+
+&usb {
+	power-domains = <&power RPI_POWER_DOMAIN_USB>;
+};

--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -185,25 +185,6 @@ rpi_firmware_print_firmware_revision(struct rpi_firmware *fw)
 	}
 }
 
-static int raspberrypi_firmware_set_power(struct rpi_firmware *fw,
-					  u32 domain, bool on)
-{
-	struct {
-		u32 domain;
-		u32 on;
-	} packet;
-	int ret;
-
-	packet.domain = domain;
-	packet.on = on;
-	ret = rpi_firmware_property(fw, RPI_FIRMWARE_SET_POWER_STATE,
-				    &packet, sizeof(packet));
-	if (!ret && packet.on != on)
-		ret = -EINVAL;
-
-	return ret;
-}
-
 static int rpi_firmware_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
@@ -231,9 +212,6 @@ static int rpi_firmware_probe(struct platform_device *pdev)
 	g_pdev = pdev;
 
 	rpi_firmware_print_firmware_revision(fw);
-
-	if (raspberrypi_firmware_set_power(fw, 3, true))
-		dev_err(dev, "failed to turn on USB power\n");
 
 	return 0;
 }


### PR DESCRIPTION
I just keep on chipping away on the downstream patches by using what's available in mainline.
@anholt has really done much good in mainline for the Pi and it's more people contributing there now.
