### PR TITLE
raspberrypi-firmware.h: Fix comments 

### DIFF
--- a/include/soc/bcm2835/raspberrypi-firmware.h
+++ b/include/soc/bcm2835/raspberrypi-firmware.h
@@ -29,8 +29,8 @@ enum rpi_firmware_property_status {
  *			struct.
  * @req_resp_size:	On submit, the length of the request (though it doesn't
  *			appear to be currently used by the firmware).  On return,
- *			the length of the response (always 4 byte aligned), with
- *			the low bit set.
+ *			the length of the response (at least 2 byte aligned), with
+ *			the highest bit set.
  */
 struct rpi_firmware_property_tag_header {
 	u32 tag;


### PR DESCRIPTION
- The Mailbox interface doesn't align the response to 4 bytes particularly for RPI_FIRMWARE_GET_BOARD_MAC_ADDRESS.
- The Mailbox interface sets the highest bit to the response code.

Please merge this to the repo. Thanks.