### PR TITLE
End log messages in one newline, not two.

### DIFF
--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -2079,7 +2079,7 @@ dump_phys_mem(void *virt_addr, u32 num_bytes)
 	pages = kmalloc(sizeof(struct page *) * num_pages, GFP_KERNEL);
 	if (!pages) {
 		vchiq_log_error(vchiq_arm_log_level,
-			"Unable to allocation memory for %d pages\n",
+			"Unable to allocation memory for %d pages",
 			num_pages);
 		return;
 	}
@@ -2098,7 +2098,7 @@ dump_phys_mem(void *virt_addr, u32 num_bytes)
 
 	if (rc < 0) {
 		vchiq_log_error(vchiq_arm_log_level,
-				"Failed to get user pages: %d\n", rc);
+				"Failed to get user pages: %d", rc);
 		goto out;
 	}
 

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
@@ -3152,7 +3152,7 @@ vchiq_pause_internal(VCHIQ_STATE_T *state)
 		break;
 	default:
 		vchiq_log_error(vchiq_core_log_level,
-			"vchiq_pause_internal in state %s\n",
+			"vchiq_pause_internal in state %s",
 			conn_state_names[state->conn_state]);
 		status = VCHIQ_ERROR;
 		VCHIQ_STATS_INC(state, error_count);

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_kern_lib.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_kern_lib.c
@@ -89,17 +89,17 @@ VCHIQ_STATUS_T vchiq_initialise(VCHIQ_INSTANCE_T *instance_out)
 	}
 	if (i == VCHIQ_INIT_RETRIES) {
 		vchiq_log_error(vchiq_core_log_level,
-			"%s: videocore not initialized\n", __func__);
+			"%s: videocore not initialized", __func__);
 		goto failed;
 	} else if (i > 0) {
 		vchiq_log_warning(vchiq_core_log_level,
-			"%s: videocore initialized after %d retries\n", __func__, i);
+			"%s: videocore initialized after %d retries", __func__, i);
 	}
 
 	instance = kzalloc(sizeof(*instance), GFP_KERNEL);
 	if (!instance) {
 		vchiq_log_error(vchiq_core_log_level,
-			"%s: error allocating vchiq instance\n", __func__);
+			"%s: error allocating vchiq instance", __func__);
 		goto failed;
 	}
 


### PR DESCRIPTION
Signed-off-by: Andreas Gustafsson <gson@gson.org>