### PR TITLE
Checkpatch cleanup of bcm2708_fb.c

### DIFF
--- a/drivers/video/fbdev/bcm2708_fb.c
+++ b/drivers/video/fbdev/bcm2708_fb.c
@@ -41,9 +41,10 @@
 #define MODULE_NAME "bcm2708_fb"
 
 #ifdef BCM2708_FB_DEBUG
-#define print_debug(fmt,...) pr_debug("%s:%s:%d: "fmt, MODULE_NAME, __func__, __LINE__, ##__VA_ARGS__)
+#define print_debug(fmt, ...) pr_debug("%s:%s:%d: "fmt, \
+			MODULE_NAME, __func__, __LINE__, ##__VA_ARGS__)
 #else
-#define print_debug(fmt,...)
+#define print_debug(fmt, ...)
 #endif
 
 /* This is limited to 16 characters when displayed by X startup */
@@ -51,10 +52,10 @@ static const char *bcm2708_name = "BCM2708 FB";
 
 #define DRIVER_NAME "bcm2708_fb"
 
-static int fbwidth = 800;  /* module parameter */
-static int fbheight = 480; /* module parameter */
-static int fbdepth = 32;   /* module parameter */
-static int fbswap = 0;     /* module parameter */
+static int fbwidth = 800;	/* module parameter */
+static int fbheight = 480;	/* module parameter */
+static int fbdepth = 32;	/* module parameter */
+static int fbswap;		/* module parameter */
 
 static u32 dma_busy_wait_threshold = 1<<15;
 module_param(dma_busy_wait_threshold, int, 0644);
@@ -221,11 +222,13 @@ static int bcm2708_fb_check_var(struct fb_var_screeninfo *var,
 				struct fb_info *info)
 {
 	/* info input, var output */
-	print_debug("bcm2708_fb_check_var info(%p) %dx%d (%dx%d), %d, %d\n", info,
+	print_debug("%s(%p) %dx%d (%dx%d), %d, %d\n",
+		__func__,
+		info,
 		info->var.xres, info->var.yres, info->var.xres_virtual,
 		info->var.yres_virtual, (int)info->screen_size,
 		info->var.bits_per_pixel);
-	print_debug("bcm2708_fb_check_var var(%p) %dx%d (%dx%d), %d\n", var,
+	print_debug("%s(%p) %dx%d (%dx%d), %d\n", __func__, var,
 		var->xres, var->yres, var->xres_virtual, var->yres_virtual,
 		var->bits_per_pixel);
 
@@ -233,7 +236,7 @@ static int bcm2708_fb_check_var(struct fb_var_screeninfo *var,
 		var->bits_per_pixel = 16;
 
 	if (bcm2708_fb_set_bitfields(var) != 0) {
-		pr_err("bcm2708_fb_check_var: invalid bits_per_pixel %d\n",
+		pr_err("%s: invalid bits_per_pixel %d\n", __func__,
 		     var->bits_per_pixel);
 		return -EINVAL;
 	}
@@ -245,9 +248,8 @@ static int bcm2708_fb_check_var(struct fb_var_screeninfo *var,
 	if (var->yres_virtual == -1) {
 		var->yres_virtual = 480;
 
-		pr_err
-		    ("bcm2708_fb_check_var: virtual resolution set to maximum of %dx%d\n",
-		     var->xres_virtual, var->yres_virtual);
+		pr_err("%s: virtual resolution set to maximum of %dx%d\n",
+		     __func__, var->xres_virtual, var->yres_virtual);
 	}
 	if (var->yres_virtual < var->yres)
 		var->yres_virtual = var->yres;
@@ -291,7 +293,7 @@ static int bcm2708_fb_set_par(struct fb_info *info)
 	};
 	int ret;
 
-	print_debug("bcm2708_fb_set_par info(%p) %dx%d (%dx%d), %d, %d\n", info,
+	print_debug("%s(%p) %dx%d (%dx%d), %d, %d\n", __func__, info,
 		info->var.xres, info->var.yres, info->var.xres_virtual,
 		info->var.yres_virtual, (int)info->screen_size,
 		info->var.bits_per_pixel);
@@ -326,11 +328,12 @@ static int bcm2708_fb_set_par(struct fb_info *info)
 		return -ENOMEM;
 	}
 
-	print_debug
-	    ("BCM2708FB: start = %p,%p width=%d, height=%d, bpp=%d, pitch=%d size=%d\n",
-	     (void *)fb->fb.screen_base, (void *)fb->fb_bus_address,
-	     fbinfo.xres, fbinfo.yres, fbinfo.bpp,
-	     fbinfo.pitch, (int)fb->fb.screen_size);
+	print_debug(
+	  "%s: start = %p,%p width=%d, height=%d, bpp=%d, pitch=%d size=%d\n",
+	  __func__,
+	  (void *)fb->fb.screen_base, (void *)fb->fb_bus_address,
+	  fbinfo.xres, fbinfo.yres, fbinfo.bpp,
+	  fbinfo.pitch, (int)fb->fb.screen_size);
 
 	return 0;
 }
@@ -349,7 +352,6 @@ static int bcm2708_fb_setcolreg(unsigned int regno, unsigned int red,
 {
 	struct bcm2708_fb *fb = to_bcm2708(info);
 
-	/*print_debug("BCM2708FB: setcolreg %d:(%02x,%02x,%02x,%02x) %x\n", regno, red, green, blue, transp, fb->fb.fix.visual);*/
 	if (fb->fb.var.bits_per_pixel <= 8) {
 		if (regno < 256) {
 			/* blue [23:16], green [15:8], red [7:0] */
@@ -357,8 +359,12 @@ static int bcm2708_fb_setcolreg(unsigned int regno, unsigned int red,
 					      ((green >> 8) & 0xff) << 8 |
 					      ((blue  >> 8) & 0xff) << 16;
 		}
-		/* Hack: we need to tell GPU the palette has changed, but currently bcm2708_fb_set_par takes noticable time when called for every (256) colour */
-		/* So just call it for what looks like the last colour in a list for now. */
+		/* Hack: we need to tell GPU the palette has changed, but
+		 * currently bcm2708_fb_set_par takes noticeable time when
+		 * called for every (256) colour
+		 * So just call it for what looks like the last colour in a
+		 * list for now.
+		 */
 		if (regno == 15 || regno == 255) {
 			struct packet {
 				u32 offset;
@@ -372,19 +378,23 @@ static int bcm2708_fb_setcolreg(unsigned int regno, unsigned int red,
 				return -ENOMEM;
 			packet->offset = 0;
 			packet->length = regno + 1;
-			memcpy(packet->cmap, fb->gpu_cmap, sizeof(packet->cmap));
-			ret = rpi_firmware_property(fb->fw, RPI_FIRMWARE_FRAMEBUFFER_SET_PALETTE,
-						    packet, (2 + packet->length) * sizeof(u32));
+			memcpy(packet->cmap, fb->gpu_cmap,
+				sizeof(packet->cmap));
+			ret = rpi_firmware_property(fb->fw,
+					RPI_FIRMWARE_FRAMEBUFFER_SET_PALETTE,
+					packet,
+					(2 + packet->length) * sizeof(u32));
 			if (ret || packet->offset)
-				dev_err(info->device, "Failed to set palette (%d,%u)\n",
+				dev_err(info->device,
+					"Failed to set palette (%d,%u)\n",
 					ret, packet->offset);
 			kfree(packet);
 		}
-        } else if (regno < 16) {
+	} else if (regno < 16) {
 		fb->cmap[regno] = convert_bitfield(transp, &fb->fb.var.transp) |
-		    convert_bitfield(blue, &fb->fb.var.blue) |
-		    convert_bitfield(green, &fb->fb.var.green) |
-		    convert_bitfield(red, &fb->fb.var.red);
+		convert_bitfield(blue, &fb->fb.var.blue) |
+		convert_bitfield(green, &fb->fb.var.green) |
+		convert_bitfield(red, &fb->fb.var.red);
 	}
 	return regno > 255;
 }
@@ -412,24 +422,28 @@ static int bcm2708_fb_blank(int blank_mode, struct fb_info *info)
 	ret = rpi_firmware_property(fb->fw, RPI_FIRMWARE_FRAMEBUFFER_BLANK,
 				    &value, sizeof(value));
 	if (ret)
-		dev_err(info->device, "bcm2708_fb_blank(%d) failed: %d\n",
+		dev_err(info->device, "%s(%d) failed: %d\n", __func__,
 			blank_mode, ret);
 
 	return ret;
 }
 
-static int bcm2708_fb_pan_display(struct fb_var_screeninfo *var, struct fb_info *info)
+static int bcm2708_fb_pan_display(struct fb_var_screeninfo *var,
+				  struct fb_info *info)
 {
 	s32 result;
+
 	info->var.xoffset = var->xoffset;
 	info->var.yoffset = var->yoffset;
 	result = bcm2708_fb_set_par(info);
 	if (result != 0)
-		pr_err("bcm2708_fb_pan_display(%d,%d) returns=%d\n", var->xoffset, var->yoffset, result);
+		pr_err("%s(%d,%d) returns=%d\n", __func__,
+			var->xoffset, var->yoffset, result);
 	return result;
 }
 
-static void dma_memcpy(struct bcm2708_fb *fb, dma_addr_t dst, dma_addr_t src, int size)
+static void dma_memcpy(struct bcm2708_fb *fb, dma_addr_t dst, dma_addr_t src,
+		       int size)
 {
 	int burst_size = (fb->dma_chan == 0) ? 8 : 2;
 	struct bcm2708_dma_cb *cb = fb->cb_base;
@@ -450,6 +464,7 @@ static void dma_memcpy(struct bcm2708_fb *fb, dma_addr_t dst, dma_addr_t src, in
 		bcm_dma_wait_idle(fb->dma_chan_base);
 	} else {
 		void __iomem *dma_chan = fb->dma_chan_base;
+
 		cb->info |= BCM2708_DMA_INT_EN;
 		bcm_dma_start(fb->dma_chan_base, fb->cb_handle);
 		while (bcm_dma_is_busy(dma_chan)) {
@@ -462,8 +477,10 @@ static void dma_memcpy(struct bcm2708_fb *fb, dma_addr_t dst, dma_addr_t src, in
 	fb->stats.dma_copies++;
 }
 
-#define INTALIAS_NORMAL(x) ((x)&~0xc0000000) // address with no aliases
-#define INTALIAS_L1L2_NONALLOCATING(x) (((x)&~0xc0000000)|0x80000000) // cache coherent but non-allocating in L1 and L2
+/* address with no aliases */
+#define INTALIAS_NORMAL(x) ((x)&~0xc0000000)
+/* cache coherent but non-allocating in L1 and L2 */
+#define INTALIAS_L1L2_NONALLOCATING(x) (((x)&~0xc0000000)|0x80000000)
 
 static long vc_mem_copy(struct bcm2708_fb *fb, unsigned long arg)
 {
@@ -475,8 +492,7 @@ static long vc_mem_copy(struct bcm2708_fb *fb, unsigned long arg)
 	size_t offset;
 
 	/* restrict this to root user */
-	if (!uid_eq(current_euid(), GLOBAL_ROOT_UID))
-	{
+	if (!uid_eq(current_euid(), GLOBAL_ROOT_UID)) {
 		rc = -EFAULT;
 		goto out;
 	}
@@ -492,12 +508,16 @@ static long vc_mem_copy(struct bcm2708_fb *fb, unsigned long arg)
 	}
 
 	if (fb->gpu.base == 0 || fb->gpu.length == 0) {
-		pr_err("[%s]: Unable to determine gpu memory (%x,%x)\n", __func__, fb->gpu.base, fb->gpu.length);
+		pr_err("[%s]: Unable to determine gpu memory (%x,%x)\n",
+			__func__, fb->gpu.base, fb->gpu.length);
 		return -EFAULT;
 	}
 
-	if (INTALIAS_NORMAL(ioparam.src) < fb->gpu.base || INTALIAS_NORMAL(ioparam.src) >= fb->gpu.base + fb->gpu.length) {
-		pr_err("[%s]: Invalid memory access %x (%x-%x)", __func__, INTALIAS_NORMAL(ioparam.src), fb->gpu.base, fb->gpu.base + fb->gpu.length);
+	if (INTALIAS_NORMAL(ioparam.src) < fb->gpu.base ||
+		INTALIAS_NORMAL(ioparam.src) >= fb->gpu.base + fb->gpu.length) {
+		pr_err("[%s]: Invalid memory access %x (%x-%x)", __func__,
+			INTALIAS_NORMAL(ioparam.src), fb->gpu.base,
+			fb->gpu.base + fb->gpu.length);
 		return -EFAULT;
 	}
 
@@ -515,7 +535,9 @@ static long vc_mem_copy(struct bcm2708_fb *fb, unsigned long arg)
 		size_t s = min(size, remaining);
 		unsigned char *p = (unsigned char *)ioparam.src + offset;
 		unsigned char *q = (unsigned char *)ioparam.dst + offset;
-		dma_memcpy(fb, bus_addr, INTALIAS_L1L2_NONALLOCATING((dma_addr_t)p), size);
+
+		dma_memcpy(fb, bus_addr,
+			   INTALIAS_L1L2_NONALLOCATING((dma_addr_t)p), size);
 		if (copy_to_user(q, buf, s) != 0) {
 			pr_err("[%s]: failed to copy-to-user\n",
 					__func__);
@@ -525,11 +547,13 @@ static long vc_mem_copy(struct bcm2708_fb *fb, unsigned long arg)
 	}
 out:
 	if (buf)
-		dma_free_coherent(fb->fb.device, PAGE_ALIGN(size), buf, bus_addr);
+		dma_free_coherent(fb->fb.device, PAGE_ALIGN(size), buf,
+				  bus_addr);
 	return rc;
 }
 
-static int bcm2708_ioctl(struct fb_info *info, unsigned int cmd, unsigned long arg)
+static int bcm2708_ioctl(struct fb_info *info, unsigned int cmd,
+			 unsigned long arg)
 {
 	struct bcm2708_fb *fb = to_bcm2708(info);
 	u32 dummy = 0;
@@ -593,13 +617,13 @@ static void bcm2708_fb_copyarea(struct fb_info *info,
 	struct bcm2708_fb *fb = to_bcm2708(info);
 	struct bcm2708_dma_cb *cb = fb->cb_base;
 	int bytes_per_pixel = (info->var.bits_per_pixel + 7) >> 3;
+
 	/* Channel 0 supports larger bursts and is a bit faster */
 	int burst_size = (fb->dma_chan == 0) ? 8 : 2;
 	int pixels = region->width * region->height;
 
 	/* Fallback to cfb_copyarea() if we don't like something */
-	if (in_atomic() ||
-	    bytes_per_pixel > 4 ||
+	if (bytes_per_pixel > 4 ||
 	    info->var.xres * info->var.yres > 1920 * 1200 ||
 	    region->width <= 0 || region->width > info->var.xres ||
 	    region->height <= 0 || region->height > info->var.yres ||
@@ -663,6 +687,7 @@ static void bcm2708_fb_copyarea(struct fb_info *info,
 	} else {
 		/* A single dma control block is enough. */
 		int sy, dy, stride;
+
 		if (region->dy <= region->sy) {
 			/* processing from top to bottom */
 			dy = region->dy;
@@ -694,6 +719,7 @@ static void bcm2708_fb_copyarea(struct fb_info *info,
 		bcm_dma_wait_idle(fb->dma_chan_base);
 	} else {
 		void __iomem *dma_chan = fb->dma_chan_base;
+
 		cb->info |= BCM2708_DMA_INT_EN;
 		bcm_dma_start(fb->dma_chan_base, fb->cb_handle);
 		while (bcm_dma_is_busy(dma_chan)) {
@@ -791,8 +817,8 @@ static int bcm2708_fb_register(struct bcm2708_fb *fb)
 	if (ret)
 		return ret;
 
-	print_debug("BCM2708FB: registering framebuffer (%dx%d@%d) (%d)\n", fbwidth,
-		fbheight, fbdepth, fbswap);
+	print_debug("BCM2708FB: registering framebuffer (%dx%d@%d) (%d)\n",
+		fbwidth, fbheight, fbdepth, fbswap);
 
 	ret = register_framebuffer(&fb->fb);
 	print_debug("BCM2708FB: register framebuffer (%d)\n", ret);
@@ -813,19 +839,17 @@ static int bcm2708_fb_probe(struct platform_device *dev)
 
 	fw_np = of_parse_phandle(dev->dev.of_node, "firmware", 0);
 /* Remove comment when booting without Device Tree is no longer supported
-	if (!fw_np) {
-		dev_err(&dev->dev, "Missing firmware node\n");
-		return -ENOENT;
-	}
-*/
+ *	if (!fw_np) {
+ *		dev_err(&dev->dev, "Missing firmware node\n");
+ *		return -ENOENT;
+ *	}
+ */
 	fw = rpi_firmware_get(fw_np);
 	if (!fw)
 		return -EPROBE_DEFER;
 
 	fb = kzalloc(sizeof(struct bcm2708_fb), GFP_KERNEL);
 	if (!fb) {
-		dev_err(&dev->dev,
-			"could not allocate new bcm2708_fb struct\n");
 		ret = -ENOMEM;
 		goto free_region;
 	}
@@ -866,7 +890,9 @@ static int bcm2708_fb_probe(struct platform_device *dev)
 	fb->dev = dev;
 	fb->fb.device = &dev->dev;
 
-	// failure here isn't fatal, but we'll fail in vc_mem_copy if fb->gpu is not valid
+	/* failure here isn't fatal, but we'll fail in vc_mem_copy if
+	 * fb->gpu is not valid
+	 */
 	rpi_firmware_property(fb->fw,
 				    RPI_FIRMWARE_GET_VC_MEMORY,
 				    &fb->gpu, sizeof(fb->gpu));


### PR DESCRIPTION
Mostly whitespace stuff, but some minor change to function - 
remove a use of in_atomic, plus replacing various debug messages
that manually specify the function name with ("%s",.__func__)