### PR TITLE
Reapply "spi-bcm2835: Disable forced software CS"

### DIFF
--- a/arch/arm/boot/dts/bcm283x.dtsi
+++ b/arch/arm/boot/dts/bcm283x.dtsi
@@ -163,6 +163,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
+			cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
 		};
 
 		i2c0: i2c@7e205000 {


### PR DESCRIPTION
bcm2708_common.dtsi is not present in linux 4.9 device tree - there seem to be duplicated functions between bcm283* and bcm270*
````
"Select software CS in bcm2708_common.dtsi, and disable the automatic
conversion in the driver to allow hardware CS to be re-enabled with an
overlay."
````