### PR TITLE
Fix added to solve CPU stall while calling  set frontend of Hauppauge WinTV-HVR-950Q dvb tuner.

### DIFF
--- a/drivers/media/usb/au0828/au0828-dvb.c
+++ b/drivers/media/usb/au0828/au0828-dvb.c
@@ -353,8 +353,6 @@ static int au0828_set_frontend(struct dvb_frontend *fe)
 	mutex_lock(&dvb->lock);
 	was_streaming = dev->urb_streaming;
 	if (was_streaming) {
-		au0828_stop_transport(dev, 1);
-
 		/*
 		 * We can't hold a mutex here, as the restart_streaming
 		 * kthread may also hold it.
@@ -364,6 +362,7 @@ static int au0828_set_frontend(struct dvb_frontend *fe)
 		mutex_lock(&dvb->lock);
 
 		stop_urb_transfer(dev);
+		au0828_stop_transport(dev, 1);
 	}
 	mutex_unlock(&dvb->lock);
 


### PR DESCRIPTION
This issue is occurring if we do the section filtering and tuning in parallel.
After changing the transport stopping sequence, issue is not happening.

Signed-off-by: Haseenamol <haseenamol@tataelxsi.co.in>