### PR TITLE
mcp2515: Change interrupt to TRIGGER_LOW

### DIFF
--- a/arch/arm/boot/dts/overlays/mcp2515-can0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp2515-can0-overlay.dts
@@ -60,7 +60,7 @@
                 pinctrl-0 = <&can0_pins>;
                 spi-max-frequency = <10000000>;
                 interrupt-parent = <&gpio>;
-                interrupts = <25 0x2>;
+                interrupts = <25 8>; /* IRQ_TYPE_LEVEL_LOW */
                 clocks = <&can0_osc>;
             };
         };

--- a/arch/arm/boot/dts/overlays/mcp2515-can1-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp2515-can1-overlay.dts
@@ -60,7 +60,7 @@
                 pinctrl-0 = <&can1_pins>;
                 spi-max-frequency = <10000000>;
                 interrupt-parent = <&gpio>;
-                interrupts = <25 0x2>;
+                interrupts = <25 8>; /* IRQ_TYPE_LEVEL_LOW */
                 clocks = <&can1_osc>;
             };
         };

--- a/drivers/net/can/spi/mcp251x.c
+++ b/drivers/net/can/spi/mcp251x.c
@@ -952,6 +952,9 @@ static int mcp251x_open(struct net_device *net)
 	priv->tx_skb = NULL;
 	priv->tx_len = 0;
 
+	if (spi->dev.of_node)
+	    flags = 0;
+
 	ret = request_threaded_irq(spi->irq, NULL, mcp251x_can_ist,
 				   flags | IRQF_ONESHOT, DEVICE_NAME, priv);
 	if (ret) {


### PR DESCRIPTION
[ If this is effective we should reconsider all usage of edge-triggered interrupts. ]

The MCP2515 datasheet clearly describes a level-triggered interrupt
pin. Therefore the receiving interrupt controller must also be
configured for level-triggered operation otherwise there is a danger
of a missed interrupt condition blocking all subsequent interrupts.

The ONESHOT flag ensures that the interrupt is masked until the
threaded interrupt handler exits.

See: https://github.com/raspberrypi/linux/issues/2175
     https://github.com/raspberrypi/linux/issues/2263

Signed-off-by: Phil Elwell <phil@raspberrypi.org>