### PR TITLE
BCM270X_DT: Flip the polarity of the CM3's HDMI HPD.

### DIFF
--- a/drivers/gpu/drm/panel/panel-raspberrypi-touchscreen.c
+++ b/drivers/gpu/drm/panel/panel-raspberrypi-touchscreen.c
@@ -220,7 +220,12 @@ static const struct drm_display_mode rpi_touchscreen_modes[] = {
 #define HBP         46
 #define HFP         ((PIXEL_CLOCK / (VTOTAL * VREFRESH)) - (HACT + HSW + HBP))
 
-		.clock = PIXEL_CLOCK / 1000,
+		/* Round up the pixel clock a bit (10khz), so that the
+		 * "don't run things faster than the requested clock
+		 * rate" rule of the clk driver doesn't reject the
+		 * divide-by-3 mode due to rounding error.
+		 */
+		.clock = PIXEL_CLOCK / 1000 + 10,
 		.hdisplay = HACT,
 		.hsync_start = HACT + HFP,
 		.hsync_end = HACT + HFP + HSW,


### PR DESCRIPTION
Testing on my CM3 board, xrandr showed HDMI connected when the cable
was unplugged, and disconnected when it was plugged in.

Signed-off-by: Eric Anholt <eric@anholt.net>