### PR TITLE
Revert "mm: alloc_contig: re-allow CMA to compact FS pages"

### DIFF
--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -7527,7 +7527,6 @@ int alloc_contig_range(unsigned long start, unsigned long end,
 		.zone = page_zone(pfn_to_page(start)),
 		.mode = MIGRATE_SYNC,
 		.ignore_skip_hint = true,
-		.gfp_mask = current_gfp_context(gfp_mask),
 	};
 	INIT_LIST_HEAD(&cc.migratepages);
 


### PR DESCRIPTION
The upstream commit caused poor video playback performance
on a busy system for many users.

See: https://github.com/raspberrypi/linux/issues/2503

This reverts commit 424f6c4818bbf1b8ccf58aa012ecc19c0bb9b446.

Signed-off-by: popcornmix <popcornmix@gmail.com>