### PR TITLE
Add overlays symlink and dtbo tagert for ARM64

### DIFF
--- a/arch/arm64/Makefile
+++ b/arch/arm64/Makefile
@@ -102,6 +102,9 @@ zinstall install:
 
 %.dtb: scripts
 	$(Q)$(MAKE) $(build)=$(boot)/dts $(boot)/dts/$@
+	
+%.dtbo: | scripts
+	$(Q)$(MAKE) $(build)=$(boot)/dts $(boot)/dts/$@
 
 PHONY += dtbs dtbs_install
 

--- a/arch/arm64/boot/dts/Makefile
+++ b/arch/arm64/boot/dts/Makefile
@@ -19,6 +19,7 @@ dts-dirs += socionext
 dts-dirs += sprd
 dts-dirs += xilinx
 dts-dirs += lg
+dts-dirs += overlays
 
 subdir-y	:= $(dts-dirs)
 

--- a/arch/arm64/boot/dts/overlays
+++ b/arch/arm64/boot/dts/overlays
@@ -1,0 +1,1 @@
+../../../arm/boot/dts/overlays/


### PR DESCRIPTION
This patch symlinks the overlays directory into ARM64 and adds the dtbo target needed to build them to the ARm64 makefile.

Signed-off-by: Gerhard de Clercq <gerharddeclercq@outlook.com>