### PR TITLE
bcm2835-gpio-exp: Copy/paste error adding base twice

### DIFF
--- a/drivers/gpio/gpio-bcm-exp.c
+++ b/drivers/gpio/gpio-bcm-exp.c
@@ -165,8 +165,6 @@ static void brcmexp_gpio_set(struct gpio_chip *gc, unsigned int off, int val)
 
 	gpio = container_of(gc, struct brcmexp_gpio, gc);
 
-	off += gpio->gc.base;
-
 	set.gpio = off + gpio->gc.base;	/* GPIO to update */
 	set.state = val;	/* Output state */
 


### PR DESCRIPTION
brcmexp_gpio_set was adding gpio->gc.base to the offset
twice, so passing an invalid number to the mailbox service.
The firmware treated it modulo-8 anyway, but was logging an
assert every time.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>