### PR TITLE
Add ability to export the pin used by the gpio-poweroff driver

### DIFF
--- a/Documentation/devicetree/bindings/power/reset/gpio-poweroff.txt
+++ b/Documentation/devicetree/bindings/power/reset/gpio-poweroff.txt
@@ -27,6 +27,7 @@ Optional properties:
   it to an output when the power-off handler is called. If this optional
   property is not specified, the GPIO is initialized as an output in its
   inactive state.
+- export : Export the GPIO line to the sysfs system
 
 Examples:
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -588,6 +588,9 @@ Params: gpiopin                 GPIO for signalling (default 26)
                                 custom dt-blob.bin to prevent a power-down
                                 during the boot process, and that a reboot
                                 will also cause the pin to go low.
+        input                   Set if the gpio pin should be configured as
+                                an input.
+        export                  Set to export the configured pin to sysfs
 
 
 Name:   gpio-shutdown

--- a/arch/arm/boot/dts/overlays/gpio-poweroff-overlay.dts
+++ b/arch/arm/boot/dts/overlays/gpio-poweroff-overlay.dts
@@ -30,5 +30,7 @@
 		gpiopin =       <&power_ctrl>,"gpios:4",
 				<&power_ctrl_pins>,"brcm,pins:0";
 		active_low =    <&power_ctrl>,"gpios:8";
+		input =         <&power_ctrl>,"input?";
+		export =        <&power_ctrl>,"export?";
 	};
 };

--- a/drivers/power/reset/gpio-poweroff.c
+++ b/drivers/power/reset/gpio-poweroff.c
@@ -50,6 +50,7 @@ static int gpio_poweroff_probe(struct platform_device *pdev)
 	bool input = false;
 	enum gpiod_flags flags;
 	bool force = false;
+	bool export = false;
 
 	/* If a pm_power_off function has already been added, leave it alone */
 	force = of_property_read_bool(pdev->dev.of_node, "force");
@@ -70,6 +71,12 @@ static int gpio_poweroff_probe(struct platform_device *pdev)
 	if (IS_ERR(reset_gpio))
 		return PTR_ERR(reset_gpio);
 
+	export = of_property_read_bool(pdev->dev.of_node, "export");
+	if (export) {
+		gpiod_export(reset_gpio, false);
+		gpiod_export_link(&pdev->dev, "poweroff-gpio", reset_gpio);
+	}
+
 	pm_power_off = &gpio_poweroff_do_poweroff;
 	return 0;
 }
@@ -78,6 +85,8 @@ static int gpio_poweroff_remove(struct platform_device *pdev)
 {
 	if (pm_power_off == &gpio_poweroff_do_poweroff)
 		pm_power_off = NULL;
+
+	gpiod_unexport(reset_gpio);
 
 	return 0;
 }


### PR DESCRIPTION
If the GPIO line is configured to be an input, or for diagnostic purposes, it would be useful to examine the state of the GPIO line from userspace. This change allows this by exporting the GPIO line to sysfs.