### PR TITLE
rpi-4.9.y: vc4 HDMI audio, unlimited CMA memory, bugfix

### DIFF
--- a/arch/arm/boot/dts/bcm283x.dtsi
+++ b/arch/arm/boot/dts/bcm283x.dtsi
@@ -339,6 +339,8 @@
 			clocks = <&clocks BCM2835_PLLH_PIX>,
 				 <&clocks BCM2835_CLOCK_HSM>;
 			clock-names = "pixel", "hdmi";
+			dmas = <&dma 17>;
+			dma-names = "audio-rx";
 			status = "disabled";
 		};
 

--- a/drivers/base/dma-contiguous.c
+++ b/drivers/base/dma-contiguous.c
@@ -35,7 +35,6 @@
 #endif
 
 struct cma *dma_contiguous_default_area;
-EXPORT_SYMBOL(dma_contiguous_default_area);
 
 /*
  * Default global CMA area size can be defined in kernel's .config.

--- a/drivers/gpu/drm/panel/panel-raspberrypi-touchscreen.c
+++ b/drivers/gpu/drm/panel/panel-raspberrypi-touchscreen.c
@@ -404,6 +404,9 @@ static struct i2c_client *rpi_touchscreen_get_i2c(struct device *dev,
 
 	of_node_put(node);
 
+	if (!client)
+		return ERR_PTR(-EPROBE_DEFER);
+
 	return client;
 }
 

--- a/drivers/gpu/drm/vc4/Kconfig
+++ b/drivers/gpu/drm/vc4/Kconfig
@@ -2,11 +2,15 @@ config DRM_VC4
 	tristate "Broadcom VC4 Graphics"
 	depends on ARCH_BCM2835 || COMPILE_TEST
 	depends on DRM
+	depends on SND && SND_SOC
 	depends on COMMON_CLK
 	select DRM_KMS_HELPER
 	select DRM_KMS_CMA_HELPER
 	select DRM_GEM_CMA_HELPER
 	select DRM_PANEL
+	select SND_PCM
+	select SND_PCM_ELD
+	select SND_SOC_GENERIC_DMAENGINE_PCM
 	select DRM_MIPI_DSI
 	help
 	  Choose this option if you have a system that has a Broadcom

--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -97,12 +97,23 @@ struct vc4_dev {
 	 */
 	struct list_head seqno_cb_list;
 
-	/* The binner overflow memory that's currently set up in
-	 * BPOA/BPOS registers.  When overflow occurs and a new one is
-	 * allocated, the previous one will be moved to
-	 * vc4->current_exec's free list.
+	/* The memory used for storing binner tile alloc, tile state,
+	 * and overflow memory allocations.  This is freed when V3D
+	 * powers down.
 	 */
-	struct vc4_bo *overflow_mem;
+	struct vc4_bo *bin_bo;
+
+	/* Size of blocks allocated within bin_bo. */
+	uint32_t bin_alloc_size;
+
+	/* Bitmask of the bin_alloc_size chunks in bin_bo that are
+	 * used.
+	 */
+	uint32_t bin_alloc_used;
+
+	/* Bitmask of the current bin_alloc used for overflow memory. */
+	uint32_t bin_alloc_overflow;
+
 	struct work_struct overflow_mem_work;
 
 	int power_refcount;
@@ -295,8 +306,12 @@ struct vc4_exec_info {
 	bool found_increment_semaphore_packet;
 	bool found_flush;
 	uint8_t bin_tiles_x, bin_tiles_y;
-	struct drm_gem_cma_object *tile_bo;
+	/* Physical address of the start of the tile alloc array
+	 * (where each tile's binned CL will start)
+	 */
 	uint32_t tile_alloc_offset;
+	/* Bitmask of which binner slots are freed when this job completes. */
+	uint32_t bin_slots;
 
 	/**
 	 * Computed addresses pointing into exec_bo where we start the
@@ -531,6 +546,7 @@ void vc4_plane_async_set_fb(struct drm_plane *plane,
 extern struct platform_driver vc4_v3d_driver;
 int vc4_v3d_debugfs_ident(struct seq_file *m, void *unused);
 int vc4_v3d_debugfs_regs(struct seq_file *m, void *unused);
+int vc4_v3d_get_bin_slot(struct vc4_dev *vc4);
 
 /* vc4_validate.c */
 int

--- a/drivers/gpu/drm/vc4/vc4_gem.c
+++ b/drivers/gpu/drm/vc4/vc4_gem.c
@@ -695,6 +695,7 @@ static void
 vc4_complete_exec(struct drm_device *dev, struct vc4_exec_info *exec)
 {
 	struct vc4_dev *vc4 = to_vc4_dev(dev);
+	unsigned long irqflags;
 	unsigned i;
 
 	if (exec->bo) {
@@ -709,6 +710,11 @@ vc4_complete_exec(struct drm_device *dev, struct vc4_exec_info *exec)
 		list_del(&bo->unref_head);
 		drm_gem_object_unreference_unlocked(&bo->base.base);
 	}
+
+	/* Free up the allocation of any bin slots we used. */
+	spin_lock_irqsave(&vc4->job_lock, irqflags);
+	vc4->bin_alloc_used &= ~exec->bin_slots;
+	spin_unlock_irqrestore(&vc4->job_lock, irqflags);
 
 	mutex_lock(&vc4->power_lock);
 	if (--vc4->power_refcount == 0) {
@@ -951,9 +957,9 @@ vc4_gem_destroy(struct drm_device *dev)
 	/* V3D should already have disabled its interrupt and cleared
 	 * the overflow allocation registers.  Now free the object.
 	 */
-	if (vc4->overflow_mem) {
-		drm_gem_object_unreference_unlocked(&vc4->overflow_mem->base.base);
-		vc4->overflow_mem = NULL;
+	if (vc4->bin_bo) {
+		drm_gem_object_unreference_unlocked(&vc4->bin_bo->base.base);
+		vc4->bin_bo = NULL;
 	}
 
 	if (vc4->hang_state)

--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -31,10 +31,26 @@
 #include "linux/clk.h"
 #include "linux/component.h"
 #include "linux/i2c.h"
+#include "linux/of_address.h"
 #include "linux/of_gpio.h"
 #include "linux/of_platform.h"
+#include "linux/rational.h"
+#include "sound/dmaengine_pcm.h"
+#include "sound/pcm_drm_eld.h"
+#include "sound/pcm_params.h"
+#include "sound/soc.h"
 #include "vc4_drv.h"
 #include "vc4_regs.h"
+
+/* HDMI audio information */
+struct vc4_hdmi_audio {
+	struct snd_soc_card card;
+	struct snd_soc_dai_link link;
+	int samplerate;
+	int channels;
+	struct snd_dmaengine_dai_dma_data dma_data;
+	struct snd_pcm_substream *substream;
+};
 
 /* General HDMI hardware state. */
 struct vc4_hdmi {
@@ -42,6 +58,8 @@ struct vc4_hdmi {
 
 	struct drm_encoder *encoder;
 	struct drm_connector *connector;
+
+	struct vc4_hdmi_audio audio;
 
 	struct i2c_adapter *ddc;
 	void __iomem *hdmicore_regs;
@@ -98,6 +116,10 @@ static const struct {
 	HDMI_REG(VC4_HDMI_SW_RESET_CONTROL),
 	HDMI_REG(VC4_HDMI_HOTPLUG_INT),
 	HDMI_REG(VC4_HDMI_HOTPLUG),
+	HDMI_REG(VC4_HDMI_MAI_CHANNEL_MAP),
+	HDMI_REG(VC4_HDMI_MAI_CONFIG),
+	HDMI_REG(VC4_HDMI_MAI_FORMAT),
+	HDMI_REG(VC4_HDMI_AUDIO_PACKET_CONFIG),
 	HDMI_REG(VC4_HDMI_RAM_PACKET_CONFIG),
 	HDMI_REG(VC4_HDMI_HORZA),
 	HDMI_REG(VC4_HDMI_HORZB),
@@ -108,6 +130,7 @@ static const struct {
 	HDMI_REG(VC4_HDMI_VERTB0),
 	HDMI_REG(VC4_HDMI_VERTB1),
 	HDMI_REG(VC4_HDMI_TX_PHY_RESET_CTL),
+	HDMI_REG(VC4_HDMI_TX_PHY_CTL0),
 };
 
 static const struct {
@@ -116,6 +139,9 @@ static const struct {
 } hd_regs[] = {
 	HDMI_REG(VC4_HD_M_CTL),
 	HDMI_REG(VC4_HD_MAI_CTL),
+	HDMI_REG(VC4_HD_MAI_THR),
+	HDMI_REG(VC4_HD_MAI_FMT),
+	HDMI_REG(VC4_HD_MAI_SMP),
 	HDMI_REG(VC4_HD_VID_CTL),
 	HDMI_REG(VC4_HD_CSC_CTL),
 	HDMI_REG(VC4_HD_FRAME_COUNT),
@@ -215,6 +241,7 @@ static int vc4_hdmi_connector_get_modes(struct drm_connector *connector)
 
 	drm_mode_connector_update_edid_property(connector, edid);
 	ret = drm_add_edid_modes(connector, edid);
+	drm_edid_to_eld(connector, edid);
 
 	return ret;
 }
@@ -300,7 +327,7 @@ static void vc4_hdmi_write_infoframe(struct drm_encoder *encoder,
 	struct drm_device *dev = encoder->dev;
 	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	u32 packet_id = frame->any.type - 0x80;
-	u32 packet_reg = VC4_HDMI_GCP_0 + VC4_HDMI_PACKET_STRIDE * packet_id;
+	u32 packet_reg = VC4_HDMI_RAM_PACKET(packet_id);
 	uint8_t buffer[VC4_HDMI_PACKET_STRIDE];
 	ssize_t len, i;
 	int ret;
@@ -381,6 +408,24 @@ static void vc4_hdmi_set_spd_infoframe(struct drm_encoder *encoder)
 	}
 
 	frame.spd.sdi = HDMI_SPD_SDI_PC;
+
+	vc4_hdmi_write_infoframe(encoder, &frame);
+}
+
+static void vc4_hdmi_set_audio_infoframe(struct drm_encoder *encoder)
+{
+	struct drm_device *drm = encoder->dev;
+	struct vc4_dev *vc4 = drm->dev_private;
+	struct vc4_hdmi *hdmi = vc4->hdmi;
+	union hdmi_infoframe frame;
+	int ret;
+
+	ret = hdmi_audio_infoframe_init(&frame.audio);
+
+	frame.audio.coding_type = HDMI_AUDIO_CODING_TYPE_STREAM;
+	frame.audio.sample_frequency = HDMI_AUDIO_SAMPLE_FREQUENCY_STREAM;
+	frame.audio.sample_size = HDMI_AUDIO_SAMPLE_SIZE_STREAM;
+	frame.audio.channels = hdmi->audio.channels;
 
 	vc4_hdmi_write_infoframe(encoder, &frame);
 }
@@ -591,6 +636,447 @@ static const struct drm_encoder_helper_funcs vc4_hdmi_encoder_helper_funcs = {
 	.enable = vc4_hdmi_encoder_enable,
 };
 
+/* HDMI audio codec callbacks */
+static void vc4_hdmi_audio_set_mai_clock(struct vc4_hdmi *hdmi)
+{
+	struct drm_device *drm = hdmi->encoder->dev;
+	struct vc4_dev *vc4 = to_vc4_dev(drm);
+	u32 hsm_clock = clk_get_rate(hdmi->hsm_clock);
+	unsigned long n, m;
+
+	rational_best_approximation(hsm_clock, hdmi->audio.samplerate,
+				    VC4_HD_MAI_SMP_N_MASK >>
+				    VC4_HD_MAI_SMP_N_SHIFT,
+				    (VC4_HD_MAI_SMP_M_MASK >>
+				     VC4_HD_MAI_SMP_M_SHIFT) + 1,
+				    &n, &m);
+
+	HD_WRITE(VC4_HD_MAI_SMP,
+		 VC4_SET_FIELD(n, VC4_HD_MAI_SMP_N) |
+		 VC4_SET_FIELD(m - 1, VC4_HD_MAI_SMP_M));
+}
+
+static void vc4_hdmi_set_n_cts(struct vc4_hdmi *hdmi)
+{
+	struct drm_encoder *encoder = hdmi->encoder;
+	struct drm_crtc *crtc = encoder->crtc;
+	struct drm_device *drm = encoder->dev;
+	struct vc4_dev *vc4 = to_vc4_dev(drm);
+	const struct drm_display_mode *mode = &crtc->state->adjusted_mode;
+	u32 samplerate = hdmi->audio.samplerate;
+	u32 n, cts;
+	u64 tmp;
+
+	n = 128 * samplerate / 1000;
+	tmp = (u64)(mode->clock * 1000) * n;
+	do_div(tmp, 128 * samplerate);
+	cts = tmp;
+
+	HDMI_WRITE(VC4_HDMI_CRP_CFG,
+		   VC4_HDMI_CRP_CFG_EXTERNAL_CTS_EN |
+		   VC4_SET_FIELD(n, VC4_HDMI_CRP_CFG_N));
+
+	/*
+	 * We could get slightly more accurate clocks in some cases by
+	 * providing a CTS_1 value.  The two CTS values are alternated
+	 * between based on the period fields
+	 */
+	HDMI_WRITE(VC4_HDMI_CTS_0, cts);
+	HDMI_WRITE(VC4_HDMI_CTS_1, cts);
+}
+
+static inline struct vc4_hdmi *dai_to_hdmi(struct snd_soc_dai *dai)
+{
+	struct snd_soc_card *card = snd_soc_dai_get_drvdata(dai);
+
+	return snd_soc_card_get_drvdata(card);
+}
+
+static int vc4_hdmi_audio_startup(struct snd_pcm_substream *substream,
+				  struct snd_soc_dai *dai)
+{
+	struct vc4_hdmi *hdmi = dai_to_hdmi(dai);
+	struct drm_encoder *encoder = hdmi->encoder;
+	struct vc4_dev *vc4 = to_vc4_dev(encoder->dev);
+	int ret;
+
+	if (hdmi->audio.substream && hdmi->audio.substream != substream)
+		return -EINVAL;
+
+	hdmi->audio.substream = substream;
+
+	/*
+	 * If the HDMI encoder hasn't probed, or the encoder is
+	 * currently in DVI mode, treat the codec dai as missing.
+	 */
+	if (!encoder->crtc || !(HDMI_READ(VC4_HDMI_RAM_PACKET_CONFIG) &
+				VC4_HDMI_RAM_PACKET_ENABLE))
+		return -ENODEV;
+
+	ret = snd_pcm_hw_constraint_eld(substream->runtime,
+					hdmi->connector->eld);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static int vc4_hdmi_audio_set_fmt(struct snd_soc_dai *dai, unsigned int fmt)
+{
+	return 0;
+}
+
+static void vc4_hdmi_audio_reset(struct vc4_hdmi *hdmi)
+{
+	struct drm_encoder *encoder = hdmi->encoder;
+	struct drm_device *drm = encoder->dev;
+	struct device *dev = &hdmi->pdev->dev;
+	struct vc4_dev *vc4 = to_vc4_dev(drm);
+	int ret;
+
+	ret = vc4_hdmi_stop_packet(encoder, HDMI_INFOFRAME_TYPE_AUDIO);
+	if (ret)
+		dev_err(dev, "Failed to stop audio infoframe: %d\n", ret);
+
+	HD_WRITE(VC4_HD_MAI_CTL, VC4_HD_MAI_CTL_RESET);
+	HD_WRITE(VC4_HD_MAI_CTL, VC4_HD_MAI_CTL_ERRORF);
+	HD_WRITE(VC4_HD_MAI_CTL, VC4_HD_MAI_CTL_FLUSH);
+}
+
+static void vc4_hdmi_audio_shutdown(struct snd_pcm_substream *substream,
+				    struct snd_soc_dai *dai)
+{
+	struct vc4_hdmi *hdmi = dai_to_hdmi(dai);
+
+	if (substream != hdmi->audio.substream)
+		return;
+
+	vc4_hdmi_audio_reset(hdmi);
+
+	hdmi->audio.substream = NULL;
+}
+
+/* HDMI audio codec callbacks */
+static int vc4_hdmi_audio_hw_params(struct snd_pcm_substream *substream,
+				    struct snd_pcm_hw_params *params,
+				    struct snd_soc_dai *dai)
+{
+	struct vc4_hdmi *hdmi = dai_to_hdmi(dai);
+	struct drm_encoder *encoder = hdmi->encoder;
+	struct drm_device *drm = encoder->dev;
+	struct device *dev = &hdmi->pdev->dev;
+	struct vc4_dev *vc4 = to_vc4_dev(drm);
+	u32 audio_packet_config, channel_mask;
+	u32 channel_map, i;
+
+	if (substream != hdmi->audio.substream)
+		return -EINVAL;
+
+	dev_dbg(dev, "%s: %u Hz, %d bit, %d channels\n", __func__,
+		params_rate(params), params_width(params),
+		params_channels(params));
+
+	hdmi->audio.channels = params_channels(params);
+	hdmi->audio.samplerate = params_rate(params);
+
+	HD_WRITE(VC4_HD_MAI_CTL,
+		 VC4_HD_MAI_CTL_RESET |
+		 VC4_HD_MAI_CTL_FLUSH |
+		 VC4_HD_MAI_CTL_DLATE |
+		 VC4_HD_MAI_CTL_ERRORE |
+		 VC4_HD_MAI_CTL_ERRORF);
+
+	vc4_hdmi_audio_set_mai_clock(hdmi);
+
+	audio_packet_config =
+		VC4_HDMI_AUDIO_PACKET_ZERO_DATA_ON_SAMPLE_FLAT |
+		VC4_HDMI_AUDIO_PACKET_ZERO_DATA_ON_INACTIVE_CHANNELS |
+		VC4_SET_FIELD(0xf, VC4_HDMI_AUDIO_PACKET_B_FRAME_IDENTIFIER);
+
+	channel_mask = GENMASK(hdmi->audio.channels - 1, 0);
+	audio_packet_config |= VC4_SET_FIELD(channel_mask,
+					     VC4_HDMI_AUDIO_PACKET_CEA_MASK);
+
+	/* Set the MAI threshold.  This logic mimics the firmware's. */
+	if (hdmi->audio.samplerate > 96000) {
+		HD_WRITE(VC4_HD_MAI_THR,
+			 VC4_SET_FIELD(0x12, VC4_HD_MAI_THR_DREQHIGH) |
+			 VC4_SET_FIELD(0x12, VC4_HD_MAI_THR_DREQLOW));
+	} else if (hdmi->audio.samplerate > 48000) {
+		HD_WRITE(VC4_HD_MAI_THR,
+			 VC4_SET_FIELD(0x14, VC4_HD_MAI_THR_DREQHIGH) |
+			 VC4_SET_FIELD(0x12, VC4_HD_MAI_THR_DREQLOW));
+	} else {
+		HD_WRITE(VC4_HD_MAI_THR,
+			 VC4_SET_FIELD(0x10, VC4_HD_MAI_THR_PANICHIGH) |
+			 VC4_SET_FIELD(0x10, VC4_HD_MAI_THR_PANICLOW) |
+			 VC4_SET_FIELD(0x10, VC4_HD_MAI_THR_DREQHIGH) |
+			 VC4_SET_FIELD(0x10, VC4_HD_MAI_THR_DREQLOW));
+	}
+
+	HDMI_WRITE(VC4_HDMI_MAI_CONFIG,
+		   VC4_HDMI_MAI_CONFIG_BIT_REVERSE |
+		   VC4_SET_FIELD(channel_mask, VC4_HDMI_MAI_CHANNEL_MASK));
+
+	channel_map = 0;
+	for (i = 0; i < 8; i++) {
+		if (channel_mask & BIT(i))
+			channel_map |= i << (3 * i);
+	}
+
+	HDMI_WRITE(VC4_HDMI_MAI_CHANNEL_MAP, channel_map);
+	HDMI_WRITE(VC4_HDMI_AUDIO_PACKET_CONFIG, audio_packet_config);
+	vc4_hdmi_set_n_cts(hdmi);
+
+	return 0;
+}
+
+static int vc4_hdmi_audio_trigger(struct snd_pcm_substream *substream, int cmd,
+				  struct snd_soc_dai *dai)
+{
+	struct vc4_hdmi *hdmi = dai_to_hdmi(dai);
+	struct drm_encoder *encoder = hdmi->encoder;
+	struct drm_device *drm = encoder->dev;
+	struct vc4_dev *vc4 = to_vc4_dev(drm);
+
+	switch (cmd) {
+	case SNDRV_PCM_TRIGGER_START:
+		vc4_hdmi_set_audio_infoframe(encoder);
+		HDMI_WRITE(VC4_HDMI_TX_PHY_CTL0,
+			   HDMI_READ(VC4_HDMI_TX_PHY_CTL0) &
+			   ~VC4_HDMI_TX_PHY_RNG_PWRDN);
+		HD_WRITE(VC4_HD_MAI_CTL,
+			 VC4_SET_FIELD(hdmi->audio.channels,
+				       VC4_HD_MAI_CTL_CHNUM) |
+			 VC4_HD_MAI_CTL_ENABLE);
+		break;
+	case SNDRV_PCM_TRIGGER_STOP:
+		HD_WRITE(VC4_HD_MAI_CTL,
+			 VC4_HD_MAI_CTL_DLATE |
+			 VC4_HD_MAI_CTL_ERRORE |
+			 VC4_HD_MAI_CTL_ERRORF);
+		HDMI_WRITE(VC4_HDMI_TX_PHY_CTL0,
+			   HDMI_READ(VC4_HDMI_TX_PHY_CTL0) |
+			   VC4_HDMI_TX_PHY_RNG_PWRDN);
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+static inline struct vc4_hdmi *
+snd_component_to_hdmi(struct snd_soc_component *component)
+{
+	struct snd_soc_card *card = snd_soc_component_get_drvdata(component);
+
+	return snd_soc_card_get_drvdata(card);
+}
+
+static int vc4_hdmi_audio_eld_ctl_info(struct snd_kcontrol *kcontrol,
+				       struct snd_ctl_elem_info *uinfo)
+{
+	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
+	struct vc4_hdmi *hdmi = snd_component_to_hdmi(component);
+
+	uinfo->type = SNDRV_CTL_ELEM_TYPE_BYTES;
+	uinfo->count = sizeof(hdmi->connector->eld);
+
+	return 0;
+}
+
+static int vc4_hdmi_audio_eld_ctl_get(struct snd_kcontrol *kcontrol,
+				      struct snd_ctl_elem_value *ucontrol)
+{
+	struct snd_soc_component *component = snd_kcontrol_chip(kcontrol);
+	struct vc4_hdmi *hdmi = snd_component_to_hdmi(component);
+
+	memcpy(ucontrol->value.bytes.data, hdmi->connector->eld,
+	       sizeof(hdmi->connector->eld));
+
+	return 0;
+}
+
+static const struct snd_kcontrol_new vc4_hdmi_audio_controls[] = {
+	{
+		.access = SNDRV_CTL_ELEM_ACCESS_READ |
+			  SNDRV_CTL_ELEM_ACCESS_VOLATILE,
+		.iface = SNDRV_CTL_ELEM_IFACE_PCM,
+		.name = "ELD",
+		.info = vc4_hdmi_audio_eld_ctl_info,
+		.get = vc4_hdmi_audio_eld_ctl_get,
+	},
+};
+
+static const struct snd_soc_dapm_widget vc4_hdmi_audio_widgets[] = {
+	SND_SOC_DAPM_OUTPUT("TX"),
+};
+
+static const struct snd_soc_dapm_route vc4_hdmi_audio_routes[] = {
+	{ "TX", NULL, "Playback" },
+};
+
+static const struct snd_soc_codec_driver vc4_hdmi_audio_codec_drv = {
+	.component_driver = {
+		.controls = vc4_hdmi_audio_controls,
+		.num_controls = ARRAY_SIZE(vc4_hdmi_audio_controls),
+		.dapm_widgets = vc4_hdmi_audio_widgets,
+		.num_dapm_widgets = ARRAY_SIZE(vc4_hdmi_audio_widgets),
+		.dapm_routes = vc4_hdmi_audio_routes,
+		.num_dapm_routes = ARRAY_SIZE(vc4_hdmi_audio_routes),
+	},
+};
+
+static const struct snd_soc_dai_ops vc4_hdmi_audio_dai_ops = {
+	.startup = vc4_hdmi_audio_startup,
+	.shutdown = vc4_hdmi_audio_shutdown,
+	.hw_params = vc4_hdmi_audio_hw_params,
+	.set_fmt = vc4_hdmi_audio_set_fmt,
+	.trigger = vc4_hdmi_audio_trigger,
+};
+
+static struct snd_soc_dai_driver vc4_hdmi_audio_codec_dai_drv = {
+	.name = "vc4-hdmi-hifi",
+	.playback = {
+		.stream_name = "Playback",
+		.channels_min = 2,
+		.channels_max = 8,
+		.rates = SNDRV_PCM_RATE_32000 | SNDRV_PCM_RATE_44100 |
+			 SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_88200 |
+			 SNDRV_PCM_RATE_96000 | SNDRV_PCM_RATE_176400 |
+			 SNDRV_PCM_RATE_192000,
+		.formats = SNDRV_PCM_FMTBIT_IEC958_SUBFRAME_LE,
+	},
+};
+
+static const struct snd_soc_component_driver vc4_hdmi_audio_cpu_dai_comp = {
+	.name = "vc4-hdmi-cpu-dai-component",
+};
+
+static int vc4_hdmi_audio_cpu_dai_probe(struct snd_soc_dai *dai)
+{
+	struct vc4_hdmi *hdmi = dai_to_hdmi(dai);
+
+	snd_soc_dai_init_dma_data(dai, &hdmi->audio.dma_data, NULL);
+
+	return 0;
+}
+
+static struct snd_soc_dai_driver vc4_hdmi_audio_cpu_dai_drv = {
+	.name = "vc4-hdmi-cpu-dai",
+	.probe  = vc4_hdmi_audio_cpu_dai_probe,
+	.playback = {
+		.stream_name = "Playback",
+		.channels_min = 1,
+		.channels_max = 8,
+		.rates = SNDRV_PCM_RATE_32000 | SNDRV_PCM_RATE_44100 |
+			 SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_88200 |
+			 SNDRV_PCM_RATE_96000 | SNDRV_PCM_RATE_176400 |
+			 SNDRV_PCM_RATE_192000,
+		.formats = SNDRV_PCM_FMTBIT_IEC958_SUBFRAME_LE,
+	},
+	.ops = &vc4_hdmi_audio_dai_ops,
+};
+
+static const struct snd_dmaengine_pcm_config pcm_conf = {
+	.chan_names[SNDRV_PCM_STREAM_PLAYBACK] = "audio-rx",
+	.prepare_slave_config = snd_dmaengine_pcm_prepare_slave_config,
+};
+
+static int vc4_hdmi_audio_init(struct vc4_hdmi *hdmi)
+{
+	struct snd_soc_dai_link *dai_link = &hdmi->audio.link;
+	struct snd_soc_card *card = &hdmi->audio.card;
+	struct device *dev = &hdmi->pdev->dev;
+	const __be32 *addr;
+	int ret;
+
+	if (!of_find_property(dev->of_node, "dmas", NULL)) {
+		dev_warn(dev,
+			 "'dmas' DT property is missing, no HDMI audio\n");
+		return 0;
+	}
+
+	/*
+	 * Get the physical address of VC4_HD_MAI_DATA. We need to retrieve
+	 * the bus address specified in the DT, because the physical address
+	 * (the one returned by platform_get_resource()) is not appropriate
+	 * for DMA transfers.
+	 * This VC/MMU should probably be exposed to avoid this kind of hacks.
+	 */
+	addr = of_get_address(dev->of_node, 1, NULL, NULL);
+	hdmi->audio.dma_data.addr = be32_to_cpup(addr) + VC4_HD_MAI_DATA;
+	hdmi->audio.dma_data.addr_width = DMA_SLAVE_BUSWIDTH_4_BYTES;
+	hdmi->audio.dma_data.maxburst = 2;
+
+	ret = devm_snd_dmaengine_pcm_register(dev, &pcm_conf, 0);
+	if (ret) {
+		dev_err(dev, "Could not register PCM component: %d\n", ret);
+		return ret;
+	}
+
+	ret = devm_snd_soc_register_component(dev, &vc4_hdmi_audio_cpu_dai_comp,
+					      &vc4_hdmi_audio_cpu_dai_drv, 1);
+	if (ret) {
+		dev_err(dev, "Could not register CPU DAI: %d\n", ret);
+		return ret;
+	}
+
+	/* register codec and codec dai */
+	ret = snd_soc_register_codec(dev, &vc4_hdmi_audio_codec_drv,
+				     &vc4_hdmi_audio_codec_dai_drv, 1);
+	if (ret) {
+		dev_err(dev, "Could not register codec: %d\n", ret);
+		return ret;
+	}
+
+	dai_link->name = "MAI";
+	dai_link->stream_name = "MAI PCM";
+	dai_link->codec_dai_name = vc4_hdmi_audio_codec_dai_drv.name;
+	dai_link->cpu_dai_name = dev_name(dev);
+	dai_link->codec_name = dev_name(dev);
+	dai_link->platform_name = dev_name(dev);
+
+	card->dai_link = dai_link;
+	card->num_links = 1;
+	card->name = "vc4-hdmi";
+	card->dev = dev;
+
+	/*
+	 * Be careful, snd_soc_register_card() calls dev_set_drvdata() and
+	 * stores a pointer to the snd card object in dev->driver_data. This
+	 * means we cannot use it for something else. The hdmi back-pointer is
+	 * now stored in card->drvdata and should be retrieved with
+	 * snd_soc_card_get_drvdata() if needed.
+	 */
+	snd_soc_card_set_drvdata(card, hdmi);
+	ret = devm_snd_soc_register_card(dev, card);
+	if (ret) {
+		dev_err(dev, "Could not register sound card: %d\n", ret);
+		goto unregister_codec;
+	}
+
+	return 0;
+
+unregister_codec:
+	snd_soc_unregister_codec(dev);
+
+	return ret;
+}
+
+static void vc4_hdmi_audio_cleanup(struct vc4_hdmi *hdmi)
+{
+	struct device *dev = &hdmi->pdev->dev;
+
+	/*
+	 * If drvdata is not set this means the audio card was not
+	 * registered, just skip codec unregistration in this case.
+	 */
+	if (dev_get_drvdata(dev))
+		snd_soc_unregister_codec(dev);
+}
+
 static int vc4_hdmi_bind(struct device *dev, struct device *master, void *data)
 {
 	struct platform_device *pdev = to_platform_device(dev);
@@ -722,6 +1208,10 @@ static int vc4_hdmi_bind(struct device *dev, struct device *master, void *data)
 		goto err_destroy_encoder;
 	}
 
+	ret = vc4_hdmi_audio_init(hdmi);
+	if (ret)
+		goto err_destroy_encoder;
+
 	return 0;
 
 err_destroy_encoder:
@@ -742,6 +1232,8 @@ static void vc4_hdmi_unbind(struct device *dev, struct device *master,
 	struct drm_device *drm = dev_get_drvdata(master);
 	struct vc4_dev *vc4 = drm->dev_private;
 	struct vc4_hdmi *hdmi = vc4->hdmi;
+
+	vc4_hdmi_audio_cleanup(hdmi);
 
 	vc4_hdmi_connector_destroy(hdmi->connector);
 	vc4_hdmi_encoder_destroy(hdmi->encoder);

--- a/drivers/gpu/drm/vc4/vc4_irq.c
+++ b/drivers/gpu/drm/vc4/vc4_irq.c
@@ -58,50 +58,45 @@ vc4_overflow_mem_work(struct work_struct *work)
 {
 	struct vc4_dev *vc4 =
 		container_of(work, struct vc4_dev, overflow_mem_work);
-	struct drm_device *dev = vc4->dev;
-	struct vc4_bo *bo;
+	struct vc4_bo *bo = vc4->bin_bo;
+	int bin_bo_slot;
+	struct vc4_exec_info *exec;
+	unsigned long irqflags;
 
-	bo = vc4_bo_create(dev, 256 * 1024, true);
-	if (IS_ERR(bo)) {
+	bin_bo_slot = vc4_v3d_get_bin_slot(vc4);
+	if (bin_bo_slot < 0) {
 		DRM_ERROR("Couldn't allocate binner overflow mem\n");
 		return;
 	}
 
-	/* If there's a job executing currently, then our previous
-	 * overflow allocation is getting used in that job and we need
-	 * to queue it to be released when the job is done.  But if no
-	 * job is executing at all, then we can free the old overflow
-	 * object direcctly.
-	 *
-	 * No lock necessary for this pointer since we're the only
-	 * ones that update the pointer, and our workqueue won't
-	 * reenter.
-	 */
-	if (vc4->overflow_mem) {
-		struct vc4_exec_info *current_exec;
-		unsigned long irqflags;
+	spin_lock_irqsave(&vc4->job_lock, irqflags);
 
-		spin_lock_irqsave(&vc4->job_lock, irqflags);
-		current_exec = vc4_first_bin_job(vc4);
-		if (!current_exec)
-			current_exec = vc4_last_render_job(vc4);
-		if (current_exec) {
-			vc4->overflow_mem->seqno = current_exec->seqno;
-			list_add_tail(&vc4->overflow_mem->unref_head,
-				      &current_exec->unref_list);
-			vc4->overflow_mem = NULL;
+	if (vc4->bin_alloc_overflow) {
+		/* If we had overflow memory allocated previously,
+		 * then that chunk will free when the current bin job
+		 * is done.  If we don't have a bin job running, then
+		 * the chunk will be done whenever the list of render
+		 * jobs has drained.
+		 */
+		exec = vc4_first_bin_job(vc4);
+		if (!exec)
+			exec = vc4_last_render_job(vc4);
+		if (exec) {
+			exec->bin_slots |= vc4->bin_alloc_overflow;
+		} else {
+			/* There's nothing queued in the hardware, so
+			 * the old slot is free immediately.
+			 */
+			vc4->bin_alloc_used &= ~vc4->bin_alloc_overflow;
 		}
-		spin_unlock_irqrestore(&vc4->job_lock, irqflags);
 	}
+	vc4->bin_alloc_overflow = BIT(bin_bo_slot);
 
-	if (vc4->overflow_mem)
-		drm_gem_object_unreference_unlocked(&vc4->overflow_mem->base.base);
-	vc4->overflow_mem = bo;
-
-	V3D_WRITE(V3D_BPOA, bo->base.paddr);
+	V3D_WRITE(V3D_BPOA, bo->base.paddr + bin_bo_slot * vc4->bin_alloc_size);
 	V3D_WRITE(V3D_BPOS, bo->base.base.size);
 	V3D_WRITE(V3D_INTCTL, V3D_INT_OUTOMEM);
 	V3D_WRITE(V3D_INTENA, V3D_INT_OUTOMEM);
+	spin_unlock_irqrestore(&vc4->job_lock, irqflags);
 }
 
 static void

--- a/drivers/gpu/drm/vc4/vc4_render_cl.c
+++ b/drivers/gpu/drm/vc4/vc4_render_cl.c
@@ -178,8 +178,7 @@ static void emit_tile(struct vc4_exec_info *exec,
 
 	if (has_bin) {
 		rcl_u8(setup, VC4_PACKET_BRANCH_TO_SUB_LIST);
-		rcl_u32(setup, (exec->tile_bo->paddr +
-				exec->tile_alloc_offset +
+		rcl_u32(setup, (exec->tile_alloc_offset +
 				(y * exec->bin_tiles_x + x) * 32));
 	}
 

--- a/drivers/gpu/drm/vc4/vc4_v3d.c
+++ b/drivers/gpu/drm/vc4/vc4_v3d.c
@@ -16,10 +16,7 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "linux/init.h"
-#include "linux/cma.h"
 #include "linux/component.h"
-#include "linux/dma-contiguous.h"
 #include "linux/pm_runtime.h"
 #include "vc4_drv.h"
 #include "vc4_regs.h"
@@ -334,22 +331,7 @@ static int vc4_v3d_bind(struct device *dev, struct device *master, void *data)
 	struct drm_device *drm = dev_get_drvdata(master);
 	struct vc4_dev *vc4 = to_vc4_dev(drm);
 	struct vc4_v3d *v3d = NULL;
-	struct cma *cma;
 	int ret;
-
-	cma = dev_get_cma_area(dev);
-	if (!cma)
-		return -EINVAL;
-
-	if ((cma_get_base(cma) & 0xf0000000) !=
-	    ((cma_get_base(cma) + cma_get_size(cma) - 1) & 0xf0000000)) {
-		DRM_ERROR("V3D requires that the CMA area (0x%08lx - 0x%08lx) "
-			  "not span a 256MB boundary, or memory corruption "
-			  "would happen.\n",
-			  (long)cma_get_base(cma),
-			  cma_get_base(cma) + cma_get_size(cma));
-		return -EINVAL;
-	}
 
 	v3d = devm_kzalloc(&pdev->dev, sizeof(*v3d), GFP_KERNEL);
 	if (!v3d)

--- a/drivers/gpu/drm/vc4/vc4_v3d.c
+++ b/drivers/gpu/drm/vc4/vc4_v3d.c
@@ -159,6 +159,144 @@ static void vc4_v3d_init_hw(struct drm_device *dev)
 	V3D_WRITE(V3D_VPMBASE, 0);
 }
 
+int vc4_v3d_get_bin_slot(struct vc4_dev *vc4)
+{
+	struct drm_device *dev = vc4->dev;
+	unsigned long irqflags;
+	int slot;
+	uint64_t seqno = 0;
+	struct vc4_exec_info *exec;
+
+try_again:
+	spin_lock_irqsave(&vc4->job_lock, irqflags);
+	slot = ffs(~vc4->bin_alloc_used);
+	if (slot != 0) {
+		/* Switch from ffs() bit index to a 0-based index. */
+		slot--;
+		vc4->bin_alloc_used |= BIT(slot);
+		spin_unlock_irqrestore(&vc4->job_lock, irqflags);
+		return slot;
+	}
+
+	/* Couldn't find an open slot.  Wait for render to complete
+	 * and try again.
+	 */
+	exec = vc4_last_render_job(vc4);
+	if (exec)
+		seqno = exec->seqno;
+	spin_unlock_irqrestore(&vc4->job_lock, irqflags);
+
+	if (seqno) {
+		int ret = vc4_wait_for_seqno(dev, seqno, ~0ull, true);
+
+		if (ret == 0)
+			goto try_again;
+
+		return ret;
+	}
+
+	return -ENOMEM;
+}
+
+/**
+ * vc4_allocate_bin_bo() - allocates the memory that will be used for
+ * tile binning.
+ *
+ * The binner has a limitation that the addresses in the tile state
+ * buffer that point into the tile alloc buffer or binner overflow
+ * memory only have 28 bits (256MB), and the top 4 on the bus for
+ * tile alloc references end up coming from the tile state buffer's
+ * address.
+ *
+ * To work around this, we allocate a single large buffer while V3D is
+ * in use, make sure that it has the top 4 bits constant across its
+ * entire extent, and then put the tile state, tile alloc, and binner
+ * overflow memory inside that buffer.
+ *
+ * This creates a limitation where we may not be able to execute a job
+ * if it doesn't fit within the buffer that we allocated up front.
+ * However, it turns out that 16MB is "enough for anybody", and
+ * real-world applications run into allocation failures from the
+ * overall CMA pool before they make scenes complicated enough to run
+ * out of bin space.
+ */
+int
+vc4_allocate_bin_bo(struct drm_device *drm)
+{
+	struct vc4_dev *vc4 = to_vc4_dev(drm);
+	struct vc4_v3d *v3d = vc4->v3d;
+	uint32_t size = 16 * 1024 * 1024;
+	int ret = 0;
+	struct list_head list;
+
+	/* We may need to try allocating more than once to get a BO
+	 * that doesn't cross 256MB.  Track the ones we've allocated
+	 * that failed so far, so that we can free them when we've got
+	 * one that succeeded (if we freed them right away, our next
+	 * allocation would probably be the same chunk of memory).
+	 */
+	INIT_LIST_HEAD(&list);
+
+	while (true) {
+		struct vc4_bo *bo = vc4_bo_create(drm, size, true);
+
+		if (IS_ERR(bo)) {
+			ret = PTR_ERR(bo);
+
+			dev_err(&v3d->pdev->dev,
+				"Failed to allocate memory for tile binning: "
+				"%d. You may need to enable CMA or give it "
+				"more memory.",
+				ret);
+			break;
+		}
+
+		/* Check if this BO won't trigger the addressing bug. */
+		if ((bo->base.paddr & 0xf0000000) ==
+		    ((bo->base.paddr + bo->base.base.size - 1) & 0xf0000000)) {
+			vc4->bin_bo = bo;
+
+			/* Set up for allocating 512KB chunks of
+			 * binner memory.  The biggest allocation we
+			 * need to do is for the initial tile alloc +
+			 * tile state buffer.  We can render to a
+			 * maximum of ((2048*2048) / (32*32) = 4096
+			 * tiles in a frame (until we do floating
+			 * point rendering, at which point it would be
+			 * 8192).  Tile state is 48b/tile (rounded to
+			 * a page), and tile alloc is 32b/tile
+			 * (rounded to a page), plus a page of extra,
+			 * for a total of 320kb for our worst-case.
+			 * We choose 512kb so that it divides evenly
+			 * into our 16MB, and the rest of the 512kb
+			 * will be used as storage for the overflow
+			 * from the initial 32b CL per bin.
+			 */
+			vc4->bin_alloc_size = 512 * 1024;
+			vc4->bin_alloc_used = 0;
+			vc4->bin_alloc_overflow = 0;
+			WARN_ON_ONCE(sizeof(vc4->bin_alloc_used) * 8 !=
+				     bo->base.base.size / vc4->bin_alloc_size);
+
+			break;
+		}
+
+		/* Put it on the list to free later, and try again. */
+		list_add(&bo->unref_head, &list);
+	}
+
+	/* Free all the BOs we allocated but didn't choose. */
+	while (!list_empty(&list)) {
+		struct vc4_bo *bo = list_last_entry(&list,
+						    struct vc4_bo, unref_head);
+
+		list_del(&bo->unref_head);
+		drm_gem_object_unreference_unlocked(&bo->base.base);
+	}
+
+	return ret;
+}
+
 #ifdef CONFIG_PM
 static int vc4_v3d_runtime_suspend(struct device *dev)
 {
@@ -167,6 +305,9 @@ static int vc4_v3d_runtime_suspend(struct device *dev)
 
 	vc4_irq_uninstall(vc4->dev);
 
+	drm_gem_object_unreference_unlocked(&vc4->bin_bo->base.base);
+	vc4->bin_bo = NULL;
+
 	return 0;
 }
 
@@ -174,6 +315,11 @@ static int vc4_v3d_runtime_resume(struct device *dev)
 {
 	struct vc4_v3d *v3d = dev_get_drvdata(dev);
 	struct vc4_dev *vc4 = v3d->vc4;
+	int ret;
+
+	ret = vc4_allocate_bin_bo(vc4->dev);
+	if (ret)
+		return ret;
 
 	vc4_v3d_init_hw(vc4->dev);
 	vc4_irq_postinstall(vc4->dev);
@@ -225,6 +371,10 @@ static int vc4_v3d_bind(struct device *dev, struct device *master, void *data)
 			  V3D_READ(V3D_IDENT0), V3D_EXPECTED_IDENT0);
 		return -EINVAL;
 	}
+
+	ret = vc4_allocate_bin_bo(drm);
+	if (ret)
+		return ret;
 
 	/* Reset the binner overflow address/size at setup, to be sure
 	 * we don't reuse an old one.

--- a/drivers/gpu/drm/vc4/vc4_validate.c
+++ b/drivers/gpu/drm/vc4/vc4_validate.c
@@ -340,10 +340,11 @@ static int
 validate_tile_binning_config(VALIDATE_ARGS)
 {
 	struct drm_device *dev = exec->exec_bo->base.dev;
-	struct vc4_bo *tile_bo;
+	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	uint8_t flags;
-	uint32_t tile_state_size, tile_alloc_size;
-	uint32_t tile_count;
+	uint32_t tile_state_size;
+	uint32_t tile_count, bin_addr;
+	int bin_slot;
 
 	if (exec->found_tile_binning_mode_config_packet) {
 		DRM_ERROR("Duplicate VC4_PACKET_TILE_BINNING_MODE_CONFIG\n");
@@ -369,13 +370,28 @@ validate_tile_binning_config(VALIDATE_ARGS)
 		return -EINVAL;
 	}
 
+	bin_slot = vc4_v3d_get_bin_slot(vc4);
+	if (bin_slot < 0) {
+		if (bin_slot != -EINTR && bin_slot != -ERESTARTSYS) {
+			DRM_ERROR("Failed to allocate binner memory: %d\n",
+				  bin_slot);
+		}
+		return bin_slot;
+	}
+
+	/* The slot we allocated will only be used by this job, and is
+	 * free when the job completes rendering.
+	 */
+	exec->bin_slots |= BIT(bin_slot);
+	bin_addr = vc4->bin_bo->base.paddr + bin_slot * vc4->bin_alloc_size;
+
 	/* The tile state data array is 48 bytes per tile, and we put it at
 	 * the start of a BO containing both it and the tile alloc.
 	 */
 	tile_state_size = 48 * tile_count;
 
 	/* Since the tile alloc array will follow us, align. */
-	exec->tile_alloc_offset = roundup(tile_state_size, 4096);
+	exec->tile_alloc_offset = bin_addr + roundup(tile_state_size, 4096);
 
 	*(uint8_t *)(validated + 14) =
 		((flags & ~(VC4_BIN_CONFIG_ALLOC_INIT_BLOCK_SIZE_MASK |
@@ -386,35 +402,13 @@ validate_tile_binning_config(VALIDATE_ARGS)
 		 VC4_SET_FIELD(VC4_BIN_CONFIG_ALLOC_BLOCK_SIZE_128,
 			       VC4_BIN_CONFIG_ALLOC_BLOCK_SIZE));
 
-	/* Initial block size. */
-	tile_alloc_size = 32 * tile_count;
-
-	/*
-	 * The initial allocation gets rounded to the next 256 bytes before
-	 * the hardware starts fulfilling further allocations.
-	 */
-	tile_alloc_size = roundup(tile_alloc_size, 256);
-
-	/* Add space for the extra allocations.  This is what gets used first,
-	 * before overflow memory.  It must have at least 4096 bytes, but we
-	 * want to avoid overflow memory usage if possible.
-	 */
-	tile_alloc_size += 1024 * 1024;
-
-	tile_bo = vc4_bo_create(dev, exec->tile_alloc_offset + tile_alloc_size,
-				true);
-	exec->tile_bo = &tile_bo->base;
-	if (IS_ERR(exec->tile_bo))
-		return PTR_ERR(exec->tile_bo);
-	list_add_tail(&tile_bo->unref_head, &exec->unref_list);
-
 	/* tile alloc address. */
-	*(uint32_t *)(validated + 0) = (exec->tile_bo->paddr +
-					exec->tile_alloc_offset);
+	*(uint32_t *)(validated + 0) = exec->tile_alloc_offset;
 	/* tile alloc size. */
-	*(uint32_t *)(validated + 4) = tile_alloc_size;
+	*(uint32_t *)(validated + 4) = (bin_addr + vc4->bin_alloc_size -
+					exec->tile_alloc_offset);
 	/* tile state address. */
-	*(uint32_t *)(validated + 8) = exec->tile_bo->paddr;
+	*(uint32_t *)(validated + 8) = bin_addr;
 
 	return 0;
 }

--- a/mm/cma.c
+++ b/mm/cma.c
@@ -47,13 +47,11 @@ phys_addr_t cma_get_base(const struct cma *cma)
 {
 	return PFN_PHYS(cma->base_pfn);
 }
-EXPORT_SYMBOL(cma_get_base);
 
 unsigned long cma_get_size(const struct cma *cma)
 {
 	return cma->count << PAGE_SHIFT;
 }
-EXPORT_SYMBOL(cma_get_size);
 
 static unsigned long cma_bitmap_aligned_mask(const struct cma *cma,
 					     int align_order)


### PR DESCRIPTION
This pull request brings in the HDMI audio support from Boris and myself (you'll need Simon's new .debs for libasound, and to use pulseaudio) that is going to be in 4.12.  It also includes my rework to remove the restriction on CMA maximum size/alignment, which isn't yet reviewed upstream.  Also a small fix for a bug that Stefan Wahren ran into, which is heading to stable.