### PR TITLE
char: broadcom : Remove unnecessary dev_info output

### DIFF
--- a/drivers/char/broadcom/bcm2835-gpiomem.c
+++ b/drivers/char/broadcom/bcm2835-gpiomem.c
@@ -76,8 +76,6 @@ static int bcm2835_gpiomem_open(struct inode *inode, struct file *file)
 	int dev = iminor(inode);
 	int ret = 0;
 
-	dev_info(inst->dev, "gpiomem device opened.");
-
 	if (dev != DEVICE_MINOR) {
 		dev_err(inst->dev, "Unknown minor device: %d", dev);
 		ret = -ENXIO;


### PR DESCRIPTION
The open function was spamming syslog every time
called, so have removed call completely.