### PR TITLE
Add overlay for ads1115 ADCs

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -4,6 +4,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	adau1977-adc.dtbo \
 	adau7002-simple.dtbo \
 	ads1015.dtbo \
+	ads1115.dtbo \
 	ads7846.dtbo \
 	akkordion-iqdacplus.dtbo \
 	allo-piano-dac-pcm512x-audio.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -196,17 +196,17 @@ Params: addr                    I2C bus address of device. Set based on how the
         http://www.ti.com/lit/ds/symlink/ads1015.pdf
 
 
-Name:  ads1115
-Info:  Texas Instruments ADS1115 ADC
-Load:  dtoverlay=ads1115,<param>[=<val>]
+Name:   ads1115
+Info:   Texas Instruments ADS1115 ADC
+Load:   dtoverlay=ads1115,<param>[=<val>]
 Params: addr                    I2C bus address of device. Set based on how the
                                 addr pin is wired. (default=0x48 assumes addr
                                 is pulled to GND)
         cha_enable              Enable virtual channel a.
-        cha_mux                 Set the input mux for virtual channel a.
+        cha_cfg                 Set the configuration for virtual channel a.
                                 (default=4 configures this channel for the
                                 voltage at A0 with respect to GND)
-        cha_rate                Set the datarate (samples/sec) for this channel.
+        cha_datarate            Set the datarate (samples/sec) for this channel.
                                 (default=7 sets 860 sps)
         cha_gain                Set the gain of the Programmable Gain
                                 Amplifier for this channel. (Default 1 sets the

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -196,6 +196,28 @@ Params: addr                    I2C bus address of device. Set based on how the
         http://www.ti.com/lit/ds/symlink/ads1015.pdf
 
 
+Name:  ads1115
+Info:  Texas Instruments ADS1115 ADC
+Load:  dtoverlay=ads1115,<param>[=<val>]
+Params: addr                    I2C bus address of device. Set based on how the
+                                addr pin is wired. (default=0x48 assumes addr
+                                is pulled to GND)
+        cha_enable              Enable virtual channel a.
+        cha_mux                 Set the input mux for virtual channel a.
+                                (default=4 configures this channel for the
+                                voltage at A0 with respect to GND)
+        cha_rate                Set the datarate (samples/sec) for this channel.
+                                (default=7 sets 860 sps)
+        cha_gain                Set the gain of the Programmable Gain
+                                Amplifier for this channel. (Default 1 sets the
+                                full scale of the channel to 4.096 Volts)
+
+        Channel parameters can be set for each enabled channel.
+        A maximum of 4 channels can be enabled (letters a thru d).
+        For more information refer to the device datasheet at:
+        http://www.ti.com/lit/ds/symlink/ads1115.pdf
+
+
 Name:   ads7846
 Info:   ADS7846 Touch controller
 Load:   dtoverlay=ads7846,<param>=<val>

--- a/arch/arm/boot/dts/overlays/ads1115-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ads1115-overlay.dts
@@ -1,0 +1,103 @@
+/*
+ * TI ADS1115 multi-channel ADC overlay
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ads1115: ads1115 {
+				compatible = "ti,ads1115";
+				status = "okay";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0x48>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "i2c_arm/ads1115";
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			channel_a: channel_a {
+				reg = <4>;
+				ti,gain = <1>;
+				ti,datarate = <7>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path = "i2c_arm/ads1115";
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			channel_b: channel_b {
+				reg = <5>;
+				ti,gain = <1>;
+				ti,datarate = <7>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target-path = "i2c_arm/ads1115";
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			channel_c: channel_c {
+				reg = <6>;
+				ti,gain = <1>;
+				ti,datarate = <7>;
+			};
+		};
+	};
+
+	fragment@4 {
+		target-path = "i2c_arm/ads1115";
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			channel_d: channel_d {
+				reg = <7>;
+				ti,gain = <1>;
+				ti,datarate = <7>;
+			};
+		};
+	};
+
+	__overrides__ {
+		addr =            <&ads1115>,"reg:0";
+		cha_enable =      <0>,"=1";
+		cha_cfg =         <&channel_a>,"reg:0";
+		cha_gain =        <&channel_a>,"ti,gain:0";
+		cha_datarate =    <&channel_a>,"ti,datarate:0";
+		chb_enable =      <0>,"=2";
+		chb_cfg =         <&channel_b>,"reg:0";
+		chb_gain =        <&channel_b>,"ti,gain:0";
+		chb_datarate =    <&channel_b>,"ti,datarate:0";
+		chc_enable =      <0>,"=3";
+		chc_cfg =         <&channel_c>,"reg:0";
+		chc_gain =        <&channel_c>,"ti,gain:0";
+		chc_datarate =    <&channel_c>,"ti,datarate:0";
+		chd_enable =      <0>,"=4";
+		chd_cfg =         <&channel_d>,"reg:0";
+		chd_gain =        <&channel_d>,"ti,gain:0";
+		chd_datarate =    <&channel_d>,"ti,datarate:0";
+	};
+};


### PR DESCRIPTION
The ads1015 kernel driver supports ads1015 and ads1115 devices but different data rate tables are used internally based on the device. The data rate tables are used to calculate timeouts. 