### PR TITLE
[4.18] rpi-wm8804-soundcard: use nicer driver_name "RPi-WM8804"

### DIFF
--- a/sound/soc/bcm/rpi-wm8804-soundcard.c
+++ b/sound/soc/bcm/rpi-wm8804-soundcard.c
@@ -313,7 +313,7 @@ static const struct of_device_id snd_rpi_wm8804_of_match[] = {
 };
 
 static struct snd_soc_card snd_rpi_wm8804 = {
-	.driver_name  = "RPI WM8804 soundcard",
+	.driver_name  = "RPi-WM8804",
 	.owner        = THIS_MODULE,
 	.dai_link     = NULL,
 	.num_links    = 1,


### PR DESCRIPTION
The driver_name shows up in /proc/asound/devices and is used
to load the proper Alsa card conf from /usr/share/alsa/cards.

But the length is limited to 15 characters and spaces are
replaced by underscore so the mangled name currently is
"RPI_WM8804_soun" which is not very nice.

Use "RPi-WM8804" instead which won't be mangled and can be used
unaltered as the card conf filename and card name in that file.

With the current rpi-4.18.y tree we have to use this conf file in LibreELEC
https://github.com/HiassofT/LibreELEC.tv/blob/le9-alsa-kernel4.18/projects/RPi/filesystem/usr/share/alsa/cards/RPI_WM8804_soun.conf

With this PR applied we'll be able to use this one:
https://github.com/HiassofT/LibreELEC.tv/blob/le9-alsa-kernel4.18-v2/projects/RPi/filesystem/usr/share/alsa/cards/RPi-WM8804.conf

PS: the new, unified wm8804 driver is highly appreciated, before we had to add a separate alsa card conf for each WM8804 based card.

ping @timg236