### PR TITLE
dwc_otg: make periodic scheduling behave properly for FS buses

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd.h
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd.h
@@ -410,7 +410,8 @@ struct dwc_otg_hcd {
 			unsigned port_suspend_change:1;
 			unsigned port_over_current_change:1;
 			unsigned port_l1_change:1;
-			unsigned reserved:26;
+			unsigned port_speed:2;
+			unsigned reserved:24;
 		} b;
 	} flags;
 
@@ -629,7 +630,7 @@ int dwc_otg_hcd_allocate_port(dwc_otg_hcd_t * hcd, dwc_otg_qh_t *qh);
 void dwc_otg_hcd_release_port(dwc_otg_hcd_t * dwc_otg_hcd, dwc_otg_qh_t *qh);
 
 extern int fiq_fsm_queue_transaction(dwc_otg_hcd_t *hcd, dwc_otg_qh_t *qh);
-extern int fiq_fsm_transaction_suitable(dwc_otg_qh_t *qh);
+extern int fiq_fsm_transaction_suitable(dwc_otg_hcd_t *hcd, dwc_otg_qh_t *qh);
 extern void dwc_otg_cleanup_fiq_channel(dwc_otg_hcd_t *hcd, uint32_t num);
 
 /** @} */
@@ -822,6 +823,8 @@ static inline uint16_t dwc_micro_frame_num(uint16_t frame)
 {
 	return frame & 0x7;
 }
+
+extern void init_hcd_usecs(dwc_otg_hcd_t *_hcd);
 
 void dwc_otg_hcd_save_data_toggle(dwc_hc_t * hc,
 				  dwc_otg_hc_regs_t * hc_regs,

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_intr.c
@@ -515,6 +515,10 @@ int32_t dwc_otg_hcd_handle_port_intr(dwc_otg_hcd_t * dwc_otg_hcd)
 			dwc_otg_host_if_t *host_if =
 			    dwc_otg_hcd->core_if->host_if;
 
+			dwc_otg_hcd->flags.b.port_speed = hprt0.b.prtspd;
+			if (microframe_schedule)
+				init_hcd_usecs(dwc_otg_hcd);
+
 			/* Every time when port enables calculate
 			 * HFIR.FrInterval
 			 */


### PR DESCRIPTION
see #2020 

This is a fix for the default parameters (microframe scheduling) not behaving well when the root port is in full-speed mode.

As a semi-bandaid fix, transfers in FS mode are not nominated for execution by FIQ code - there's still a bug in there relating to isochronous transfers misbehaving when the endpoint is being shutdown.