### PR TITLE
Overlay for JEDEC SPI NOR flash

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -54,6 +54,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	iqaudio-dac.dtbo \
 	iqaudio-dacplus.dtbo \
 	iqaudio-digi-wm8804-audio.dtbo \
+	jedec-spi-nor.dtbo \
 	justboom-dac.dtbo \
 	justboom-digi.dtbo \
 	lirc-rpi.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -902,6 +902,15 @@ Params: card_name               Override the default, "IQAudIODigi", card name.
                                 dai stream name.
 
 
+Name:   jedec-spi-nor
+Info:   Adds support for JEDEC-compliant SPI NOR flash devices.  (Note: The
+        "jedec,spi-nor" kernel driver was formerly known as "m25p80".)
+Load:   dtoverlay=jedec-spi-nor,<param>=<val>
+Params: flash-spi<n>-<m>        Enables flash device on SPI<n>, CS#<m>.
+        flash-fastr-spi<n>-<m>  Enables flash device with fast read capability
+                                on SPI<n>, CS#<m>.
+
+
 Name:   justboom-dac
 Info:   Configures the JustBoom DAC HAT, Amp HAT, DAC Zero and Amp Zero audio
         cards

--- a/arch/arm/boot/dts/overlays/jedec-spi-nor-overlay.dts
+++ b/arch/arm/boot/dts/overlays/jedec-spi-nor-overlay.dts
@@ -1,0 +1,309 @@
+// Overlay for JEDEC SPI-NOR Flash Devices (aka m25p80)
+
+// dtparams:
+//     flash-spi<n>-<m>        - Enables flash device on SPI<n>, CS#<m>.
+//     flash-fastr-spi<n>-<m>  - Enables flash device with fast read capability on SPI<n>, CS#<m>.
+//
+// If devices are present on SPI1 or SPI2, those interfaces must be enabled with one of the spi1-1/2/3cs and/or spi2-1/2/3cs overlays.
+//
+// Example: A single flash device with fast read capability on SPI0, CS#0:
+// dtoverlay=jedec-spi-nor:flash-fastr-spi0-0
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	// disable spi-dev on spi0.0
+	fragment@0 {
+		target = <&spidev0>;
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	// disable spi-dev on spi0.1
+	fragment@1 {
+		target = <&spidev1>;
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	// disable spi-dev on spi1.0
+	fragment@2 {
+		target-path = "spi1/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	// disable spi-dev on spi1.1
+	fragment@3 {
+		target-path = "spi1/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	// disable spi-dev on spi1.2
+	fragment@4 {
+		target-path = "spi1/spidev@2";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	// disable spi-dev on spi2.0
+	fragment@5 {
+		target-path = "spi2/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	// disable spi-dev on spi2.1
+	fragment@6 {
+		target-path = "spi2/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	// disable spi-dev on spi2.2
+	fragment@7 {
+		target-path = "spi2/spidev@2";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	// enable flash on spi0.0
+	fragment@8 {
+		target = <&spi0>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+			spi_nor_00: spi_nor@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	// enable flash on spi0.1
+	fragment@9 {
+		target = <&spi0>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+			spi_nor_01: spi_nor@1 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "jedec,spi-nor";
+				reg = <1>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	// enable flash on spi1.0
+	fragment@10 {
+		target = <&spi1>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+			spi_nor_10: spi_nor@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	// enable flash on spi1.1
+	fragment@11 {
+		target = <&spi1>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+			spi_nor_11: spi_nor@1 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "jedec,spi-nor";
+				reg = <1>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	// enable flash on spi1.2
+	fragment@12 {
+		target = <&spi1>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+			spi_nor_12: spi_nor@2 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "jedec,spi-nor";
+				reg = <2>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	// enable flash on spi2.0
+	fragment@13 {
+		target = <&spi2>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+			spi_nor_20: spi_nor@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "jedec,spi-nor";
+				reg = <0>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	// enable flash on spi2.1
+	fragment@14 {
+		target = <&spi2>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+			spi_nor_21: spi_nor@1 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "jedec,spi-nor";
+				reg = <1>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	// enable flash on spi2.2
+	fragment@15 {
+		target = <&spi2>;
+		__dormant__ {
+			status = "okay";
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+			spi_nor_22: spi_nor@2 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "jedec,spi-nor";
+				reg = <2>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	// Enable fast read for device on spi0.0.
+	// Use default active low interrupt signalling.
+	fragment@16 {
+		target = <&spi_nor_00>;
+		__dormant__ {
+			m25p,fast-read;
+		};
+	};
+
+	// Enable fast read for device on spi0.1.
+	// Use default active low interrupt signalling.
+	fragment@17 {
+		target = <&spi_nor_01>;
+		__dormant__ {
+			m25p,fast-read;
+		};
+	};
+
+	// Enable fast read for device on spi1.0.
+	// Use default active low interrupt signalling.
+	fragment@18 {
+		target = <&spi_nor_10>;
+		__dormant__ {
+			m25p,fast-read;
+		};
+	};
+
+	// Enable fast read for device on spi1.1.
+	// Use default active low interrupt signalling.
+	fragment@19 {
+		target = <&spi_nor_11>;
+		__dormant__ {
+			m25p,fast-read;
+		};
+	};
+
+	// Enable fast read for device on spi1.2.
+	// Use default active low interrupt signalling.
+	fragment@20 {
+		target = <&spi_nor_12>;
+		__dormant__ {
+			m25p,fast-read;
+		};
+	};
+
+	// Enable fast read for device on spi2.0.
+	// Use default active low interrupt signalling.
+	fragment@21 {
+		target = <&spi_nor_20>;
+		__dormant__ {
+			m25p,fast-read;
+		};
+	};
+
+	// Enable fast read for device on spi2.1.
+	// Use default active low interrupt signalling.
+	fragment@22 {
+		target = <&spi_nor_21>;
+		__dormant__ {
+			m25p,fast-read;
+		};
+	};
+
+	// Enable fast read for device on spi2.2.
+	// Use default active low interrupt signalling.
+	fragment@23 {
+		target = <&spi_nor_22>;
+		__dormant__ {
+			m25p,fast-read;
+		};
+	};
+
+	__overrides__ {
+		flash-spi0-0       = <0>,"+0+8";
+		flash-spi0-1       = <0>,"+1+9";
+		flash-spi1-0       = <0>,"+2+10";
+		flash-spi1-1       = <0>,"+3+11";
+		flash-spi1-2       = <0>,"+4+12";
+		flash-spi2-0       = <0>,"+5+13";
+		flash-spi2-1       = <0>,"+6+14";
+		flash-spi2-2       = <0>,"+7+15";
+		flash-fastr-spi0-0 = <0>,"+0+8+16";
+		flash-fastr-spi0-1 = <0>,"+1+9+17";
+		flash-fastr-spi1-0 = <0>,"+2+10+18";
+		flash-fastr-spi1-1 = <0>,"+3+11+19";
+		flash-fastr-spi1-2 = <0>,"+4+12+20";
+		flash-fastr-spi2-0 = <0>,"+5+13+21";
+		flash-fastr-spi2-1 = <0>,"+6+14+22";
+		flash-fastr-spi2-2 = <0>,"+7+15+23";
+	};
+};
+


### PR DESCRIPTION
An overlay for the "jedec,spi-nor" kernel driver, formerly known as m25p80.  (Is this the only kernel driver with a comma in its name?  dtc didn't like it when I tried to include the comma in the overlay name so I've substituted a hyphen.)

I've tested this on a RPI3 with a Cypress S25FL032P flash chip.
