### PR TITLE
add gpio-key overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -30,6 +30,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	goodix.dtbo \
 	googlevoicehat-soundcard.dtbo \
 	gpio-ir.dtbo \
+	gpio-key.dtbo \
 	gpio-poweroff.dtbo \
 	gpio-shutdown.dtbo \
 	hifiberry-amp.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -503,10 +503,11 @@ Params: gpio_pin                Input pin number. Default is 18.
         rc-map-name             Default rc keymap (can also be changed by
                                 ir-keytable), defaults to "rc-rc6-mce"
 
+
 Name:   gpio-key
-Info:   This is a generic overlay for activating GPIO keypresses using 
+Info:   This is a generic overlay for activating GPIO keypresses using
         the gpio-keys library and this dtoverlay. Multiple keys can be
-        set up using multiple calls to the overlay for configuring 
+        set up using multiple calls to the overlay for configuring
         additional buttons or joysticks. You can see available keycodes
         at https://github.com/torvalds/linux/blob/v4.12/include/uapi/
         linux/input-event-codes.h#L64
@@ -520,7 +521,7 @@ Params: gpio                    GPIO pin to trigger on (default 3)
         gpio_pull               Desired pull-up/down state (off, down, up)
                                 Default is "up". Note that the default pin
                                 (GPIO3) has an external pullup
-        label                   Set a label for the key 
+        label                   Set a label for the key
         keycode                 Set the key code for the button
 
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -503,6 +503,26 @@ Params: gpio_pin                Input pin number. Default is 18.
         rc-map-name             Default rc keymap (can also be changed by
                                 ir-keytable), defaults to "rc-rc6-mce"
 
+Name:   gpio-key
+Info:   This is a generic overlay for activating GPIO keypresses using 
+        the gpio-keys library and this dtoverlay. Multiple keys can be
+        set up using multiple calls to the overlay for configuring 
+        additional buttons or joysticks. You can see available keycodes
+        at https://github.com/torvalds/linux/blob/v4.12/include/uapi/
+        linux/input-event-codes.h#L64
+Load:   dtoverlay=gpio-key,<param>=<val>
+Params: gpio                    GPIO pin to trigger on (default 3)
+        active_low              When this is 1 (active low), a falling
+                                edge generates a key down event and a
+                                rising edge generates a key up event.
+                                When this is 0 (active high), this is
+                                reversed. The default is 1 (active low)
+        gpio_pull               Desired pull-up/down state (off, down, up)
+                                Default is "up". Note that the default pin
+                                (GPIO3) has an external pullup
+        label                   Set a label for the key 
+        keycode                 Set the key code for the button
+
 
 Name:   gpio-poweroff
 Info:   Drives a GPIO high or low on poweroff (including halt). Enabling this

--- a/arch/arm/boot/dts/overlays/gpio-key-overlay.dts
+++ b/arch/arm/boot/dts/overlays/gpio-key-overlay.dts
@@ -1,0 +1,50 @@
+// Definitions for gpio-key module
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		// Configure the gpio pin controller
+		target = <&gpio>;
+		__overlay__ {
+			pin_state: button_pins {
+				brcm,pins = <3>; // gpio number
+				brcm,function = <0>; // 0 = input, 1 = output
+				brcm,pull = <2>; // 0 = none, 1 = pull down, 2 = pull up
+			};
+		};
+	};
+	fragment@1 {
+		target-path = "/soc";
+		__overlay__ {
+			button {
+				compatible = "gpio-keys";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&pin_state>;
+				status = "okay";
+
+				key@0 {
+					reg = < 0 >;
+					linux,code = <116>;
+					gpios = <&gpio 3 1>;
+					label = "KEY_POWER";
+				};
+			};
+		};
+	};
+
+	__overrides__ {
+		gpio =       <&key>,"gpios:4",
+		             <&key>,"reg:0",
+		             <&pin_state>,"brcm,pins:0";
+		label =      <&key>,"label";
+		keycode =    <&key>,"linux,code:0"
+		gpio_pull =  <&pin_state>,"brcm,pull:0";
+		active_low = <&key>,"gpios:8";
+	};
+
+};

--- a/arch/arm/boot/dts/overlays/gpio-key-overlay.dts
+++ b/arch/arm/boot/dts/overlays/gpio-key-overlay.dts
@@ -9,7 +9,7 @@
 		// Configure the gpio pin controller
 		target = <&gpio>;
 		__overlay__ {
-			pin_state: button_pins {
+			pin_state: button_pins@0 {
 				brcm,pins = <3>; // gpio number
 				brcm,function = <0>; // 0 = input, 1 = output
 				brcm,pull = <2>; // 0 = none, 1 = pull down, 2 = pull up
@@ -17,18 +17,15 @@
 		};
 	};
 	fragment@1 {
-		target-path = "/soc";
+		target-path = "/";
 		__overlay__ {
-			button {
+			button: button@0 {
 				compatible = "gpio-keys";
-				#address-cells = <1>;
-				#size-cells = <0>;
 				pinctrl-names = "default";
 				pinctrl-0 = <&pin_state>;
 				status = "okay";
 
-				key@0 {
-					reg = < 0 >;
+				key: key {
 					linux,code = <116>;
 					gpios = <&gpio 3 1>;
 					label = "KEY_POWER";
@@ -39,10 +36,11 @@
 
 	__overrides__ {
 		gpio =       <&key>,"gpios:4",
-		             <&key>,"reg:0",
-		             <&pin_state>,"brcm,pins:0";
+		             <&button>,"reg:0",
+		             <&pin_state>,"brcm,pins:0",
+		             <&pin_state>,"reg:0";
 		label =      <&key>,"label";
-		keycode =    <&key>,"linux,code:0"
+		keycode =    <&key>,"linux,code:0";
 		gpio_pull =  <&pin_state>,"brcm,pull:0";
 		active_low = <&key>,"gpios:8";
 	};


### PR DESCRIPTION
as discussed in #2312 this is my first attempt at a generic gpio-key overlay with overrides for all of the necessary changes.

The one thing I am unsure of (other than generally whether it will work or not!!) is the `key@0` part - have I done that right?

Also - perhaps it is better to not have the active-low on by default and to configure it to something less unexpected than a shutdown? Since gpio-shutdown overlay already does that. Not sure it matters hugely, but could just map it to an up arrow or something and have active low off. Let me know what you think?

P.S. this is untested so far with any buttons. I will test tomorrow when I am close to some hardware.

P.P.S i just noticed that I have accidentally deleted some stuff from the last commit (the mcp3202 overlay stuff) - off to fix that now!
  