### PR TITLE
[4.16] Fix outstanding GCC 6.4.0 and GCC 7.3.0 warnings

### DIFF
--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_ap.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_ap.c
@@ -210,7 +210,7 @@ void rtw_add_bcn_ie(_adapter *padapter, WLAN_BSSID_EX *pnetwork, u8 index, u8 *d
 	PNDIS_802_11_VARIABLE_IEs	pIE;
 	u8	bmatch = _FALSE;
 	u8	*pie = pnetwork->IEs;
-	u8	*p, *dst_ie, *premainder_ie=NULL, *pbackup_remainder_ie=NULL;
+	u8	*p=NULL, *dst_ie=NULL, *premainder_ie=NULL, *pbackup_remainder_ie=NULL;
 	u32	i, offset, ielen, ie_offset, remainder_ielen = 0;
 
 	for (i = sizeof(NDIS_802_11_FIXED_IEs); i < pnetwork->IELength;)
@@ -249,6 +249,9 @@ void rtw_add_bcn_ie(_adapter *padapter, WLAN_BSSID_EX *pnetwork, u8 index, u8 *d
 		else
 			dst_ie = (p+ielen);
 	}
+
+	if(dst_ie == NULL)
+		return;
 
 	if(remainder_ielen>0)
 	{
@@ -357,7 +360,7 @@ void	expire_timeout_chk(_adapter *padapter)
 {
 	_irqL irqL;
 	_list	*phead, *plist;
-	u8 updated;
+	u8 updated = _FALSE;
 	struct sta_info *psta=NULL;	
 	struct sta_priv *pstapriv = &padapter->stapriv;
 	u8 chk_alive_num = 0;

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_ieee80211.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_ieee80211.c
@@ -1859,7 +1859,8 @@ int rtw_action_frame_parse(const u8 *frame, u32 frame_len, u8* category, u8 *act
 {
 	const u8 *frame_body = frame + sizeof(struct rtw_ieee80211_hdr_3addr);
 	u16 fc;
-	u8 c, a;
+	u8 c;
+	u8 a = ACT_PUBLIC_MAX;
 
 	fc = le16_to_cpu(((struct rtw_ieee80211_hdr_3addr *)frame)->frame_ctl);
 

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_mlme_ext.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_mlme_ext.c
@@ -2454,7 +2454,7 @@ unsigned int OnDeAuth(_adapter *padapter, union recv_frame *precv_frame)
 		psta = rtw_get_stainfo(pstapriv, GetAddr2Ptr(pframe));	
 		if(psta)
 		{
-			u8 updated;
+			u8 updated = _FALSE;
 		
 			_enter_critical_bh(&pstapriv->asoc_list_lock, &irqL);
 			if(rtw_is_list_empty(&psta->asoc_list)==_FALSE)
@@ -2548,7 +2548,7 @@ unsigned int OnDisassoc(_adapter *padapter, union recv_frame *precv_frame)
 		psta = rtw_get_stainfo(pstapriv, GetAddr2Ptr(pframe));	
 		if(psta)
 		{
-			u8 updated;
+			u8 updated = _FALSE;
 			
 			_enter_critical_bh(&pstapriv->asoc_list_lock, &irqL);
 			if(rtw_is_list_empty(&psta->asoc_list)==_FALSE)
@@ -11932,7 +11932,7 @@ u8 setkey_hdl(_adapter *padapter, u8 *pbuf)
 u8 set_stakey_hdl(_adapter *padapter, u8 *pbuf)
 {
 	u16 ctrl=0;
-	u8 cam_id;//cam_entry
+	u8 cam_id=0;//cam_entry
 	struct mlme_ext_priv	*pmlmeext = &padapter->mlmeextpriv;
 	struct mlme_ext_info	*pmlmeinfo = &(pmlmeext->mlmext_info);
 	struct set_stakey_parm	*pparm = (struct set_stakey_parm *)pbuf;

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_mlme_ext.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_mlme_ext.c
@@ -733,9 +733,10 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 		case WIFI_AUTH:
 			if(check_fwstate(pmlmepriv, WIFI_AP_STATE) == _TRUE)
 				ptable->func = &OnAuth;
+				/* falls through */
 			else
 				ptable->func = &OnAuthClient;
-			//pass through
+				/* falls through */
 		case WIFI_ASSOCREQ:
 		case WIFI_REASSOCREQ:
 			_mgt_dispatcher(padapter, ptable, precv_frame);	

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_mlme_ext.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_mlme_ext.c
@@ -5663,7 +5663,7 @@ unsigned int on_action_public_p2p(union recv_frame *precv_frame)
 
 				//	Commented by Kurt 20120113
 				//	Get peer_dev_addr here if peer doesn't issue prov_disc frame.
-				if( _rtw_memcmp(pwdinfo->rx_prov_disc_info.peerDevAddr, empty_addr, ETH_ALEN) );
+				if( _rtw_memcmp(pwdinfo->rx_prov_disc_info.peerDevAddr, empty_addr, ETH_ALEN) )
 					_rtw_memcpy(pwdinfo->rx_prov_disc_info.peerDevAddr, GetAddr2Ptr(pframe), ETH_ALEN);
 
 				result = process_p2p_group_negotation_req( pwdinfo, frame_body, len );

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_p2p.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_p2p.c
@@ -4955,9 +4955,9 @@ void init_wifidirect_info( _adapter* padapter, enum P2P_ROLE role)
 #endif
 #ifdef CONFIG_CONCURRENT_MODE
 	_adapter				*pbuddy_adapter = padapter->pbuddy_adapter;
-	struct wifidirect_info	*pbuddy_wdinfo;
-	struct mlme_priv		*pbuddy_mlmepriv;
-	struct mlme_ext_priv	*pbuddy_mlmeext;
+	struct wifidirect_info	*pbuddy_wdinfo = NULL;
+	struct mlme_priv		*pbuddy_mlmepriv = NULL;
+	struct mlme_ext_priv	*pbuddy_mlmeext = NULL;
 #endif
 
 	pwdinfo = &padapter->wdinfo;

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_security.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_security.c
@@ -1477,7 +1477,7 @@ _func_enter_;
     bitwise_xor(aes_out, mic_header2, chain_buffer);
     aes128k128d(key, chain_buffer, aes_out);
 
-	for (i = 0; i < num_blocks; i++)
+    for (i = 0; i < num_blocks; i++)
     {
         bitwise_xor(aes_out, &pframe[payload_index], chain_buffer);//bitwise_xor(aes_out, &message[payload_index], chain_buffer);
 
@@ -1504,8 +1504,8 @@ _func_enter_;
     for (j = 0; j < 8; j++)
     	pframe[payload_index+j] = mic[j];	//message[payload_index+j] = mic[j];
 
-	payload_index = hdrlen + 8;
-	for (i=0; i< num_blocks; i++)
+    payload_index = hdrlen + 8;
+    for (i=0; i< num_blocks; i++)
     {
         construct_ctr_preload(
                                 ctr_preload,
@@ -1878,8 +1878,8 @@ _func_enter_;
     for (j = 0; j < 8; j++)
     	message[payload_index+j] = mic[j];
 
-	payload_index = hdrlen + 8;
-	for (i=0; i< num_blocks; i++)
+    payload_index = hdrlen + 8;
+    for (i=0; i< num_blocks; i++)
     {
         construct_ctr_preload(
                                 ctr_preload,

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_wlan_util.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_wlan_util.c
@@ -853,7 +853,7 @@ void flush_all_cam_entry(_adapter *padapter)
 		{
 			struct sta_priv	*pstapriv = &padapter->stapriv;
 			struct sta_info	*psta;
-			u8 cam_id;//cam_entry
+			u8 cam_id=0;//cam_entry
 
 			psta = rtw_get_stainfo(pstapriv, pmlmeinfo->network.MacAddress);
 			if(psta) {

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_xmit.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_xmit.c
@@ -2590,7 +2590,7 @@ exit:
 s32 rtw_free_xmitframe(struct xmit_priv *pxmitpriv, struct xmit_frame *pxmitframe)
 {	
 	_irqL irqL;
-	_queue *queue;
+	_queue *queue = NULL;
 	_adapter *padapter = pxmitpriv->adapter;
 	_pkt *pndis_pkt = NULL;
 

--- a/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/rtl8192c_phycfg.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/rtl8192c_phycfg.c
@@ -2363,6 +2363,7 @@ phy_TxPwrIdxToDbm(
 	case WIRELESS_MODE_G:
 	case WIRELESS_MODE_N_24G:
 		Offset = -8;
+		break;
 	default:
 		Offset = -8;	
 		break;

--- a/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/rtl8192c_rf6052.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/rtl8192c_rf6052.c
@@ -373,7 +373,7 @@ static void getTxPowerWriteValByRegulatory(
 {
 	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(Adapter);
 	struct dm_priv	*pdmpriv = &pHalData->dmpriv;
-	u8	i, chnlGroup, pwr_diff_limit[4];
+	u8	i, chnlGroup = 0, pwr_diff_limit[4];
 	u32 	writeVal, customer_limit, rf;
 	
 	//
@@ -615,7 +615,7 @@ phy_RF6052_Config_ParaFile(
 	IN	PADAPTER		Adapter
 	)
 {
-	u32					u4RegValue;
+	u32					u4RegValue=0;
 	u8					eRFPath;		
 	BB_REGISTER_DEFINITION_T	*pPhyReg;	
 

--- a/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/rtl8192c_rf6052.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/rtl8192c_rf6052.c
@@ -1015,7 +1015,7 @@ PHY_RFShadowRefresh(
 
 	for (eRFPath = 0; eRFPath < RF6052_MAX_PATH; eRFPath++)
 	{
-		for (Offset = 0; Offset <= RF6052_MAX_REG; Offset++)
+		for (Offset = 0; Offset < RF6052_MAX_REG; Offset++)
 		{
 			RF_Shadow[eRFPath][Offset].Value = 0;
 			RF_Shadow[eRFPath][Offset].Compare = _FALSE;

--- a/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/usb/usb_halinit.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/hal/rtl8192c/usb/usb_halinit.c
@@ -5692,6 +5692,7 @@ _func_enter_;
 	{
 		case HW_VAR_BASIC_RATE:
 			*((u16 *)(val)) = pHalData->BasicRateSet;
+			/* falls through */
 		case HW_VAR_TXPAUSE:
 			val[0] = rtw_read8(Adapter, REG_TXPAUSE);
 			break;

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_cfg80211.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_cfg80211.c
@@ -221,7 +221,7 @@ exit:
 
 void rtw_spt_band_free(struct ieee80211_supported_band *spt_band)
 {
-	u32 size;
+	u32 size = 0;
 
 	if(!spt_band)
 		return;
@@ -3805,7 +3805,7 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 	int ret=0;	
 	_irqL irqL;
 	_list	*phead, *plist;
-	u8 updated;
+	u8 updated = _FALSE;
 	struct sta_info *psta = NULL;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct mlme_priv *pmlmepriv = &(padapter->mlmepriv);

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_cfg80211.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_cfg80211.c
@@ -810,6 +810,7 @@ static int set_group_key(_adapter *padapter, u8 *key, u8 alg, int keyid)
 		case _TKIP_WTMIC_:		
 		case _AES_:
 			keylen = 16;		
+			break;
 		default:
 			keylen = 16;		
 	}

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_linux.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_linux.c
@@ -7381,6 +7381,7 @@ static int set_group_key(_adapter *padapter, u8 *key, u8 alg, int keyid)
 		case _TKIP_WTMIC_:		
 		case _AES_:
 			keylen = 16;		
+			break;
 		default:
 			keylen = 16;		
 	}

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_linux.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/ioctl_linux.c
@@ -6584,7 +6584,6 @@ static int rtw_dbg_port(struct net_device *dev,
 				case 0x01: //dbg mode
 					padapter->recvpriv.is_signal_dbg = 1;
 					extra_arg = extra_arg>100?100:extra_arg;
-					extra_arg = extra_arg<0?0:extra_arg;
 					padapter->recvpriv.signal_strength_dbg=extra_arg;
 					break;
 			}
@@ -6956,7 +6955,7 @@ static int rtw_dbg_port(struct net_device *dev,
 				{
 					struct registry_priv	*pregpriv = &padapter->registrypriv;
 					// 0: disable, 0x1:enable (but wifi_spec should be 0), 0x2: force enable (don't care wifi_spec)
-					if( pregpriv && extra_arg >= 0 && extra_arg < 3 )
+					if( pregpriv && extra_arg < 3 )
 					{
 						pregpriv->ampdu_enable= extra_arg;
 						DBG_871X("set ampdu_enable=%d\n",pregpriv->ampdu_enable);

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/recv_linux.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/recv_linux.c
@@ -136,7 +136,7 @@ int rtw_os_recvbuf_resource_free(_adapter *padapter, struct recv_buf *precvbuf)
 void rtw_handle_tkip_mic_err(_adapter *padapter,u8 bgroup)
 {
 #ifdef CONFIG_IOCTL_CFG80211
-	enum nl80211_key_type key_type;
+	enum nl80211_key_type key_type = 0;
 #endif
 	union iwreq_data wrqu;
 	struct iw_michaelmicfailure    ev;

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/usb_intf.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/usb_intf.c
@@ -996,7 +996,7 @@ static int rtw_resume(struct usb_interface *pusb_intf)
 int rtw_resume_process(_adapter *padapter)
 {
 	struct net_device *pnetdev;
-	struct pwrctrl_priv *pwrpriv;
+	struct pwrctrl_priv *pwrpriv=NULL;
 	int ret = -1;
 	u32 start_time = rtw_get_current_time();
 	_func_enter_;
@@ -1059,7 +1059,8 @@ exit:
 	rtw_unlock_suspend();
 	#endif //CONFIG_RESUME_IN_WORKQUEUE
 
-	pwrpriv->bInSuspend = _FALSE;
+	if (pwrpriv)
+		pwrpriv->bInSuspend = _FALSE;
 	DBG_871X("<===  %s return %d.............. in %dms\n", __FUNCTION__
 		, ret, rtw_get_passing_time_ms(start_time));
 


### PR DESCRIPTION
Same ones as #2413, with a couple of extra commits ported forward from older branches since it appears d3b1ce08060e64592a184375ad953044eb06f5d4 overrode the fixes from 9db27f31d9476c5629b63d3e0619259a68e0544f and 65290084ac865025a134fc50249579f0d4b7e8ce in 2d806f1f8a37cab9516ef2525e3391be06ca601c. I will look into submitting these upstream so you don't have to worry about constantly carrying them forward.