### PR TITLE
Add Raspberry Pi firmware driver to the dependencies of RPi backlight driver

### DIFF
--- a/drivers/video/backlight/Kconfig
+++ b/drivers/video/backlight/Kconfig
@@ -267,6 +267,7 @@ config BACKLIGHT_PWM
 
 config BACKLIGHT_RPI
 	tristate "Raspberry Pi display firmware driven backlight"
+	depends on RASPBERRYPI_FIRMWARE
 	help
 	  If you have the Raspberry Pi DSI touchscreen display, say Y to
 	  enable the mailbox-controlled backlight driver.


### PR DESCRIPTION
Otherwise the backlight driver fails to build if the firmware
loading driver is not in the kernel

Signed-off-by: Alex Riesen <alexander.riesen@cetitec.com>