### PR TITLE
Fix DTB overlay compilation for arm64 broadcom

### DIFF
--- a/arch/arm64/boot/dts/broadcom/Makefile
+++ b/arch/arm64/boot/dts/broadcom/Makefile
@@ -11,7 +11,7 @@ dtb-$(CONFIG_ARCH_BCM2835) += bcm2710-rpi-3-b.dtb
 
 dts-dirs += ../overlays
 
-dts-dirs	:= stingray
+dts-dirs	+= stingray
 always		:= $(dtb-y)
 subdir-y	:= $(dts-dirs)
 clean-files	:= *.dtb


### PR DESCRIPTION
The dts-dirs variable was overwritten by the assignment of the
stingray directory after the overlays directory, thus no overlays
were being built

Signed-off-by: Olivier Schonken <olivier.schonken@gmail.com>