### PR TITLE
dwc_otg: Fix memory corruption

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
@@ -1003,25 +1003,11 @@ static void endpoint_disable(struct usb_hcd *hcd, struct usb_host_endpoint *ep)
 static void endpoint_reset(struct usb_hcd *hcd, struct usb_host_endpoint *ep)
 {
 	dwc_irqflags_t flags;
-	struct usb_device *udev = NULL;
-	int epnum = usb_endpoint_num(&ep->desc);
-	int is_out = usb_endpoint_dir_out(&ep->desc);
-	int is_control = usb_endpoint_xfer_control(&ep->desc);
 	dwc_otg_hcd_t *dwc_otg_hcd = hcd_to_dwc_otg_hcd(hcd);
-        struct device *dev = DWC_OTG_OS_GETDEV(dwc_otg_hcd->otg_dev->os_dep);
-
-	if (dev)
-		udev = to_usb_device(dev);
-	else
-		return;
 
 	DWC_DEBUGPL(DBG_HCD, "DWC OTG HCD EP RESET: Endpoint Num=0x%02d\n", epnum);
 
 	DWC_SPINLOCK_IRQSAVE(dwc_otg_hcd->lock, &flags);
-	usb_settoggle(udev, epnum, is_out, 0);
-	if (is_control)
-		usb_settoggle(udev, epnum, !is_out, 0);
-
 	if (ep->hcpriv) {
 		dwc_otg_hcd_endpoint_reset(dwc_otg_hcd, ep->hcpriv);
 	}


### PR DESCRIPTION
This bug in dwc_otg was already fixed in the upstream dwc2 driver four years ago. On a <a href="https://revolution.kunbus.com/">Revolution Pi</a> with CM1 it caused a probe failure of the driver for i2c1 because dwc_otg corrupted the `num_resources` field in its `struct platform_device`:

```
i2c-bcm2835 20804000.i2c: invalid resource
i2c-bcm2835: probe of 20804000.i2c failed with error -22
```

Port the mainline kernel's fix over to the out-of-tree dwc_otg driver.

Cc: @mduckeck