### PR TITLE
bcm2710: Refactor bcm2710.dtsi using bcm2837.dtsi

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2708-rpi.dtsi
@@ -156,7 +156,5 @@ sdhost_pins: &sdhost_gpio48 {
 };
 
 &cpu_thermal {
-	coefficients = <(-538)	407000>;
-
 	/delete-node/ trips;
 };

--- a/arch/arm/boot/dts/bcm2710.dtsi
+++ b/arch/arm/boot/dts/bcm2710.dtsi
@@ -1,23 +1,9 @@
-#include "bcm283x.dtsi"
+#include "bcm2837.dtsi"
 #include "bcm270x.dtsi"
 #include "bcm2708-rpi.dtsi"
 
 / {
-	compatible = "brcm,bcm2837", "brcm,bcm2836";
-	model = "BCM2837";
-
 	soc {
-		ranges = <0x7e000000 0x3f000000 0x01000000>,
-		         <0x40000000 0x40000000 0x00040000>;
-		dma-ranges = <0xc0000000 0x00000000 0x3f000000>;
-
-		local_intc: local_intc {
-			compatible = "brcm,bcm2836-l1-intc";
-			reg = <0x40000000 0x100>;
-			interrupt-controller;
-			#interrupt-cells = <1>;
-			interrupt-parent = <&local_intc>;
-		};
 
 		arm-pmu {
 #ifdef RPI364
@@ -29,120 +15,16 @@
 			interrupts = <9>;
 		};
 
-		timer {
-#ifdef RPI364
-			compatible = "arm,armv8-timer", "arm,armv7-timer";
-#else
-			compatible = "arm,armv7-timer";
-#endif
-			interrupt-parent = <&local_intc>;
-			interrupts = <0>, // PHYS_SECURE_PPI
-				     <1>, // PHYS_NONSECURE_PPI
-				     <3>, // VIRT_PPI
-				     <2>; // HYP_PPI
-			always-on;
-		};
-
 		syscon@40000000 {
 			compatible = "brcm,bcm2836-arm-local", "syscon";
 			reg = <0x40000000 0x100>;
 		};
 	};
 
-#ifdef RPI364
-	cpus: cpus {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		v8_cpu0: cpu@0 {
-			device_type = "cpu";
-			compatible = "arm,cortex-a53", "arm,armv8";
-			reg = <0x0>;
-			clock-frequency = <1200000000>;
-		};
-
-		v8_cpu1: cpu@1 {
-			device_type = "cpu";
-			compatible = "arm,cortex-a53", "arm,armv8";
-			reg = <0x1>;
-			clock-frequency = <1200000000>;
-			enable-method = "spin-table";
-			cpu-release-addr = <0x0 0x000000e0>;
-		};
-
-		v8_cpu2: cpu@2 {
-			device_type = "cpu";
-			compatible = "arm,cortex-a53", "arm,armv8";
-			reg = <0x2>;
-			clock-frequency = <1200000000>;
-			enable-method = "spin-table";
-			cpu-release-addr = <0x0 0x000000e8>;
-		};
-
-		v8_cpu3: cpu@3 {
-			device_type = "cpu";
-			compatible = "arm,cortex-a53", "arm,armv8";
-			reg = <0x3>;
-			clock-frequency = <1200000000>;
-			enable-method = "spin-table";
-			cpu-release-addr = <0x0 0x000000f0>;
-		};
-	};
-
 	__overrides__ {
-		arm_freq = <&v8_cpu0>, "clock-frequency:0",
-		       <&v8_cpu1>, "clock-frequency:0",
-		       <&v8_cpu2>, "clock-frequency:0",
-		       <&v8_cpu3>, "clock-frequency:0";
+		arm_freq = <&cpu0>, "clock-frequency:0",
+		       <&cpu1>, "clock-frequency:0",
+		       <&cpu2>, "clock-frequency:0",
+		       <&cpu3>, "clock-frequency:0";
 	};
-
-#else
-	cpus: cpus {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		v7_cpu0: cpu@0 {
-			device_type = "cpu";
-			compatible = "arm,cortex-a7";
-			reg = <0x000>;
-			clock-frequency = <800000000>;
-		};
-
-		v7_cpu1: cpu@1 {
-			device_type = "cpu";
-			compatible = "arm,cortex-a7";
-			reg = <0x001>;
-			clock-frequency = <800000000>;
-		};
-
-		v7_cpu2: cpu@2 {
-			device_type = "cpu";
-			compatible = "arm,cortex-a7";
-			reg = <0x002>;
-			clock-frequency = <800000000>;
-		};
-
-		v7_cpu3: cpu@3 {
-			device_type = "cpu";
-			compatible = "arm,cortex-a7";
-			reg = <0x003>;
-			clock-frequency = <800000000>;
-		};
-	};
-
-	__overrides__ {
-		arm_freq = <&v7_cpu0>, "clock-frequency:0",
-		       <&v7_cpu1>, "clock-frequency:0",
-		       <&v7_cpu2>, "clock-frequency:0",
-		       <&v7_cpu3>, "clock-frequency:0";
-	};
-#endif
 };
-
-&intc {
-	compatible = "brcm,bcm2836-armctrl-ic";
-	reg = <0x7e00b200 0x200>;
-	interrupt-parent = <&local_intc>;
-	interrupts = <8>;
-};
-


### PR DESCRIPTION
The 4.14 tree includes bcm2837.dtsi - use it as a basis for
the downstream bcm2710.dtsi, which only contains a few tweaks.

See: https://github.com/raspberrypi/linux/issues/2235

Signed-off-by: Phil Elwell <phil@raspberrypi.org>