### PR TITLE
Add driver_name properties to JustBoom drivers

### DIFF
--- a/sound/soc/bcm/justboom-dac.c
+++ b/sound/soc/bcm/justboom-dac.c
@@ -98,6 +98,7 @@ static struct snd_soc_dai_link snd_rpi_justboom_dac_dai[] = {
 /* audio machine driver */
 static struct snd_soc_card snd_rpi_justboom_dac = {
 	.name         = "snd_rpi_justboom_dac",
+	.driver_name  = "JustBoomDac",
 	.owner        = THIS_MODULE,
 	.dai_link     = snd_rpi_justboom_dac_dai,
 	.num_links    = ARRAY_SIZE(snd_rpi_justboom_dac_dai),

--- a/sound/soc/bcm/justboom-digi.c
+++ b/sound/soc/bcm/justboom-digi.c
@@ -154,6 +154,7 @@ static struct snd_soc_dai_link snd_rpi_justboom_digi_dai[] = {
 /* audio machine driver */
 static struct snd_soc_card snd_rpi_justboom_digi = {
 	.name         = "snd_rpi_justboom_digi",
+	.driver_name  = "JustBoomDigi",
 	.owner        = THIS_MODULE,
 	.dai_link     = snd_rpi_justboom_digi_dai,
 	.num_links    = ARRAY_SIZE(snd_rpi_justboom_digi_dai),


### PR DESCRIPTION
Relates to [this thread](https://forum.libreelec.tv/thread-3524.html) on LibreElec forums and subsequent discussions with @HiassofT @chewitt @lrusak with regard to correctly enabling passthrough audio support for 5.1 systems when using Kodi based OSs and JustBoom.