### PR TITLE
Audioinjector Fix channel two bit offsets for equal volume

### DIFF
--- a/sound/soc/bcm/audioinjector-pi-soundcard.c
+++ b/sound/soc/bcm/audioinjector-pi-soundcard.c
@@ -55,19 +55,21 @@ static int snd_audioinjector_pi_soundcard_hw_params(struct snd_pcm_substream *su
 
 	switch (params_rate(params)){
 		case 8000:
-			return snd_soc_dai_set_bclk_ratio(cpu_dai, 1508);
+			return snd_soc_dai_set_bclk_ratio(cpu_dai, 1500);
+		case 16000:
+			return snd_soc_dai_set_bclk_ratio(cpu_dai, 750);
 		case 32000:
-			return snd_soc_dai_set_bclk_ratio(cpu_dai, 378);
+			return snd_soc_dai_set_bclk_ratio(cpu_dai, 375);
 		case 44100:
-			return snd_soc_dai_set_bclk_ratio(cpu_dai, 274);
+			return snd_soc_dai_set_bclk_ratio(cpu_dai, 272);
 		case 48000:
-			return snd_soc_dai_set_bclk_ratio(cpu_dai, 252);
+			return snd_soc_dai_set_bclk_ratio(cpu_dai, 250);
 		case 88200:
 			return snd_soc_dai_set_bclk_ratio(cpu_dai, 136);
 		case 96000:
-			return snd_soc_dai_set_bclk_ratio(cpu_dai, 126);
+			return snd_soc_dai_set_bclk_ratio(cpu_dai, 125);
 		default:
-			return snd_soc_dai_set_bclk_ratio(cpu_dai, 126);
+			return snd_soc_dai_set_bclk_ratio(cpu_dai, 125);
 	}
 }
 


### PR DESCRIPTION
Applying to the audioinjector sound card only. This patch offsets channel
2 correctly from the LR clock. This ensures that channel 2 doesn't loose
any bits during capture. It also results in both channels 1 and 2 having
the same volume.

Signed-off-by: Matt Flax <flatmax@flatmax.org>