### PR TITLE
bcm2835-camera: Correct port_parameter_get return value

### DIFF
--- a/drivers/media/platform/bcm2835/mmal-vchiq.c
+++ b/drivers/media/platform/bcm2835/mmal-vchiq.c
@@ -1292,6 +1292,7 @@ static int port_parameter_get(struct vchiq_mmal_instance *instance,
 	struct mmal_msg m;
 	struct mmal_msg *rmsg;
 	VCHI_HELD_MSG_T rmsg_handle;
+	u32 reply_size;
 
 	m.h.type = MMAL_MSG_TYPE_PORT_PARAMETER_GET;
 
@@ -1315,21 +1316,27 @@ static int port_parameter_get(struct vchiq_mmal_instance *instance,
 	}
 
 	ret = -rmsg->u.port_parameter_get_reply.status;
-	/* port_parameter_get_reply.size includes the header,
+	/*
+	 * port_parameter_get_reply.size includes the header,
 	 * whilst *value_size doesn't.
 	 */
-	rmsg->u.port_parameter_get_reply.size -= (2 * sizeof(u32));
+	reply_size = rmsg->u.port_parameter_get_reply.size - (2 * sizeof(u32));
 
-	if (ret || rmsg->u.port_parameter_get_reply.size > *value_size) {
+	if (ret || (reply_size > *value_size)) {
 		/* Copy only as much as we have space for
 		 * but report true size of parameter
 		 */
 		memcpy(value, &rmsg->u.port_parameter_get_reply.value,
 		       *value_size);
-		*value_size = rmsg->u.port_parameter_get_reply.size;
 	} else
 		memcpy(value, &rmsg->u.port_parameter_get_reply.value,
-		       rmsg->u.port_parameter_get_reply.size);
+		       reply_size);
+
+	/*
+	 * Return amount of data copied if big enough,
+	 * or wanted if not big enough.
+	 */
+	*value_size = reply_size;
 
 	pr_debug("%s:result:%d component:0x%x port:%d parameter:%d\n", __func__,
 	        ret, port->component->handle, port->handle, parameter_id);


### PR DESCRIPTION
The API for port_parameter_get() requires that the
filled length is returned, or if insufficient space
that the required space is returned.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>