### PR TITLE
bcm2835-camera: Fix timestamp calculation problem

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-camera.c
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.c
@@ -368,11 +368,12 @@ static void buffer_cb(struct vchiq_mmal_instance *instance,
 				buf->vb.vb2_buf.timestamp = (runtime_us * NSEC_PER_USEC) +
 				    dev->capture.kernel_start_timestamp;
 				v4l2_dbg(1, bcm2835_v4l2_debug, &dev->v4l2_dev,
-					 "Convert start time %llu (nsec) and %llu (usec) "
-					 "with offset %llu (usec) to %llu (nsec)\n",
-					 dev->capture.kernel_start_timestamp,
-					 dev->capture.vc_start_timestamp, pts,
-					 buf->vb.vb2_buf.timestamp);
+					 "Buffer time set as converted timestamp - %llu "
+					 "= (pts [%lld usec] - vc start time [%llu usec]) "
+					 "+ kernel start time [%llu nsec]\n",
+					 buf->vb.vb2_buf.timestamp,
+					 pts, dev->capture.vc_start_timestamp,
+					 dev->capture.kernel_start_timestamp);
 			} else {
 				if (dev->capture.last_timestamp) {
 					buf->vb.vb2_buf.timestamp = dev->capture.last_timestamp;

--- a/drivers/media/platform/bcm2835/bcm2835-camera.c
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.c
@@ -363,37 +363,16 @@ static void buffer_cb(struct vchiq_mmal_instance *instance,
 				 buf->vb.vb2_buf.timestamp);
 
 			} else if(pts != 0) {
-				struct timeval timestamp;
 				s64 runtime_us = pts -
 				    dev->capture.vc_start_timestamp;
-				s64 div = 0;
-				s32 rem = 0;
-
-				div =
-				    div_s64_rem(runtime_us, USEC_PER_SEC, &rem);
-				timestamp.tv_sec =
-				    dev->capture.kernel_start_ts.tv_sec + div;
-				timestamp.tv_usec =
-				    dev->capture.kernel_start_ts.tv_usec + rem;
-
-				if (timestamp.tv_usec >=
-				    USEC_PER_SEC) {
-					timestamp.tv_sec++;
-					timestamp.tv_usec -=
-					    USEC_PER_SEC;
-				}
+				buf->vb.vb2_buf.timestamp = (runtime_us * NSEC_PER_USEC) +
+				    dev->capture.kernel_start_timestamp;
 				v4l2_dbg(1, bcm2835_v4l2_debug, &dev->v4l2_dev,
-					 "Convert start time %d.%06d and %llu "
-					 "with offset %llu to %d.%06d\n",
-					 (int)dev->capture.kernel_start_ts.
-					 tv_sec,
-					 (int)dev->capture.kernel_start_ts.
-					 tv_usec,
+					 "Convert start time %llu (nsec) and %llu (usec) "
+					 "with offset %llu (usec) to %llu (nsec)\n",
+					 dev->capture.kernel_start_timestamp,
 					 dev->capture.vc_start_timestamp, pts,
-					 (int)timestamp.tv_sec,
-					 (int)timestamp.tv_usec);
-				buf->vb.vb2_buf.timestamp = timestamp.tv_sec * 1000000000ULL +
-					timestamp.tv_usec * 1000ULL;
+					 buf->vb.vb2_buf.timestamp);
 			} else {
 				if (dev->capture.last_timestamp) {
 					buf->vb.vb2_buf.timestamp = dev->capture.last_timestamp;
@@ -403,8 +382,7 @@ static void buffer_cb(struct vchiq_mmal_instance *instance,
 				}
 				else {
 					buf->vb.vb2_buf.timestamp =
-					dev->capture.kernel_start_ts.tv_sec  * 1000000000ULL +
-					dev->capture.kernel_start_ts.tv_usec * 1000ULL;
+					dev->capture.kernel_start_timestamp;
 					v4l2_dbg(1, bcm2835_v4l2_debug, &dev->v4l2_dev,
 					 "Buffer time set as start timestamp - %lld",
 					 buf->vb.vb2_buf.timestamp);
@@ -586,7 +564,7 @@ static int start_streaming(struct vb2_queue *vq, unsigned int count)
 
 	dev->capture.last_timestamp = 0;
 
-	v4l2_get_timestamp(&dev->capture.kernel_start_ts);
+	dev->capture.kernel_start_timestamp = ktime_get_ns();
 
 	/* enable the camera port */
 	dev->capture.port->cb_ctx = dev;

--- a/drivers/media/platform/bcm2835/bcm2835-camera.c
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.c
@@ -366,11 +366,11 @@ static void buffer_cb(struct vchiq_mmal_instance *instance,
 				struct timeval timestamp;
 				s64 runtime_us = pts -
 				    dev->capture.vc_start_timestamp;
-				u32 div = 0;
-				u32 rem = 0;
+				s64 div = 0;
+				s32 rem = 0;
 
 				div =
-				    div_u64_rem(runtime_us, USEC_PER_SEC, &rem);
+				    div_s64_rem(runtime_us, USEC_PER_SEC, &rem);
 				timestamp.tv_sec =
 				    dev->capture.kernel_start_ts.tv_sec + div;
 				timestamp.tv_usec =

--- a/drivers/media/platform/bcm2835/bcm2835-camera.h
+++ b/drivers/media/platform/bcm2835/bcm2835-camera.h
@@ -92,7 +92,7 @@ struct bm2835_mmal_dev {
 		/* VC start timestamp for streaming */
 		s64         vc_start_timestamp;
 		/* Kernel start timestamp for streaming */
-		struct timeval kernel_start_ts;
+		u64         kernel_start_timestamp;
 		/* Timestamp of last frame */
 		u64 		last_timestamp;
 


### PR DESCRIPTION
Use div_s64_rem() to convert usec timestamp to timeval to avoid integer signedness bug.

While capturing uncompressed frames with ffmpeg, I notice the `bcm2835-v4l2` module generates very large negative timestamp values (e.g., -140448221.376697). These large negative values trigger a bunch of issues (e.g., DTS/PTS "invalid dropping" warnings) during capture.

    ffmpeg -hide_banner -f v4l2 -input_format yuv420p -framerate 30 -i /dev/video0 -show_streams -f null -

By turning on module's debug flag, I see this in system log:

    Convert start time 14389.960211 and 14393894979 with offset 14393759849 to -140448221.376697

Reading the `bcm2835-camera.c` carefully, I noticed the use of `div_u64_rem(...)` causes an integer signedness bug. For the conversion, it should be `14389.825081` Instead of `-140448221.376697`.