### PR TITLE
net: lan78xx: Request s/w csum check on VLAN tagged packets.

### DIFF
--- a/drivers/net/usb/lan78xx.c
+++ b/drivers/net/usb/lan78xx.c
@@ -2954,8 +2954,12 @@ static void lan78xx_rx_csum_offload(struct lan78xx_net *dev,
 				    struct sk_buff *skb,
 				    u32 rx_cmd_a, u32 rx_cmd_b)
 {
+	/* Checksum offload appears to be flawed if used with VLANs.
+	 * Elect for sw checksum check instead.
+	 */
 	if (!(dev->net->features & NETIF_F_RXCSUM) ||
-	    unlikely(rx_cmd_a & RX_CMD_A_ICSM_)) {
+	    unlikely(rx_cmd_a & RX_CMD_A_ICSM_) ||
+	    (rx_cmd_a & RX_CMD_A_FVTG_)) {
 		skb->ip_summed = CHECKSUM_NONE;
 	} else {
 		skb->csum = ntohs((u16)(rx_cmd_b >> RX_CMD_B_CSUM_SHIFT_));


### PR DESCRIPTION
There appears to be some issue in the LAN78xx where the checksum
computed on a VLAN tagged packet is incorrect, or at least not
in the form that the kernel is after. This is most easily shown
by pinging a device via a VLAN tagged interface and it will dump
out the error message and stack trace from netdev_rx_csum_fault.
It has also been seen with standard TCP and UDP packets.

Until this is fully understood, request that the network stack
computes the checksum on packets signalled as having a VLAN tag
applied.

See https://github.com/raspberrypi/linux/issues/2458

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>