### PR TITLE
[4.14] Fix GCC 6.4.0 and 7.3.0 warnings

### DIFF
--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_mlme_ext.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_mlme_ext.c
@@ -733,9 +733,10 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 		case WIFI_AUTH:
 			if(check_fwstate(pmlmepriv, WIFI_AP_STATE) == _TRUE)
 				ptable->func = &OnAuth;
+				/* falls through */
 			else
 				ptable->func = &OnAuthClient;
-			//pass through
+				/* falls through */
 		case WIFI_ASSOCREQ:
 		case WIFI_REASSOCREQ:
 			_mgt_dispatcher(padapter, ptable, precv_frame);

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_security.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_security.c
@@ -1477,7 +1477,7 @@ _func_enter_;
     bitwise_xor(aes_out, mic_header2, chain_buffer);
     aes128k128d(key, chain_buffer, aes_out);
 
-	for (i = 0; i < num_blocks; i++)
+    for (i = 0; i < num_blocks; i++)
     {
         bitwise_xor(aes_out, &pframe[payload_index], chain_buffer);//bitwise_xor(aes_out, &message[payload_index], chain_buffer);
 
@@ -1504,8 +1504,8 @@ _func_enter_;
     for (j = 0; j < 8; j++)
 	pframe[payload_index+j] = mic[j];	//message[payload_index+j] = mic[j];
 
-	payload_index = hdrlen + 8;
-	for (i=0; i< num_blocks; i++)
+    payload_index = hdrlen + 8;
+    for (i=0; i< num_blocks; i++)
     {
         construct_ctr_preload(
                                 ctr_preload,
@@ -1878,8 +1878,8 @@ _func_enter_;
     for (j = 0; j < 8; j++)
 	message[payload_index+j] = mic[j];
 
-	payload_index = hdrlen + 8;
-	for (i=0; i< num_blocks; i++)
+    payload_index = hdrlen + 8;
+    for (i=0; i< num_blocks; i++)
     {
         construct_ctr_preload(
                                 ctr_preload,

--- a/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/rtl8192c_phycfg.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/rtl8192c_phycfg.c
@@ -2363,6 +2363,7 @@ phy_TxPwrIdxToDbm(
 	case WIRELESS_MODE_G:
 	case WIRELESS_MODE_N_24G:
 		Offset = -8;
+		break;
 	default:
 		Offset = -8;
 		break;

--- a/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/usb/usb_halinit.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/usb/usb_halinit.c
@@ -5692,6 +5692,7 @@ _func_enter_;
 	{
 		case HW_VAR_BASIC_RATE:
 			*((u16 *)(val)) = pHalData->BasicRateSet;
+			/* falls through */
 		case HW_VAR_TXPAUSE:
 			val[0] = rtw_read8(Adapter, REG_TXPAUSE);
 			break;

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_cfg80211.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_cfg80211.c
@@ -820,6 +820,7 @@ static int set_group_key(_adapter *padapter, u8 *key, u8 alg, int keyid)
 		case _TKIP_WTMIC_:
 		case _AES_:
 			keylen = 16;
+			break;
 		default:
 			keylen = 16;
 	}

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_linux.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_linux.c
@@ -7381,6 +7381,7 @@ static int set_group_key(_adapter *padapter, u8 *key, u8 alg, int keyid)
 		case _TKIP_WTMIC_:
 		case _AES_:
 			keylen = 16;
+			break;
 		default:
 			keylen = 16;
 	}

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -1732,7 +1732,6 @@ vchiq_open(struct inode *inode, struct file *file)
 	vchiq_log_info(vchiq_arm_log_level, "vchiq_open");
 	switch (dev) {
 	case VCHIQ_MINOR: {
-		int ret;
 		VCHIQ_STATE_T *state = vchiq_get_state();
 		VCHIQ_INSTANCE_T instance;
 

--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
@@ -591,8 +591,8 @@ static int notrace noinline fiq_fsm_update_hs_isoc(struct fiq_state *state, int 
 		}
 
 	} else {
-		switch (st->hcchar_copy.b.multicnt) {
 		st->hctsiz_copy.b.xfersize = nrpackets * st->hcchar_copy.b.mps;
+		switch (st->hcchar_copy.b.multicnt) {
 		case 1:
 			st->hctsiz_copy.b.pid = DWC_PID_DATA0;
 			break;

--- a/sound/soc/bcm/allo-piano-dac-plus.c
+++ b/sound/soc/bcm/allo-piano-dac-plus.c
@@ -704,11 +704,10 @@ static int snd_allo_piano_dac_init(struct snd_soc_pcm_runtime *rtd)
 	struct snd_soc_card *card = rtd->card;
 	struct glb_pool *glb_ptr;
 
-	glb_ptr = kmalloc(sizeof(struct glb_pool), GFP_KERNEL);
+	glb_ptr = kzalloc(sizeof(struct glb_pool), GFP_KERNEL);
 	if (!glb_ptr)
 		return -ENOMEM;
 
-	memset(glb_ptr, 0x00, sizeof(glb_ptr));
 	card->drvdata = glb_ptr;
 	glb_ptr->dual_mode = 2;
 	glb_ptr->set_mode = 0;


### PR DESCRIPTION
I ran into these warnings on the latest 4.14 branch.

```bash
../drivers/net/wireless/realtek/rtl8192cu/core/rtw_security.c: In function ‘aes_cipher’:
../drivers/net/wireless/realtek/rtl8192cu/core/rtw_security.c:1504:5: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
     for (j = 0; j < 8; j++)
     ^~~
../drivers/net/wireless/realtek/rtl8192cu/core/rtw_security.c:1507:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘for’
  payload_index = hdrlen + 8;
  ^~~~~~~~~~~~~
../drivers/net/wireless/realtek/rtl8192cu/core/rtw_security.c: In function ‘aes_decipher’:
../drivers/net/wireless/realtek/rtl8192cu/core/rtw_security.c:1878:5: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
     for (j = 0; j < 8; j++)
     ^~~
../drivers/net/wireless/realtek/rtl8192cu/core/rtw_security.c:1881:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘for’
  payload_index = hdrlen + 8;
  ^~~~~~~~~~~~~
../drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c: In function ‘vchiq_open’:
../drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c:1735:7: warning: unused variable ‘ret’ [-Wunused-variable]
   int ret;
       ^~~
```
Pretty simple to fix and now `make > /dev/null` is clean.