### PR TITLE
Update i2c1-bcm2708-overlay.dts

### DIFF
--- a/arch/arm/boot/dts/overlays/i2c1-bcm2708-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c1-bcm2708-overlay.dts
@@ -19,16 +19,6 @@
       };
    };
 
-   fragment@1 {
-      target = <&gpio>;
-      __overlay__ {
-         i2c1_pins: i2c1 {
-            brcm,pins = <2 3>;
-            brcm,function = <4>; /* alt0 */
-         };
-      };
-   };
-
    __overrides__ {
       sda1_pin = <&i2c1_pins>,"brcm,pins:0";
       scl1_pin = <&i2c1_pins>,"brcm,pins:4";


### PR DESCRIPTION
Removing fragment@1 as it is not required. 
The fragment 1 creates another device node  with name i2c1_pins which is already created by dts files bcm2710-rpi-3-b.dts, bcm2708-rpi-b-plus.dts and bcm2709-rpi-2-b.dts.