### PR TITLE
dwc_otg: fiq_fsm: Add non-periodic TT exclusivity constraints

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
@@ -191,6 +191,32 @@ static void notrace fiq_fsm_setup_csplit(struct fiq_state *st, int n)
 	mb();
 }
 
+/**
+ * fiq_fsm_restart_np_pending() - Restart a single non-periodic contended transfer
+ * @st: Pointer to the channel's state
+ * @num_channels: Total number of host channels
+ * @orig_channel: Channel index of completed transfer
+ *
+ * In the case where an IN and OUT transfer are simultaneously scheduled to the
+ * same device/EP, inadequate hub implementations will misbehave. Once the first
+ * transfer is complete, a pending non-periodic split can then be issued.
+ */
+static void notrace fiq_fsm_restart_np_pending(struct fiq_state *st, int num_channels, int orig_channel)
+{
+	int i;
+	int dev_addr = st->channel[orig_channel].hcchar_copy.b.devaddr;
+	int ep_num = st->channel[orig_channel].hcchar_copy.b.epnum;
+	for (i = 0; i < num_channels; i++) {
+		if (st->channel[i].fsm == FIQ_NP_SSPLIT_PENDING &&
+			st->channel[i].hcchar_copy.b.devaddr == dev_addr &&
+			st->channel[i].hcchar_copy.b.epnum == ep_num) {
+			st->channel[i].fsm = FIQ_NP_SSPLIT_STARTED;
+			fiq_fsm_restart_channel(st, i, 0);
+			break;
+		}
+	}
+}
+
 static inline int notrace fiq_get_xfer_len(struct fiq_state *st, int n)
 {
 	/* The xfersize register is a bit wonky. For IN transfers, it decrements by the packet size. */
@@ -870,6 +896,9 @@ static int notrace noinline fiq_fsm_do_hcintr(struct fiq_state *state, int num_c
 				st->fsm = FIQ_NP_SPLIT_HS_ABORTED;
 			}
 		}
+		if (st->fsm != FIQ_NP_IN_CSPLIT_RETRY) {
+			fiq_fsm_restart_np_pending(state, num_channels, n);
+		}
 		break;
 
 	case FIQ_NP_OUT_CSPLIT_RETRY:
@@ -918,6 +947,9 @@ static int notrace noinline fiq_fsm_do_hcintr(struct fiq_state *state, int num_c
 				// Something unexpected happened. AHBerror or babble perhaps. Let the IRQ deal with it.
 				st->fsm = FIQ_NP_SPLIT_HS_ABORTED;
 			}
+		}
+		if (st->fsm != FIQ_NP_OUT_CSPLIT_RETRY) {
+			fiq_fsm_restart_np_pending(state, num_channels, n);
 		}
 		break;
 

--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h
+++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h
@@ -178,6 +178,8 @@ enum fiq_fsm_state {
 	/* Nonperiodic state groups */
 	FIQ_NP_SSPLIT_STARTED = 1,
 	FIQ_NP_SSPLIT_RETRY = 2,
+	/* TT contention - working around hub bugs */
+	FIQ_NP_SSPLIT_PENDING = 33,
 	FIQ_NP_OUT_CSPLIT_RETRY = 3,
 	FIQ_NP_IN_CSPLIT_RETRY = 4,
 	FIQ_NP_SPLIT_DONE = 5,


### PR DESCRIPTION
Certain hub types do not discriminate between pipe direction (IN or OUT)
when considering non-periodic transfers. Therefore these hubs get confused
if multiple transfers are issued in different directions with the same
device address and endpoint number.

Constrain queuing non-periodic split transactions so they are performed
serially in such cases.

Related: https://github.com/raspberrypi/linux/issues/2024