### PR TITLE
Revert downstream wm8804 changes

### DIFF
--- a/sound/soc/codecs/wm8804.c
+++ b/sound/soc/codecs/wm8804.c
@@ -304,7 +304,6 @@ static int wm8804_hw_params(struct snd_pcm_substream *substream,
 		blen = 0x1;
 		break;
 	case 24:
-	case 32:
 		blen = 0x2;
 		break;
 	default:
@@ -516,7 +515,7 @@ static const struct snd_soc_dai_ops wm8804_dai_ops = {
 };
 
 #define WM8804_FORMATS (SNDRV_PCM_FMTBIT_S16_LE | SNDRV_PCM_FMTBIT_S20_3LE | \
-			SNDRV_PCM_FMTBIT_S24_3LE | SNDRV_PCM_FMTBIT_S32_LE)
+			SNDRV_PCM_FMTBIT_S24_LE)
 
 #define WM8804_RATES (SNDRV_PCM_RATE_32000 | SNDRV_PCM_RATE_44100 | \
 		      SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_64000 | \
@@ -544,7 +543,7 @@ static struct snd_soc_dai_driver wm8804_dai = {
 };
 
 static const struct snd_soc_codec_driver soc_codec_dev_wm8804 = {
-	.idle_bias_off = false,
+	.idle_bias_off = true,
 
 	.component_driver = {
 		.dapm_widgets		= wm8804_dapm_widgets,


### PR DESCRIPTION
It looks like the changes to the wm8804 codec that we have here in the rpi tree come from a time where the i2s driver didn't support mmap and hacking in 32bit support (which isn't supported by the codec and breaks 24-bit support) was used as a workaround. Not exactly sure why idle_bias_off was changed, but that smells rather suspicously like a workaround, too.

I've successfully tested the Hifiberry Digi Pro, Justboom Digi and Cirrus Logic Audio Card with the local changes reverted.

ping @hifiberry @shawaj could you test with this PR as well?