### PR TITLE
overlays: Add overlay for missing AUX interrupt controller support

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -122,7 +122,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	tinylcd35.dtbo \
 	uart0.dtbo \
 	uart1.dtbo \
-	upstream-aux-interrupt-overlay.dtbo \
+	upstream-aux-interrupt.dtbo \
 	vc4-fkms-v3d.dtbo \
 	vc4-kms-v3d.dtbo \
 	vga666.dtbo \

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -122,6 +122,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	tinylcd35.dtbo \
 	uart0.dtbo \
 	uart1.dtbo \
+	upstream-aux-interrupt-overlay.dtbo \
 	vc4-fkms-v3d.dtbo \
 	vc4-kms-v3d.dtbo \
 	vga666.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1717,6 +1717,13 @@ Params: txd1_pin                GPIO pin for TXD1 (14, 32 or 40 - default 14)
         rxd1_pin                GPIO pin for RXD1 (15, 33 or 41 - default 15)
 
 
+Name:   upstream-aux-interrupt
+Info:   Allow usage of downstream .dtb with upstream kernel by binding AUX
+        devices directly to the shared AUX interrupt line.
+Load:   dtoverlay=upstream-aux-interrupt
+Params: <None>
+
+
 Name:   vc4-fkms-v3d
 Info:   Enable Eric Anholt's DRM VC4 V3D driver on top of the dispmanx
         display stack.

--- a/arch/arm/boot/dts/overlays/upstream-aux-interrupt-overlay.dts
+++ b/arch/arm/boot/dts/overlays/upstream-aux-interrupt-overlay.dts
@@ -1,0 +1,33 @@
+// Overlay for missing AUX interrupt controller
+// Instead we bind all AUX devices to the generic AUX interrupt line
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "brcm,bcm2708";
+
+    fragment@0 {
+        target = <&uart1>;
+        __overlay__ {
+            interrupt-parent = <&intc>;
+            interrupts = <0x1 0x1d>;
+        };
+    };
+
+    fragment@1 {
+        target = <&spi1>;
+        __overlay__ {
+            interrupt-parent = <&intc>;
+            interrupts = <0x1 0x1d>;
+        };
+    };
+
+    fragment@2 {
+        target = <&spi2>;
+        __overlay__ {
+            interrupt-parent = <&intc>;
+            interrupts = <0x1 0x1d>;
+        };
+    };
+};
+


### PR DESCRIPTION
Upstream Linux today does not support the AUX interrupt controller
yet. To make sure it can use our device tree, add an overlay that
reverts it to something upstream understands again.

See: raspberrypi/firmware#943
