### PR TITLE
Add overlay for mcp3008 adc

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -57,6 +57,7 @@ dtbo-$(RPI_DT_OVERLAYS) += mcp23017.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += mcp23s17.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += mcp2515-can0.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += mcp2515-can1.dtbo
+dtbo-$(RPI_DT_OVERLAYS) += mcp3008.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += mmc.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += mz61581.dtbo
 dtbo-$(RPI_DT_OVERLAYS) += pi3-act-led.dtbo

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -736,6 +736,15 @@ Params: oscillator              Clock frequency for the CAN controller (Hz)
         interrupt               GPIO for interrupt signal
 
 
+Name:   mcp3008
+Info:   Configures MCP3008 A/D converters
+        For devices on spi1 or spi2, the interfaces should be enabled
+        with one of the spi1-1/2/3cs and/or spi2-1/2/3cs overlays.
+Load:   dtoverlay=mcp3008,<param>[=<val>]
+Params: spi<n>-<m>-present      boolean, configure device at spi<n>, cs<m>
+        spi<n>-<m>-speed        integer, set the spi bus speed for this device
+
+
 Name:   mmc
 Info:   Selects the bcm2835-mmc SD/MMC driver, optionally with overclock
 Load:   dtoverlay=mmc,<param>=<val>

--- a/arch/arm/boot/dts/overlays/mcp3008-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp3008-overlay.dts
@@ -68,8 +68,8 @@
 		target = <&spi0>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 
 			mcp3008_00: mcp3008@0 {
 				compatible = "mcp3008";
@@ -83,8 +83,8 @@
 		target = <&spi0>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 
 			mcp3008_01: mcp3008@1 {
 				compatible = "mcp3008";
@@ -98,8 +98,8 @@
 		target = <&spi1>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 
 			mcp3008_10: mcp3008@0 {
 				compatible = "mcp3008";
@@ -113,8 +113,8 @@
 		target = <&spi1>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 
 			mcp3008_11: mcp3008@1 {
 				compatible = "mcp3008";
@@ -128,8 +128,8 @@
 		target = <&spi1>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 
 			mcp3008_12: mcp3008@2 {
 				compatible = "mcp3008";
@@ -143,10 +143,10 @@
 		target = <&spi2>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-			mcp3008_20: mcp3008@2 {
+			mcp3008_20: mcp3008@0 {
 				compatible = "mcp3008";
 				reg = <0>;
 				spi-max-frequency = <1600000>;
@@ -158,10 +158,10 @@
 		target = <&spi2>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-			mcp3008_21: mcp3008@2 {
+			mcp3008_21: mcp3008@1 {
 				compatible = "mcp3008";
 				reg = <1>;
 				spi-max-frequency = <1600000>;
@@ -173,8 +173,8 @@
 		target = <&spi2>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 
 			mcp3008_22: mcp3008@2 {
 				compatible = "mcp3008";

--- a/arch/arm/boot/dts/overlays/mcp3008-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp3008-overlay.dts
@@ -1,0 +1,205 @@
+/*
+ * Device tree overlay for Microchip mcp3008 10-Bit A/D Converters
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target = <&spidev0>;
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev1>;
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target-path = "spi1/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target-path = "spi1/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target-path = "spi1/spidev@2";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@5 {
+		target-path = "spi2/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@6 {
+		target-path = "spi2/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@7 {
+		target-path = "spi2/spidev@2";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@8 {
+		target = <&spi0>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+			mcp3008_00: mcp3008@0 {
+				compatible = "mcp3008";
+				reg = <0>;
+				spi-max-frequency = <1600000>;
+			};
+		};
+	};
+
+	fragment@9 {
+		target = <&spi0>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+			mcp3008_01: mcp3008@1 {
+				compatible = "mcp3008";
+				reg = <1>;
+				spi-max-frequency = <1600000>;
+			};
+		};
+	};
+
+	fragment@10 {
+		target = <&spi1>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+			mcp3008_10: mcp3008@0 {
+				compatible = "mcp3008";
+				reg = <0>;
+				spi-max-frequency = <1600000>;
+			};
+		};
+	};
+
+	fragment@11 {
+		target = <&spi1>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+			mcp3008_11: mcp3008@1 {
+				compatible = "mcp3008";
+				reg = <1>;
+				spi-max-frequency = <1600000>;
+			};
+		};
+	};
+
+	fragment@12 {
+		target = <&spi1>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+			mcp3008_12: mcp3008@2 {
+				compatible = "mcp3008";
+				reg = <2>;
+				spi-max-frequency = <1600000>;
+			};
+		};
+	};
+
+	fragment@13 {
+		target = <&spi2>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+			mcp3008_20: mcp3008@2 {
+				compatible = "mcp3008";
+				reg = <0>;
+				spi-max-frequency = <1600000>;
+			};
+		};
+	};
+
+	fragment@14 {
+		target = <&spi2>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+			mcp3008_21: mcp3008@2 {
+				compatible = "mcp3008";
+				reg = <1>;
+				spi-max-frequency = <1600000>;
+			};
+		};
+	};
+
+	fragment@15 {
+		target = <&spi2>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+			mcp3008_22: mcp3008@2 {
+				compatible = "mcp3008";
+				reg = <2>;
+				spi-max-frequency = <1600000>;
+			};
+		};
+	};
+
+	__overrides__ {
+		spi0-0-present = <0>, "+0+8";
+		spi0-1-present = <0>, "+1+9";
+		spi1-0-present = <0>, "+2+10";
+		spi1-1-present = <0>, "+3+11";
+		spi1-2-present = <0>, "+4+12";
+		spi2-0-present = <0>, "+5+13";
+		spi2-1-present = <0>, "+6+14";
+		spi2-2-present = <0>, "+7+15";
+		spi0-0-speed = <&mcp3008_00>, "spi-max-frequency:0";
+		spi0-1-speed = <&mcp3008_01>, "spi-max-frequency:0";
+		spi1-0-speed = <&mcp3008_10>, "spi-max-frequency:0";
+		spi1-1-speed = <&mcp3008_11>, "spi-max-frequency:0";
+		spi1-2-speed = <&mcp3008_12>, "spi-max-frequency:0";
+		spi2-0-speed = <&mcp3008_20>, "spi-max-frequency:0";
+		spi2-1-speed = <&mcp3008_21>, "spi-max-frequency:0";
+		spi2-2-speed = <&mcp3008_22>, "spi-max-frequency:0";
+	};
+};


### PR DESCRIPTION
The default 1.6MHz speed in the dts gives me 1MHz SCLK watching with a scope. Not sure why. 1MHz is I think the preferred default running at 3.3.v. Changing speeds works. The mcp320x kernel module is already part of the defconfigs.

Some example usage:

SPI0.0
  dtparam=spi=on
  dtoverlay=mcp3008:spi0-0-present

SPI0.1
  dtparam=spi=on
  dtoverlay=mcp3008:spi0-1-present

SPI0.0 and SPI0.1
  dtparam=spi=on
  dtoverlay=mcp3008:spi0-0-present,spi0-1-present
  
SPI1.0
  dtparam=spi=on
  dtoverlay=spi1-1cs
  dtoverlay=mcp3008:spi1-0-present
  
SPI1.2
  dtparam=spi=on
  dtoverlay=spi1-1cs:cs0_pin=16
  dtoverlay=mcp3008:spi1-0-present

SPI1.0 and SPI1.1
  dtoverlay=spi1-2cs
  dtoverlay=mcp3008:spi1-0-present,spi1-1-present 

Changing the speed

SPI0.0
  dtparam=spi=on
  dtoverlay=mcp3008:spi0-0-present,spi0-0-speed=2000000
