### PR TITLE
Add device tree overlay for bme280 via spi

### DIFF
--- a/arch/arm/boot/dts/overlays/bme280-spi.dts
+++ b/arch/arm/boot/dts/overlays/bme280-spi.dts
@@ -1,0 +1,32 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+
+		__overlay__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			bme280@0 {
+				compatible = "bosch,bme280";
+				reg = <0x0>;
+				spi-max-frequency = <500000>;
+				default-oversampling = <3>;
+				status = "okay";
+			};
+		};
+	};
+};


### PR DESCRIPTION
Maybe not quite there, but enough to get feedback. This overlay works, but I am not sure how you want to include it in the project.