### PR TITLE
Use all seven dwc2 gadget fifos.

### DIFF
--- a/arch/arm/boot/dts/overlays/dwc2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/dwc2-overlay.dts
@@ -15,7 +15,7 @@
 			dr_mode = "otg";
 			g-np-tx-fifo-size = <32>;
 			g-rx-fifo-size = <256>;
-			g-tx-fifo-size = <512 512 512 512 512 768>;
+			g-tx-fifo-size = <512 512 512 512 512 256 256>;
 			status = "okay";
 		};
 	};


### PR DESCRIPTION
Linux 4.9 needed fifos to be set to their default values,
 leaving the last one (silently) set to zero size.
From 4.12 Linux allows fifos to be set to any size EXCEPT zero.

Resolves https://github.com/raspberrypi/linux/issues/2390
