### PR TITLE
usb: dwc2: Avoid suspending if we're in gadget mode

### DIFF
--- a/drivers/usb/dwc2/hcd.c
+++ b/drivers/usb/dwc2/hcd.c
@@ -4365,6 +4365,9 @@ static int _dwc2_hcd_suspend(struct usb_hcd *hcd)
 	if (!HCD_HW_ACCESSIBLE(hcd))
 		goto unlock;
 
+	if (hsotg->op_state == OTG_STATE_B_PERIPHERAL)
+		goto unlock;
+
 	if (!hsotg->core_params->hibernation)
 		goto skip_power_saving;
 


### PR DESCRIPTION
Backport from upstream 4.10-rc5 to resolve https://github.com/raspberrypi/linux/issues/1713

It seems that the usb autosuspend is suspending the bus shortly after bootup when the gadget cable is attached. I have not been able to trigger this bug with the Raspbian kernel, where dwc2 is built as a module.
 There is only a small number of use-cases where the USB driver might need to be built into a monolithic kernel, but this small patch is entirely harmless unless using the dwc2 driver, and it may be possible to hit this bug on a compute module in gadget mode.