### PR TITLE
USB: Gadget Ethernet: Re-enable Jumbo frames.

### DIFF
--- a/drivers/usb/gadget/function/u_ether.c
+++ b/drivers/usb/gadget/function/u_ether.c
@@ -848,6 +848,10 @@ struct net_device *gether_setup_name_default(const char *netname)
 	net->ethtool_ops = &ops;
 	SET_NETDEV_DEVTYPE(net, &gadget_type);
 
+	/* MTU range: 14 - 15412 */
+	net->min_mtu = ETH_HLEN;
+	net->max_mtu = GETHER_MAX_ETH_FRAME_LEN;
+
 	return net;
 }
 EXPORT_SYMBOL_GPL(gether_setup_name_default);


### PR DESCRIPTION
Cherry-pick from upstream in testing branch: https://kernel.googlesource.com/pub/scm/linux/kernel/git/balbi/usb/+log/testing/next

Increasing mtu size can double transfer rates or better for gadget ethernet on slow cpus like PiZero, and there was a serious regression from 4.9 to 4.14 reported in the RPI forums.


Fixes: <b3e3893e1253> ("net: use core MTU range checking")
which patched only one of two functions used to setup the
USB Gadget Ethernet driver, causing a serious performance
regression in the ability to increase mtu size above 1500.

Signed-off-by: John Greb <h3x4m3r0n@gmail.com>
Signed-off-by: Felipe Balbi <felipe.balbi@linux.intel.com>