### PR TITLE
dtoverlays: Add support for ADV7280-M and ADV7281-M chips.

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -7,6 +7,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	ads1115.dtbo \
 	ads7846.dtbo \
 	adv7282m.dtbo \
+	adv728x-m.dtbo \
 	akkordion-iqdacplus.dtbo \
 	allo-boss-dac-pcm512x-audio.dtbo \
 	allo-digione.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -274,6 +274,19 @@ Info:   Analog Devices ADV7282M analogue video to CSI2 bridge.
 Load:   dtoverlay=adv7282m,<param>=<val>
 Params: i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
                                 This is required for Pi B+, 2, 0, and 0W.
+        addr                    Overrides the I2C address (default 0x21)
+
+
+Name:   adv728x-m
+Info:   Analog Devices ADV728[0|1|2]-M analogue video to CSI2 bridges.
+        This is a wrapper for adv7282m, and defaults to ADV7282M.
+Load:   dtoverlay=adv728x-m,<param>=<val>
+Params: i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
+                                This is required for Pi B+, 2, 0, and 0W.
+        addr                    Overrides the I2C address (default 0x21)
+        adv7280m                Select ADV7280-M.
+        adv7281m                Select ADV7281-M.
+        adv7281ma               Select ADV7281-MA.
 
 
 Name:   akkordion-iqdacplus

--- a/arch/arm/boot/dts/overlays/adv7282m-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adv7282m-overlay.dts
@@ -12,13 +12,13 @@
 			#size-cells = <0>;
 			status = "okay";
 
-			adv7282: adv7282@21 {
+			adv728x: adv728x@21 {
 				compatible = "adi,adv7282-m";
 				reg = <0x21>;
 				status = "okay";
 				clock-frequency = <24000000>;
 				port {
-					adv7282_0: endpoint {
+					adv728x_0: endpoint {
 						remote-endpoint = <&csi1_ep>;
 						clock-lanes = <0>;
 						data-lanes = <1>;
@@ -42,7 +42,7 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				csi1_ep: endpoint {
-					remote-endpoint = <&adv7282_0>;
+					remote-endpoint = <&adv728x_0>;
 				};
 			};
 		};
@@ -70,6 +70,7 @@
 	};
 
 	__overrides__ {
-		i2c_pins_28_29 = <0>,"+2-3";
+		i2c_pins_28_29 =	<0>,"+2-3";
+		addr =			<&adv728x>,"reg:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/adv728x-m-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adv728x-m-overlay.dts
@@ -1,0 +1,36 @@
+// Definitions for Analog Devices ADV728[0|1|2]-M video to CSI2 bridges on VC
+// I2C bus
+
+#include "adv7282m-overlay.dts"
+
+/{
+	compatible = "brcm,bcm2708";
+
+	// Fragment numbers deliberately high to avoid conflicts with the
+	// included adv7282m overlay file.
+
+	fragment@101 {
+		target = <&adv728x>;
+		__dormant__ {
+			compatible = "adi,adv7280-m";
+		};
+	};
+	fragment@102 {
+		target = <&adv728x>;
+		__dormant__ {
+			compatible = "adi,adv7281-m";
+		};
+	};
+	fragment@103 {
+		target = <&adv728x>;
+		__dormant__ {
+			compatible = "adi,adv7281-ma";
+		};
+	};
+
+	__overrides__ {
+		adv7280m = <0>, "+101";
+		adv7281m = <0>, "+102";
+		adv7281ma = <0>, "+103";
+	};
+};


### PR DESCRIPTION
The driver that supports the ADV7282-M also supports the ADV7280-M and
ADV7281-M.
The 7280 exposes 2 extra analogue inputs. The 7281 doesn't have the
I2P deinterlacing block. Otherwise they are the same as ADV7282-M.

Rename the existing overlay to adv728x-m.
Add a backwards compatibility overlay for adv7282m that includes adv728x-m.
Add parameters to alter the compatible string for the 7280 and 7281.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>