### PR TITLE
vc-sm: Fix a printf of a dma_addr_t from %u to %pad

### DIFF
--- a/drivers/char/broadcom/vc_sm/vmcs_sm.c
+++ b/drivers/char/broadcom/vc_sm/vmcs_sm.c
@@ -575,8 +575,8 @@ static int vc_sm_global_state_show(struct seq_file *s, void *v)
 				   resource->attach);
 			seq_printf(s, "           SGT          %p\n",
 				   resource->sgt);
-			seq_printf(s, "           DMA_ADDR     0x%08X\n",
-				   resource->dma_addr);
+			seq_printf(s, "           DMA_ADDR     %pad\n",
+				   &resource->dma_addr);
 		}
 	}
 	seq_printf(s, "\n\nTotal resource count:   %d\n\n", resource_count);


### PR DESCRIPTION
Avoids issues when other build parameters result in
dma_addr_t being a 64 bit value.
See #2196.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>