### PR TITLE
SQUASH: staging: vc04_services: Fix warnings

### DIFF
--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
@@ -534,8 +534,8 @@ create_pagelist(char __user *buf, size_t count, unsigned short type,
 		 * aligned and a multiple of the page size
 		 */
 		WARN_ON(len == 0);
-		WARN_ON(k && (k != (dma_buffers - 1)) && (len & ~PAGE_MASK));
-		WARN_ON(k && (addr & ~PAGE_MASK));
+		WARN_ON(i && (i != (dma_buffers - 1)) && (len & ~PAGE_MASK));
+		WARN_ON(i && (addr & ~PAGE_MASK));
 		if (k > 0 &&
 		    ((addrs[k - 1] & PAGE_MASK) +
 		     (((addrs[k - 1] & ~PAGE_MASK) + 1) << PAGE_SHIFT))


### PR DESCRIPTION
create_pagelist uses a number of WARNs to sanity-check check the input
user pages, verifying that only the first and last entries in the
array are not integral pages. These WARNs use the output array index
when it should be input array index. Although the difference is only
significant in one instance, change all the indices for consistency.

See: https://github.com/raspberrypi/linux/pull/1987

Signed-off-by: Phil Elwell <phil@raspberrypi.org>