### PR TITLE
Pisound dynamic overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/pisound-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pisound-overlay.dts
@@ -26,6 +26,54 @@
 	compatible = "brcm,bcm2708";
 
 	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pisound_spi: pisound_spi@0{
+				compatible = "blokaslabs,pisound-spi";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&spi0_pins>;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+
+	fragment@4 {
+		target-path = "/";
+		__overlay__ {
+			pcm5102a-codec {
+				#sound-dai-cells = <0>;
+				compatible = "ti,pcm5102a";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@5 {
 		target = <&sound>;
 		__overlay__ {
 			compatible = "blokaslabs,pisound";
@@ -49,7 +97,7 @@
 		};
 	};
 
-	fragment@1 {
+	fragment@6 {
 		target = <&gpio>;
 		__overlay__ {
 			pinctrl-names = "default";
@@ -63,52 +111,10 @@
 		};
 	};
 
-	fragment@2 {
+	fragment@7 {
 		target = <&i2s>;
 		__overlay__ {
 			status = "okay";
-		};
-	};
-
-	fragment@3 {
-		target-path = "/";
-		__overlay__ {
-			pcm5102a-codec {
-				#sound-dai-cells = <0>;
-				compatible = "ti,pcm5102a";
-				status = "okay";
-			};
-		};
-	};
-
-	fragment@4 {
-		target = <&spi0>;
-		__overlay__ {
-			status = "okay";
-
-			spidev@0{
-				status = "disabled";
-			};
-
-			spidev@1{
-				status = "okay";
-			};
-		};
-	};
-
-	fragment@5 {
-		target = <&spi0>;
-		__overlay__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			pisound_spi: pisound_spi@0{
-				compatible = "blokaslabs,pisound-spi";
-				reg = <0>;
-				pinctrl-names = "default";
-				pinctrl-0 = <&spi0_pins>;
-				spi-max-frequency = <1000000>;
-			};
 		};
 	};
 };

--- a/sound/soc/bcm/pisound.c
+++ b/sound/soc/bcm/pisound.c
@@ -954,6 +954,8 @@ static int pisnd_probe(struct platform_device *pdev)
 
 static int pisnd_remove(struct platform_device *pdev)
 {
+	printi("Unloading.\n");
+
 	if (pisnd_kobj) {
 		kobject_put(pisnd_kobj);
 		pisnd_kobj = NULL;


### PR DESCRIPTION
This pull requests contains changes to make pisound overlay loadable dynamically using 'dtoverlay', as well as minor logging change in the related module code.

Tested the changes by building and installing the kernel based on this branch on RPi3, using dtoverlay to add / remove the overlay as well as checking if dtoverlay=pisound in /boot/config.txt still behaves ok, all is working fine.

Thank you!