### PR TITLE
Feature cm3 64 dev

### DIFF
--- a/arch/arm/boot/dts/bcm2835-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2835-rpi.dtsi
@@ -6,7 +6,30 @@
 		reg = <0 0x10000000>;
 	};
 
-	leds {
+	aliases {
+		aux = &aux;
+		dma = &dma;
+		intc = &intc;
+		watchdog = &watchdog;
+		random = &random;
+		mailbox = &mailbox;
+		gpio = &gpio;
+		uart0 = &uart0;
+		i2s = &i2s;
+		spi0 = &spi0;
+		i2c0 = &i2c0;
+		uart1 = &uart1;
+		spi1 = &spi1;
+		spi2 = &spi2;
+		mmc = &mmc;
+		i2c1 = &i2c1;
+		i2c2 = &i2c2;
+		usb = &usb;
+		leds = &leds;
+		fb = &fb;
+	};
+
+	leds: leds {
 		compatible = "gpio-leds";
 
 		act {
@@ -17,6 +40,45 @@
 	};
 
 	soc {
+		virtgpio: virtgpio {
+			compatible = "brcm,bcm2835-virtgpio";
+			gpio-controller;
+			#gpio-cells = <2>;
+			firmware = <&firmware>;
+			status = "okay";
+		};
+
+		expgpio: expgpio {
+			compatible = "brcm,bcm2835-expgpio";
+			gpio-controller;
+			#gpio-cells = <2>;
+			firmware = <&firmware>;
+			status = "okay";
+		};
+
+		arm-pmu {
+			compatible = "arm,armv8-pmuv3", "arm,cortex-a7-pmu";
+			interrupt-parent = <&local_intc>;
+			interrupts = <9>;
+		};
+
+		gpiomem {
+			compatible = "brcm,bcm2835-gpiomem";
+			reg = <0x7e200000 0x1000>;
+		};
+
+		watchdog: watchdog@7e100000 {
+			/* Add alias */
+		};
+
+		cprman: cprman@7e101000 {
+			/* Add alias */
+		};
+
+		random: rng@7e104000 {
+			/* Add alias */
+		};
+
 		firmware: firmware {
 			compatible = "raspberrypi,bcm2835-firmware";
 			mboxes = <&mailbox>;
@@ -27,6 +89,105 @@
 			firmware = <&firmware>;
 			#power-domain-cells = <1>;
 		};
+
+		fb: fb {
+			compatible = "brcm,bcm2708-fb";
+			firmware = <&firmware>;
+			status = "disabled";
+		};
+
+		vchiq: vchiq {
+			compatible = "brcm,bcm2835-vchiq";
+			reg = <0x7e00b840 0xf>;
+			interrupts = <0 2>;
+			cache-line-size = <32>;
+			firmware = <&firmware>;
+		};
+
+		mmc: mmc@7e300000 {
+			compatible = "brcm,bcm2835-mmc";
+			reg = <0x7e300000 0x100>;
+			interrupts = <2 30>;
+			clocks = <&clocks BCM2835_CLOCK_EMMC>;
+			dmas = <&dma 11>;
+			dma-names = "rx-tx";
+			brcm,overclock-50 = <0>;
+			status = "disabled";
+		};
+
+		spi0: spi@7e204000 {
+			/* Add alias */
+			dmas = <&dma 6>, <&dma 7>;
+			dma-names = "tx", "rx";
+		};
+
+		pixelvalve0: pixelvalve@7e206000 {
+			/* Add alias */
+			status = "disabled";
+		};
+
+		pixelvalve1: pixelvalve@7e207000 {
+			/* Add alias */
+			status = "disabled";
+		};
+
+		hvs: hvs@7e400000 {
+			/* Add alias */
+			status = "disabled";
+		};
+
+		firmwarekms: firmwarekms@7e600000 {
+			compatible = "raspberrypi,rpi-firmware-kms";
+			/* SMI interrupt reg */
+			reg = <0x7e600000 0x100>;
+			interrupts = <2 16>;
+			brcm,firmware = <&firmware>;
+			status = "disabled";
+		};
+		/* videocore shared memory */
+		vcsm: vcsm {
+			compatible = "raspberrypi,bcm2835-vcsm";
+			firmware = <&firmware>;
+			status = "okay";
+		};
+
+		smi: smi@7e600000 {
+			compatible = "brcm,bcm2835-smi";
+			reg = <0x7e600000 0x100>;
+			interrupts = <2 16>;
+			clocks = <&clocks BCM2835_CLOCK_SMI>;
+			assigned-clocks = <&cprman BCM2835_CLOCK_SMI>;
+			assigned-clock-rates = <125000000>;
+			dmas = <&dma 4>;
+			dma-names = "rx-tx";
+			status = "disabled";
+		};
+
+		pixelvalve2: pixelvalve@7e807000 {
+			/* Add alias */
+			status = "disabled";
+		};
+
+	};
+
+	vdd_5v0_reg: fixedregulator_5v0 {
+		compatible = "regulator-fixed";
+		regulator-name = "5v0";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	vdd_3v3_reg: fixedregulator_3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "3v3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	__overrides__ {
+		cache_line_size = <&vchiq>, "cache-line-size:0";
 	};
 };
 
@@ -96,4 +257,8 @@
 &vec {
 	power-domains = <&power RPI_POWER_DOMAIN_VEC>;
 	status = "okay";
+};
+
+&clocks {
+	firmware = <&firmware>;
 };

--- a/arch/arm64/boot/dts/broadcom/Makefile
+++ b/arch/arm64/boot/dts/broadcom/Makefile
@@ -5,6 +5,7 @@ DTC_FLAGS ?= -@ -H epapr
 endif
 
 dtb-$(CONFIG_ARCH_BCM2835) += bcm2837-rpi-3-b.dtb
+dtb-$(CONFIG_ARCH_BCM2835) += bcm2837-rpi-cm3.dtb
 dtb-$(CONFIG_ARCH_BCM_IPROC) += ns2-svk.dtb
 dtb-$(CONFIG_ARCH_VULCAN) += vulcan-eval.dtb
 dtb-$(CONFIG_ARCH_BCM2835) += bcm2710-rpi-3-b.dtb

--- a/arch/arm64/boot/dts/broadcom/bcm2837-rpi-cm3.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2837-rpi-cm3.dts
@@ -1,0 +1,186 @@
+/dts-v1/;
+#include "bcm2837.dtsi"
+#include "bcm2835-rpi.dtsi"
+#include "bcm283x-rpi-smsc9514.dtsi"
+
+/ {
+  compatible = "brcm,bcm2837";
+  model = "Raspberry Pi Compute Module 3";
+
+  memory {
+    reg = <0 0x40000000>;
+  };
+
+  leds {
+    act_led: act {
+      gpios = <&gpio 47 0>;
+    };
+  };
+};
+
+&uart0 {
+  status = "okay";
+};
+
+&uart1 {
+  status = "okay";
+};
+
+&mmc {
+  status = "okay";
+};
+
+&firmwarekms {
+  status = "okay";
+};
+
+&hdmi {
+  status = "okay";
+};
+
+&fb {
+  status = "okay";
+};
+
+&gpio {
+  spi0_pins: spi0_pins {
+    brcm,pins = <9 10 11>;
+    brcm,function = <4>; /* alt0 */
+  };
+
+  spi0_cs_pins: spi0_cs_pins {
+    brcm,pins = <8 7>;
+    brcm,function = <1>; /* output */
+  };
+
+  spi1_pins: spi1_pins {
+    brcm,pins = <19 20 21>;
+    brcm,function = <3>; /* alt4 */
+  };
+
+  spi1_cs_pins: spi1_cs_pins {
+    brcm,pins = <18>;
+    brcm,function = <1>; /* output */
+  };
+
+  i2c0_pins: i2c0 {
+    brcm,pins = <0 1>;
+    brcm,function = <4>;
+  };
+
+  i2c1_pins: i2c1 {
+    brcm,pins = <2 3>;
+    brcm,function = <4>;
+  };
+
+  i2s_pins: i2s {
+    brcm,pins = <18 19 20 21>;
+    brcm,function = <4>; /* alt0 */
+  };
+};
+
+&i2c0 {
+  pinctrl-names = "default";
+  pinctrl-0 = <&i2c0_pins>;
+  clock-frequency = <100000>;
+};
+
+&i2c1 {
+  pinctrl-names = "default";
+  pinctrl-0 = <&i2c1_pins>;
+  clock-frequency = <100000>;
+};
+
+&i2c2 {
+  clock-frequency = <100000>;
+};
+
+&i2s {
+  pinctrl-names = "default";
+  pinctrl-0 = <&i2s_pins>;
+};
+
+&spi0 {
+  pinctrl-names = "default";
+  pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
+  cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+
+  spidev0: spidev@0{
+    compatible = "spidev";
+    reg = <0>;  /* CE0 */
+    #address-cells = <1>;
+    #size-cells = <0>;
+    spi-max-frequency = <125000000>;
+  };
+
+  spidev1: spidev@1{
+    compatible = "spidev";
+    reg = <1>;  /* CE1 */
+    #address-cells = <1>;
+    #size-cells = <0>;
+    spi-max-frequency = <125000000>;
+  };
+
+};
+
+&aux {
+  status = "okay";
+};
+
+&spi1 {
+    /* needed to avoid dtc warning */
+    #address-cells = <1>;
+    #size-cells = <0>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&spi1_pins &spi1_cs_pins>;
+    cs-gpios = <&gpio 18 1>;
+    status = "okay";
+
+    spidev1_0: spidev@0 {
+      compatible = "spidev";
+      reg = <0>;      /* CE0 */
+      #address-cells = <1>;
+      #size-cells = <0>;
+      spi-max-frequency = <500000>;
+      status = "okay";
+    };
+};
+
+&vc4 {
+  status = "disabled";
+};
+
+/ {
+  chosen {
+    bootargs = "8250.nr_uarts=1";
+  };
+};
+
+/ {
+  __overrides__ {
+    uart0 = <&uart0>,"status";
+    uart1 = <&uart1>,"status";
+    i2s = <&i2s>,"status";
+    spi = <&spi0>,"status";
+    spi1 = <&spi1>,"status";
+    spi2 = <&spi2>,"status";
+    i2c0 = <&i2c0>,"status";
+    i2c1 = <&i2c1>,"status";
+    i2c2_iknowwhatimdoing = <&i2c2>,"status";
+    i2c0_baudrate = <&i2c0>,"clock-frequency:0";
+    i2c1_baudrate = <&i2c1>,"clock-frequency:0";
+    i2c2_baudrate = <&i2c2>,"clock-frequency:0";
+
+    act_led_gpio = <&act_led>,"gpios:4";
+    act_led_activelow = <&act_led>,"gpios:8";
+    act_led_trigger = <&act_led>,"linux,default-trigger";
+
+    watchdog = <&watchdog>,"status";
+    random = <&random>,"status";
+
+    cs0_pin  = <&spi1_cs_pins>,"brcm,pins:0",
+      <&spi1>,"cs-gpios:4";
+    cs0_spidev = <&spidev1_0>,"status";
+  };
+};
+

--- a/arch/arm64/boot/dts/broadcom/bcm2837.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2837.dtsi
@@ -18,12 +18,12 @@
 	};
 
 	timer {
-		compatible = "arm,armv7-timer";
+		compatible = "arm,armv8-timer", "arm,armv7-timer";
 		interrupt-parent = <&local_intc>;
 		interrupts = <0>, // PHYS_SECURE_PPI
-			     <1>, // PHYS_NONSECURE_PPI
-			     <3>, // VIRT_PPI
-			     <2>; // HYP_PPI
+			    <1>, // PHYS_NONSECURE_PPI
+			    <3>, // VIRT_PPI
+			    <2>; // HYP_PPI
 		always-on;
 	};
 
@@ -33,35 +33,45 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "arm,cortex-a53";
+			compatible = "arm,cortex-a53", "arm,armv8";
 			reg = <0>;
+			clock-frequency = <1200000000>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000d8>;
 		};
 
 		cpu1: cpu@1 {
 			device_type = "cpu";
-			compatible = "arm,cortex-a53";
+			compatible = "arm,cortex-a53", "arm,armv8";
 			reg = <1>;
+			clock-frequency = <1200000000>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000e0>;
 		};
 
 		cpu2: cpu@2 {
 			device_type = "cpu";
-			compatible = "arm,cortex-a53";
+			compatible = "arm,cortex-a53", "arm,armv8";
 			reg = <2>;
+			clock-frequency = <1200000000>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000e8>;
 		};
 
 		cpu3: cpu@3 {
 			device_type = "cpu";
-			compatible = "arm,cortex-a53";
+			compatible = "arm,cortex-a53", "arm,armv8";
 			reg = <3>;
+			clock-frequency = <1200000000>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000f0>;
 		};
+	};
+	__overrides__ {
+		arm_freq = <&cpu0>, "clock-frequency:0",
+		       <&cpu1>, "clock-frequency:0",
+		       <&cpu2>, "clock-frequency:0",
+		       <&cpu3>, "clock-frequency:0";
 	};
 };
 


### PR DESCRIPTION
I am working on a CM3 64 bits OS. I manage to boot, the kernel log seems really promising. My only issue is it seems device tree overlays are ignored, for a reason I ignore. Because they are ignored, I cannot use `pi3-disable-bt` enabling to log in. Hence the message console [ttyS0] enabled is not displayed.

I think dtoverlays are ignored since adding overlay to use uart1 doesn't change any behavior.

The setup:
* `cmdline.txt: dwc_otg.lpm_enable=0 console=tty1 console=serial0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait cma=128M@64M`
* config.txt:
    * enable_uart=1
    * dtoverlay=pi3-disable-bt
    * dtoverlay=vc4-kms-v3d
    * gpu_mem=16
    * device_tree=bcm2837-rpi-cm3.dtb (WIP)
    * core_freq=250

PS: I know it's a bit messy in the commits, I will merge when PR is done
Resolves https://github.com/raspberrypi/linux/issues/2133