### PR TITLE
Add device tree overlay for GPIO connected rotary encoder.

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -74,6 +74,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	pwm-2chan.dtbo \
 	qca7000.dtbo \
 	raspidac3.dtbo \
+	rotary-encoder.dtbo \
 	rpi-backlight.dtbo \
 	rpi-cirrus-wm5102.dtbo \
 	rpi-dac.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1107,6 +1107,15 @@ Load:   dtoverlay=raspidac3
 Params: <None>
 
 
+Name:   rotary-encoder
+Info:   Overlay for GPIO connected rotary encoder.
+Load:   dtoverlay=rotary-encoder,<param>=<val>
+Params: rotary0_pin_a           GPIO connected to rotary encoder channel A
+                                (default 4).
+        rotary0_pin_b           GPIO connected to rotary encoder channel B
+                                (default 17).
+
+
 Name:   rpi-backlight
 Info:   Raspberry Pi official display backlight driver
 Load:   dtoverlay=rpi-backlight

--- a/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
@@ -1,0 +1,43 @@
+// Device tree overlay for GPIO connected rotary encoder.
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&gpio>;
+		__overlay__ {
+			rotary0_pins: rotary0_pins {
+				brcm,pins = <4 17>; /* gpio 4 17 */
+				brcm,function = <0 0>; /* input */
+				brcm,pull = <2 2>; /* pull-up */
+			};
+
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			rotary0: rotary@0 {
+					compatible = "rotary-encoder";
+					status = "okay";
+					pinctrl-names = "default";
+					pinctrl-0 = <&rotary0_pins>;
+					gpios = <&gpio 4 0>, <&gpio 17 0>;
+					linux,axis = <0>; /* REL_X */
+					rotary-encoder,encoding = "gray";
+					rotary-encoder,relative-axis;
+			};
+		};
+
+	};  
+
+	__overrides__ {
+		rotary0_pin_a = <&rotary0>,"gpios:4",
+				<&rotary0_pins>,"brcm,pins:0";
+		rotary0_pin_b = <&rotary0>,"gpios:16",
+				<&rotary0_pins>,"brcm,pins:4";
+	};  
+};


### PR DESCRIPTION
You can feel free to choose which pin to use, just change the following DT parameters .
rotary0_pin_a           GPIO connected to rotary encoder channel A (default 4).
rotary0_pin_b           GPIO connected to rotary encoder channel B (default 17).
See Documentation/input/rotary-encoder.txt for more information about rotary-encoder.