### PR TITLE
Add .dtbo rule for arm64 dts overlay

### DIFF
--- a/arch/arm64/Makefile
+++ b/arch/arm64/Makefile
@@ -113,6 +113,9 @@ zinstall install:
 %.dtb: scripts
 	$(Q)$(MAKE) $(build)=$(boot)/dts $(boot)/dts/$@
 
+%.dtbo: | scripts
+	$(Q)$(MAKE) $(build)=$(boot)/dts MACHINE=$(MACHINE) $(boot)/dts/$@
+
 PHONY += dtbs dtbs_install
 
 dtbs: prepare scripts


### PR DESCRIPTION
We now create overlays as .dtbo files.

Signed-off-by: Khem Raj <raj.khem@gmail.com>