### PR TITLE
Sets the BCDC priority to constant 0

### DIFF
--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/bcdc.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/bcdc.c
@@ -274,7 +274,7 @@ brcmf_proto_bcdc_hdrpush(struct brcmf_pub *drvr, int ifidx, u8 offset,
 	if (pktbuf->ip_summed == CHECKSUM_PARTIAL)
 		h->flags |= BCDC_FLAG_SUM_NEEDED;
 
-	h->priority = (pktbuf->priority & BCDC_PRIORITY_MASK);
+	h->priority = 0;
 	h->flags2 = 0;
 	h->data_offset = offset;
 	BCDC_SET_IF_IDX(h, ifidx);


### PR DESCRIPTION
This is to workaround for a possible issue in the
wireless chip firmware where some packets with
higher priorities seem to go missing.

See https://github.com/raspberrypi/linux/issues/1342 for
details.