### PR TITLE
add override for backlight GPIO pin selection

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -991,6 +991,7 @@ Params: speed                   Display SPI bus speed
         fps                     Delay between frame updates
         xohms                   Touchpanel sensitivity (X-plate resistance)
         swapxy                  Swap x and y axis
+        backlight               Change backlight GPIO pin {e.g. 12, 18}
         gpio_out_pin            GPIO for output (default "17")
         gpio_in_pin             GPIO for input (default "18")
         gpio_in_pull            Pull up/down/off on the input pin

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1305,6 +1305,7 @@ Params: speed                   Display SPI bus speed
         debug                   Debug output level {0-7}
         xohms                   Touchpanel sensitivity (X-plate resistance)
         swapxy                  Swap x and y axis
+        backlight               Change backlight GPIO pin {e.g. 12, 18}
 
 
 Name:   rpi-ft5406

--- a/arch/arm/boot/dts/overlays/media-center-overlay.dts
+++ b/arch/arm/boot/dts/overlays/media-center-overlay.dts
@@ -113,13 +113,15 @@
 	};
 
 	__overrides__ {
-		speed =   <&rpidisplay>,"spi-max-frequency:0";
-		rotate =  <&rpidisplay>,"rotate:0";
-		fps =     <&rpidisplay>,"fps:0";
-		debug =   <&rpidisplay>,"debug:0", 
-		          <&lirc_rpi>,"rpi,debug:0";
-		xohms =   <&rpidisplay_ts>,"ti,x-plate-ohms;0";
-		swapxy =  <&rpidisplay_ts>,"ti,swap-xy?";
+		speed =     <&rpidisplay>,"spi-max-frequency:0";
+		rotate =    <&rpidisplay>,"rotate:0";
+		fps =       <&rpidisplay>,"fps:0";
+		debug =     <&rpidisplay>,"debug:0", 
+		            <&lirc_rpi>,"rpi,debug:0";
+		xohms =     <&rpidisplay_ts>,"ti,x-plate-ohms;0";
+		swapxy =    <&rpidisplay_ts>,"ti,swap-xy?";
+		backlight = <&rpidisplay>,"led-gpios:4",
+		            <&rpi_display_pins>,"brcm,pins:0";
 
 		gpio_out_pin =  <&lirc_pins>,"brcm,pins:0";
 		gpio_in_pin =   <&lirc_pins>,"brcm,pins:4";

--- a/arch/arm/boot/dts/overlays/rpi-display-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-display-overlay.dts
@@ -79,11 +79,13 @@
 		};
 	};
 	__overrides__ {
-		speed =   <&rpidisplay>,"spi-max-frequency:0";
-		rotate =  <&rpidisplay>,"rotate:0";
-		fps =     <&rpidisplay>,"fps:0";
-		debug =   <&rpidisplay>,"debug:0";
-		xohms =   <&rpidisplay_ts>,"ti,x-plate-ohms;0";
-		swapxy =  <&rpidisplay_ts>,"ti,swap-xy?";
+		speed =     <&rpidisplay>,"spi-max-frequency:0";
+		rotate =    <&rpidisplay>,"rotate:0";
+		fps =       <&rpidisplay>,"fps:0";
+		debug =     <&rpidisplay>,"debug:0";
+		xohms =     <&rpidisplay_ts>,"ti,x-plate-ohms;0";
+		swapxy =    <&rpidisplay_ts>,"ti,swap-xy?";
+		backlight = <&rpidisplay>,"led-gpios:4",
+		            <&rpi_display_pins>,"brcm,pins:0";
 	};
 };


### PR DESCRIPTION
Both the watterott rpi-display and media center hat have ability to control with a jumper the ability to change the backlight of the display from GPIO18 to GPIO12 to avoid clashes with the I2S audio pins and enable use with HiFiBerry / JustBoom / Iqaudio etc boards.

These changes add an easy dt parameter "backlight" to change the backlight setting.

These have been tested and working successfully with both boards - [see here](https://github.com/raspberrypi/linux/pull/2313)

Watterott overlay defaults to GPIO18, media center to gpio12