### PR TITLE
properly fix S24_LE mode with pcm512x codec

### DIFF
--- a/sound/soc/bcm/allo-boss-dac.c
+++ b/sound/soc/bcm/allo-boss-dac.c
@@ -222,14 +222,6 @@ static int snd_allo_boss_update_rate_den(
 	return 0;
 }
 
-static int snd_allo_boss_set_bclk_ratio_pro(
-	struct snd_soc_dai *cpu_dai, struct snd_pcm_hw_params *params)
-{
-	int bratio = snd_pcm_format_physical_width(params_format(params))
-		* params_channels(params);
-	return snd_soc_dai_set_bclk_ratio(cpu_dai, bratio);
-}
-
 static void snd_allo_boss_gpio_mute(struct snd_soc_card *card)
 {
 	if (mute_gpio)
@@ -281,9 +273,6 @@ static int snd_allo_boss_hw_params(
 {
 	int ret = 0;
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
-	unsigned int sample_bits =
-		snd_pcm_format_physical_width(params_format(params));
 
 	if (snd_soc_allo_boss_master) {
 		struct snd_soc_codec *codec = rtd->codec;
@@ -291,13 +280,8 @@ static int snd_allo_boss_hw_params(
 		snd_allo_boss_set_sclk(codec,
 			params_rate(params));
 
-		ret = snd_allo_boss_set_bclk_ratio_pro(cpu_dai,
-			params);
-		if (!ret)
-			ret = snd_allo_boss_update_rate_den(
-				substream, params);
-	} else {
-		ret = snd_soc_dai_set_bclk_ratio(cpu_dai, sample_bits * 2);
+		ret = snd_allo_boss_update_rate_den(
+			substream, params);
 	}
 	return ret;
 }

--- a/sound/soc/bcm/allo-piano-dac-plus.c
+++ b/sound/soc/bcm/allo-piano-dac-plus.c
@@ -795,9 +795,6 @@ static int snd_allo_piano_dac_hw_params(
 		struct snd_pcm_hw_params *params)
 {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
-	unsigned int sample_bits =
-		snd_pcm_format_physical_width(params_format(params));
 	unsigned int rate = params_rate(params);
 	struct snd_soc_card *card = rtd->card;
 	struct glb_pool *glb_ptr = card->drvdata;
@@ -838,8 +835,6 @@ static int snd_allo_piano_dac_hw_params(
 						glb_ptr->set_lowpass);
 	if (ret < 0)
 		return ret;
-
-	ret = snd_soc_dai_set_bclk_ratio(cpu_dai, sample_bits * 2);
 
 	return ret;
 }

--- a/sound/soc/bcm/allo-piano-dac.c
+++ b/sound/soc/bcm/allo-piano-dac.c
@@ -42,23 +42,6 @@ static int snd_allo_piano_dac_init(struct snd_soc_pcm_runtime *rtd)
 	return 0;
 }
 
-static int snd_allo_piano_dac_hw_params(
-	struct snd_pcm_substream *substream, struct snd_pcm_hw_params *params)
-{
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
-
-	unsigned int sample_bits =
-		snd_pcm_format_physical_width(params_format(params));
-
-	return snd_soc_dai_set_bclk_ratio(cpu_dai, sample_bits * 2);
-}
-
-/* machine stream operations */
-static struct snd_soc_ops snd_allo_piano_dac_ops = {
-	.hw_params = snd_allo_piano_dac_hw_params,
-};
-
 static struct snd_soc_dai_link snd_allo_piano_dac_dai[] = {
 {
 	.name		= "Piano DAC",
@@ -70,7 +53,6 @@ static struct snd_soc_dai_link snd_allo_piano_dac_dai[] = {
 	.dai_fmt	= SND_SOC_DAIFMT_I2S |
 			  SND_SOC_DAIFMT_NB_NF |
 			  SND_SOC_DAIFMT_CBS_CFS,
-	.ops		= &snd_allo_piano_dac_ops,
 	.init		= snd_allo_piano_dac_init,
 },
 };

--- a/sound/soc/bcm/dionaudio_loco-v2.c
+++ b/sound/soc/bcm/dionaudio_loco-v2.c
@@ -41,24 +41,6 @@ static int snd_rpi_dionaudio_loco_v2_init(struct snd_soc_pcm_runtime *rtd)
 	return 0;
 }
 
-static int snd_rpi_dionaudio_loco_v2_hw_params(
-	struct snd_pcm_substream *substream,
-	struct snd_pcm_hw_params *params)
-{
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
-
-	unsigned int sample_bits =
-		snd_pcm_format_physical_width(params_format(params));
-
-	return snd_soc_dai_set_bclk_ratio(cpu_dai, sample_bits * 2);
-}
-
-/* machine stream operations */
-static struct snd_soc_ops snd_rpi_dionaudio_loco_v2_ops = {
-	.hw_params = snd_rpi_dionaudio_loco_v2_hw_params,
-};
-
 static struct snd_soc_dai_link snd_rpi_dionaudio_loco_v2_dai[] = {
 {
 	.name		= "DionAudio LOCO-V2",
@@ -69,7 +51,6 @@ static struct snd_soc_dai_link snd_rpi_dionaudio_loco_v2_dai[] = {
 	.codec_name	= "pcm512x.1-004d",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
 			  SND_SOC_DAIFMT_CBS_CFS,
-	.ops		= &snd_rpi_dionaudio_loco_v2_ops,
 	.init		= snd_rpi_dionaudio_loco_v2_init,
 },};
 

--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -216,20 +216,11 @@ static int snd_rpi_hifiberry_dacplus_update_rate_den(
 	return 0;
 }
 
-static int snd_rpi_hifiberry_dacplus_set_bclk_ratio_pro(
-	struct snd_soc_dai *cpu_dai, struct snd_pcm_hw_params *params)
-{
-	int bratio = snd_pcm_format_physical_width(params_format(params))
-		* params_channels(params);
-	return snd_soc_dai_set_bclk_ratio(cpu_dai, bratio);
-}
-
 static int snd_rpi_hifiberry_dacplus_hw_params(
 	struct snd_pcm_substream *substream, struct snd_pcm_hw_params *params)
 {
-	int ret;
+	int ret = 0;
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
 
 	if (snd_rpi_hifiberry_is_dacpro) {
 		struct snd_soc_codec *codec = rtd->codec;
@@ -237,13 +228,8 @@ static int snd_rpi_hifiberry_dacplus_hw_params(
 		snd_rpi_hifiberry_dacplus_set_sclk(codec,
 			params_rate(params));
 
-		ret = snd_rpi_hifiberry_dacplus_set_bclk_ratio_pro(cpu_dai,
-			params);
-		if (!ret)
-			ret = snd_rpi_hifiberry_dacplus_update_rate_den(
-				substream, params);
-	} else {
-		ret = snd_soc_dai_set_bclk_ratio(cpu_dai, 64);
+		ret = snd_rpi_hifiberry_dacplus_update_rate_den(
+			substream, params);
 	}
 	return ret;
 }

--- a/sound/soc/bcm/iqaudio-dac.c
+++ b/sound/soc/bcm/iqaudio-dac.c
@@ -43,18 +43,6 @@ static int snd_rpi_iqaudio_dac_init(struct snd_soc_pcm_runtime *rtd)
 	return 0;
 }
 
-static int snd_rpi_iqaudio_dac_hw_params(struct snd_pcm_substream *substream,
-	struct snd_pcm_hw_params *params)
-{
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
-
-	unsigned int sample_bits =
-		snd_pcm_format_physical_width(params_format(params));
-
-	return snd_soc_dai_set_bclk_ratio(cpu_dai, sample_bits * 2);
-}
-
 static void snd_rpi_iqaudio_gpio_mute(struct snd_soc_card *card)
 {
 	if (mute_gpio) {
@@ -109,11 +97,6 @@ static int snd_rpi_iqaudio_set_bias_level(struct snd_soc_card *card,
 	return 0;
 }
 
-/* machine stream operations */
-static struct snd_soc_ops snd_rpi_iqaudio_dac_ops = {
-	.hw_params = snd_rpi_iqaudio_dac_hw_params,
-};
-
 static struct snd_soc_dai_link snd_rpi_iqaudio_dac_dai[] = {
 {
 	.cpu_dai_name	= "bcm2708-i2s.0",
@@ -122,7 +105,6 @@ static struct snd_soc_dai_link snd_rpi_iqaudio_dac_dai[] = {
 	.codec_name	= "pcm512x.1-004c",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
 				SND_SOC_DAIFMT_CBS_CFS,
-	.ops		= &snd_rpi_iqaudio_dac_ops,
 	.init		= snd_rpi_iqaudio_dac_init,
 },
 };

--- a/sound/soc/bcm/justboom-dac.c
+++ b/sound/soc/bcm/justboom-dac.c
@@ -49,17 +49,6 @@ static int snd_rpi_justboom_dac_init(struct snd_soc_pcm_runtime *rtd)
 	return 0;
 }
 
-static int snd_rpi_justboom_dac_hw_params(struct snd_pcm_substream *substream,
-				       struct snd_pcm_hw_params *params)
-{
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
-	/*return snd_soc_dai_set_bclk_ratio(cpu_dai, 64);*/
-	unsigned int sample_bits =
-		snd_pcm_format_physical_width(params_format(params));
-	return snd_soc_dai_set_bclk_ratio(cpu_dai, sample_bits * 2);
-}
-
 static int snd_rpi_justboom_dac_startup(struct snd_pcm_substream *substream) {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	struct snd_soc_codec *codec = rtd->codec;
@@ -75,7 +64,6 @@ static void snd_rpi_justboom_dac_shutdown(struct snd_pcm_substream *substream) {
 
 /* machine stream operations */
 static struct snd_soc_ops snd_rpi_justboom_dac_ops = {
-	.hw_params = snd_rpi_justboom_dac_hw_params,
 	.startup = snd_rpi_justboom_dac_startup,
 	.shutdown = snd_rpi_justboom_dac_shutdown,
 };

--- a/sound/soc/bcm/raspidac3.c
+++ b/sound/soc/bcm/raspidac3.c
@@ -68,19 +68,6 @@ static int snd_rpi_raspidac3_init(struct snd_soc_pcm_runtime *rtd)
 	return 0;
 }
 
-/* set hw parameters */
-static int snd_rpi_raspidac3_hw_params(struct snd_pcm_substream *substream,
-				       struct snd_pcm_hw_params *params)
-{
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
-
-	unsigned int sample_bits =
-		snd_pcm_format_physical_width(params_format(params));
-
-	return snd_soc_dai_set_bclk_ratio(cpu_dai, sample_bits * 2);
-}
-
 /* startup */
 static int snd_rpi_raspidac3_startup(struct snd_pcm_substream *substream) {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
@@ -98,7 +85,6 @@ static void snd_rpi_raspidac3_shutdown(struct snd_pcm_substream *substream) {
 
 /* machine stream operations */
 static struct snd_soc_ops snd_rpi_raspidac3_ops = {
-	.hw_params = snd_rpi_raspidac3_hw_params,
 	.startup = snd_rpi_raspidac3_startup,
 	.shutdown = snd_rpi_raspidac3_shutdown,
 };

--- a/sound/soc/codecs/pcm512x.c
+++ b/sound/soc/codecs/pcm512x.c
@@ -851,8 +851,7 @@ static int pcm512x_set_dividers(struct snd_soc_dai *dai,
 	int fssp;
 	int gpio;
 
-	lrclk_div = snd_pcm_format_physical_width(params_format(params))
-		* params_channels(params);
+	lrclk_div = snd_soc_params_to_frame_size(params);
 	if (lrclk_div == 0) {
 		dev_err(dev, "No LRCLK?\n");
 		return -EINVAL;


### PR DESCRIPTION
This reverts the pcm512x downstream changes introduced in commit 185ea05465aac8bf02a0d2b2f4289d42c72870b7 / PR #1152

The downstream pcm512x changes caused a regression, it broke normal use of the 24bit format with the codec, eg when using simple-audio-card.

The actual bug with 24bit playback is the incorrect usage of physical_width in various drivers in the downstream tree which causes 24bit data to be transmitted with 32 clock cycles. So it's not the pcm512x that needs fixing, it's the soundcard drivers.

I had a go at fixing all the pcm512x based soundcard drivers. Actually using the codec driver as it was intended to be used simplified them quite a bit as I could remove all those set_bclk_ratio calls (and in some cases hw_params / ops as all they did was call set_bclk_ratio).

I've successfully tested 16, 24 and 32bit playback with the IQaudio DAC+ and JustBoom DAC cards. But as I don't have any of the other pcm512x based cards here some more testing and feedback would be welcome - not sure if I got all the soundcard drivers right.

@hifiberry could you check if this works with your DAC+ and DAC pro cards? The non-pro case in your hifiberry_dacplus driver looked rather odd to me - setting bclk ratio to a fixed value of 64 should have broken 16-bit playback IMHO. The allo-boss driver which seems to be a clone of the dacplus driver uses 2 * physical_width in the non-master case (which would be your non-pro case) - which looks more sensible to me.

@iqaudio @shawaj @babuenir @clivem @allocom @miquel83blauw @jgrulich it would be great if you could test this with your pcm512x based cards as well.