### PR TITLE
Unicam simplified DT overlays

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-0-w.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-0-w.dts
@@ -1,6 +1,7 @@
 /dts-v1/;
 
 #include "bcm2708.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,model-zero-w", "brcm,bcm2835";

--- a/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
@@ -2,6 +2,7 @@
 
 #include "bcm2708.dtsi"
 #include "bcm283x-rpi-smsc9514.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	model = "Raspberry Pi Model B+";

--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -2,6 +2,7 @@
 
 #include "bcm2708.dtsi"
 #include "bcm283x-rpi-smsc9512.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	model = "Raspberry Pi Model B";

--- a/arch/arm/boot/dts/bcm2708-rpi-cm.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-cm.dts
@@ -1,6 +1,8 @@
 /dts-v1/;
 
 #include "bcm2708-rpi-cm.dtsi"
+#include "bcm283x-rpi-csi0-2lane.dtsi"
+#include "bcm283x-rpi-csi1-4lane.dtsi"
 
 / {
 	model = "Raspberry Pi Compute Module";

--- a/arch/arm/boot/dts/bcm2708-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2708-rpi.dtsi
@@ -160,3 +160,11 @@ sdhost_pins: &sdhost_gpio48 {
 &vec {
 	status = "disabled";
 };
+
+&csi0 {
+	power-domains = <&power RPI_POWER_DOMAIN_UNICAM0>;
+};
+
+&csi1 {
+	power-domains = <&power RPI_POWER_DOMAIN_UNICAM1>;
+};

--- a/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
@@ -2,6 +2,7 @@
 
 #include "bcm2709.dtsi"
 #include "bcm283x-rpi-smsc9514.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,2-model-b", "brcm,bcm2836";

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
@@ -2,6 +2,7 @@
 
 #include "bcm2710.dtsi"
 #include "bcm283x-rpi-lan7515.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,3-model-b-plus", "brcm,bcm2837";

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
@@ -2,6 +2,7 @@
 
 #include "bcm2710.dtsi"
 #include "bcm283x-rpi-smsc9514.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,3-model-b", "brcm,bcm2837";

--- a/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
@@ -1,6 +1,8 @@
 /dts-v1/;
 
 #include "bcm2710.dtsi"
+#include "bcm283x-rpi-csi0-2lane.dtsi"
+#include "bcm283x-rpi-csi1-4lane.dtsi"
 
 / {
 	model = "Raspberry Pi Compute Module 3";

--- a/arch/arm/boot/dts/bcm2835-rpi-a-plus.dts
+++ b/arch/arm/boot/dts/bcm2835-rpi-a-plus.dts
@@ -3,6 +3,7 @@
 #include "bcm2835.dtsi"
 #include "bcm2835-rpi.dtsi"
 #include "bcm283x-rpi-usb-host.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,model-a-plus", "brcm,bcm2835";

--- a/arch/arm/boot/dts/bcm2835-rpi-a.dts
+++ b/arch/arm/boot/dts/bcm2835-rpi-a.dts
@@ -3,6 +3,7 @@
 #include "bcm2835.dtsi"
 #include "bcm2835-rpi.dtsi"
 #include "bcm283x-rpi-usb-host.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,model-a", "brcm,bcm2835";

--- a/arch/arm/boot/dts/bcm2835-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2835-rpi-b-plus.dts
@@ -4,6 +4,7 @@
 #include "bcm2835-rpi.dtsi"
 #include "bcm283x-rpi-smsc9514.dtsi"
 #include "bcm283x-rpi-usb-host.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,model-b-plus", "brcm,bcm2835";

--- a/arch/arm/boot/dts/bcm2835-rpi-b-rev2.dts
+++ b/arch/arm/boot/dts/bcm2835-rpi-b-rev2.dts
@@ -4,6 +4,7 @@
 #include "bcm2835-rpi.dtsi"
 #include "bcm283x-rpi-smsc9512.dtsi"
 #include "bcm283x-rpi-usb-host.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,model-b-rev2", "brcm,bcm2835";

--- a/arch/arm/boot/dts/bcm2835-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2835-rpi-b.dts
@@ -4,6 +4,7 @@
 #include "bcm2835-rpi.dtsi"
 #include "bcm283x-rpi-smsc9512.dtsi"
 #include "bcm283x-rpi-usb-host.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,model-b", "brcm,bcm2835";

--- a/arch/arm/boot/dts/bcm2835-rpi-zero.dts
+++ b/arch/arm/boot/dts/bcm2835-rpi-zero.dts
@@ -13,6 +13,7 @@
 #include "bcm2835.dtsi"
 #include "bcm2835-rpi.dtsi"
 #include "bcm283x-rpi-usb-otg.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,model-zero", "brcm,bcm2835";

--- a/arch/arm/boot/dts/bcm2835-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2835-rpi.dtsi
@@ -106,3 +106,11 @@
 &dsi1 {
 	power-domains = <&power RPI_POWER_DOMAIN_DSI1>;
 };
+
+&csi0 {
+	power-domains = <&power RPI_POWER_DOMAIN_UNICAM0>;
+};
+
+&csi1 {
+	power-domains = <&power RPI_POWER_DOMAIN_UNICAM1>;
+};

--- a/arch/arm/boot/dts/bcm2836-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2836-rpi-2-b.dts
@@ -4,6 +4,7 @@
 #include "bcm2835-rpi.dtsi"
 #include "bcm283x-rpi-smsc9514.dtsi"
 #include "bcm283x-rpi-usb-host.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,2-model-b", "brcm,bcm2836";

--- a/arch/arm/boot/dts/bcm2837-rpi-3-b.dts
+++ b/arch/arm/boot/dts/bcm2837-rpi-3-b.dts
@@ -4,6 +4,7 @@
 #include "bcm2835-rpi.dtsi"
 #include "bcm283x-rpi-smsc9514.dtsi"
 #include "bcm283x-rpi-usb-host.dtsi"
+#include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
 	compatible = "raspberrypi,3-model-b", "brcm,bcm2837";

--- a/arch/arm/boot/dts/bcm283x-rpi-csi0-2lane.dtsi
+++ b/arch/arm/boot/dts/bcm283x-rpi-csi0-2lane.dtsi
@@ -1,0 +1,7 @@
+&csi0 {
+	port {
+		endpoint {
+			data-lanes = <1 2>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/bcm283x-rpi-csi1-2lane.dtsi
+++ b/arch/arm/boot/dts/bcm283x-rpi-csi1-2lane.dtsi
@@ -1,0 +1,7 @@
+&csi1 {
+	port {
+		endpoint {
+			data-lanes = <1 2>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/bcm283x-rpi-csi1-4lane.dtsi
+++ b/arch/arm/boot/dts/bcm283x-rpi-csi1-4lane.dtsi
@@ -1,0 +1,7 @@
+&csi1 {
+	port {
+		endpoint {
+			data-lanes = <1 2 3 4>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/bcm283x.dtsi
+++ b/arch/arm/boot/dts/bcm283x.dtsi
@@ -544,6 +544,34 @@
 			status = "disabled";
 		};
 
+		csi0: csi0@7e800000 {
+			compatible = "brcm,bcm2835-unicam";
+			reg = <0x7e800000 0x800>,
+			      <0x7e802000 0x4>;
+			interrupts = <2 6>;
+			clocks = <&clocks BCM2835_CLOCK_CAM0>;
+			clock-names = "lp";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#clock-cells = <1>;
+
+			status = "disabled";
+		};
+
+		csi1: csi1@7e801000 {
+			compatible = "brcm,bcm2835-unicam";
+			reg = <0x7e801000 0x800>,
+			      <0x7e802004 0x4>;
+			interrupts = <2 7>;
+			clocks = <&clocks BCM2835_CLOCK_CAM1>;
+			clock-names = "lp";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#clock-cells = <1>;
+
+			status = "disabled";
+		};
+
 		i2c1: i2c@7e804000 {
 			compatible = "brcm,bcm2835-i2c";
 			reg = <0x7e804000 0x1000>;

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -6,6 +6,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	ads1015.dtbo \
 	ads1115.dtbo \
 	ads7846.dtbo \
+	adv7282m.dtbo \
 	akkordion-iqdacplus.dtbo \
 	allo-boss-dac-pcm512x-audio.dtbo \
 	allo-digione.dtbo \
@@ -77,6 +78,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	mmc.dtbo \
 	mpu6050.dtbo \
 	mz61581.dtbo \
+	ov5647.dtbo \
 	papirus.dtbo \
 	pi3-act-led.dtbo \
 	pi3-disable-bt.dtbo \
@@ -127,6 +129,8 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	spi2-3cs.dtbo \
 	superaudioboard.dtbo \
 	sx150x.dtbo \
+	tc358743.dtbo \
+	tc358743-audio.dtbo \
 	tinylcd35.dtbo \
 	uart0.dtbo \
 	uart1.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -267,6 +267,15 @@ Params: cs                      SPI bus Chip Select (default 1)
         www.kernel.org/doc/Documentation/devicetree/bindings/input/ads7846.txt
 
 
+Name:   adv7282m
+Info:   Analog Devices ADV7282M analogue video to CSI2 bridge.
+        Uses Unicam1, which is the standard camera connector on most Pi
+        variants.
+Load:   dtoverlay=adv7282m,<param>=<val>
+Params: i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
+                                This is required for Pi B+, 2, 0, and 0W.
+
+
 Name:   akkordion-iqdacplus
 Info:   Configures the Digital Dreamtime Akkordion Music Player (based on the
         OEM IQAudIO DAC+ or DAC Zero module).
@@ -1232,6 +1241,23 @@ Params: speed                   Display SPI bus speed
         xohms                   Touchpanel sensitivity (X-plate resistance)
 
 
+Name:   ov5647
+Info:   Omnivision OV5647 camera module.
+        Uses Unicam 1, which is the standard camera connector on most Pi
+        variants.
+Load:   dtoverlay=ov5647,<param>=<val>
+Params: cam0-pwdn               GPIO used to control the sensor powerdown line.
+
+        cam0-led                GPIO used to control the sensor led
+                                Both these fields should be automatically filled
+                                in by the firmware to reflect the default GPIO
+                                configuration of the particular Pi variant in
+                                use.
+
+        i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
+                                This is required for Pi B+, 2, 0, and 0W.
+
+
 Name:   papirus
 Info:   PaPiRus ePaper Screen by Pi Supply (both HAT and pHAT)
 Load:   dtoverlay=papirus,<param>=<val>
@@ -1826,6 +1852,31 @@ Params: sx150<x>-<n>-<m>        Enables SX150X device on I2C#<n> with slave
                                 I2C#<n> with slave address <m>, specifies
                                 the GPIO pin to which NINT output of SX150X is
                                 connected.
+
+
+Name:   tc358743
+Info:   Toshiba TC358743 HDMI to CSI-2 bridge chip.
+        Uses Unicam 1, which is the standard camera connector on most Pi
+        variants.
+Load:   dtoverlay=tc358743,<param>=<val>
+Params: 4lane                   Use 4 lanes (only applicable to Compute Modules
+                                CAM1 connector).
+
+        link-frequency          Set the link frequency. Only values of 297000000
+                                (574Mbit/s) and 486000000 (972Mbit/s - default)
+                                are supported by the driver.
+
+        i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
+                                This is required for Pi B+, 2, 0, and 0W.
+
+
+Name:   tc358743-audio
+Info:   Used in combination with the tc358743-fast overlay to route the audio
+        from the TC358743 over I2S to the Pi.
+        Wiring is LRCK/WFS to GPIO 19, BCK/SCK to GPIO 18, and DATA/SD to GPIO
+        20.
+Load:   dtoverlay=tc358743-audio,<param>=<val>
+Params: card-name               Override the default, "tc358743", card name.
 
 
 Name:   tinylcd35

--- a/arch/arm/boot/dts/overlays/adv7282m-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adv7282m-overlay.dts
@@ -1,0 +1,75 @@
+// Definitions for Analog Devices ADV7282-M video to CSI2 bridge on VC I2C bus
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&i2c_vc>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adv7282: adv7282@21 {
+				compatible = "adi,adv7282-m";
+				reg = <0x21>;
+				status = "okay";
+				clock-frequency = <24000000>;
+				port {
+					adv7282_0: endpoint {
+						remote-endpoint = <&csi1_ep>;
+						clock-lanes = <0>;
+						data-lanes = <1>;
+						link-frequencies =
+							/bits/ 64 <297000000>;
+
+						mclk-frequency = <12000000>;
+					};
+				};
+			};
+		};
+	};
+	fragment@1 {
+		target = <&csi1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			port {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				csi1_ep: endpoint {
+					remote-endpoint = <&adv7282_0>;
+				};
+			};
+		};
+	};
+	fragment@2 {
+		target = <&i2c0_pins>;
+		__dormant__ {
+			brcm,pins = <28 29>;
+			brcm,function = <4>; /* alt0 */
+		};
+
+	};
+	fragment@3 {
+		target = <&i2c0_pins>;
+		__overlay__ {
+			brcm,pins = <44 45>;
+			brcm,function = <5>; /* alt1 */
+		};
+	};
+	fragment@4 {
+		target = <&i2c_vc>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	__overrides__ {
+		i2c_pins_28_29 = <0>,"+2-3";
+	};
+};

--- a/arch/arm/boot/dts/overlays/ov5647-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov5647-overlay.dts
@@ -1,0 +1,86 @@
+// Definitions for OV5647 camera module on VC I2C bus
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&i2c_vc>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ov5647: ov5647@36 {
+				compatible = "ov5647";
+				reg = <0x36>;
+				status = "okay";
+
+				pwdn-gpios = <&gpio 41 1>, <&gpio 32 1>;
+				clocks = <&ov5647_clk>;
+
+				ov5647_clk: camera-clk {
+					compatible = "fixed-clock";
+					#clock-cells = <0>;
+					clock-frequency = <25000000>;
+				};
+
+				port {
+					ov5647_0: endpoint {
+						remote-endpoint = <&csi1_ep>;
+						clock-lanes = <0>;
+						data-lanes = <1 2>;
+						clock-noncontinuous;
+						link-frequencies =
+							/bits/ 64 <297000000>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&csi1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			port {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				csi1_ep: endpoint {
+					remote-endpoint = <&ov5647_0>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c0_pins>;
+		__dormant__ {
+			brcm,pins = <28 29>;
+			brcm,function = <4>; /* alt0 */
+		};
+	};
+	fragment@3 {
+		target = <&i2c0_pins>;
+		__overlay__ {
+			brcm,pins = <44 45>;
+			brcm,function = <5>; /* alt1 */
+		};
+	};
+	fragment@4 {
+		target = <&i2c_vc>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	__overrides__ {
+		i2c_pins_28_29 = <0>,"+4-5";
+		cam0-pwdn = <&ov5647>,"pwdn-gpios:4";
+		cam0-led = <&ov5647>,"pwdn-gpios:16";
+	};
+};

--- a/arch/arm/boot/dts/overlays/tc358743-audio-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tc358743-audio-overlay.dts
@@ -1,0 +1,51 @@
+// Definitions to add I2S audio from the Toshiba TC358743 HDMI to CSI2 bridge.
+// Requires tc358743 overlay to have been loaded to actually function.
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&i2s>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			tc358743_codec: tc358743-codec {
+				#sound-dai-cells = <0>;
+				compatible = "linux,spdif-dir";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&sound>;
+		sound_overlay: __overlay__ {
+			compatible = "simple-audio-card";
+			simple-audio-card,format = "i2s";
+			simple-audio-card,name = "tc358743";
+			simple-audio-card,bitclock-master = <&dailink0_slave>;
+			simple-audio-card,frame-master = <&dailink0_slave>;
+			status = "okay";
+
+			simple-audio-card,cpu {
+				sound-dai = <&i2s>;
+				dai-tdm-slot-num = <2>;
+				dai-tdm-slot-width = <32>;
+			};
+			dailink0_slave: simple-audio-card,codec {
+				sound-dai = <&tc358743_codec>;
+			};
+		};
+	};
+
+	__overrides__ {
+		card-name = <&sound_overlay>,"simple-audio-card,name";
+	};
+};

--- a/arch/arm/boot/dts/overlays/tc358743-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tc358743-overlay.dts
@@ -1,0 +1,111 @@
+// Definitions for Toshiba TC358743 HDMI to CSI2 bridge on VC I2C bus
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&i2c_vc>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			tc358743@0f {
+				compatible = "toshiba,tc358743";
+				reg = <0x0f>;
+				status = "okay";
+
+				clocks = <&tc358743_clk>;
+				clock-names = "refclk";
+
+				tc358743_clk: bridge-clk {
+					compatible = "fixed-clock";
+					#clock-cells = <0>;
+					clock-frequency = <27000000>;
+				};
+
+				port {
+					tc358743: endpoint {
+						remote-endpoint = <&csi1_ep>;
+						clock-lanes = <0>;
+						clock-noncontinuous;
+						link-frequencies =
+							/bits/ 64 <486000000>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&csi1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			port {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				csi1_ep: endpoint {
+					remote-endpoint = <&tc358743>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c_vc>;
+		__overlay__ {
+			tc358743@0f {
+				port {
+					endpoint {
+						data-lanes = <1 2>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&i2c_vc>;
+		__dormant__ {
+			tc358743@0f {
+				port {
+					endpoint {
+						data-lanes = <1 2 3 4>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&i2c0_pins>;
+		__dormant__ {
+			brcm,pins = <28 29>;
+			brcm,function = <4>; /* alt0 */
+		};
+	};
+	fragment@5 {
+		target = <&i2c0_pins>;
+		__overlay__ {
+			brcm,pins = <44 45>;
+			brcm,function = <5>; /* alt1 */
+		};
+	};
+	fragment@6 {
+		target = <&i2c_vc>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	__overrides__ {
+		i2c_pins_28_29 = <0>,"+4-5";
+		4lane = <0>, "-2+3";
+	        link-frequency = <&tc358743>,"link-frequencies#0";
+	};
+};

--- a/arch/arm64/boot/dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi
@@ -1,0 +1,1 @@
+../../../../arm/boot/dts/bcm283x-rpi-csi1-2lane.dtsi


### PR DESCRIPTION
This is the simplified version of #2578 which drops all the I2C pinctrl mux stuff but provides options to adjust the pinctrl setup as required.
I'll come back to #2578 when I have more enthusiasm to fight DT.