### PR TITLE
overlays: Add overlay to run an upstream kernel

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -123,6 +123,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	tinylcd35.dtbo \
 	uart0.dtbo \
 	uart1.dtbo \
+	upstream.dtbo \
 	upstream-aux-interrupt.dtbo \
 	vc4-fkms-v3d.dtbo \
 	vc4-kms-v3d.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1737,6 +1737,25 @@ Load:   dtoverlay=upstream-aux-interrupt
 Params: <None>
 
 
+Name:   upstream
+Info:   Allow usage of downstream .dtb with upstream kernel. Apply this if
+        you want to run an upstream kernel.
+        This overlay combines the dwc2, vc4-kms-v3d and upstream-aux-interrupt
+        overlays into one convenience overlay.
+Load:   dtoverlay=upstream,<param>
+Params: --- from dwc2 ---
+        dr_mode                 Dual role mode: "host", "peripheral" or "otg"
+        g-rx-fifo-size          Size of rx fifo size in gadget mode
+        g-np-tx-fifo-size       Size of non-periodic tx fifo size in gadget
+                                mode
+        --- from vc4-kms-v3d ---
+        cma-256                 CMA is 256MB, 256MB-aligned (needs 1GB)
+        cma-192                 CMA is 192MB, 256MB-aligned (needs 1GB)
+        cma-128                 CMA is 128MB, 128MB-aligned
+        cma-96                  CMA is 96MB, 128MB-aligned
+        cma-64                  CMA is 64MB, 64MB-aligned
+
+
 Name:   vc4-fkms-v3d
 Info:   Enable Eric Anholt's DRM VC4 V3D driver on top of the dispmanx
         display stack.

--- a/arch/arm/boot/dts/overlays/upstream-overlay.dts
+++ b/arch/arm/boot/dts/overlays/upstream-overlay.dts
@@ -1,0 +1,164 @@
+// redo: ovmerge -c vc4-kms-v3d-overlay.dts dwc2-overlay.dts upstream-aux-interrupt-overlay.dts
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/bcm2835.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+	fragment@0 {
+		target-path = "/chosen";
+		__overlay__ {
+			bootargs = "cma=256M";
+		};
+	};
+	fragment@1 {
+		target-path = "/chosen";
+		__dormant__ {
+			bootargs = "cma=192M";
+		};
+	};
+	fragment@2 {
+		target-path = "/chosen";
+		__dormant__ {
+			bootargs = "cma=128M";
+		};
+	};
+	fragment@3 {
+		target-path = "/chosen";
+		__dormant__ {
+			bootargs = "cma=96M";
+		};
+	};
+	fragment@4 {
+		target-path = "/chosen";
+		__dormant__ {
+			bootargs = "cma=64M";
+		};
+	};
+	fragment@5 {
+		target = <&i2c2>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+	fragment@6 {
+		target = <&fb>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+	fragment@7 {
+		target = <&pixelvalve0>;
+		__overlay__ {
+			interrupts = <2 13>;
+			status = "okay";
+		};
+	};
+	fragment@8 {
+		target = <&pixelvalve1>;
+		__overlay__ {
+			interrupts = <2 14>;
+			status = "okay";
+		};
+	};
+	fragment@9 {
+		target = <&pixelvalve2>;
+		__overlay__ {
+			interrupts = <2 10>;
+			status = "okay";
+		};
+	};
+	fragment@10 {
+		target = <&hvs>;
+		__overlay__ {
+			interrupts = <2 1>;
+			status = "okay";
+		};
+	};
+	fragment@11 {
+		target = <&hdmi>;
+		__overlay__ {
+			interrupts = <2 8>, <2 9>;
+			status = "okay";
+		};
+	};
+	fragment@12 {
+		target = <&v3d>;
+		__overlay__ {
+			interrupts = <1 10>;
+			status = "okay";
+		};
+	};
+	fragment@13 {
+		target = <&vc4>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+	fragment@14 {
+		target-path = "/soc/dma";
+		__overlay__ {
+			brcm,dma-channel-mask = <0x7f35>;
+		};
+	};
+	fragment@15 {
+		target = <&clocks>;
+		__overlay__ {
+			claim-clocks = <BCM2835_PLLD_DSI0 BCM2835_PLLD_DSI1 BCM2835_PLLH_AUX BCM2835_PLLH_PIX>;
+		};
+	};
+	fragment@16 {
+		target = <&vec>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+	fragment@17 {
+		target = <&usb>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		dwc2_usb: __overlay__ {
+			compatible = "brcm,bcm2835-usb";
+			reg = <0x7e980000 0x10000>;
+			interrupts = <1 9>;
+			dr_mode = "otg";
+			g-np-tx-fifo-size = <32>;
+			g-rx-fifo-size = <256>;
+			g-tx-fifo-size = <512 512 512 512 512 768>;
+			status = "okay";
+		};
+	};
+	fragment@18 {
+		target = <&uart1>;
+		__overlay__ {
+			interrupt-parent = <&intc>;
+			interrupts = <0x1 0x1d>;
+		};
+	};
+	fragment@19 {
+		target = <&spi1>;
+		__overlay__ {
+			interrupt-parent = <&intc>;
+			interrupts = <0x1 0x1d>;
+		};
+	};
+	fragment@20 {
+		target = <&spi2>;
+		__overlay__ {
+			interrupt-parent = <&intc>;
+			interrupts = <0x1 0x1d>;
+		};
+	};
+	__overrides__ {
+		cma-256 = <0>, "+0-1-2-3-4";
+		cma-192 = <0>, "-0+1-2-3-4";
+		cma-128 = <0>, "-0-1+2-3-4";
+		cma-96 = <0>, "-0-1-2+3-4";
+		cma-64 = <0>, "-0-1-2-3+4";
+		dr_mode = <&dwc2_usb>, "dr_mode";
+		g-np-tx-fifo-size = <&dwc2_usb>, "g-np-tx-fifo-size:0";
+		g-rx-fifo-size = <&dwc2_usb>, "g-rx-fifo-size:0";
+	};
+};


### PR DESCRIPTION
The difference between upstream and downstream device trees is
marginal by now. This overlay combines all overlays required to
make the downstream device tree upstream compatible.

See: https://github.com/raspberrypi/firmware/issues/943

The idea behind this overlay is that the RPi firmware can then
based on the upstream flag apply this overlay automatically,
providing kernels that need to follow upstream bindings (like
U-Boot) with a device tree to work against.

Signed-off-by: Alexander Graf <agraf@suse.de>