### PR TITLE
firmware/raspberrypi: Add a get_throttled sysfs file

### DIFF
--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -14,6 +14,7 @@
 #include <linux/module.h>
 #include <linux/of_platform.h>
 #include <linux/platform_device.h>
+#include <linux/workqueue.h>
 #include <soc/bcm2835/raspberrypi-firmware.h>
 
 #define MBOX_MSG(chan, data28)		(((data28) & ~0xf) | ((chan) & 0xf))
@@ -21,11 +22,14 @@
 #define MBOX_DATA28(msg)		((msg) & ~0xf)
 #define MBOX_CHAN_PROPERTY		8
 
+#define UNDERVOLTAGE_BIT		BIT(0)
+
 struct rpi_firmware {
 	struct mbox_client cl;
 	struct mbox_chan *chan; /* The property channel. */
 	struct completion c;
 	u32 enabled;
+	struct delayed_work get_throttled_poll_work;
 };
 
 static struct platform_device *g_pdev;
@@ -166,6 +170,101 @@ int rpi_firmware_property(struct rpi_firmware *fw,
 }
 EXPORT_SYMBOL_GPL(rpi_firmware_property);
 
+static int rpi_firmware_get_throttled(struct rpi_firmware *fw, u32 *value)
+{
+	static ktime_t old_timestamp;
+	static u32 old_value;
+	u32 new_sticky, old_sticky, new_uv, old_uv;
+	ktime_t new_timestamp;
+	s64 elapsed_ms;
+	int ret;
+
+	if (!fw)
+		return -EBUSY;
+
+	/*
+	 * We can't run faster than the sticky shift (100ms) since we get
+	 * flipping in the sticky bits that are cleared.
+	 * This happens on polling, so just return the previous value.
+	 */
+	new_timestamp = ktime_get();
+	elapsed_ms = ktime_ms_delta(new_timestamp, old_timestamp);
+	if (elapsed_ms < 150) {
+		*value = old_value;
+		return 0;
+	}
+	old_timestamp = new_timestamp;
+
+	/* Clear sticky bits */
+	*value = 0xffff;
+
+	ret = rpi_firmware_property(fw, RPI_FIRMWARE_GET_THROTTLED,
+				    value, sizeof(*value));
+	if (ret)
+		return ret;
+
+	new_sticky = *value >> 16;
+	old_sticky = old_value >> 16;
+	old_value = *value;
+
+	/* Only notify about changes in the sticky bits */
+	if (new_sticky == old_sticky)
+		return 0;
+
+	new_uv = new_sticky & UNDERVOLTAGE_BIT;
+	old_uv = old_sticky & UNDERVOLTAGE_BIT;
+
+	if (new_uv != old_uv) {
+		if (new_uv)
+			pr_crit("Under-voltage detected! (0x%08x)\n", *value);
+		else
+			pr_info("Voltage normalised (0x%08x)\n", *value);
+	}
+
+	sysfs_notify(&fw->cl.dev->kobj, NULL, "get_throttled");
+
+	return 0;
+}
+
+static void get_throttled_poll(struct work_struct *work)
+{
+	struct rpi_firmware *fw = container_of(work, struct rpi_firmware,
+					       get_throttled_poll_work.work);
+	u32 dummy;
+	int ret;
+
+	ret = rpi_firmware_get_throttled(fw, &dummy);
+	if (ret)
+		pr_debug("%s: Failed to read value (%d)", __func__, ret);
+
+	schedule_delayed_work(&fw->get_throttled_poll_work, 2 * HZ);
+}
+
+static ssize_t get_throttled_show(struct device *dev,
+				  struct device_attribute *attr, char *buf)
+{
+	struct rpi_firmware *fw = dev_get_drvdata(dev);
+	u32 value;
+	int ret;
+
+	ret = rpi_firmware_get_throttled(fw, &value);
+	if (ret)
+		return ret;
+
+	return sprintf(buf, "%x\n", value);
+}
+
+static DEVICE_ATTR_RO(get_throttled);
+
+static struct attribute *rpi_firmware_dev_attrs[] = {
+	&dev_attr_get_throttled.attr,
+	NULL,
+};
+
+static const struct attribute_group rpi_firmware_dev_group = {
+	.attrs = rpi_firmware_dev_attrs,
+};
+
 static void
 rpi_firmware_print_firmware_revision(struct rpi_firmware *fw)
 {
@@ -190,6 +289,11 @@ static int rpi_firmware_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
 	struct rpi_firmware *fw;
+	int ret;
+
+	ret = devm_device_add_group(dev, &rpi_firmware_dev_group);
+	if (ret)
+		return ret;
 
 	fw = devm_kzalloc(dev, sizeof(*fw), GFP_KERNEL);
 	if (!fw)
@@ -208,11 +312,14 @@ static int rpi_firmware_probe(struct platform_device *pdev)
 	}
 
 	init_completion(&fw->c);
+	INIT_DELAYED_WORK(&fw->get_throttled_poll_work, get_throttled_poll);
 
 	platform_set_drvdata(pdev, fw);
 	g_pdev = pdev;
 
 	rpi_firmware_print_firmware_revision(fw);
+
+	schedule_delayed_work(&fw->get_throttled_poll_work, 0);
 
 	return 0;
 }
@@ -221,6 +328,7 @@ static int rpi_firmware_remove(struct platform_device *pdev)
 {
 	struct rpi_firmware *fw = platform_get_drvdata(pdev);
 
+	cancel_delayed_work_sync(&fw->get_throttled_poll_work);
 	mbox_free_channel(fw->chan);
 	g_pdev = NULL;
 

--- a/include/soc/bcm2835/raspberrypi-firmware.h
+++ b/include/soc/bcm2835/raspberrypi-firmware.h
@@ -77,6 +77,7 @@ enum rpi_firmware_property_tag {
 	RPI_FIRMWARE_GET_EDID_BLOCK =                         0x00030020,
 	RPI_FIRMWARE_GET_CUSTOMER_OTP =                       0x00030021,
 	RPI_FIRMWARE_GET_DOMAIN_STATE =                       0x00030030,
+	RPI_FIRMWARE_GET_THROTTLED =                          0x00030046,
 	RPI_FIRMWARE_SET_CLOCK_STATE =                        0x00038001,
 	RPI_FIRMWARE_SET_CLOCK_RATE =                         0x00038002,
 	RPI_FIRMWARE_SET_VOLTAGE =                            0x00038003,


### PR DESCRIPTION
This is a result of the discussion in #2367.

Kernel log:
```
[  530.474085] Under-voltage detected! (0x00050005)
[  534.634106] Voltage normalised (0x00000000)
```

A simple script that polls on the sysfs file and shows the changes:
```python
import select
import datetime

epoll = select.epoll()

file = open("/sys/devices/platform/soc/soc:firmware/get_throttled")
epoll.register(file.fileno(), select.EPOLLPRI | select.EPOLLERR)
status = file.read()

while(True):
    epoll.poll()
    file.seek(0)
    status = file.read()
    get_throttled = int(status, 16)
    print("%s 0x%08x" % (datetime.datetime.now().strftime('%H:%M:%S'), get_throttled))

epoll.unregister(file.fileno())
file.close()

```

A simple proof of concept for desktop notification:
```python
import dbus
import select
import datetime
import signal

msg = """Under-voltage is blah blah not good.
See: http://some-explanation.org
"""

def quit(signo, _frame):
    exit(0)

for sig in ('TERM', 'HUP', 'INT'):
    signal.signal(getattr(signal, 'SIG'+sig), quit);

bus = dbus.SessionBus()
notifier = bus.get_object('org.freedesktop.Notifications', '/org/freedesktop/Notifications')
iface = dbus.Interface(notifier, 'org.freedesktop.Notifications')
nid = None

epoll = select.epoll()
file = open("/sys/devices/platform/soc/soc:firmware/get_throttled")
epoll.register(file.fileno(), select.EPOLLPRI | select.EPOLLERR)
status = file.read()

while(True):
    epoll.poll()
    file.seek(0)
    status = file.read()
    get_throttled = int(status, 16)

    if get_throttled & (1 << 16):
        try:
            nid = iface.Notify('get_throttled', 0, 'dialog-warning', 'Under-voltage!', msg, [], {}, 0)
        except dbus.exceptions.DBusException as e:
            sys.stderr.write("Error sending notification: %s\n" % e); sys.stderr.flush()
    elif nid:
        try: # The user might have closed it
            iface.CloseNotification(nid)
        except dbus.exceptions.DBusException:
            pass
        nid = None

epoll.unregister(file.fileno())
file.close()

```

dbus notification daemon (supports cancelling notifications):
```
sudo apt install dunst
```
