### PR TITLE
dwc_otg: fiq_fsm: fix incorrect DMA register offset calculation

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
@@ -250,7 +250,7 @@ static int notrace fiq_increment_dma_buf(struct fiq_state *st, int num_channels,
 		BUG();
 
 	hcdma.d32 = (dma_addr_t) &blob->channel[n].index[i].buf[0];
-	FIQ_WRITE(st->dwc_regs_base + HC_DMA + (HC_OFFSET * n), hcdma.d32);
+	FIQ_WRITE(st->dwc_regs_base + HC_START + (HC_OFFSET * n) + HC_DMA, hcdma.d32);
 	st->channel[n].dma_info.index = i;
 	return 0;
 }
@@ -302,7 +302,7 @@ static int notrace fiq_iso_out_advance(struct fiq_state *st, int num_channels, i
 
 	/* New DMA address - address of bounce buffer referred to in index */
 	hcdma.d32 = (uint32_t) &blob->channel[n].index[i].buf[0];
-	//hcdma.d32 = FIQ_READ(st->dwc_regs_base + HC_DMA + (HC_OFFSET * n));
+	//hcdma.d32 = FIQ_READ(st->dwc_regs_base + HC_START + (HC_OFFSET * n) + HC_DMA);
 	//hcdma.d32 += st->channel[n].dma_info.slot_len[i];
 	fiq_print(FIQDBG_INT, st, "LAST: %01d ", last);
 	fiq_print(FIQDBG_INT, st, "LEN: %03d", st->channel[n].dma_info.slot_len[i]);
@@ -317,7 +317,7 @@ static int notrace fiq_iso_out_advance(struct fiq_state *st, int num_channels, i
 	st->channel[n].dma_info.index++;
 	FIQ_WRITE(st->dwc_regs_base + HC_START + (HC_OFFSET * n) + HCSPLT, hcsplt.d32);
 	FIQ_WRITE(st->dwc_regs_base + HC_START + (HC_OFFSET * n) + HCTSIZ, hctsiz.d32);
-	FIQ_WRITE(st->dwc_regs_base + HC_DMA + (HC_OFFSET * n), hcdma.d32);
+	FIQ_WRITE(st->dwc_regs_base + HC_START + (HC_OFFSET * n) + HC_DMA, hcdma.d32);
 	return last;
 }
 
@@ -564,7 +564,7 @@ static int notrace noinline fiq_fsm_update_hs_isoc(struct fiq_state *state, int 
 
 	/* grab the next DMA address offset from the array */
 	hcdma.d32 = st->hcdma_copy.d32 + st->hs_isoc_info.iso_desc[st->hs_isoc_info.index].offset;
-	FIQ_WRITE(state->dwc_regs_base + HC_DMA + (HC_OFFSET * n), hcdma.d32);
+	FIQ_WRITE(state->dwc_regs_base + HC_START + (HC_OFFSET * n) + HC_DMA, hcdma.d32);
 
 	/* We need to set multi_count. This is a bit tricky - has to be set per-transaction as
 	 * the core needs to be told to send the correct number. Caution: for IN transfers,

--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h
+++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h
@@ -94,7 +94,7 @@ do {							\
 #define HC_START	0x500
 #define HC_OFFSET	0x020
 
-#define HC_DMA		0x514
+#define HC_DMA		0x14
 
 #define HCCHAR		0x00
 #define HCSPLT		0x04


### PR DESCRIPTION
Rationalise the offset and update all call sites.

Fixes https://github.com/raspberrypi/linux/issues/2408