### PR TITLE
Fixing memset call in pisound.c

### DIFF
--- a/sound/soc/bcm/pisound.c
+++ b/sound/soc/bcm/pisound.c
@@ -313,7 +313,7 @@ static void spi_transfer(const uint8_t *txbuf, uint8_t *rxbuf, int len)
 	struct spi_transfer transfer;
 	struct spi_message msg;
 
-	memset(rxbuf, 0, sizeof(txbuf));
+	memset(rxbuf, 0, len);
 
 	if (!pisnd_spi_device) {
 		printe("pisnd_spi_device null, returning\n");


### PR DESCRIPTION
The incorrect call was causing a stack check fail kernel panic on Arch Linux. Strangely it was happening only on 4.14 versions, Arch Linux on 4.9 kernel with the same incorrect code was not triggering the panic.

With the fix included, I can confirm that Arch Linux on 4.14 works correctly.

I will open another pull request for the same change to be integrated to 4.14 branch.