### PR TITLE
BCM_VC_SM: select DMA_SHARED_BUFFER

### DIFF
--- a/drivers/char/broadcom/Kconfig
+++ b/drivers/char/broadcom/Kconfig
@@ -27,6 +27,7 @@ config BCM_VC_SM
 	bool "VMCS Shared Memory"
 	depends on BCM2708_VCHIQ
 	select BCM2708_VCMEM
+	select DMA_SHARED_BUFFER
 	default n
 	help
 	Support for the VC shared memory on the Broadcom reference


### PR DESCRIPTION
This driver was refactored to use the kernel DMA buffer sharing api
in commit a97390852b14e8f06cf579adaaf8b664184e92d2.

Per Documentation/dma-buf-sharing.txt, it must select DMA_SHARED_BUFFER
in its Kconfig.

Signed-off-by: Alistair Buxton <a.j.buxton@gmail.com>