### PR TITLE
vc4 unbalanced irq fix

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_irq.c
+++ b/drivers/gpu/drm/vc4/vc4_irq.c
@@ -204,9 +204,6 @@ vc4_irq_postinstall(struct drm_device *dev)
 {
 	struct vc4_dev *vc4 = to_vc4_dev(dev);
 
-	/* Undo the effects of a previous vc4_irq_uninstall. */
-	enable_irq(dev->irq);
-
 	/* Enable both the render done and out of memory interrupts. */
 	V3D_WRITE(V3D_INTENA, V3D_DRIVER_IRQS);
 


### PR DESCRIPTION
Fixes the following warning:

```
[  414.810574] WARNING: CPU: 1 PID: 394 at /kernel-source//kernel/irq/manage.c:527 __enable_irq+0x54/0x80
[  414.820018] Unbalanced enable for IRQ 40
[  414.823993] Modules linked in: rfcomm bnep hci_uart btbcm ecryptfs bluetooth panel_raspberrypi_touchscreen brcmfmac brcmutil cfg80211 rfkill vc4 snd_soc_core snd_compress i2c_gpio snd_pcm_dmaengine bcm2835_gpi
omem uio_pdrv_genirq uio fixed evdev joydev sch_fq_codel snd_bcm2835 snd_pcm snd_timer snd hid_multitouch fuse ipv6
[  414.853179] CPU: 1 PID: 394 Comm: QSGRenderThread Tainted: G        W       4.9.80 #1
[  414.861123] Hardware name: BCM2835
[  414.864592] [<8011102c>] (unwind_backtrace) from [<8010c8f0>] (show_stack+0x20/0x24)
[  414.872458] [<8010c8f0>] (show_stack) from [<8045af48>] (dump_stack+0xcc/0x110)
[  414.879886] [<8045af48>] (dump_stack) from [<8011e7fc>] (__warn+0xf8/0x110)
[  414.886956] [<8011e7fc>] (__warn) from [<8011e85c>] (warn_slowpath_fmt+0x48/0x50)
[  414.894556] [<8011e85c>] (warn_slowpath_fmt) from [<8017752c>] (__enable_irq+0x54/0x80)
[  414.902685] [<8017752c>] (__enable_irq) from [<8017759c>] (enable_irq+0x44/0x7c)
[  414.910283] [<8017759c>] (enable_irq) from [<7f1c2b64>] (vc4_irq_postinstall+0x24/0x40 [vc4])
[  414.919062] [<7f1c2b64>] (vc4_irq_postinstall [vc4]) from [<7f1c5858>] (vc4_v3d_runtime_resume+0x58/0x60 [vc4])
[  414.929368] [<7f1c5858>] (vc4_v3d_runtime_resume [vc4]) from [<8053eb74>] (pm_generic_runtime_resume+0x3c/0x48)
[  414.939617] [<8053eb74>] (pm_generic_runtime_resume) from [<80542a28>] (__genpd_runtime_resume+0x3c/0xc0)
[  414.949334] [<80542a28>] (__genpd_runtime_resume) from [<80544638>] (genpd_runtime_resume+0x84/0x198)
[  414.958699] [<80544638>] (genpd_runtime_resume) from [<80540140>] (__rpm_callback+0x48/0x98)
[  414.967271] [<80540140>] (__rpm_callback) from [<805401c0>] (rpm_callback+0x30/0x90)
[  414.975138] [<805401c0>] (rpm_callback) from [<805415ec>] (rpm_resume+0x500/0x7c0)
[  414.982827] [<805415ec>] (rpm_resume) from [<8054191c>] (__pm_runtime_resume+0x70/0x9c)
[  414.991025] [<8054191c>] (__pm_runtime_resume) from [<7f1bf6c4>] (vc4_submit_cl_ioctl+0x2e4/0x9cc [vc4])
[  415.000716] [<7f1bf6c4>] (vc4_submit_cl_ioctl [vc4]) from [<80511dfc>] (drm_ioctl+0x1f0/0x3f8)
[  415.009466] [<80511dfc>] (drm_ioctl) from [<802867a4>] (do_vfs_ioctl+0xb0/0x814)
[  415.016981] [<802867a4>] (do_vfs_ioctl) from [<80286f4c>] (SyS_ioctl+0x44/0x68)
[  415.024410] [<80286f4c>] (SyS_ioctl) from [<801082a0>] (ret_fast_syscall+0x0/0x1c)
[  415.032092] ---[ end trace 3f3b9a47efa1f1f8 ]---
```