### PR TITLE
Added spi2-enc28j60.dts overlay file that works on SPI2 interface

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -349,6 +349,14 @@ Load:   dtoverlay=enc28j60,<param>=<val>
 Params: int_pin                 GPIO used for INT (default 25)
 
         speed                   SPI bus speed (default 12000000)
+        
+        
+Name:   spi2-enc28j60
+Info:   Overlay for the Microchip ENC28J60 Ethernet Controller (SPI)
+Load:   dtoverlay=spi2-enc28j60,<param>=<val>
+Params: int_pin                 GPIO used for INT (default 39)
+
+        speed                   SPI bus speed (default 12000000)
 
 
 Name:   gpio-ir

--- a/arch/arm/boot/dts/overlays/spi2-enc28j60.dts
+++ b/arch/arm/boot/dts/overlays/spi2-enc28j60.dts
@@ -1,0 +1,47 @@
+// Overlay for the Microchip ENC28J60 Ethernet Controller - SPI2 Compute Module 
+//Interrupt pin: 39 
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "brcm,bcm2708";
+
+    fragment@0 {
+        target = <&spi2>;
+        __overlay__ {
+            /* needed to avoid dtc warning */
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            status = "okay";
+
+            eth1: enc28j60@0{
+                compatible = "microchip,enc28j60";
+                reg = <0>; /* CE0 */
+                pinctrl-names = "default";
+                pinctrl-0 = <&eth1_pins>;
+                interrupt-parent = <&gpio>;
+                interrupts = <39 0x2>; /* falling edge */
+                spi-max-frequency = <12000000>;
+                status = "okay";
+            };
+        };
+    };
+
+    fragment@1 {
+        target = <&gpio>;
+        __overlay__ {
+            eth1_pins: eth1_pins {
+                brcm,pins = <39>;
+                brcm,function = <0>; /* in */
+                brcm,pull = <0>; /* none */
+            };
+        };
+    };
+
+    __overrides__ {
+        int_pin = <&eth1>, "interrupts:0",
+                  <&eth1_pins>, "brcm,pins:0";
+        speed   = <&eth1>, "spi-max-frequency:0";
+    };
+};


### PR DESCRIPTION
The current enc28j60.dts only works on SPI0 interface and does not support SPI2. 

The new overlay file works on SPI2 and is already tested