### PR TITLE
added capture_clear option to pps-gpio via dtoverlay

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1261,7 +1261,10 @@ Info:   Configures the pps-gpio (pulse-per-second time signal via GPIO).
 Load:   dtoverlay=pps-gpio,<param>=<val>
 Params: gpiopin                 Input GPIO (default "18")
         assert_falling_edge     When present, assert is indicated by a falling
-                                edge, rather than by a rising edge
+                                edge, rather than by a rising edge (default
+                                off)
+        capture_clear           Generate clear events on the trailing edge
+                                (default off)
 
 
 Name:   pwm

--- a/arch/arm/boot/dts/overlays/pps-gpio-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pps-gpio-overlay.dts
@@ -33,5 +33,6 @@
 			  <&pps_pins>,"brcm,pins:0",
 			  <&pps_pins>,"reg:0";
 		assert_falling_edge = <&pps>,"assert-falling-edge?";
+		capture_clear = <&pps>,"capture-clear?";
 	};
 };

--- a/drivers/pps/clients/pps-gpio.c
+++ b/drivers/pps/clients/pps-gpio.c
@@ -119,6 +119,9 @@ static int pps_gpio_probe(struct platform_device *pdev)
 
 		if (of_get_property(np, "assert-falling-edge", NULL))
 			data->assert_falling_edge = true;
+
+                if (of_get_property(np, "capture-clear", NULL))
+                        data->capture_clear = true;
 	}
 
 	/* GPIO setup */


### PR DESCRIPTION
Adds "capture_clear" option to get the PPS falling edge. Enabled in /boot/config.txt via 
`dtoverlay=pps-gpio,gpiopin=18,capture_clear`

As discussed in #2431 