### PR TITLE
Stop to read while writing

### DIFF
--- a/drivers/staging/media/lirc/lirc_rpi.c
+++ b/drivers/staging/media/lirc/lirc_rpi.c
@@ -487,6 +487,12 @@ static ssize_t lirc_write(struct file *file, const char *buf,
 	wbuf = memdup_user(buf, n);
 	if (IS_ERR(wbuf))
 		return PTR_ERR(wbuf);
+
+        dprintk(KERN_INFO LIRC_DRIVER_NAME
+                ": sending %d pulses/spaces\n", count);
+
+        set_use_dec(NULL);
+
 	spin_lock_irqsave(&lock, flags);
 
 	for (i = 0; i < count; i++) {
@@ -498,6 +504,9 @@ static ssize_t lirc_write(struct file *file, const char *buf,
 	gpiochip->set(gpiochip, gpio_out_pin, invert);
 
 	spin_unlock_irqrestore(&lock, flags);
+
+        set_use_inc(NULL);
+
 	kfree(wbuf);
 	return n;
 }


### PR DESCRIPTION
I am using this driver for 433Mhz radio sender/receiver.
It seems that if the receiver gets its own data while sending, the destination devices do not receive data properly.
So I added extra code to stop to receive data while writing.