### PR TITLE
[4.17] Justboom Dac+Digi: change codec to component

### DIFF
--- a/sound/soc/bcm/justboom-dac.c
+++ b/sound/soc/bcm/justboom-dac.c
@@ -31,10 +31,10 @@ static bool digital_gain_0db_limit = true;
 
 static int snd_rpi_justboom_dac_init(struct snd_soc_pcm_runtime *rtd)
 {
-	struct snd_soc_codec *codec = rtd->codec;
-	snd_soc_update_bits(codec, PCM512x_GPIO_EN, 0x08, 0x08);
-	snd_soc_update_bits(codec, PCM512x_GPIO_OUTPUT_4, 0xf, 0x02);
-	snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x08,0x08);
+	struct snd_soc_component *component = rtd->codec_dai->component;
+	snd_soc_component_update_bits(component, PCM512x_GPIO_EN, 0x08, 0x08);
+	snd_soc_component_update_bits(component, PCM512x_GPIO_OUTPUT_4, 0xf, 0x02);
+	snd_soc_component_update_bits(component, PCM512x_GPIO_CONTROL_1, 0x08,0x08);
 
 	if (digital_gain_0db_limit)
 	{
@@ -51,15 +51,15 @@ static int snd_rpi_justboom_dac_init(struct snd_soc_pcm_runtime *rtd)
 
 static int snd_rpi_justboom_dac_startup(struct snd_pcm_substream *substream) {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_codec *codec = rtd->codec;
-	snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x08,0x08);
+	struct snd_soc_component *component = rtd->codec_dai->component;
+	snd_soc_component_update_bits(component, PCM512x_GPIO_CONTROL_1, 0x08,0x08);
 	return 0;
 }
 
 static void snd_rpi_justboom_dac_shutdown(struct snd_pcm_substream *substream) {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_codec *codec = rtd->codec;
-	snd_soc_update_bits(codec, PCM512x_GPIO_CONTROL_1, 0x08,0x00);
+	struct snd_soc_component *component = rtd->codec_dai->component;
+	snd_soc_component_update_bits(component, PCM512x_GPIO_CONTROL_1, 0x08,0x00);
 }
 
 /* machine stream operations */

--- a/sound/soc/bcm/justboom-digi.c
+++ b/sound/soc/bcm/justboom-digi.c
@@ -29,10 +29,10 @@
 
 static int snd_rpi_justboom_digi_init(struct snd_soc_pcm_runtime *rtd)
 {
-	struct snd_soc_codec *codec = rtd->codec;
+	struct snd_soc_component *component = rtd->codec_dai->component;
 
 	/* enable TX output */
-	snd_soc_update_bits(codec, WM8804_PWRDN, 0x4, 0x0);
+	snd_soc_component_update_bits(component, WM8804_PWRDN, 0x4, 0x0);
 
 	return 0;
 }
@@ -40,16 +40,16 @@ static int snd_rpi_justboom_digi_init(struct snd_soc_pcm_runtime *rtd)
 static int snd_rpi_justboom_digi_startup(struct snd_pcm_substream *substream) {
 	/* turn on digital output */
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_codec *codec = rtd->codec;
-	snd_soc_update_bits(codec, WM8804_PWRDN, 0x3c, 0x00);
+	struct snd_soc_component *component = rtd->codec_dai->component;
+	snd_soc_component_update_bits(component, WM8804_PWRDN, 0x3c, 0x00);
 	return 0;
 }
 
 static void snd_rpi_justboom_digi_shutdown(struct snd_pcm_substream *substream) {
 	/* turn off output */
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_codec *codec = rtd->codec;
-	snd_soc_update_bits(codec, WM8804_PWRDN, 0x3c, 0x3c);
+	struct snd_soc_component *component = rtd->codec_dai->component;
+	snd_soc_component_update_bits(component, WM8804_PWRDN, 0x3c, 0x3c);
 }
 
 static int snd_rpi_justboom_digi_hw_params(struct snd_pcm_substream *substream,
@@ -57,7 +57,7 @@ static int snd_rpi_justboom_digi_hw_params(struct snd_pcm_substream *substream,
 {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	struct snd_soc_dai *codec_dai = rtd->codec_dai;
-	struct snd_soc_codec *codec = rtd->codec;
+	struct snd_soc_component *component = rtd->codec_dai->component;
 	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
 
 	int sysclk = 27000000; /* This is fixed on this board */
@@ -101,7 +101,7 @@ static int snd_rpi_justboom_digi_hw_params(struct snd_pcm_substream *substream,
 			sampling_freq=0x0e;
 			break;
 		default:
-			dev_err(codec->dev,
+			dev_err(rtd->card->dev,
 			"Failed to set WM8804 SYSCLK, unsupported samplerate %d\n",
 			samplerate);
 	}
@@ -112,19 +112,19 @@ static int snd_rpi_justboom_digi_hw_params(struct snd_pcm_substream *substream,
 	ret = snd_soc_dai_set_sysclk(codec_dai, WM8804_TX_CLKSRC_PLL,
 					sysclk, SND_SOC_CLOCK_OUT);
 	if (ret < 0) {
-		dev_err(codec->dev,
+		dev_err(rtd->card->dev,
 		"Failed to set WM8804 SYSCLK: %d\n", ret);
 		return ret;
 	}
 
 	/* Enable TX output */
-	snd_soc_update_bits(codec, WM8804_PWRDN, 0x4, 0x0);
+	snd_soc_component_update_bits(component, WM8804_PWRDN, 0x4, 0x0);
 
 	/* Power on */
-	snd_soc_update_bits(codec, WM8804_PWRDN, 0x9, 0);
+	snd_soc_component_update_bits(component, WM8804_PWRDN, 0x9, 0);
 
 	/* set sampling frequency status bits */
-	snd_soc_update_bits(codec, WM8804_SPDTX4, 0x0f, sampling_freq);
+	snd_soc_component_update_bits(component, WM8804_SPDTX4, 0x0f, sampling_freq);
 
 	return snd_soc_dai_set_bclk_ratio(cpu_dai,64);
 }


### PR DESCRIPTION
struct snd_soc_codec has been replaced with snd_soc_component.

In 4.17 the struct is still present, but for example codec in snd_soc_runtime isn't initiallized anymore and accessing it results in a null pointer oops.

In 4.18 snd_soc_codec is removed completely and code using it will no longer compile.

This PR fixes the Justboom Dac and Digi drivers, compile and runtime test on RPi3 worked fine.

@popcornmix the other soundcard drivers need to be changed following the same pattern