### PR TITLE
Generic Rotary Encoder overlay for multiple instances

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1321,9 +1321,9 @@ Params: <None>
 Name:   rotary-encoder
 Info:   Overlay for GPIO connected rotary encoder.
 Load:   dtoverlay=rotary-encoder,<param>=<val>
-Params: rotary0_pin_a           GPIO connected to rotary encoder channel A
+Params: pin_a                   GPIO connected to rotary encoder channel A
                                 (default 4).
-        rotary0_pin_b           GPIO connected to rotary encoder channel B
+        pin_b                   GPIO connected to rotary encoder channel B
                                 (default 17).
         relative_axis           register a relative axis rather than an
                                 absolute one. Relative axis will only

--- a/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
@@ -38,8 +38,8 @@
 	__overrides__ {
 		pin_a =             <&rotary>,"gpios:4",
 		                    <&rotary_pins>,"brcm,pins:0",
-                            <&rotary>,"reg:0",  /* modify reg values to allow multiple instantiation */  
-                            <&rotary_pins>,"reg:0"; 
+                                    <&rotary>,"reg:0",  /* modify reg values to allow multiple instantiation */  
+                                    <&rotary_pins>,"reg:0"; 
 		pin_b =             <&rotary>,"gpios:16",
 		                    <&rotary_pins>,"brcm,pins:4";
 		relative_axis =     <&rotary>,"rotary-encoder,relative-axis?";

--- a/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
@@ -8,7 +8,7 @@
 	fragment@0 {
 		target = <&gpio>;
 		__overlay__ {
-			rotary_pins: rotary_pins@0 {
+			rotary_pins: rotary_pins@4 {
 				brcm,pins = <4 17>; /* gpio 4 17 */
 				brcm,function = <0 0>; /* input */
 				brcm,pull = <2 2>; /* pull-up */
@@ -20,7 +20,7 @@
 	fragment@1 {
 		target-path = "/";
 		__overlay__ {
-			rotary: rotary@0 {
+			rotary: rotary@4 {
 				compatible = "rotary-encoder";
 				status = "okay";
 				pinctrl-names = "default";

--- a/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
@@ -8,7 +8,7 @@
 	fragment@0 {
 		target = <&gpio>;
 		__overlay__ {
-			rotary0_pins: rotary0_pins {
+			rotary_pins: rotary_pins@0 {
 				brcm,pins = <4 17>; /* gpio 4 17 */
 				brcm,function = <0 0>; /* input */
 				brcm,pull = <2 2>; /* pull-up */
@@ -20,11 +20,11 @@
 	fragment@1 {
 		target-path = "/";
 		__overlay__ {
-			rotary0: rotary@0 {
+			rotary: rotary@0 {
 					compatible = "rotary-encoder";
 					status = "okay";
 					pinctrl-names = "default";
-					pinctrl-0 = <&rotary0_pins>;
+					pinctrl-0 = <&rotary_pins>;
 					gpios = <&gpio 4 0>, <&gpio 17 0>;
 					linux,axis = <0>; /* REL_X */
 					rotary-encoder,encoding = "gray";
@@ -36,16 +36,18 @@
 	};  
 
 	__overrides__ {
-		rotary0_pin_a =     <&rotary0>,"gpios:4",
-		                    <&rotary0_pins>,"brcm,pins:0";
-		rotary0_pin_b =     <&rotary0>,"gpios:16",
-		                    <&rotary0_pins>,"brcm,pins:4";
-		relative_axis =     <&rotary0>,"rotary-encoder,relative-axis?";
-		linux_axis =        <&rotary0>,"linux,axis:0";
-		rollover =          <&rotary0>,"rotary-encoder,rollover?";
-		steps-per-period =  <&rotary0>,"rotary-encoder,steps-per-period:0";
-		steps =             <&rotary0>,"rotary-encoder,steps:0";
-		wakeup =            <&rotary0>,"wakeup-source?";
-		encoding =          <&rotary0>,"rotary-encoder,encoding";
+		pin_a =             <&rotary>,"gpios:4",
+		                    <&rotary_pins>,"brcm,pins:0",
+                            <&rotary>,"reg:0",  /* modify reg values to allow multiple instantiation */  
+                            <&rotary_pins>,"reg:0"; 
+		pin_b =             <&rotary>,"gpios:16",
+		                    <&rotary_pins>,"brcm,pins:4";
+		relative_axis =     <&rotary>,"rotary-encoder,relative-axis?";
+		linux_axis =        <&rotary>,"linux,axis:0";
+		rollover =          <&rotary>,"rotary-encoder,rollover?";
+		steps-per-period =  <&rotary>,"rotary-encoder,steps-per-period:0";
+		steps =             <&rotary>,"rotary-encoder,steps:0";
+		wakeup =            <&rotary>,"wakeup-source?";
+		encoding =          <&rotary>,"rotary-encoder,encoding";
 	};  
 };

--- a/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rotary-encoder-overlay.dts
@@ -21,27 +21,28 @@
 		target-path = "/";
 		__overlay__ {
 			rotary: rotary@0 {
-					compatible = "rotary-encoder";
-					status = "okay";
-					pinctrl-names = "default";
-					pinctrl-0 = <&rotary_pins>;
-					gpios = <&gpio 4 0>, <&gpio 17 0>;
-					linux,axis = <0>; /* REL_X */
-					rotary-encoder,encoding = "gray";
-					rotary-encoder,steps = <24>; /* 24 default */
-					rotary-encoder,steps-per-period = <1>; /* corresponds to full period mode. See README */
+				compatible = "rotary-encoder";
+				status = "okay";
+				pinctrl-names = "default";
+				pinctrl-0 = <&rotary_pins>;
+				gpios = <&gpio 4 0>, <&gpio 17 0>;
+				linux,axis = <0>; /* REL_X */
+				rotary-encoder,encoding = "gray";
+				rotary-encoder,steps = <24>; /* 24 default */
+				rotary-encoder,steps-per-period = <1>; /* corresponds to full period mode. See README */
 			};
 		};
 
 	};  
 
 	__overrides__ {
-		pin_a =             <&rotary>,"gpios:4",
-		                    <&rotary_pins>,"brcm,pins:0",
-                                    <&rotary>,"reg:0",  /* modify reg values to allow multiple instantiation */  
-                                    <&rotary_pins>,"reg:0"; 
-		pin_b =             <&rotary>,"gpios:16",
-		                    <&rotary_pins>,"brcm,pins:4";
+		pin_a =		    <&rotary>,"gpios:4",
+				    <&rotary_pins>,"brcm,pins:0",
+				    /* modify reg values to allow multiple instantiation */
+				    <&rotary>,"reg:0",
+				    <&rotary_pins>,"reg:0";
+		pin_b =		    <&rotary>,"gpios:16",
+				    <&rotary_pins>,"brcm,pins:4";
 		relative_axis =     <&rotary>,"rotary-encoder,relative-axis?";
 		linux_axis =        <&rotary>,"linux,axis:0";
 		rollover =          <&rotary>,"rotary-encoder,rollover?";
@@ -49,5 +50,10 @@
 		steps =             <&rotary>,"rotary-encoder,steps:0";
 		wakeup =            <&rotary>,"wakeup-source?";
 		encoding =          <&rotary>,"rotary-encoder,encoding";
-	};  
+                /* legacy parameters*/
+		rotary0_pin_a =     <&rotary>,"gpios:4",
+		                    <&rotary_pins>,"brcm,pins:0";
+		rotary0_pin_b =     <&rotary>,"gpios:16",
+		                    <&rotary_pins>,"brcm,pins:4";
+	};
 };


### PR DESCRIPTION
A slightly modified `rotary-encoder-overlay` to allow multiple instances.
It make use of the `<reg>` property, similar to the `gpio-keys-overlay`, bounded to the `pin_a` parameter.

Then, it is possible to attach multiple rotary encoders to different pins, like the following example:
```
dtoverlay=rotary-encoder,pin_a=13,pin_b=19,relative_axis
dtoverlay=rotary-encoder,pin_a=22,pin_b=27,relative_axis,linux_axis=1
```

Parameters `rotary0_pin_a` and `rotary0_pin_b` are renamed to just `pin_a` and `pin_b` since they do not only refer to one rotary node only.