### PR TITLE
overlays: Add gpio-shutdown overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -30,6 +30,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	googlevoicehat-soundcard.dtbo \
 	gpio-ir.dtbo \
 	gpio-poweroff.dtbo \
+	gpio-shutdown.dtbo \
 	hifiberry-amp.dtbo \
 	hifiberry-dac.dtbo \
 	hifiberry-dacplus.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -507,6 +507,7 @@ Params: gpiopin                 GPIO for signalling (default 26)
                                 during the boot process, and that a reboot
                                 will also cause the pin to go low.
 
+
 Name:   gpio-shutdown
 Info:   Initiates a shutdown when GPIO pin changes. The given GPIO pin
         is configured as an input key that generates KEY_POWER events.
@@ -514,7 +515,9 @@ Info:   Initiates a shutdown when GPIO pin changes. The given GPIO pin
         shutdown. Systemd versions older than 225 need an udev rule
         enable listening to the input device:
 
-                ACTION!="REMOVE", SUBSYSTEM=="input", KERNEL=="event*", SUBSYSTEMS=="platform", DRIVERS=="gpio-keys", ATTRS{keys}=="116", TAG+="power-switch"
+                ACTION!="REMOVE", SUBSYSTEM=="input", KERNEL=="event*", \
+                        SUBSYSTEMS=="platform", DRIVERS=="gpio-keys", \
+                        ATTRS{keys}=="116", TAG+="power-switch"
 
         This overlay only handles shutdown. After shutdown, the system
         can be powered up again by driving GPIO3 low. The default
@@ -535,6 +538,7 @@ Params: gpio_pin                GPIO pin to trigger on (default 3)
 
                                 Note that the default pin (GPIO3) has an
                                 external pullup.
+
 
 Name:   hifiberry-amp
 Info:   Configures the HifiBerry Amp and Amp+ audio cards

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -507,6 +507,34 @@ Params: gpiopin                 GPIO for signalling (default 26)
                                 during the boot process, and that a reboot
                                 will also cause the pin to go low.
 
+Name:   gpio-shutdown
+Info:   Initiates a shutdown when GPIO pin changes. The given GPIO pin
+        is configured as an input key that generates KEY_POWER events.
+        This event is handled by systemd-logind by initiating a
+        shutdown. Systemd versions older than 225 need an udev rule
+        enable listening to the input device:
+
+                ACTION!="REMOVE", SUBSYSTEM=="input", KERNEL=="event*", SUBSYSTEMS=="platform", DRIVERS=="gpio-keys", ATTRS{keys}=="116", TAG+="power-switch"
+
+        This overlay only handles shutdown. After shutdown, the system
+        can be powered up again by driving GPIO3 low. The default
+        configuration uses GPIO3 with a pullup, so if you connect a
+        button between GPIO3 and GND (pin 5 and 6 on the 40-pin header),
+        you get a shutdown and power-up button.
+Load:   dtoverlay=gpio-shutdown,<param>=<val>
+Params: gpio_pin                GPIO pin to trigger on (default 3)
+
+        active_low              When this is 1 (active low), a falling
+                                edge generates a key down event and a
+                                rising edge generates a key up event.
+                                When this is 0 (active high), this is
+                                reversed. The default is 1 (active low).
+
+        gpio_pull               Desired pull-up/down state (off, down, up)
+                                Default is "up".
+
+                                Note that the default pin (GPIO3) has an
+                                external pullup.
 
 Name:   hifiberry-amp
 Info:   Configures the HifiBerry Amp and Amp+ audio cards

--- a/arch/arm/boot/dts/overlays/gpio-shutdown-overlay.dts
+++ b/arch/arm/boot/dts/overlays/gpio-shutdown-overlay.dts
@@ -1,0 +1,80 @@
+// Definitions for gpio-poweroff module
+/dts-v1/;
+/plugin/;
+
+// This overlay sets up an input device that generates KEY_POWER events
+// when a given GPIO pin changes. It defaults to using GPIO3, which can
+// also be used to wake up (start) the Rpi again after shutdown. Since
+// wakeup is active-low, this defaults to active-low with a pullup
+// enabled, but all of this can be changed using overlay parameters (but
+// note that GPIO3 has an external pullup on at least some boards).
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		// Configure the gpio pin controller
+		target = <&gpio>;
+		__overlay__ {
+			// Define a pinctrl state, that sets up the gpio
+			// as an input with a pullup enabled. This does
+			// not take effect by itself, only when referenced
+			// by a "pinctrl client", as is done below. See:
+			//   https://www.kernel.org/doc/Documentation/devicetree/bindings/pinctrl/pinctrl-bindings.txt
+			//   https://www.kernel.org/doc/Documentation/devicetree/bindings/pinctrl/brcm,bcm2835-gpio.txt
+			pin_state: shutdown_button_pins {
+				brcm,pins = <3>; // gpio number
+				brcm,function = <0>; // 0 = input, 1 = output
+				brcm,pull = <2>; // 0 = none, 1 = pull down, 2 = pull up
+			};
+		};
+	};
+	fragment@1 {
+		// Add a new device to the /soc devicetree node
+		target-path = "/soc";
+		__overlay__ {
+			shutdown_button {
+				// Let the gpio-keys driver handle this device. See:
+				// https://www.kernel.org/doc/Documentation/devicetree/bindings/input/gpio-keys.txt
+				compatible = "gpio-keys";
+
+				// Declare a single pinctrl state (referencing the one declared above) and name it
+				// default, so it is activated automatically.
+				pinctrl-names = "default";
+				pinctrl-0 = <&pin_state>;
+
+				// Enable this device
+				status = "okay";
+
+				// Define a single key, called "shutdown" that monitors the gpio and sends KEY_POWER
+				// (keycode 116, see
+				// https://github.com/torvalds/linux/blob/v4.12/include/uapi/linux/input-event-codes.h#L190)
+				button: shutdown {
+					label = "shutdown";
+					linux,code = <116>; // KEY_POWER
+					gpios = <&gpio 3 1>;
+				};
+			};
+		};
+	};
+
+	// This defines parameters that can be specified when loading
+	// the overlay. Each foo = line specifies one parameter, named
+	// foo. The rest of the specification gives properties where the
+	// parameter value is inserted into (changing the values above
+	// or adding new ones).
+	__overrides__ {
+		// Allow overriding the GPIO number.
+		gpio_pin = <&button>,"gpios:4",
+		           <&pin_state>,"brcm,pins:0";
+
+		// Allow changing the internal pullup/down state. 0 = none, 1 = pulldown, 2 = pullup
+		// Note that GPIO3 and GPIO2 are the I2c pins and have an external pullup (at least
+                // on some boards).
+		gpio_pull = <&pin_state>,"brcm,pull:0";
+
+		// Allow setting the active_low flag. 0 = active high, 1 = active low
+		active_low = <&button>,"gpios:8";
+	};
+
+};


### PR DESCRIPTION
This overlay facilitates the addition of a powerbutton by converting
GPIO edges into KEY_POWER keypresses, which can be handled by
systemd-logind to shut down the system.

The overlay was separately tested on:

 - Raspberry Pi Zero W running Linux telegraaf 4.9.28+ #998 Mon May 15 16:50:35 BST 2017 armv6l GNU/Linux
 - Raspberry Pi B+ running Linux raspberrypi 4.4.50+ #970 Mon Feb 20 19:12:50 GMT 2017 armv6l GNU/Linux
 - Rasbperry Pi B running Linux raspberrypi 4.4.34+ #930 Wed Nov 23 15:12:30 GMT 2016 armv6l GNU/Linux

I tested manually using `dtc -@ -I dts -O dtb -o gpio-shutdown.dtbo gpio-shutdown-overlay.dts`. I did not test compilation inside the kernel tree, for I have not got the environment set up for that.

For some more background, see the comments in the overlay source file and this blogpost: http://www.stderr.nl/Blog/Hardware/RaspberryPi/PowerButton.html