### PR TITLE
Add overlay for Semtech SX150X I2C GPIO Expanders

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -103,6 +103,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	spi2-1cs.dtbo \
 	spi2-2cs.dtbo \
 	spi2-3cs.dtbo \
+	sx150x.dtbo \
 	tinylcd35.dtbo \
 	uart1.dtbo \
 	vc4-fkms-v3d.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1381,6 +1381,25 @@ Params: cs0_pin                 GPIO pin for CS0 (default 43 - BCM SPI2_CE0).
                                 is 'okay' or enabled).
 
 
+Name:   sx150x
+Info:   Configures the Semtech SX150X I2C GPIO expanders.
+Load:   dtoverlay=sx150x,<param>=<val>
+Params: sx150<x>-<n>-<m>        Enables SX150X device on I2C#<n> with slave
+                                address <m>. <x> may be 1-9. <n> may be 0 or 1.
+                                Permissible values of <m> (which is denoted in
+                                hex) depend on the device variant. For SX1501,
+                                SX1502, SX1504 and SX1505, <m> may be 20 or 21.
+                                For SX1503 and SX1506, <m> may be 20. For
+                                SX1507 and SX1509, <m> may be 3E, 3F, 70 or 71.
+                                For SX1508, <m> may be 20, 21, 22 or 23.
+
+        sx150<x>-<n>-<m>-int-gpio
+                                Integer, enables interrupts on SX150X device on
+                                I2C#<n> with slave address <m>, specifies
+                                the GPIO pin to which NINT output of SX150X is
+                                connected.
+
+
 Name:   tinylcd35
 Info:   3.5" Color TFT Display by www.tinylcd.com
         Options: Touch, RTC, keypad

--- a/arch/arm/boot/dts/overlays/sx150x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sx150x-overlay.dts
@@ -1,0 +1,1618 @@
+// Definitions for SX150x I2C GPIO Expanders from Semtech
+
+// dtparams:
+//     sx150<x>-<n>-<m>          - Enables SX150X device on I2C#<n> with slave address <m>. <x> may be 1-9.
+//                                 <n> may be 0 or 1.  Permissible values of <m> (which is denoted in hex)
+//                                 depend on the device variant.
+//                                 For SX1501, SX1502, SX1504 and SX1505, <m> may be 20 or 21.
+//                                 For SX1503 and SX1506, <m> may be 20.
+//                                 For SX1507 and SX1509, <m> may be 3E, 3F, 70 or 71.
+//                                 For SX1508, <m> may be 20, 21, 22 or 23.
+//     sx150<x>-<n>-<m>-int-gpio - Integer, enables interrupts on SX150X device on I2C#<n> with slave address <m>,
+//                                 specifies the GPIO pin to which NINT output of SX150X is connected.
+//
+//
+// Example 1: A single SX1505 device on I2C#1 with its slave address set to 0x20 and NINT output connected to GPIO25:
+// dtoverlay=sx150x:sx1505-1-20,sx1505-1-20-int-gpio=25
+//
+// Example 2: Two SX1507 devices on I2C#0 with their slave addresses set to 0x3E and 0x70 (interrupts not used):
+// dtoverlay=sx150x:sx1507-0-3E,sx1507-0-70
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	// Enable I2C#0 interface
+	fragment@0 {
+		target = <&i2c0>;
+		__dormant__ {
+			status = "okay";
+		};
+	};
+
+	// Enable I2C#1 interface
+	fragment@1 {
+		target = <&i2c1>;
+		__dormant__ {
+			status = "okay";
+		};
+	};
+
+	// Enable a SX1501 on I2C#0 at slave addr 0x20
+	fragment@2 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1501_0_20: sx150x@20 {
+				compatible = "semtech,sx1501q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1501-0-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1501 on I2C#1 at slave addr 0x20
+	fragment@3 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1501_1_20: sx150x@20 {
+				compatible = "semtech,sx1501q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1501-1-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1501 on I2C#0 at slave addr 0x21
+	fragment@4 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1501_0_21: sx150x@21 {
+				compatible = "semtech,sx1501q";
+				reg = <0x21>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1501-0-21-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1501 on I2C#1 at slave addr 0x21
+	fragment@5 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1501_1_21: sx150x@21 {
+				compatible = "semtech,sx1501q";
+				reg = <0x21>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1501-1-21-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1502 on I2C#0 at slave addr 0x20
+	fragment@6 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1502_0_20: sx150x@20 {
+				compatible = "semtech,sx1502q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1502-0-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1502 on I2C#1 at slave addr 0x20
+	fragment@7 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1502_1_20: sx150x@20 {
+				compatible = "semtech,sx1502q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1502-1-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1502 on I2C#0 at slave addr 0x21
+	fragment@8 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1502_0_21: sx150x@21 {
+				compatible = "semtech,sx1502q";
+				reg = <0x21>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1502-0-21-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1502 on I2C#1 at slave addr 0x21
+	fragment@9 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1502_1_21: sx150x@21 {
+				compatible = "semtech,sx1502q";
+				reg = <0x21>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1501-1-21-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1503 on I2C#0 at slave addr 0x20
+	fragment@10 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1503_0_20: sx150x@20 {
+				compatible = "semtech,sx1503q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1503-0-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1503 on I2C#1 at slave addr 0x20
+	fragment@11 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1503_1_20: sx150x@20 {
+				compatible = "semtech,sx1503q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1503-1-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1504 on I2C#0 at slave addr 0x20
+	fragment@12 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1504_0_20: sx150x@20 {
+				compatible = "semtech,sx1504q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1504-0-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1504 on I2C#1 at slave addr 0x20
+	fragment@13 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1504_1_20: sx150x@20 {
+				compatible = "semtech,sx1504q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1504-1-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1504 on I2C#0 at slave addr 0x21
+	fragment@14 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1504_0_21: sx150x@21 {
+				compatible = "semtech,sx1504q";
+				reg = <0x21>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1504-0-21-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1504 on I2C#1 at slave addr 0x21
+	fragment@15 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1504_1_21: sx150x@21 {
+				compatible = "semtech,sx1504q";
+				reg = <0x21>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1504-1-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1505 on I2C#0 at slave addr 0x20
+	fragment@16 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1505_0_20: sx150x@20 {
+				compatible = "semtech,sx1505q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1505-0-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1505 on I2C#1 at slave addr 0x20
+	fragment@17 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1505_1_20: sx150x@20 {
+				compatible = "semtech,sx1505q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1505-1-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1505 on I2C#0 at slave addr 0x21
+	fragment@18 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1505_0_21: sx150x@21 {
+				compatible = "semtech,sx1505q";
+				reg = <0x21>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1505-0-21-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1505 on I2C#1 at slave addr 0x21
+	fragment@19 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1505_1_21: sx150x@21 {
+				compatible = "semtech,sx1505q";
+				reg = <0x21>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1505-1-21-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1506 on I2C#0 at slave addr 0x20
+	fragment@20 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1506_0_20: sx150x@20 {
+				compatible = "semtech,sx1506q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1506-0-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1506 on I2C#1 at slave addr 0x20
+	fragment@21 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1506_1_20: sx150x@20 {
+				compatible = "semtech,sx1506q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1506-1-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1507 on I2C#0 at slave addr 0x3E
+	fragment@22 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1507_0_3E: sx150x@3E {
+				compatible = "semtech,sx1507q";
+				reg = <0x3E>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1507_0_3E-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1507 on I2C#1 at slave addr 0x3E
+	fragment@23 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1507_1_3E: sx150x@3E {
+				compatible = "semtech,sx1507q";
+				reg = <0x3E>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1507_1_3E-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1507 on I2C#0 at slave addr 0x3F
+	fragment@24 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1507_0_3F: sx150x@3F {
+				compatible = "semtech,sx1507q";
+				reg = <0x3F>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1507_0_3F-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1507 on I2C#1 at slave addr 0x3F
+	fragment@25 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1507_1_3F: sx150x@3F {
+				compatible = "semtech,sx1507q";
+				reg = <0x3F>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1507_1_3F-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1507 on I2C#0 at slave addr 0x70
+	fragment@26 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1507_0_70: sx150x@70 {
+				compatible = "semtech,sx1507q";
+				reg = <0x70>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1507-0-70-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1507 on I2C#1 at slave addr 0x70
+	fragment@27 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1507_1_70: sx150x@70 {
+				compatible = "semtech,sx1507q";
+				reg = <0x70>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1507-1-70-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1507 on I2C#0 at slave addr 0x71
+	fragment@28 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1507_0_71: sx150x@71 {
+				compatible = "semtech,sx1507q";
+				reg = <0x71>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1507-0-71-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1507 on I2C#1 at slave addr 0x71
+	fragment@29 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1507_1_71: sx150x@71 {
+				compatible = "semtech,sx1507q";
+				reg = <0x71>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1507-1-71-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1508 on I2C#0 at slave addr 0x20
+	fragment@30 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1508_0_20: sx150x@20 {
+				compatible = "semtech,sx1508q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1508-0-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1508 on I2C#1 at slave addr 0x20
+	fragment@31 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1508_1_20: sx150x@20 {
+				compatible = "semtech,sx1508q";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1508-1-20-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1508 on I2C#0 at slave addr 0x21
+	fragment@32 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1508_0_21: sx150x@21 {
+				compatible = "semtech,sx1508q";
+				reg = <0x21>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1508-0-21-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1508 on I2C#1 at slave addr 0x21
+	fragment@33 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1508_1_21: sx150x@21 {
+				compatible = "semtech,sx1508q";
+				reg = <0x21>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1508-1-21-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1508 on I2C#0 at slave addr 0x22
+	fragment@34 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1508_0_22: sx150x@22 {
+				compatible = "semtech,sx1508q";
+				reg = <0x22>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1508-0-22-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1508 on I2C#1 at slave addr 0x22
+	fragment@35 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1508_1_22: sx150x@22 {
+				compatible = "semtech,sx1508q";
+				reg = <0x22>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1508-1-22-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1508 on I2C#0 at slave addr 0x23
+	fragment@36 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1508_0_23: sx150x@23 {
+				compatible = "semtech,sx1508q";
+				reg = <0x23>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1508-0-23-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1508 on I2C#1 at slave addr 0x23
+	fragment@37 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1508_1_23: sx150x@23 {
+				compatible = "semtech,sx1508q";
+				reg = <0x23>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1508-1-23-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1509 on I2C#0 at slave addr 0x3E
+	fragment@38 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1509_0_3E: sx150x@3E {
+				compatible = "semtech,sx1509q";
+				reg = <0x3E>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1509_0_3E-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1509 on I2C#1 at slave addr 0x3E
+	fragment@39 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1509_1_3E: sx150x@3E {
+				compatible = "semtech,sx1509q";
+				reg = <0x3E>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1509_1_3E-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1509 on I2C#0 at slave addr 0x3F
+	fragment@40 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1509_0_3F: sx150x@3F {
+				compatible = "semtech,sx1509q";
+				reg = <0x3F>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1509_0_3F-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1509 on I2C#1 at slave addr 0x3F
+	fragment@41 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1509_1_3F: sx150x@3F {
+				compatible = "semtech,sx1509q";
+				reg = <0x3F>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1509_1_3F-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1509 on I2C#0 at slave addr 0x70
+	fragment@42 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1509_0_70: sx150x@70 {
+				compatible = "semtech,sx1509q";
+				reg = <0x70>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1509-0-70-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1509 on I2C#1 at slave addr 0x70
+	fragment@43 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1509_1_70: sx150x@70 {
+				compatible = "semtech,sx1509q";
+				reg = <0x70>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1509-1-70-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1509 on I2C#0 at slave addr 0x71
+	fragment@44 {
+		target = <&i2c0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1509_0_71: sx150x@71 {
+				compatible = "semtech,sx1509q";
+				reg = <0x71>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1509-0-71-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable a SX1509 on I2C#1 at slave addr 0x71
+	fragment@45 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sx1509_1_71: sx150x@71 {
+				compatible = "semtech,sx1509q";
+				reg = <0x71>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#interrupt-cells = <2>;
+				interrupts = <25 2>; /* 1st word overwritten by sx1509-1-71-int-gpio parameter
+				                        2nd word is 2 for falling-edge triggered */
+				status = "okay";
+			};
+		};
+	};
+
+	// Enable interrupts for a SX1501 on I2C#0 at slave addr 0x20
+	fragment@46 {
+		target = <&sx1501_0_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1501 on I2C#1 at slave addr 0x20
+	fragment@47 {
+		target = <&sx1501_1_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1501 on I2C#0 at slave addr 0x21
+	fragment@48 {
+		target = <&sx1501_0_21>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1501 on I2C#1 at slave addr 0x21
+	fragment@49 {
+		target = <&sx1501_1_21>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1502 on I2C#0 at slave addr 0x20
+	fragment@50 {
+		target = <&sx1502_0_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1502 on I2C#1 at slave addr 0x20
+	fragment@51 {
+		target = <&sx1502_1_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1502 on I2C#0 at slave addr 0x21
+	fragment@52 {
+		target = <&sx1502_0_21>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1502 on I2C#1 at slave addr 0x21
+	fragment@53 {
+		target = <&sx1502_1_21>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1503 on I2C#0 at slave addr 0x20
+	fragment@54 {
+		target = <&sx1503_0_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1503 on I2C#1 at slave addr 0x20
+	fragment@55 {
+		target = <&sx1503_1_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1504 on I2C#0 at slave addr 0x20
+	fragment@56 {
+		target = <&sx1504_0_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1504 on I2C#1 at slave addr 0x20
+	fragment@57 {
+		target = <&sx1504_1_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1504 on I2C#0 at slave addr 0x21
+	fragment@58 {
+		target = <&sx1504_0_21>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1504 on I2C#1 at slave addr 0x21
+	fragment@59 {
+		target = <&sx1504_1_21>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1505 on I2C#0 at slave addr 0x20
+	fragment@60 {
+		target = <&sx1505_0_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1505 on I2C#1 at slave addr 0x20
+	fragment@61 {
+		target = <&sx1505_1_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1505 on I2C#0 at slave addr 0x21
+	fragment@62 {
+		target = <&sx1505_0_21>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1505 on I2C#1 at slave addr 0x21
+	fragment@63 {
+		target = <&sx1505_1_21>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1506 on I2C#0 at slave addr 0x20
+	fragment@64 {
+		target = <&sx1506_0_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1506 on I2C#1 at slave addr 0x20
+	fragment@65 {
+		target = <&sx1506_1_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1507 on I2C#0 at slave addr 0x3E
+	fragment@66 {
+		target = <&sx1507_0_3E>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1507 on I2C#1 at slave addr 0x3E
+	fragment@67 {
+		target = <&sx1507_1_3E>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1507 on I2C#0 at slave addr 0x3F
+	fragment@68 {
+		target = <&sx1507_0_3F>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1507 on I2C#1 at slave addr 0x3F
+	fragment@69 {
+		target = <&sx1507_1_3F>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1507 on I2C#0 at slave addr 0x70
+	fragment@70 {
+		target = <&sx1507_0_70>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1507 on I2C#1 at slave addr 0x70
+	fragment@71 {
+		target = <&sx1507_1_70>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1507 on I2C#0 at slave addr 0x71
+	fragment@72 {
+		target = <&sx1507_0_71>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1507 on I2C#1 at slave addr 0x71
+	fragment@73 {
+		target = <&sx1507_1_71>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1508 on I2C#0 at slave addr 0x20
+	fragment@74 {
+		target = <&sx1508_0_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1508 on I2C#1 at slave addr 0x20
+	fragment@75 {
+		target = <&sx1508_1_20>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1508 on I2C#0 at slave addr 0x21
+	fragment@76 {
+		target = <&sx1508_0_21>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1508 on I2C#1 at slave addr 0x21
+	fragment@77 {
+		target = <&sx1508_1_21>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1508 on I2C#0 at slave addr 0x22
+	fragment@78 {
+		target = <&sx1508_0_22>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1508 on I2C#1 at slave addr 0x22
+	fragment@79 {
+		target = <&sx1508_1_22>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1508 on I2C#0 at slave addr 0x23
+	fragment@80 {
+		target = <&sx1508_0_23>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1508 on I2C#1 at slave addr 0x23
+	fragment@81 {
+		target = <&sx1508_1_23>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1509 on I2C#0 at slave addr 0x3E
+	fragment@82 {
+		target = <&sx1509_0_3E>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1509 on I2C#1 at slave addr 0x3E
+	fragment@83 {
+		target = <&sx1509_1_3E>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1509 on I2C#0 at slave addr 0x3F
+	fragment@84 {
+		target = <&sx1509_0_3F>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1509 on I2C#1 at slave addr 0x3F
+	fragment@85 {
+		target = <&sx1509_1_3F>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1509 on I2C#0 at slave addr 0x70
+	fragment@86 {
+		target = <&sx1509_0_70>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1509 on I2C#1 at slave addr 0x70
+	fragment@87 {
+		target = <&sx1509_1_70>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1509 on I2C#0 at slave addr 0x71
+	fragment@88 {
+		target = <&sx1509_0_71>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Enable interrupts for a SX1509 on I2C#1 at slave addr 0x71
+	fragment@89 {
+		target = <&sx1509_1_71>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupt-controller;
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#0 interface at slave addr 0x20
+        // Configure as a input with no pull-up/down
+	fragment@90 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_0_20_pins: sx150x_0_20_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-0-20-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#1 interface at slave addr 0x20
+        // Configure as a input with no pull-up/down
+	fragment@91 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_1_20_pins: sx150x_1_20_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-1-20-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#0 interface at slave addr 0x21
+        // Configure as a input with no pull-up/down
+	fragment@92 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_0_21_pins: sx150x_0_21_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-0-21-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#1 interface at slave addr 0x21
+        // Configure as a input with no pull-up/down
+	fragment@93 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_1_21_pins: sx150x_1_21_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-1-21-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#0 interface at slave addr 0x22
+        // Configure as a input with no pull-up/down
+	fragment@94 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_0_22_pins: sx150x_0_22_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-0-22-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#1 interface at slave addr 0x22
+        // Configure as a input with no pull-up/down
+	fragment@95 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_1_22_pins: sx150x_1_22_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-1-22-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#0 interface at slave addr 0x23
+        // Configure as a input with no pull-up/down
+	fragment@96 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_0_23_pins: sx150x_0_23_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-0-23-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#1 interface at slave addr 0x23
+        // Configure as a input with no pull-up/down
+	fragment@97 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_1_23_pins: sx150x_1_23_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-1-23-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#0 interface at slave addr 0x3E
+        // Configure as a input with no pull-up/down
+	fragment@98 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_0_3E_pins: sx150x_0_3E_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-0-3E-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#1 interface at slave addr 0x3E
+        // Configure as a input with no pull-up/down
+	fragment@99 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_1_3E_pins: sx150x_1_3E_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-1-3E-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#0 interface at slave addr 0x3F
+        // Configure as a input with no pull-up/down
+	fragment@100 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_0_3F_pins: sx150x_0_3F_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-0-3F-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#1 interface at slave addr 0x3F
+        // Configure as a input with no pull-up/down
+	fragment@101 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_1_3F_pins: sx150x_1_3F_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-1-3F-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#0 interface at slave addr 0x70
+        // Configure as a input with no pull-up/down
+	fragment@102 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_0_70_pins: sx150x_0_70_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-0-70-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#1 interface at slave addr 0x70
+        // Configure as a input with no pull-up/down
+	fragment@103 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_1_70_pins: sx150x_1_70_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-1-70-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#0 interface at slave addr 0x71
+        // Configure as a input with no pull-up/down
+	fragment@104 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_0_71_pins: sx150x_0_71_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-0-71-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	// Configure GPIO pin connected to NINT output of a SX150x on I2C#1 interface at slave addr 0x71
+        // Configure as a input with no pull-up/down
+	fragment@105 {
+		target = <&gpio>;
+		__dormant__ {
+			sx150x_1_71_pins: sx150x_1_71_pins {
+				brcm,pins = <0>;  /* overwritten by sx150x-1-71-int-gpio parameter */
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	__overrides__ {
+		sx1501-0-20          = <0>,"+0+2";
+		sx1501-1-20          = <0>,"+1+3";
+		sx1501-0-21          = <0>,"+0+4";
+		sx1501-1-21          = <0>,"+1+5";
+		sx1502-0-20          = <0>,"+0+6";
+		sx1502-1-20          = <0>,"+1+7";
+		sx1502-0-21          = <0>,"+0+8";
+		sx1502-1-21          = <0>,"+1+9";
+		sx1503-0-20          = <0>,"+0+10";
+		sx1503-1-20          = <0>,"+1+11";
+		sx1504-0-20          = <0>,"+0+12";
+		sx1504-1-20          = <0>,"+1+13";
+		sx1504-0-21          = <0>,"+0+14";
+		sx1504-1-21          = <0>,"+1+15";
+		sx1505-0-20          = <0>,"+0+16";
+		sx1505-1-20          = <0>,"+1+17";
+		sx1505-0-21          = <0>,"+0+18";
+		sx1505-1-21          = <0>,"+1+19";
+		sx1506-0-20          = <0>,"+0+20";
+		sx1506-1-20          = <0>,"+1+21";
+		sx1507-0-3E          = <0>,"+0+22";
+		sx1507-1-3E          = <0>,"+1+23";
+		sx1507-0-3F          = <0>,"+0+24";
+		sx1507-1-3F          = <0>,"+1+25";
+		sx1507-0-70          = <0>,"+0+26";
+		sx1507-1-70          = <0>,"+1+27";
+		sx1507-0-71          = <0>,"+0+28";
+		sx1507-1-71          = <0>,"+1+29";
+		sx1508-0-20          = <0>,"+0+30";
+		sx1508-1-20          = <0>,"+1+31";
+		sx1508-0-21          = <0>,"+0+32";
+		sx1508-1-21          = <0>,"+1+33";
+		sx1508-0-22          = <0>,"+0+34";
+		sx1508-1-22          = <0>,"+1+35";
+		sx1508-0-23          = <0>,"+0+36";
+		sx1508-1-23          = <0>,"+1+37";
+		sx1509-0-3E          = <0>,"+0+38";
+		sx1509-1-3E          = <0>,"+1+39";
+		sx1509-0-3F          = <0>,"+0+40";
+		sx1509-1-3F          = <0>,"+1+41";
+		sx1509-0-70          = <0>,"+0+42";
+		sx1509-1-70          = <0>,"+1+43";
+		sx1509-0-71          = <0>,"+0+44";
+		sx1509-1-71          = <0>,"+1+45";
+		sx1501-0-20-int-gpio = <0>,"+46+90",  <&sx150x_0_20_pins>,"brcm,pins:0", <&sx1501_0_20>,"interrupts:0";
+		sx1501-1-20-int-gpio = <0>,"+47+91",  <&sx150x_1_20_pins>,"brcm,pins:0", <&sx1501_1_20>,"interrupts:0";
+		sx1501-0-21-int-gpio = <0>,"+48+92",  <&sx150x_0_21_pins>,"brcm,pins:0", <&sx1501_0_21>,"interrupts:0";
+		sx1501-1-21-int-gpio = <0>,"+49+93",  <&sx150x_1_21_pins>,"brcm,pins:0", <&sx1501_1_21>,"interrupts:0";
+		sx1502-0-20-int-gpio = <0>,"+50+90",  <&sx150x_0_20_pins>,"brcm,pins:0", <&sx1502_0_20>,"interrupts:0";
+		sx1502-1-20-int-gpio = <0>,"+51+91",  <&sx150x_1_20_pins>,"brcm,pins:0", <&sx1502_1_20>,"interrupts:0";
+		sx1502-0-21-int-gpio = <0>,"+52+92",  <&sx150x_0_21_pins>,"brcm,pins:0", <&sx1502_0_21>,"interrupts:0";
+		sx1502-1-21-int-gpio = <0>,"+53+93",  <&sx150x_1_21_pins>,"brcm,pins:0", <&sx1502_1_21>,"interrupts:0";
+		sx1503-0-20-int-gpio = <0>,"+54+90",  <&sx150x_0_20_pins>,"brcm,pins:0", <&sx1503_0_20>,"interrupts:0";
+		sx1503-1-20-int-gpio = <0>,"+55+91",  <&sx150x_1_20_pins>,"brcm,pins:0", <&sx1503_1_20>,"interrupts:0";
+		sx1504-0-20-int-gpio = <0>,"+56+90",  <&sx150x_0_20_pins>,"brcm,pins:0", <&sx1504_0_20>,"interrupts:0";
+		sx1504-1-20-int-gpio = <0>,"+57+91",  <&sx150x_1_20_pins>,"brcm,pins:0", <&sx1504_1_20>,"interrupts:0";
+		sx1504-0-21-int-gpio = <0>,"+58+92",  <&sx150x_0_21_pins>,"brcm,pins:0", <&sx1504_0_21>,"interrupts:0";
+		sx1504-1-21-int-gpio = <0>,"+59+93",  <&sx150x_1_21_pins>,"brcm,pins:0", <&sx1504_1_21>,"interrupts:0";
+		sx1505-0-20-int-gpio = <0>,"+60+90",  <&sx150x_0_20_pins>,"brcm,pins:0", <&sx1505_0_20>,"interrupts:0";
+		sx1505-1-20-int-gpio = <0>,"+61+91",  <&sx150x_1_20_pins>,"brcm,pins:0", <&sx1505_1_20>,"interrupts:0";
+		sx1505-0-21-int-gpio = <0>,"+62+92",  <&sx150x_0_21_pins>,"brcm,pins:0", <&sx1505_0_21>,"interrupts:0";
+		sx1505-1-21-int-gpio = <0>,"+63+93",  <&sx150x_1_21_pins>,"brcm,pins:0", <&sx1505_1_21>,"interrupts:0";
+		sx1506-0-20-int-gpio = <0>,"+64+90",  <&sx150x_0_20_pins>,"brcm,pins:0", <&sx1506_0_20>,"interrupts:0";
+		sx1506-1-20-int-gpio = <0>,"+65+91",  <&sx150x_1_20_pins>,"brcm,pins:0", <&sx1506_1_20>,"interrupts:0";
+		sx1507-0-3E-int-gpio = <0>,"+66+98",  <&sx150x_0_3E_pins>,"brcm,pins:0", <&sx1507_0_3E>,"interrupts:0";
+		sx1507-1-3E-int-gpio = <0>,"+67+99",  <&sx150x_1_3E_pins>,"brcm,pins:0", <&sx1507_1_3E>,"interrupts:0";
+		sx1507-0-3F-int-gpio = <0>,"+68+100", <&sx150x_0_3F_pins>,"brcm,pins:0", <&sx1507_0_3F>,"interrupts:0";
+		sx1507-1-3F-int-gpio = <0>,"+69+101", <&sx150x_1_3F_pins>,"brcm,pins:0", <&sx1507_1_3F>,"interrupts:0";
+		sx1507-0-70-int-gpio = <0>,"+60+102", <&sx150x_0_70_pins>,"brcm,pins:0", <&sx1507_0_70>,"interrupts:0";
+		sx1507-1-70-int-gpio = <0>,"+71+103", <&sx150x_1_70_pins>,"brcm,pins:0", <&sx1507_1_70>,"interrupts:0";
+		sx1507-0-71-int-gpio = <0>,"+72+104", <&sx150x_0_71_pins>,"brcm,pins:0", <&sx1507_0_71>,"interrupts:0";
+		sx1507-1-71-int-gpio = <0>,"+73+105", <&sx150x_1_71_pins>,"brcm,pins:0", <&sx1507_1_71>,"interrupts:0";
+		sx1508-0-20-int-gpio = <0>,"+74+90",  <&sx150x_0_20_pins>,"brcm,pins:0", <&sx1508_0_20>,"interrupts:0";
+		sx1508-1-20-int-gpio = <0>,"+75+91",  <&sx150x_1_20_pins>,"brcm,pins:0", <&sx1508_1_20>,"interrupts:0";
+		sx1508-0-21-int-gpio = <0>,"+76+92",  <&sx150x_0_21_pins>,"brcm,pins:0", <&sx1508_0_21>,"interrupts:0";
+		sx1508-1-21-int-gpio = <0>,"+77+93",  <&sx150x_1_21_pins>,"brcm,pins:0", <&sx1508_1_21>,"interrupts:0";
+		sx1508-0-22-int-gpio = <0>,"+78+94",  <&sx150x_0_22_pins>,"brcm,pins:0", <&sx1508_0_22>,"interrupts:0";
+		sx1508-1-22-int-gpio = <0>,"+79+95",  <&sx150x_1_22_pins>,"brcm,pins:0", <&sx1508_1_22>,"interrupts:0";
+		sx1508-0-23-int-gpio = <0>,"+80+96",  <&sx150x_0_23_pins>,"brcm,pins:0", <&sx1508_0_23>,"interrupts:0";
+		sx1508-1-23-int-gpio = <0>,"+81+97",  <&sx150x_1_23_pins>,"brcm,pins:0", <&sx1508_1_23>,"interrupts:0";
+		sx1509-0-3E-int-gpio = <0>,"+82+98",  <&sx150x_0_3E_pins>,"brcm,pins:0", <&sx1509_0_3E>,"interrupts:0";
+		sx1509-1-3E-int-gpio = <0>,"+83+99",  <&sx150x_1_3E_pins>,"brcm,pins:0", <&sx1509_1_3E>,"interrupts:0";
+		sx1509-0-3F-int-gpio = <0>,"+84+100", <&sx150x_0_3F_pins>,"brcm,pins:0", <&sx1509_0_3F>,"interrupts:0";
+		sx1509-1-3F-int-gpio = <0>,"+85+101", <&sx150x_1_3F_pins>,"brcm,pins:0", <&sx1509_1_3F>,"interrupts:0";
+		sx1509-0-70-int-gpio = <0>,"+86+102", <&sx150x_0_70_pins>,"brcm,pins:0", <&sx1509_0_70>,"interrupts:0";
+		sx1509-1-70-int-gpio = <0>,"+87+103", <&sx150x_1_70_pins>,"brcm,pins:0", <&sx1509_1_70>,"interrupts:0";
+		sx1509-0-71-int-gpio = <0>,"+88+104", <&sx150x_0_71_pins>,"brcm,pins:0", <&sx1509_0_71>,"interrupts:0";
+		sx1509-1-71-int-gpio = <0>,"+89+105", <&sx150x_1_71_pins>,"brcm,pins:0", <&sx1509_1_71>,"interrupts:0";
+	};
+};
+


### PR DESCRIPTION
Herewith for your consideration a devicetree overlay for Semtech SX150X I2C GPIO Expanders.  I've tested the overlay with a SX1505 device on a Raspberry Pi 3.

Note that the kernel driver for these devices is only present in kernel versions 4.10.y onwards.