### PR TITLE
add additional overrides to rotary-encoder overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1307,6 +1307,29 @@ Params: rotary0_pin_a           GPIO connected to rotary encoder channel A
                                 (default 4).
         rotary0_pin_b           GPIO connected to rotary encoder channel B
                                 (default 17).
+        relative_axis           register a relative axis rather than an
+                                absolute one. Relative axis will only
+                                generate +1/-1 events on the input device,
+                                hence no steps need to be passed.
+        linux_axis              the input subsystem axis to map to this
+                                rotary encoder. Defaults to 0 (ABS_X / REL_X)
+        rollover                Automatic rollover when the rotary value
+                                becomes greater than the specified steps or
+                                smaller than 0. For absolute axis only.
+        steps-per-period        Number of steps (stable states) per period.
+                                The values have the following meaning:
+                                1: Full-period mode (default)
+                                2: Half-period mode
+                                4: Quarter-period mode
+        steps                   Number of steps in a full turnaround of the
+                                encoder. Only relevant for absolute axis.
+                                Defaults to 24 which is a typical value for
+                                such devices.
+        wakeup                  Boolean, rotary encoder can wake up the
+                                system.
+        encoding                String, the method used to encode steps.
+                                Supported are "gray" (the default and more
+                                common) and "binary".
 
 
 Name:   rpi-backlight

--- a/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
@@ -28,16 +28,24 @@
 					gpios = <&gpio 4 0>, <&gpio 17 0>;
 					linux,axis = <0>; /* REL_X */
 					rotary-encoder,encoding = "gray";
-					rotary-encoder,relative-axis;
+					rotary-encoder,steps = <24>; /* 24 default */
+					rotary-encoder,steps-per-period = <1>; /* corresponds to full period mode. See README */
 			};
 		};
 
 	};  
 
 	__overrides__ {
-		rotary0_pin_a = <&rotary0>,"gpios:4",
-				<&rotary0_pins>,"brcm,pins:0";
-		rotary0_pin_b = <&rotary0>,"gpios:16",
-				<&rotary0_pins>,"brcm,pins:4";
+		rotary0_pin_a =     <&rotary0>,"gpios:4",
+		                    <&rotary0_pins>,"brcm,pins:0";
+		rotary0_pin_b =     <&rotary0>,"gpios:16",
+		                    <&rotary0_pins>,"brcm,pins:4";
+		relative_axis =     <&rotary0>,"rotary-encoder,relative-axis:?";
+		linux_axis =        <&rotary0>,"linux,axis:0";
+		rollover =          <&rotary0>,"rotary-encoder,rollover:?";
+		steps-per-period =  <&rotary0>,"rotary-encoder,steps-per-period:0";
+		steps =             <&rotary0>,"rotary-encoder,steps:0";
+		wakeup =            <&rotary0>,"wakeup-source:?";
+		encoding =          <&rotary0>,"rotary-encoder,encoding";
 	};  
 };

--- a/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
@@ -40,12 +40,12 @@
 		                    <&rotary0_pins>,"brcm,pins:0";
 		rotary0_pin_b =     <&rotary0>,"gpios:16",
 		                    <&rotary0_pins>,"brcm,pins:4";
-		relative_axis =     <&rotary0>,"rotary-encoder,relative-axis:?";
+		relative_axis =     <&rotary0>,"rotary-encoder,relative-axis?";
 		linux_axis =        <&rotary0>,"linux,axis:0";
-		rollover =          <&rotary0>,"rotary-encoder,rollover:?";
+		rollover =          <&rotary0>,"rotary-encoder,rollover?";
 		steps-per-period =  <&rotary0>,"rotary-encoder,steps-per-period:0";
 		steps =             <&rotary0>,"rotary-encoder,steps:0";
-		wakeup =            <&rotary0>,"wakeup-source:?";
+		wakeup =            <&rotary0>,"wakeup-source?";
 		encoding =          <&rotary0>,"rotary-encoder,encoding";
 	};  
 };


### PR DESCRIPTION
Updates to the rotary-encoder overlay to add additional overrides that are possible according to this doc - https://elixir.free-electrons.com/linux/latest/source/Documentation/devicetree/bindings/input/rotary-encoder.txt

See #2331 for more details also