### PR TITLE
arm: dts: bcm2710-rpi-3-b-plus: fix hpd gpio pin

### DIFF
--- a/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
@@ -162,7 +162,7 @@
 };
 
 &hdmi {
-	hpd-gpios = <&expgpio 4 GPIO_ACTIVE_LOW>;
+	hpd-gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
 };
 
 &audio {


### PR DESCRIPTION
hpd gpio is listed as 28 in https://github.com/raspberrypi/firmware/blob/master/extra/dt-blob.dts#L1335

This fixes hotplug detection when using vc4