### PR TITLE
dmaengine: bcm2835: Fix cyclic DMA period splitting

### DIFF
--- a/drivers/dma/bcm2835-dma.c
+++ b/drivers/dma/bcm2835-dma.c
@@ -253,8 +253,11 @@ static void bcm2835_dma_create_cb_set_length(
 	 */
 
 	/* have we filled in period_length yet? */
-	if (*total_len + control_block->length < period_len)
+	if (*total_len + control_block->length < period_len) {
+		/* update number of bytes in this period so far */
+		*total_len += control_block->length;
 		return;
+	}
 
 	/* calculate the length that remains to reach period_length */
 	control_block->length = period_len - *total_len;


### PR DESCRIPTION
This patch got lost during upstreaming. I've resubmitted it and it should appear in future upstream kernels:
https://lkml.org/lkml/2017/2/20/506

For the time being it would be good to have this in the 4.9 and 4.10 trees - it was included in 4.4 as well.

Without that patch we get repeated clicks when playing audio on I2S cards (eg at 192 kHz)