### PR TITLE
Add support for Silicon Labs Si7013/20/21 humidity/temperature sensor.

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -543,6 +543,9 @@ Params: bmp085                  Select the Bosch sensortronic BMP085
 
         bmp280                  Select the Bosch sensortronic BMP280
 
+        si7020                  Select the Silicon Labs Si7013/20/21 humidity/
+                                temperature sensor
+
 
 Name:   i2c0-bcm2708
 Info:   Enable the i2c_bcm2708 driver for the i2c0 bus. Not all pin combinations

--- a/arch/arm/boot/dts/overlays/i2c-sensor-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-overlay.dts
@@ -1,34 +1,41 @@
-// Definitions for a few digital barometric pressure and temperature sensors
+// Definitions for I2C based sensors using the Industrial IO interface.
 /dts-v1/;
 /plugin/;
 
 / {
-        compatible = "brcm,bcm2708";
+	compatible = "brcm,bcm2708";
 
-        fragment@0 {
-                target = <&i2c_arm>;
-                __overlay__ {
-                        #address-cells = <1>;
-                        #size-cells = <0>;
-                        status = "okay";
+	fragment@0 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
 
-                        bmp085: bmp085@77 {
-                                compatible = "bosch,bmp085";
-                                reg = <0x77>;
-                                default-oversampling = <3>;
-                                status = "disable";
-                        };
+			bmp085: bmp085@77 {
+				compatible = "bosch,bmp085";
+				reg = <0x77>;
+				default-oversampling = <3>;
+				status = "disable";
+			};
 
-                        bmp280: bmp280@76 {
-                                compatible = "bosch,bmp280";
-                                reg = <0x76>;
-                                status = "disable";
-                        };
-                };
-        };
+			bmp280: bmp280@76 {
+				compatible = "bosch,bmp280";
+				reg = <0x76>;
+				status = "disable";
+			};
+
+			si7020: si7020@40 {
+				compatible = "si7020";
+				reg = <0x40>;
+				status = "disable";
+			};
+		};
+	};
 
 	__overrides__ {
 		bmp085 = <&bmp085>,"status";
 		bmp280 = <&bmp280>,"status";
+		si7020 = <&si7020>,"status";
 	};
 };


### PR DESCRIPTION
The SI7021 is a humidity and temperature sensor that uses the I2C bus and has a driver in the kernel, si7020.  I have wired one up to my Pi and used this device overlay to enable it at boot time.

The driver provides an IIO interface via sysfs at /sys/bus/iio/devices/iio:device? where the relative humidity and temperature can be read from the in_temp* and in_humidity* files.  Note that the values must be computed by taking the raw value, adding the offset and multiplying by the scale factor and then dividing by 1000, e.g.

temperature in degrees C = (in_temp_raw + in_temp_offset) * in_temp_scale / 1000

