### PR TITLE
Revert "Sets the BCDC priority to constant 0"

### DIFF
--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/bcdc.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/bcdc.c
@@ -274,7 +274,7 @@ brcmf_proto_bcdc_hdrpush(struct brcmf_pub *drvr, int ifidx, u8 offset,
 	if (pktbuf->ip_summed == CHECKSUM_PARTIAL)
 		h->flags |= BCDC_FLAG_SUM_NEEDED;
 
-	h->priority = 0;
+	h->priority = (pktbuf->priority & BCDC_PRIORITY_MASK);
 	h->flags2 = 0;
 	h->data_offset = offset;
 	BCDC_SET_IF_IDX(h, ifidx);


### PR DESCRIPTION
This reverts commit 8e4cdcb1c2ff7e991044e2ee01dba7f572ab29a2.

Testing the latest wireless firmware and unable to replicate the
bug once this change is reverted.

Test used is :

Connect a Pi wirelessly to an AP (PiA), with another device
connected either wirelessly or via ethernet to the same
network (PiB).

On PiB run

sudo tcpdump -n 'udp port 7' -v -i wlan0

On PiA,

nc -T 0x10 -u <PiB ipaddress> 7

This sends a UDP packet to port 7, with the TOS flag set to 0x10.

Previously this would NOT arrive (or sometime be very badly delayed, 10's of seconds)

Sending TOS as 0

nc -T 0x0 -u <PiB ipaddress> 7

would arrive.

Now with the change reverted but the latest wireless firmware present
the tests works in all cases.