### PR TITLE
Avoid Oops in rpi_touchscreen_dsi_probe by checking for bridge_i2c = …

### DIFF
--- a/drivers/gpu/drm/panel/panel-raspberrypi-touchscreen.c
+++ b/drivers/gpu/drm/panel/panel-raspberrypi-touchscreen.c
@@ -428,6 +428,9 @@ static int rpi_touchscreen_dsi_probe(struct mipi_dsi_device *dsi)
 
 	ts->bridge_i2c =
 		rpi_touchscreen_get_i2c(dev, "raspberrypi,touchscreen-bridge");
+	if (!ts->bridge_i2c)
+		return -ENODEV;
+
 	if (IS_ERR(ts->bridge_i2c)) {
 		ret = -EPROBE_DEFER;
 		return ret;


### PR DESCRIPTION
…NULL

Fixes https://github.com/raspberrypi/linux/issues/1948

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>