### PR TITLE
v4l2 - ioctl 2 times bugfix on still mode

### DIFF
--- a/drivers/media/platform/bcm2835/mmal-vchiq.c
+++ b/drivers/media/platform/bcm2835/mmal-vchiq.c
@@ -1655,6 +1655,11 @@ int vchiq_mmal_submit_buffer(struct vchiq_mmal_instance *instance,
 	return 0;
 }
 
+bool vchiq_mmal_port_buffer_empty(struct vchiq_mmal_port *port)
+{
+	return list_empty(&port->buffers);
+}
+
 /* Initialise a mmal component and its ports
  *
  */

--- a/drivers/media/platform/bcm2835/mmal-vchiq.h
+++ b/drivers/media/platform/bcm2835/mmal-vchiq.h
@@ -175,4 +175,6 @@ int vchiq_mmal_submit_buffer(struct vchiq_mmal_instance *instance,
 			     struct vchiq_mmal_port *port,
 			     struct mmal_buffer *buf);
 
+bool vchiq_mmal_port_buffer_empty(struct vchiq_mmal_port *port);
+
 #endif /* MMAL_VCHIQ_H */


### PR DESCRIPTION
Avoid 2 times VIDIOC_QBUF, VIDIOC_DQBUF call on JPEG format capture.
#1297
