### PR TITLE
drm/vc4: Mark the device as active when enabling runtime PM.

### DIFF
--- a/arch/arm/boot/dts/overlays/vc4-kms-v3d-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-v3d-overlay.dts
@@ -13,35 +13,35 @@
 	fragment@0 {
 		target-path = "/chosen";
 		__overlay__ {
-			bootargs = "cma=256M@256M";
+			bootargs = "cma=256M";
 		};
 	};
 
 	fragment@1 {
 		target-path = "/chosen";
 		__dormant__ {
-			bootargs = "cma=192M@256M";
+			bootargs = "cma=192M";
 		};
 	};
 
 	fragment@2 {
 		target-path = "/chosen";
 		__dormant__ {
-			bootargs = "cma=128M@128M";
+			bootargs = "cma=128M";
 		};
 	};
 
 	fragment@3 {
 		target-path = "/chosen";
 		__dormant__ {
-			bootargs = "cma=96M@128M";
+			bootargs = "cma=96M";
 		};
 	};
 
 	fragment@4 {
 		target-path = "/chosen";
 		__dormant__ {
-			bootargs = "cma=64M@64M";
+			bootargs = "cma=64M";
 		};
 	};
 

--- a/drivers/gpu/drm/vc4/vc4_v3d.c
+++ b/drivers/gpu/drm/vc4/vc4_v3d.c
@@ -372,6 +372,7 @@ static int vc4_v3d_bind(struct device *dev, struct device *master, void *data)
 		return ret;
 	}
 
+	pm_runtime_set_active(dev);
 	pm_runtime_use_autosuspend(dev);
 	pm_runtime_set_autosuspend_delay(dev, 40); /* a little over 2 frames. */
 	pm_runtime_enable(dev);


### PR DESCRIPTION
Failing to do so meant that we got a resume() callback on first use of
the device, so we would leak the bin BO that we allocated during
probe.

Signed-off-by: Eric Anholt <eric@anholt.net>
Fixes: 553c942f8b2c ("drm/vc4: Allow using more than 256MB of CMA memory.")