### PR TITLE
PCM sound on HDMI output: Support higher sampling rates up to 192 kHz, 24 bit depth, 5.1 channels

### DIFF
--- a/sound/arm/bcm2835-ctl.c
+++ b/sound/arm/bcm2835-ctl.c
@@ -129,7 +129,7 @@ static int snd_bcm2835_ctl_put(struct snd_kcontrol *kcontrol,
 		if (changed
 		    || (ucontrol->value.integer.value[0] != chip2alsa(chip->volume))) {
 
-			chip->volume = alsa2chip(ucontrol->value.integer.value[0]);
+			chip->volume = alsa2chip(0);//alsa2chip(ucontrol->value.integer.value[0]);
 			changed = 1;
 		}
 

--- a/sound/arm/bcm2835-vchiq.c
+++ b/sound/arm/bcm2835-vchiq.c
@@ -592,6 +592,35 @@ int bcm2835_audio_set_params(bcm2835_alsa_stream_t * alsa_stream,
 	m.u.config.channels = channels;
 	m.u.config.samplerate = samplerate;
 	m.u.config.bps = bps;
+	m.u.config.channelmap = 0;
+
+	// We only support 5.1 surround channel map... for now
+	if(channels > 5)
+	{
+		// Always set the channel mapping to 5.1 surround 3/2/0.1 most common
+		m.u.config.channelmap  = 0x0B000000;
+		// Values that were found by trial and error
+		// Having documentation about this would be nice
+		// 0x0C000000; // 5.0 2/3/0
+		// 0x0D000000; // (5.1 2/3/0.1)
+		// 0x0E000000; // (6.0 3/3/0)
+		// 0x0F000000; // 6.1 (3/3/0.1)
+		// 0x11000000; // 6.1
+		// 0x10000000; // 6.0 chan
+		// 0x08000000; // 4.0 chan <- I found this on a forum, this was my starting point
+
+		// To test this run : speaker-test -Dplughw:0,1 -c6
+		// You also run this to check for glitches:
+		// speaker-test -Dplughw:0,1 -c6 -t sine -f 110
+		// It would be nice to chonge the value below by defines, I am sure that it is define
+		// somewhere... but where
+		m.u.config.channelmap |= 0;	//L
+		m.u.config.channelmap |= 1 << 3;//R
+		m.u.config.channelmap |= 4 << 6;//RL
+		m.u.config.channelmap |= 5 << 9;//RR
+		m.u.config.channelmap |= 3 << 12;//Center
+		m.u.config.channelmap |= 2 << 15;//LFE
+	}
 
 	/* Create the message available completion */
 	init_completion(&instance->msg_avail_comp);

--- a/sound/arm/vc_vchi_audioserv_defs.h
+++ b/sound/arm/vc_vchi_audioserv_defs.h
@@ -16,7 +16,7 @@
 #define _VC_AUDIO_DEFS_H_
 
 #define VC_AUDIOSERV_MIN_VER 1
-#define VC_AUDIOSERV_VER 2
+#define VC_AUDIOSERV_VER 3
 
 // FourCC code used for VCHI connection
 #define VC_AUDIO_SERVER_NAME  MAKE_FOURCC("AUDS")
@@ -36,6 +36,7 @@ typedef enum {
 	VC_AUDIO_MSG_TYPE_START,	// Configure audio
 	VC_AUDIO_MSG_TYPE_STOP,	// Configure audio
 	VC_AUDIO_MSG_TYPE_WRITE,	// Configure audio
+	VC_AUDIO_MSG_TYPE_LATENCY,	// request latency in cycles
 	VC_AUDIO_MSG_TYPE_MAX
 } VC_AUDIO_MSG_TYPE;
 
@@ -44,7 +45,7 @@ typedef struct {
 	uint32_t channels;
 	uint32_t samplerate;
 	uint32_t bps;
-
+	uint32_t channelmap;
 } VC_AUDIO_CONFIG_T;
 
 typedef struct {
@@ -84,6 +85,11 @@ typedef struct {
 	uint16_t max_packet;
 } VC_AUDIO_WRITE_T;
 
+typedef struct
+{
+	uint32_t dummy;
+} VC_AUDIO_LATENCY_T;
+
 // Generic result for a request (VC->HOST)
 typedef struct {
 	int32_t success;	// Success value
@@ -110,6 +116,7 @@ typedef struct {
 		VC_AUDIO_WRITE_T write;
 		VC_AUDIO_RESULT_T result;
 		VC_AUDIO_COMPLETE_T complete;
+		VC_AUDIO_LATENCY_T latency;
 	} u;
 } VC_AUDIO_MSG_T;
 


### PR DESCRIPTION
The goal of this patch is to allow sampling rate greater than 48kHz, 24 bit and 5.1 speaker config trough the HDMI port.

Seems that the only way to get 5.1 is to pass 8 channels but with two silent channels. In order to do that, you have to use plughw instead of hw device.

The channel map was found by trial and errors. It is a bit dirty, but I could not find any documentation.

Currently, this only support 5.1 config for channel count greater than 4. It would be nice, to support other configs... if we could find any documentation.

You can run this to check that channel map is set properly using:
speaker-test -Dplughw:0,1 -c6

I used this to test for glitches:
speaker-test -Dplughw:0,1 -c6 -t sine -f 110

I also tested it with flac files of the following formats:

Stereo 44.1 kHz 16 bit
Stereo 96 kHz 24 bit
5.1 96 kHz 24 bit
5.1 88.2 kHz 24 bit
5.1 48 kHz 24 bit