### PR TITLE
Arm fiq stat

### DIFF
--- a/arch/arm/include/asm/fiq.h
+++ b/arch/arm/include/asm/fiq.h
@@ -31,6 +31,8 @@ struct fiq_handler {
 	/* data for the relinquish/reacquire functions
 	 */
 	void *dev_id;
+	/* fiq stats percpu */
+	unsigned int __percpu *fiq_kstat;
 };
 
 extern int claim_fiq(struct fiq_handler *f);
@@ -51,6 +53,14 @@ static inline void set_fiq_regs(struct pt_regs const *regs)
 static inline void get_fiq_regs(struct pt_regs *regs)
 {
 	__get_fiq_regs(&regs->ARM_r8);
+}
+
+extern int fiq_kstat_enable(struct fiq_handler *fh);
+extern void fiq_kstat_disable(struct fiq_handler *fh);
+
+static inline void fiq_kstat_this_cpu_inc(struct fiq_handler *fh)
+{
+	__this_cpu_inc(*fh->fiq_kstat);
 }
 
 #endif

--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
@@ -51,6 +51,7 @@
  */
 
 #include "dwc_otg_fiq_fsm.h"
+#include <asm/fiq.h>
 
 
 char buffer[1000*16];
@@ -1175,6 +1176,7 @@ static int notrace noinline fiq_fsm_do_hcintr(struct fiq_state *state, int num_c
 	return handled;
 }
 
+extern struct fiq_handler dwc_usb_fh;
 
 /**
  * dwc_otg_fiq_fsm() - Flying State Machine (monster) FIQ
@@ -1200,6 +1202,9 @@ void notrace dwc_otg_fiq_fsm(struct fiq_state *state, int num_channels)
 	haint_data_t haint, haint_handled;
 	haintmsk_data_t haintmsk;
 	int kick_irq = 0;
+
+	if (dwc_usb_fh.fiq_kstat)
+		fiq_kstat_this_cpu_inc(&dwc_usb_fh);
 
 	gintsts_handled.d32 = 0;
 	haint_handled.d32 = 0;

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
@@ -393,7 +393,7 @@ static struct dwc_otg_hcd_function_ops hcd_fops = {
 	.get_b_hnp_enable = _get_b_hnp_enable,
 };
 
-static struct fiq_handler fh = {
+struct fiq_handler dwc_usb_fh = {
   .name = "usb_fiq",
 };
 
@@ -404,7 +404,10 @@ static void hcd_init_fiq(void *cookie)
 	struct pt_regs regs;
 	int irq;
 
-	if (claim_fiq(&fh)) {
+	if (fiq_kstat_enable(&dwc_usb_fh))
+		DWC_ERROR("Can't enable fiq kstat");
+
+	if (claim_fiq(&dwc_usb_fh)) {
 		DWC_ERROR("Can't claim FIQ");
 		BUG();
 	}


### PR DESCRIPTION
Hello,

Last year I've added stat support to arm fiq and usb driver.
If this is interesting I can rebase it on a new branch.
    
This patch allows drivers that uses fiq to have a stat on the
execution number of the fiq handler.
For that three APIs has been defined:
- fiq_kstat_enable: this function enables fiq stat and allocates required
memory for it
- fiq_kstat_disable: this function disable fiq stat and free its allocated
memory
- fiq_kstat_this_cpu_inc: This function increments the fiq stat counter of
the current CPU running the fiq handler

A driver may call fiq_kstat_enable at its initialization to enable fiq
stat and then call fiq_kstat_this_cpu_inc from the fiq handler

When the fiq stat is enabled by a driver, then /proc/interrupts shows the
fiq entry as the following example:
FIQ:          0   21642080          0          0  usb_fiq
If the fiq stat is not enabled, the content will be similar to the old one
as the following example:
FIQ:                                              usb_fiq
The fiq name will be always written on the first column after the last CPU
  column

Thanks

 
    