### PR TITLE
vchiq_2835_arm: Implement a DMA pool for small bulk transfers

### DIFF
--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
@@ -199,7 +199,7 @@ int vchiq_platform_init(struct platform_device *pdev, VCHIQ_STATE_T *state)
 
 	g_dev = dev;
 	g_dma_pool = dmam_pool_create("vchiq_scatter_pool", dev,
-				     VCHIQ_DMA_POOL_SIZE, g_cache_line_size, 0);
+				      VCHIQ_DMA_POOL_SIZE, g_cache_line_size, 0);
 	if (!g_dma_pool) {
 		dev_err(dev, "failed to create dma pool");
 		return -ENOMEM;

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
@@ -199,7 +199,8 @@ int vchiq_platform_init(struct platform_device *pdev, VCHIQ_STATE_T *state)
 
 	g_dev = dev;
 	g_dma_pool = dmam_pool_create("vchiq_scatter_pool", dev,
-				      VCHIQ_DMA_POOL_SIZE, g_cache_line_size, 0);
+				      VCHIQ_DMA_POOL_SIZE, g_cache_line_size,
+				      0);
 	if (!g_dma_pool) {
 		dev_err(dev, "failed to create dma pool");
 		return -ENOMEM;

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
@@ -37,6 +37,7 @@
 #include <linux/interrupt.h>
 #include <linux/pagemap.h>
 #include <linux/dma-mapping.h>
+#include <linux/dmapool.h>
 #include <linux/io.h>
 #include <linux/platform_device.h>
 #include <linux/uaccess.h>
@@ -59,6 +60,8 @@
 #define BELL0	0x00
 #define BELL2	0x08
 
+#define VCHIQ_DMA_POOL_SIZE PAGE_SIZE
+
 typedef struct vchiq_2835_state_struct {
 	int inited;
 	VCHIQ_ARM_STATE_T arm_state;
@@ -68,6 +71,7 @@ struct vchiq_pagelist_info {
 	PAGELIST_T *pagelist;
 	size_t pagelist_buffer_size;
 	dma_addr_t dma_addr;
+	bool is_from_pool;
 	enum dma_data_direction dma_dir;
 	unsigned int num_pages;
 	unsigned int pages_need_release;
@@ -78,6 +82,7 @@ struct vchiq_pagelist_info {
 
 static void __iomem *g_regs;
 static unsigned int g_cache_line_size = sizeof(CACHE_LINE_SIZE);
+static struct dma_pool *g_dma_pool;
 static unsigned int g_fragments_size;
 static char *g_fragments_base;
 static char *g_free_fragments;
@@ -193,6 +198,13 @@ int vchiq_platform_init(struct platform_device *pdev, VCHIQ_STATE_T *state)
 	}
 
 	g_dev = dev;
+	g_dma_pool = dmam_pool_create("vchiq_scatter_pool", dev,
+				     VCHIQ_DMA_POOL_SIZE, g_cache_line_size, 0);
+	if(!g_dma_pool) {
+		dev_err(dev, "failed to create dma pool");
+		return -ENOMEM;
+	}
+
 	vchiq_log_info(vchiq_arm_log_level,
 		"vchiq_init - done (slots %pK, phys %pad)",
 		vchiq_slot_zero, &slot_phys);
@@ -377,9 +389,14 @@ cleanup_pagelistinfo(struct vchiq_pagelist_info *pagelistinfo)
 		for (i = 0; i < pagelistinfo->num_pages; i++)
 			put_page(pagelistinfo->pages[i]);
 	}
-
-	dma_free_coherent(g_dev, pagelistinfo->pagelist_buffer_size,
-			  pagelistinfo->pagelist, pagelistinfo->dma_addr);
+	if(pagelistinfo->is_from_pool) {
+		dma_pool_free(g_dma_pool, pagelistinfo->pagelist,
+			      pagelistinfo->dma_addr);
+	} else {
+		dma_free_coherent(g_dev, pagelistinfo->pagelist_buffer_size,
+				  pagelistinfo->pagelist,
+				  pagelistinfo->dma_addr);
+	}
 }
 
 /* There is a potential problem with partial cache lines (pages?)
@@ -400,6 +417,7 @@ create_pagelist(char __user *buf, size_t count, unsigned short type,
 	u32 *addrs;
 	unsigned int num_pages, offset, i, k;
 	int actual_pages;
+	bool is_from_pool;
 	size_t pagelist_size;
 	struct scatterlist *scatterlist, *sg;
 	int dma_buffers;
@@ -417,10 +435,16 @@ create_pagelist(char __user *buf, size_t count, unsigned short type,
 	/* Allocate enough storage to hold the page pointers and the page
 	** list
 	*/
-	pagelist = dma_zalloc_coherent(g_dev,
-				       pagelist_size,
-				       &dma_addr,
-				       GFP_KERNEL);
+	if(pagelist_size > VCHIQ_DMA_POOL_SIZE) {
+		pagelist = dma_zalloc_coherent(g_dev,
+					       pagelist_size,
+					       &dma_addr,
+					       GFP_KERNEL);
+		is_from_pool = false;
+	} else {
+		pagelist = dma_pool_zalloc(g_dma_pool, GFP_KERNEL, &dma_addr);
+		is_from_pool = true;
+	}
 
 	vchiq_log_trace(vchiq_arm_log_level, "create_pagelist - %pK",
 			pagelist);
@@ -441,6 +465,7 @@ create_pagelist(char __user *buf, size_t count, unsigned short type,
 	pagelistinfo->pagelist = pagelist;
 	pagelistinfo->pagelist_buffer_size = pagelist_size;
 	pagelistinfo->dma_addr = dma_addr;
+	pagelistinfo->is_from_pool = is_from_pool;
 	pagelistinfo->dma_dir =  (type == PAGELIST_WRITE) ?
 				  DMA_TO_DEVICE : DMA_FROM_DEVICE;
 	pagelistinfo->num_pages = num_pages;

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_2835_arm.c
@@ -200,7 +200,7 @@ int vchiq_platform_init(struct platform_device *pdev, VCHIQ_STATE_T *state)
 	g_dev = dev;
 	g_dma_pool = dmam_pool_create("vchiq_scatter_pool", dev,
 				     VCHIQ_DMA_POOL_SIZE, g_cache_line_size, 0);
-	if(!g_dma_pool) {
+	if (!g_dma_pool) {
 		dev_err(dev, "failed to create dma pool");
 		return -ENOMEM;
 	}
@@ -389,7 +389,7 @@ cleanup_pagelistinfo(struct vchiq_pagelist_info *pagelistinfo)
 		for (i = 0; i < pagelistinfo->num_pages; i++)
 			put_page(pagelistinfo->pages[i]);
 	}
-	if(pagelistinfo->is_from_pool) {
+	if (pagelistinfo->is_from_pool) {
 		dma_pool_free(g_dma_pool, pagelistinfo->pagelist,
 			      pagelistinfo->dma_addr);
 	} else {
@@ -435,7 +435,7 @@ create_pagelist(char __user *buf, size_t count, unsigned short type,
 	/* Allocate enough storage to hold the page pointers and the page
 	** list
 	*/
-	if(pagelist_size > VCHIQ_DMA_POOL_SIZE) {
+	if (pagelist_size > VCHIQ_DMA_POOL_SIZE) {
 		pagelist = dma_zalloc_coherent(g_dev,
 					       pagelist_size,
 					       &dma_addr,


### PR DESCRIPTION
An attempt to address https://github.com/raspberrypi/linux/issues/2680 by using a DMA pool for small allocations during bulk transfers.

Thanks to @pelwell and @lategoodbye for reviewing V1 of this patch.