### PR TITLE
net: lan78xx: fix rx handling before first packet is send

### DIFF
--- a/drivers/net/usb/lan78xx.c
+++ b/drivers/net/usb/lan78xx.c
@@ -2606,6 +2606,8 @@ static int lan78xx_open(struct net_device *net)
 
 	dev->link_on = false;
 
+	tasklet_schedule(&dev->bh);
+
 	lan78xx_defer_kevent(dev, EVENT_LINK_RESET);
 done:
 	usb_autopm_put_interface(dev->intf);


### PR DESCRIPTION
As long the bh tasklet isn't scheduled once, no packet from the rx path
will be handled. Since the tx path also schedule the same tasklet
this situation only persits until the first packet transmission.
So fix this issue by scheduling the tasklet during ndo_open like in usbnet.

https://github.com/raspberrypi/linux/issues/2617