### PR TITLE
rpi 4.14.y: fkms support

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -685,14 +685,7 @@ static void vc4_crtc_atomic_flush(struct drm_crtc *crtc,
 
 static int vc4_enable_vblank(struct drm_crtc *crtc)
 {
-	struct drm_device *dev = crtc->dev;
-	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct vc4_crtc *vc4_crtc = to_vc4_crtc(crtc);
-
-	if (vc4->firmware_kms) {
-		/* XXX: Can we mask the SMI interrupt? */
-		return 0;
-	}
 
 	CRTC_WRITE(PV_INTEN, PV_INT_VFP_START);
 
@@ -701,14 +694,7 @@ static int vc4_enable_vblank(struct drm_crtc *crtc)
 
 static void vc4_disable_vblank(struct drm_crtc *crtc)
 {
-	struct drm_device *dev = crtc->dev;
-	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct vc4_crtc *vc4_crtc = to_vc4_crtc(crtc);
-
-	if (vc4->firmware_kms) {
-		/* XXX: Can we mask the SMI interrupt? */
-		return;
-	}
 
 	CRTC_WRITE(PV_INTEN, 0);
 }

--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -204,10 +204,6 @@ static void vc4_cursor_plane_atomic_update(struct drm_plane *plane,
 		state->crtc_y,
 		0
 	};
-	u32 packet_info[] = { state->crtc_w, state->crtc_h,
-			      0, /* unused */
-			      bo->paddr + fb->offsets[0],
-			      0, 0, /* hotx, hoty */};
 	WARN_ON_ONCE(fb->pitches[0] != state->crtc_w * 4);
 
 	DRM_DEBUG_ATOMIC("[PLANE:%d:%s] update %dx%d cursor at %d,%d (0x%08x/%d)",
@@ -232,12 +228,26 @@ static void vc4_cursor_plane_atomic_update(struct drm_plane *plane,
 	if (ret || packet_state[0] != 0)
 		DRM_ERROR("Failed to set cursor state: 0x%08x\n", packet_state[0]);
 
-	ret = rpi_firmware_property(vc4->firmware,
-				    RPI_FIRMWARE_SET_CURSOR_INFO,
-				    &packet_info,
-				    sizeof(packet_info));
-	if (ret || packet_info[0] != 0)
-		DRM_ERROR("Failed to set cursor info: 0x%08x\n", packet_info[0]);
+	/* Note: When the cursor contents change, the modesetting
+	 * driver calls drm_mode_cursor_univeral() with
+	 * DRM_MODE_CURSOR_BO, which means a new fb will be allocated.
+	 */
+	if (!old_state ||
+	    state->crtc_w != old_state->crtc_w ||
+	    state->crtc_h != old_state->crtc_h ||
+	    fb != old_state->fb) {
+		u32 packet_info[] = { state->crtc_w, state->crtc_h,
+				      0, /* unused */
+				      bo->paddr + fb->offsets[0],
+				      0, 0, /* hotx, hoty */};
+
+		ret = rpi_firmware_property(vc4->firmware,
+					    RPI_FIRMWARE_SET_CURSOR_INFO,
+					    &packet_info,
+					    sizeof(packet_info));
+		if (ret || packet_info[0] != 0)
+			DRM_ERROR("Failed to set cursor info: 0x%08x\n", packet_info[0]);
+	}
 }
 
 static void vc4_cursor_plane_atomic_disable(struct drm_plane *plane,

--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -37,8 +37,6 @@ struct vc4_crtc {
 	struct drm_crtc base;
 	struct drm_encoder *encoder;
 	struct drm_connector *connector;
-	struct drm_plane *primary;
-	struct drm_plane *cursor;
 	void __iomem *regs;
 
 	struct drm_pending_vblank_event *event;
@@ -356,29 +354,24 @@ static void vc4_crtc_mode_set_nofb(struct drm_crtc *crtc)
 
 static void vc4_crtc_disable(struct drm_crtc *crtc, struct drm_crtc_state *old_state)
 {
-	struct vc4_crtc *vc4_crtc = to_vc4_crtc(crtc);
-
 	/* Always turn the planes off on CRTC disable. In DRM, planes
 	 * are enabled/disabled through the update/disable hooks
 	 * above, and the CRTC enable/disable independently controls
 	 * whether anything scans out at all, but the firmware doesn't
 	 * give us a CRTC-level control for that.
 	 */
-	vc4_cursor_plane_atomic_disable(vc4_crtc->cursor,
-					vc4_crtc->cursor->state);
-	vc4_plane_set_primary_blank(vc4_crtc->primary, true);
+	vc4_cursor_plane_atomic_disable(crtc->cursor, crtc->cursor->state);
+	vc4_plane_set_primary_blank(crtc->primary, true);
 }
 
 static void vc4_crtc_enable(struct drm_crtc *crtc, struct drm_crtc_state *old_state)
 {
-	struct vc4_crtc *vc4_crtc = to_vc4_crtc(crtc);
-
 	/* Unblank the planes (if they're supposed to be displayed). */
-	if (vc4_crtc->primary->state->fb)
-		vc4_plane_set_primary_blank(vc4_crtc->primary, false);
-	if (vc4_crtc->cursor->state->fb) {
-		vc4_cursor_plane_atomic_update(vc4_crtc->cursor,
-					       vc4_crtc->cursor->state);
+	if (crtc->primary->state->fb)
+		vc4_plane_set_primary_blank(crtc->primary, false);
+	if (crtc->cursor->state->fb) {
+		vc4_cursor_plane_atomic_update(crtc->cursor,
+					       crtc->cursor->state);
 	}
 }
 
@@ -688,9 +681,6 @@ static int vc4_fkms_bind(struct device *dev, struct device *master, void *data)
 	drm_crtc_helper_add(crtc, &vc4_crtc_helper_funcs);
 	primary_plane->crtc = crtc;
 	cursor_plane->crtc = crtc;
-
-	vc4_crtc->primary = primary_plane;
-	vc4_crtc->cursor = cursor_plane;
 
 	vc4_encoder = devm_kzalloc(dev, sizeof(*vc4_encoder), GFP_KERNEL);
 	if (!vc4_encoder)

--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -43,6 +43,7 @@ struct vc4_crtc {
 
 	struct drm_pending_vblank_event *event;
 	u32 overscan[4];
+	bool vblank_enabled;
 };
 
 static inline struct vc4_crtc *to_vc4_crtc(struct drm_crtc *crtc)
@@ -420,7 +421,8 @@ static irqreturn_t vc4_crtc_irq_handler(int irq, void *data)
 
 	if (stat & SMICS_INTERRUPTS) {
 		writel(0, vc4_crtc->regs + SMICS);
-		drm_crtc_handle_vblank(&vc4_crtc->base);
+		if (vc4_crtc->vblank_enabled)
+			drm_crtc_handle_vblank(&vc4_crtc->base);
 		vc4_crtc_handle_page_flip(vc4_crtc);
 		ret = IRQ_HANDLED;
 	}
@@ -443,9 +445,9 @@ static int vc4_page_flip(struct drm_crtc *crtc,
 
 static int vc4_fkms_enable_vblank(struct drm_crtc *crtc)
 {
-	/* XXX: Need a way to enable/disable the interrupt, to avoid
-	 * DRM warnings at boot time.
-	 */
+	struct vc4_crtc *vc4_crtc = to_vc4_crtc(crtc);
+
+	vc4_crtc->vblank_enabled = true;
 
 	return 0;
 }

--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -17,6 +17,7 @@
 #include "drm/drm_atomic_helper.h"
 #include "drm/drm_plane_helper.h"
 #include "drm/drm_crtc_helper.h"
+#include "drm/drm_fourcc.h"
 #include "linux/clk.h"
 #include "linux/debugfs.h"
 #include "drm/drm_fb_cma_helper.h"
@@ -135,6 +136,10 @@ static void vc4_primary_plane_atomic_update(struct drm_plane *plane,
 	fbinfo->yoffset = state->crtc_y;
 	fbinfo->base = bo->paddr + fb->offsets[0];
 	fbinfo->pitch = fb->pitches[0];
+
+	if (fb->modifier == DRM_FORMAT_MOD_BROADCOM_VC4_T_TILED)
+		fbinfo->bpp |= BIT(31);
+
 	/* A bug in the firmware makes it so that if the fb->base is
 	 * set to nonzero, the configured pitch gets overwritten with
 	 * the previous pitch.  So, to get the configured pitch

--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -441,6 +441,19 @@ static int vc4_page_flip(struct drm_crtc *crtc,
 	return drm_atomic_helper_page_flip(crtc, fb, event, flags, ctx);
 }
 
+static int vc4_fkms_enable_vblank(struct drm_crtc *crtc)
+{
+	/* XXX: Need a way to enable/disable the interrupt, to avoid
+	 * DRM warnings at boot time.
+	 */
+
+	return 0;
+}
+
+static void vc4_fkms_disable_vblank(struct drm_crtc *crtc)
+{
+}
+
 static const struct drm_crtc_funcs vc4_crtc_funcs = {
 	.set_config = drm_atomic_helper_set_config,
 	.destroy = drm_crtc_cleanup,
@@ -451,6 +464,8 @@ static const struct drm_crtc_funcs vc4_crtc_funcs = {
 	.reset = drm_atomic_helper_crtc_reset,
 	.atomic_duplicate_state = drm_atomic_helper_crtc_duplicate_state,
 	.atomic_destroy_state = drm_atomic_helper_crtc_destroy_state,
+	.enable_vblank = vc4_fkms_enable_vblank,
+	.disable_vblank = vc4_fkms_disable_vblank,
 };
 
 static const struct drm_crtc_helper_funcs vc4_crtc_helper_funcs = {

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -53,7 +53,8 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 	 * display lists before we free it and potentially reallocate
 	 * and overwrite the dlist memory with a new modeset.
 	 */
-	state->legacy_cursor_update = false;
+	if (!vc4->firmware_kms)
+		state->legacy_cursor_update = false;
 
 	drm_atomic_helper_commit_hw_done(state);
 


### PR DESCRIPTION
The forward port of the fkms code missed that enable/disable_vblank moved to the CRTC funcs, so we had fkms code in vc4_crtc.c that never got called because our enable/disable were entirely missing.  Also brings forward the T tiling patch that got dropped.