### PR TITLE
bcm2835-i2s: Changes for allowing asymmetric sample formats.

### DIFF
--- a/sound/soc/bcm/bcm2835-i2s.c
+++ b/sound/soc/bcm/bcm2835-i2s.c
@@ -310,6 +310,7 @@ static int bcm2835_i2s_hw_params(struct snd_pcm_substream *substream,
 	unsigned int sampling_rate = params_rate(params);
 	unsigned int data_length, data_delay, bclk_ratio;
 	unsigned int ch1pos, ch2pos, mode, format;
+	unsigned int previous_ftxp, previous_frxp;
 	unsigned int mash = BCM2835_CLK_MASH_1;
 	unsigned int divi, divf, target_frequency;
 	int clk_src = -1;
@@ -320,6 +321,7 @@ static int bcm2835_i2s_hw_params(struct snd_pcm_substream *substream,
 	bool frame_master =	(master == SND_SOC_DAIFMT_CBS_CFS
 					|| master == SND_SOC_DAIFMT_CBM_CFS);
 	uint32_t csreg;
+	bool packed;
 
 	/*
 	 * If a stream is already enabled,
@@ -465,26 +467,46 @@ static int bcm2835_i2s_hw_params(struct snd_pcm_substream *substream,
 		return -EINVAL;
 	}
 
-	/*
-	 * Set format for both streams.
-	 * We cannot set another frame length
-	 * (and therefore word length) anyway,
-	 * so the format will be the same.
-	 */
-	regmap_write(dev->i2s_regmap, BCM2835_I2S_RXC_A_REG, format);
-	regmap_write(dev->i2s_regmap, BCM2835_I2S_TXC_A_REG, format);
+	/* Set the format for the matching stream direction. */
+	switch (substream->stream) {
+	case SNDRV_PCM_STREAM_PLAYBACK:
+		regmap_write(dev->i2s_regmap, BCM2835_I2S_TXC_A_REG, format);
+		break;
+	case SNDRV_PCM_STREAM_CAPTURE:
+		regmap_write(dev->i2s_regmap, BCM2835_I2S_RXC_A_REG, format);
+		break;
+	default:
+		return -EINVAL;
+	}
 
 	/* Setup the I2S mode */
+	/* Keep existing FTXP and FRXP values. */
+	regmap_read(dev->i2s_regmap, BCM2835_I2S_MODE_A_REG, &mode);
+
+	previous_ftxp = mode & BCM2835_I2S_FTXP;
+	previous_frxp = mode & BCM2835_I2S_FRXP;
+
 	mode = 0;
 
-	if (data_length <= 16) {
-		/*
-		 * Use frame packed mode (2 channels per 32 bit word)
-		 * We cannot set another frame length in the second stream
-		 * (and therefore word length) anyway,
-		 * so the format will be the same.
-		 */
-		mode |= BCM2835_I2S_FTXP | BCM2835_I2S_FRXP;
+	/*
+	 * Retain the frame packed mode (2 channels per 32 bit word)
+	 * of the other direction stream intact. The formats of each
+	 * direction can be different as long as the frame length is
+	 * shared for both.
+	 */
+	packed = data_length <= 16;
+
+	switch (substream->stream) {
+	case SNDRV_PCM_STREAM_PLAYBACK:
+		mode |= previous_frxp;
+		mode |= packed ? BCM2835_I2S_FTXP : 0;
+		break;
+	case SNDRV_PCM_STREAM_CAPTURE:
+		mode |= previous_ftxp;
+		mode |= packed ? BCM2835_I2S_FRXP : 0;
+		break;
+	default:
+		return -EINVAL;
 	}
 
 	mode |= BCM2835_I2S_FLEN(bclk_ratio - 1);


### PR DESCRIPTION
Hey,

I've noticed that when overdubbing audio with Audacity using 16-bit sample format for recording, it still uses 32 bits for playback, causing corrupt audio to get recorded. The bcm2835-i2s forces format symmetry between the streams, but it needn't be the case. (I alternatively tried to set .symmetric_formats=1 in bcm2835_i2s_dai, but Audacity wasn't able to detect this, and failed to record completely which would be unacceptable.)

I've made some changes that allow having asymmetric sample formats, and tested various combinations of simultaneous playback and recording with the pisound card, however, I don't own any other audio cards, so I can't test the changes using them.

Anyway, I tried to keep the changes to minimum, the only cases these changes should affect is when the user software is requesting asymmetric sample format for playback and capture, in all other cases, it should behave the same as without the changes.

Thank you,
Giedrius.