### PR TITLE
Reduce log spam when mailbox call not implemented

### DIFF
--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -151,7 +151,7 @@ int rpi_firmware_property_list(struct rpi_firmware *fw,
 		 * error, if there were multiple tags in the request.
 		 * But single-tag is the most common, so go with it.
 		 */
-		dev_err(fw->cl.dev, "Request 0x%08x returned status 0x%08x\n",
+		dev_dbg(fw->cl.dev, "Request 0x%08x returned status 0x%08x\n",
 			buf[2], buf[1]);
 		ret = -EINVAL;
 	}
@@ -204,6 +204,7 @@ EXPORT_SYMBOL_GPL(rpi_firmware_property);
 
 static int rpi_firmware_get_throttled(struct rpi_firmware *fw, u32 *value)
 {
+	static int old_firmware;
 	static ktime_t old_timestamp;
 	static u32 old_value;
 	u32 new_sticky, old_sticky, new_uv, old_uv;
@@ -213,6 +214,9 @@ static int rpi_firmware_get_throttled(struct rpi_firmware *fw, u32 *value)
 
 	if (!fw)
 		return -EBUSY;
+
+	if (old_firmware)
+		return -EINVAL;
 
 	/*
 	 * We can't run faster than the sticky shift (100ms) since we get
@@ -232,8 +236,17 @@ static int rpi_firmware_get_throttled(struct rpi_firmware *fw, u32 *value)
 
 	ret = rpi_firmware_property(fw, RPI_FIRMWARE_GET_THROTTLED,
 				    value, sizeof(*value));
-	if (ret)
+
+	if (ret) {
+		/* If the mailbox call fails once, then it will continue to
+		 * fail in the future, so no point in continuing to call it
+		 * Usual failure reason is older firmware
+		 */
+		old_firmware = 1;
+		dev_err(fw->cl.dev, "Get Throttled mailbox call failed");
+
 		return ret;
+	}
 
 	new_sticky = *value >> 16;
 	old_sticky = old_value >> 16;
@@ -270,10 +283,10 @@ static void get_throttled_poll(struct work_struct *work)
 	int ret;
 
 	ret = rpi_firmware_get_throttled(fw, &dummy);
-	if (ret)
-		pr_debug("%s: Failed to read value (%d)", __func__, ret);
 
-	schedule_delayed_work(&fw->get_throttled_poll_work, 2 * HZ);
+	/* Only reschedule if we are getting valid responses */
+	if (!ret)
+		schedule_delayed_work(&fw->get_throttled_poll_work, 2 * HZ);
 }
 
 static ssize_t get_throttled_show(struct device *dev,


### PR DESCRIPTION
This changes the logging message when a mailbox call
fails to the dev_dbg level. In addition, it fixes the
low voltage detection logging code so that if the
mailbox call doies fails, it logs at error level
and flags so the call is no longer attempted.