### PR TITLE
Reimplement the disabling of the memory cgroup

### DIFF
--- a/kernel/cgroup.c
+++ b/kernel/cgroup.c
@@ -5637,7 +5637,7 @@ int __init cgroup_init_early(void)
 	return 0;
 }
 
-static u16 cgroup_disable_mask __initdata = 1<<0;
+static u16 cgroup_disable_mask __initdata;
 
 /**
  * cgroup_init - cgroup initialization
@@ -6177,28 +6177,6 @@ static int __init cgroup_no_v1(char *str)
 	return 1;
 }
 __setup("cgroup_no_v1=", cgroup_no_v1);
-
-static int __init cgroup_enable(char *str)
-{
-	struct cgroup_subsys *ss;
-	char *token;
-	int i;
-
-	while ((token = strsep(&str, ",")) != NULL) {
-		if (!*token)
-			continue;
-
-		for_each_subsys(ss, i) {
-			if (strcmp(token, ss->name) &&
-			    strcmp(token, ss->legacy_name))
-				continue;
-
-			cgroup_disable_mask &= ~(1 << i);
-		}
-	}
-	return 1;
-}
-__setup("cgroup_enable=", cgroup_enable);
 
 /**
  * css_tryget_online_from_dir - get corresponding css from a cgroup dentry

--- a/kernel/cgroup.c
+++ b/kernel/cgroup.c
@@ -5638,6 +5638,8 @@ int __init cgroup_init_early(void)
 }
 
 static u16 cgroup_disable_mask __initdata;
+static bool cgroup_enable_memory;
+static int __init cgroup_disable(char *str);
 
 /**
  * cgroup_init - cgroup initialization
@@ -5675,6 +5677,9 @@ int __init cgroup_init(void)
 	BUG_ON(cgroup_setup_root(&cgrp_dfl_root, 0));
 
 	mutex_unlock(&cgroup_mutex);
+
+	if (!cgroup_enable_memory)
+		cgroup_disable("memory");
 
 	for_each_subsys(ss, ssid) {
 		if (ss->early_init) {
@@ -6150,6 +6155,13 @@ static int __init cgroup_disable(char *str)
 	return 1;
 }
 __setup("cgroup_disable=", cgroup_disable);
+
+static int __init cgroup_memory(char *str)
+{
+	kstrtobool(str, &cgroup_enable_memory);
+	return 1;
+}
+__setup("cgroup_memory=", cgroup_memory);
 
 static int __init cgroup_no_v1(char *str)
 {


### PR DESCRIPTION
As discussed in https://github.com/raspberrypi/linux/issues/1950, the current mechanism for disabling the memory cgroup does not always work. This PR reverts the existing mechanism and adds a simpler one that doesn't rely on the particular mask bit assignments.