### PR TITLE
Added 3-wire functionality to spidev_test.c

### DIFF
--- a/Documentation/spi/spidev_test.c
+++ b/Documentation/spi/spidev_test.c
@@ -122,7 +122,7 @@ static void transfer(int fd, uint8_t const *tx, uint8_t const *rx, size_t len)
 	else if (mode & SPI_RX_DUAL)
 		tr.rx_nbits = 2;
 	if (!(mode & SPI_LOOP)) {
-		if (mode & (SPI_TX_QUAD | SPI_TX_DUAL))
+		if (mode & (SPI_TX_QUAD | SPI_TX_DUAL | SPI_3WIRE))
 			tr.rx_buf = 0;
 		else if (mode & (SPI_RX_QUAD | SPI_RX_DUAL))
 			tr.tx_buf = 0;
@@ -134,6 +134,18 @@ static void transfer(int fd, uint8_t const *tx, uint8_t const *rx, size_t len)
 
 	if (verbose)
 		hex_dump(tx, len, 32, "TX");
+	
+	if (!(mode & SPI_LOOP)) {
+		if (mode & SPI_3WIRE) {
+			tr.rx_buf = (unsigned long)rx;
+			tr.tx_buf = 0;
+			
+			ret = ioctl(fd, SPI_IOC_MESSAGE(1), &tr);
+			if (ret < 1)
+				pabort("can't send spi message");
+			}
+	}
+
 	hex_dump(rx, len, 32, "RX");
 }
 


### PR DESCRIPTION
3-wire mode requires half-duplex operation, write first, then read, using seperate transfers. rx_buf and tx_buf pointer have to be NULLed, respectively, otherwise the transfer will fail.

Did anyone ever check 3-wire mode with a 3-wire capable driver (e.g., spi-bcm2835)?