### PR TITLE
Read without -r will mangle backslashes. (Fix)

### DIFF
--- a/scripts/adjust_autoksyms.sh
+++ b/scripts/adjust_autoksyms.sh
@@ -61,7 +61,7 @@ cat > "$new_ksyms_file" << EOT
 EOT
 [ "$(ls -A "$MODVERDIR")" ] &&
 sed -ns -e '3{s/ /\n/g;/^$/!p;}' "$MODVERDIR"/*.mod | sort -u |
-while read sym; do
+while read -r sym; do
 	if [ -n "$CONFIG_HAVE_UNDERSCORE_SYMBOL_PREFIX" ]; then
 		sym="${sym#_}"
 	fi
@@ -79,7 +79,7 @@ changed=$(
 count=0
 sort "$cur_ksyms_file" "$new_ksyms_file" | uniq -u |
 sed -n 's/^#define __KSYM_\(.*\) 1/\1/p' | tr "A-Z_" "a-z/" |
-while read sympath; do
+while read -r sympath; do
 	if [ -z "$sympath" ]; then continue; fi
 	depfile="include/config/ksym/${sympath}.h"
 	mkdir -p "$(dirname "$depfile")"

--- a/scripts/checksyscalls.sh
+++ b/scripts/checksyscalls.sh
@@ -204,7 +204,7 @@ EOF
 
 syscall_list() {
     grep '^[0-9]' "$1" | sort -n |
-	while read nr abi name entry ; do
+	while read -r nr abi name entry ; do
 		echo "#if !defined(__NR_${name}) && !defined(__IGNORE_${name})"
 		echo "#warning syscall ${name} not implemented"
 		echo "#endif"

--- a/scripts/gen_initramfs_list.sh
+++ b/scripts/gen_initramfs_list.sh
@@ -181,7 +181,7 @@ dir_filelist() {
 		${dep_list}print_mtime "$1"
 
 		echo "${dirlist}" | \
-		while read x; do
+		while read -r x; do
 			${dep_list}parse ${x}
 		done
 	fi
@@ -206,7 +206,7 @@ input_file() {
 			cat "$1"         >> ${output}
 		else
 		        echo "$1 \\"
-			cat "$1" | while read type dir file perm ; do
+			cat "$1" | while read -r type dir file perm ; do
 				if [ "$type" = "file" ]; then
 					echo "$file \\";
 				fi

--- a/scripts/tracing/ftrace-bisect.sh
+++ b/scripts/tracing/ftrace-bisect.sh
@@ -98,7 +98,7 @@ fi
 
 if [ -f $test ]; then
 	echo -n "$test exists, delete it? [y/N]"
-	read a
+	read -r a
 	if [ "$a" != "y" -a "$a" != "Y" ]; then
 		exit 1
 	fi
@@ -106,7 +106,7 @@ fi
 
 if [ -f $nontest ]; then
 	echo -n "$nontest exists, delete it? [y/N]"
-	read a
+	read -r a
 	if [ "$a" != "y" -a "$a" != "Y" ]; then
 		exit 1
 	fi

--- a/tools/perf/arch/x86/entry/syscalls/syscalltbl.sh
+++ b/tools/perf/arch/x86/entry/syscalls/syscalltbl.sh
@@ -24,7 +24,7 @@ sorted_table=$(mktemp /tmp/syscalltbl.XXXXXX)
 grep '^[0-9]' "$in" | sort -n > $sorted_table
 
 max_nr=0
-while read nr abi name entry compat; do
+while read -r nr abi name entry compat; do
     if [ $nr -ge 512 ] ; then # discard compat sycalls
         break
     fi

--- a/tools/perf/perf-archive.sh
+++ b/tools/perf/perf-archive.sh
@@ -33,7 +33,7 @@ MANIFEST=$(mktemp /tmp/perf-archive-manifest.XXXXXX)
 PERF_BUILDID_LINKDIR=$(readlink -f $PERF_BUILDID_DIR)/
 
 cut -d ' ' -f 1 $BUILDIDS | \
-while read build_id ; do
+while read -r build_id ; do
 	linkname=$PERF_BUILDID_DIR.build-id/${build_id:0:2}/${build_id:2}
 	filename=$(readlink -f $linkname)
 	echo ${linkname#$PERF_BUILDID_DIR} >> $MANIFEST

--- a/tools/perf/tests/shell/trace+probe_libc_inet_pton.sh
+++ b/tools/perf/tests/shell/trace+probe_libc_inet_pton.sh
@@ -38,7 +38,7 @@ trace_libc_inet_pton_backtrace() {
 		;;
 	esac
 
-	perf trace --no-syscalls -e probe_libc:inet_pton/$eventattr/ ping -6 -c 1 ::1 2>&1 | grep -v ^$ | while read line ; do
+	perf trace --no-syscalls -e probe_libc:inet_pton/$eventattr/ ping -6 -c 1 ::1 2>&1 | grep -v ^$ | while read -r line ; do
 		echo $line
 		echo "$line" | egrep -q "${expected[$idx]}"
 		if [ $? -ne 0 ] ; then

--- a/tools/perf/util/generate-cmdlist.sh
+++ b/tools/perf/util/generate-cmdlist.sh
@@ -12,7 +12,7 @@ static struct cmdname_help common_cmds[] = {"
 
 sed -n -e 's/^perf-\([^ 	]*\)[ 	].* common.*/\1/p' command-list.txt |
 sort |
-while read cmd
+while read -r cmd
 do
      sed -n '
      /^NAME/,/perf-'"$cmd"'/H
@@ -26,7 +26,7 @@ done
 echo "#ifdef HAVE_LIBELF_SUPPORT"
 sed -n -e 's/^perf-\([^ 	]*\)[ 	].* full.*/\1/p' command-list.txt |
 sort |
-while read cmd
+while read -r cmd
 do
      sed -n '
      /^NAME/,/perf-'"$cmd"'/H
@@ -41,7 +41,7 @@ echo "#endif /* HAVE_LIBELF_SUPPORT */"
 echo "#ifdef HAVE_LIBAUDIT_SUPPORT"
 sed -n -e 's/^perf-\([^ 	]*\)[ 	].* audit*/\1/p' command-list.txt |
 sort |
-while read cmd
+while read -r cmd
 do
      sed -n '
      /^NAME/,/perf-'"$cmd"'/H

--- a/tools/testing/selftests/memfd/run_tests.sh
+++ b/tools/testing/selftests/memfd/run_tests.sh
@@ -19,7 +19,7 @@ hpages_test=8
 #
 # Get count of free huge pages from /proc/meminfo
 #
-while read name size unit; do
+while read -r name size unit; do
         if [ "$name" = "HugePages_Free:" ]; then
                 freepgs=$size
         fi
@@ -39,7 +39,7 @@ if [ -n "$freepgs" ] && [ $freepgs -lt $hpages_test ]; then
 
 	echo 3 > /proc/sys/vm/drop_caches
 	echo $(( $hpages_needed + $nr_hugepgs )) > /proc/sys/vm/nr_hugepages
-	while read name size unit; do
+	while read -r name size unit; do
 		if [ "$name" = "HugePages_Free:" ]; then
 			freepgs=$size
 		fi

--- a/tools/testing/selftests/net/netdevice.sh
+++ b/tools/testing/selftests/net/netdevice.sh
@@ -192,7 +192,7 @@ if [ ! -e "$TMP_LIST_NETDEV" ];then
 fi
 
 ip link show |grep '^[0-9]' | grep -oE '[[:space:]].*eth[0-9]*:|[[:space:]].*enp[0-9]s[0-9]:' | cut -d\  -f2 | cut -d: -f1> "$TMP_LIST_NETDEV"
-while read netdev
+while read -r netdev
 do
 	kci_test_netdev "$netdev"
 done < "$TMP_LIST_NETDEV"

--- a/tools/testing/selftests/powerpc/scripts/hmi.sh
+++ b/tools/testing/selftests/powerpc/scripts/hmi.sh
@@ -44,7 +44,7 @@ trap "ppc64_cpu --smt-snooze-delay=100" 0 1
 # for each chip+core combination
 # todo - less fragile parsing
 egrep -o 'OCC: Chip [0-9a-f]+ Core [0-9a-f]' < /sys/firmware/opal/msglog |
-while read chipcore; do
+while read -r chipcore; do
 	chip=$(echo "$chipcore"|awk '{print $3}')
 	core=$(echo "$chipcore"|awk '{print $5}')
 	fir="0x1${core}013100"


### PR DESCRIPTION
By default, read will interpret backslashes before spaces and line feeds, and otherwise strip them. This is rarely expected or desired.

Normally you just want to read data, which is what read -r does. You should always use -r unless you have a good reason not to.   ( I like Raspberry Pi's so I want to help :P hello! )