### PR TITLE
OV5647 kernel driver/overlay tweaks

### DIFF
--- a/arch/arm/boot/dts/bcm270x.dtsi
+++ b/arch/arm/boot/dts/bcm270x.dtsi
@@ -152,6 +152,13 @@
 		regulator-max-microvolt = <3300000>;
 		regulator-always-on;
 	};
+
+	__overrides__ {
+		cam0-pwdn-ctrl;
+		cam0-pwdn;
+		cam0-led-ctrl;
+		cam0-led;
+	};
 };
 
 /* Configure and use the auxilliary interrupt controller */

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1283,15 +1283,7 @@ Info:   Omnivision OV5647 camera module.
         Uses Unicam 1, which is the standard camera connector on most Pi
         variants.
 Load:   dtoverlay=ov5647,<param>=<val>
-Params: cam0-pwdn               GPIO used to control the sensor powerdown line.
-
-        cam0-led                GPIO used to control the sensor led
-                                Both these fields should be automatically filled
-                                in by the firmware to reflect the default GPIO
-                                configuration of the particular Pi variant in
-                                use.
-
-        i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
+Params: i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
                                 This is required for Pi B+, 2, 0, and 0W.
 
 

--- a/arch/arm/boot/dts/overlays/ov5647-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov5647-overlay.dts
@@ -78,9 +78,17 @@
 		};
 	};
 
+	fragment@5 {
+		target-path="/__overrides__";
+		__overlay__ {
+			cam0-pwdn-ctrl = <&ov5647>,"pwdn-gpios:0";
+			cam0-pwdn      = <&ov5647>,"pwdn-gpios:4";
+			cam0-led-ctrl  = <&ov5647>,"pwdn-gpios:12";
+			cam0-led       = <&ov5647>,"pwdn-gpios:16";
+		};
+	};
+
 	__overrides__ {
 		i2c_pins_28_29 = <0>,"+4-5";
-		cam0-pwdn = <&ov5647>,"pwdn-gpios:4";
-		cam0-led = <&ov5647>,"pwdn-gpios:16";
 	};
 };

--- a/drivers/media/i2c/ov5647.c
+++ b/drivers/media/i2c/ov5647.c
@@ -348,7 +348,7 @@ static int ov5647_sensor_power(struct v4l2_subdev *sd, int on)
 		dev_dbg(&client->dev, "OV5647 power on\n");
 
 		if (ov5647->pwdn) {
-			gpiod_set_value(ov5647->pwdn, 0);
+			gpiod_set_value_cansleep(ov5647->pwdn, 0);
 			msleep(PWDN_ACTIVE_DELAY_MS);
 		}
 
@@ -390,7 +390,7 @@ static int ov5647_sensor_power(struct v4l2_subdev *sd, int on)
 
 		clk_disable_unprepare(ov5647->xclk);
 
-		gpiod_set_value(ov5647->pwdn, 1);
+		gpiod_set_value_cansleep(ov5647->pwdn, 1);
 	}
 
 	/* Update the power count. */
@@ -624,13 +624,13 @@ static int ov5647_probe(struct i2c_client *client,
 		goto mutex_remove;
 
 	if (sensor->pwdn) {
-		gpiod_set_value(sensor->pwdn, 0);
+		gpiod_set_value_cansleep(sensor->pwdn, 0);
 		msleep(PWDN_ACTIVE_DELAY_MS);
 	}
 
 	ret = ov5647_detect(sd);
 
-	gpiod_set_value(sensor->pwdn, 1);
+	gpiod_set_value_cansleep(sensor->pwdn, 1);
 
 	if (ret < 0)
 		goto error;


### PR DESCRIPTION
It seems that I asked for an old set of DT changes to be merged for setting up the camera GPIOs resulting in it not working with the OV5647 where we need to power up the sensor (TC358743 and ADV7282 don't bother).
I've amended the DT patches appropriately and confirmed it works on a 3B+. On doing that I found that the kernel objected because the driver was calling gpiod_set_value on a GPIO controller that can sleep. There's therefore a driver patch to call gpiod_set_value_cansleep instead (which probably ought to be the default for all media drivers in this use case).

https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=222851