### PR TITLE
RPI-FT5406: Enable aarch64 support through explicit iomem interface

### DIFF
--- a/drivers/input/touchscreen/rpi-ft5406.c
+++ b/drivers/input/touchscreen/rpi-ft5406.c
@@ -20,6 +20,7 @@
 #include <linux/input/mt.h>
 #include <linux/kthread.h>
 #include <linux/platform_device.h>
+#include <linux/stddef.h>
 #include <asm/io.h>
 #include <linux/dma-mapping.h>
 #include <soc/bcm2835/raspberrypi-firmware.h>
@@ -47,7 +48,6 @@ struct ft5406 {
 	struct input_dev       * input_dev;
 	void __iomem           * ts_base;
 	dma_addr_t		 bus_addr;
-	struct ft5406_regs     * regs;
 	struct task_struct     * thread;
 };
 
@@ -68,8 +68,8 @@ static int ft5406_thread(void *arg)
 	{
 		// 60fps polling
 		msleep_interruptible(17);
-		memcpy_fromio(&regs, ts->regs, sizeof(*ts->regs));
-		writel(99, &ts->regs->num_points);
+		memcpy_fromio(&regs, ts->ts_base, sizeof(struct ft5406_regs));
+		iowrite8(99, ts->ts_base + offsetof(struct ft5406_regs, num_points));
 		// Do not output if theres no new information (num_points is 99)
 		// or we have no touch points and don't need to release any
 		if(!(regs.num_points == 99 || (regs.num_points == 0 && known_ids == 0)))
@@ -190,7 +190,7 @@ static int ft5406_probe(struct platform_device *pdev)
 
 		// mmap the physical memory
 		touchbuf &= ~0xc0000000;
-		ts->ts_base = ioremap(touchbuf, sizeof(*ts->regs));
+		ts->ts_base = ioremap(touchbuf, sizeof(struct ft5406_regs));
 		if (ts->ts_base == NULL)
 		{
 			dev_err(dev, "Failed to map physical address\n");
@@ -222,8 +222,6 @@ static int ft5406_probe(struct platform_device *pdev)
 			err);
 		goto out;
 	}
-	
-	ts->regs = (struct ft5406_regs *) ts->ts_base;
 
 	// create thread to poll the touch events
 	ts->thread = kthread_run(ft5406_thread, ts, "ft5406");


### PR DESCRIPTION
Signed-off-by: Gerhard de Clercq <gerharddeclercq@outlook.com>