### PR TITLE
bcm2708: Drop CMA alignment from FKMS mode as well.

### DIFF
--- a/arch/arm/boot/dts/overlays/vc4-fkms-v3d-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-fkms-v3d-overlay.dts
@@ -11,35 +11,35 @@
 	fragment@0 {
 		target-path = "/chosen";
 		__overlay__ {
-			bootargs = "cma=256M@256M";
+			bootargs = "cma=256M";
 		};
 	};
 
 	fragment@1 {
 		target-path = "/chosen";
 		__dormant__ {
-			bootargs = "cma=192M@256M";
+			bootargs = "cma=192M";
 		};
 	};
 
 	fragment@2 {
 		target-path = "/chosen";
 		__dormant__ {
-			bootargs = "cma=128M@128M";
+			bootargs = "cma=128M";
 		};
 	};
 
 	fragment@3 {
 		target-path = "/chosen";
 		__dormant__ {
-			bootargs = "cma=96M@128M";
+			bootargs = "cma=96M";
 		};
 	};
 
 	fragment@4 {
 		target-path = "/chosen";
 		__dormant__ {
-			bootargs = "cma=64M@64M";
+			bootargs = "cma=64M";
 		};
 	};
 


### PR DESCRIPTION
I dropped it from KMS mode in d88274d88ed81de1ade8e18e4c0ed91792ec82ea
and should have done both of them at that time.

Signed-off-by: Eric Anholt <eric@anholt.net>