### PR TITLE
thermal: add hysteresis support and adjust PoE HAT trip points

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1596,9 +1596,16 @@ Params: touchscreen-size-x      Touchscreen X resolution (default 800)
 
 
 Name:   rpi-poe
-Info:   Raspberry Pi POE HAT
-Load:   dtoverlay=rpi-poe
-Params: <None>
+Info:   Raspberry Pi PoE HAT fan
+Load:   dtoverlay=rpi-poe,<param>[=<val>]
+Params: poe_fan_temp0           Temperature (in millicelcius) at which the fan
+                                turns on (default 50000)
+        poe_fan_temp0_hyst      Temperature delta (in millicelcius) at which
+                                the fan turns off (default 5000)
+        poe_fan_temp1           Temperature (in millicelcius) at which the fan
+                                speeds up (default 55000)
+        poe_fan_temp1_hyst      Temperature delta (in millicelcius) at which
+                                the fan slows down (default 5000)
 
 
 Name:   rpi-proto

--- a/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
@@ -50,4 +50,14 @@
 			};
 		};
 	};
+
+	fragment@2 {
+		target-path = "/__overrides__";
+		__overlay__ {
+			poe_fan_temp0 =		<&trip0>,"temperature:0";
+			poe_fan_temp0_hyst =	<&trip0>,"hysteresis:0";
+			poe_fan_temp1 =		<&trip1>,"temperature:0";
+			poe_fan_temp1_hyst =	<&trip1>,"hysteresis:0";
+		};
+	};
 };

--- a/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
@@ -14,9 +14,9 @@
 				compatible = "raspberrypi,rpi-poe-fan";
 				firmware = <&firmware>;
 				cooling-min-state = <0>;
-				cooling-max-state = <3>;
+				cooling-max-state = <2>;
 				#cooling-cells = <2>;
-				cooling-levels = <0 50 150 255>;
+				cooling-levels = <0 150 255>;
 				status = "okay";
 			};
 		};
@@ -26,34 +26,26 @@
 		target = <&cpu_thermal>;
 		__overlay__ {
 			trips {
-				threshold: trip-point@0 {
-					temperature = <45000>;
+				trip0: trip0 {
+					temperature = <50000>;
 					hysteresis = <5000>;
 					type = "active";
 				};
-				target: trip-point@1 {
-					temperature = <50000>;
-					hysteresis = <2000>;
-					type = "active";
-				};
-				cpu_hot: cpu_hot@0 {
+				trip1: trip1 {
+
 					temperature = <55000>;
-					hysteresis = <2000>;
+					hysteresis = <5000>;
 					type = "active";
 				};
 			};
 			cooling-maps {
 				map0 {
-					trip = <&threshold>;
+					trip = <&trip0>;
 					cooling-device = <&fan0 0 1>;
 				};
 				map1 {
-					trip = <&target>;
+					trip = <&trip1>;
 					cooling-device = <&fan0 1 2>;
-				};
-				map2 {
-					trip = <&cpu_hot>;
-					cooling-device = <&fan0 2 3>;
 				};
 			};
 		};

--- a/drivers/thermal/step_wise.c
+++ b/drivers/thermal/step_wise.c
@@ -36,7 +36,7 @@
  *       for this trip point
  *    d. if the trend is THERMAL_TREND_DROP_FULL, use lower limit
  *       for this trip point
- * If the temperature is lower than a trip point,
+ * If the temperature is lower than a hysteresis temperature,
  *    a. if the trend is THERMAL_TREND_RAISING, do nothing
  *    b. if the trend is THERMAL_TREND_DROPPING, use lower cooling
  *       state for this trip point, if the cooling state already
@@ -127,7 +127,7 @@ static void update_passive_instance(struct thermal_zone_device *tz,
 
 static void thermal_zone_trip_update(struct thermal_zone_device *tz, int trip)
 {
-	int trip_temp;
+	int trip_temp, hyst_temp;
 	enum thermal_trip_type trip_type;
 	enum thermal_trend trend;
 	struct thermal_instance *instance;
@@ -135,22 +135,23 @@ static void thermal_zone_trip_update(struct thermal_zone_device *tz, int trip)
 	int old_target;
 
 	if (trip == THERMAL_TRIPS_NONE) {
-		trip_temp = tz->forced_passive;
+		hyst_temp = trip_temp = tz->forced_passive;
 		trip_type = THERMAL_TRIPS_NONE;
 	} else {
 		tz->ops->get_trip_temp(tz, trip, &trip_temp);
+		hyst_temp = trip_temp;
+		if (tz->ops->get_trip_hyst) {
+			tz->ops->get_trip_hyst(tz, trip, &hyst_temp);
+			hyst_temp = trip_temp - hyst_temp;
+		}
 		tz->ops->get_trip_type(tz, trip, &trip_type);
 	}
 
 	trend = get_tz_trend(tz, trip);
 
-	if (tz->temperature >= trip_temp) {
-		throttle = true;
-		trace_thermal_zone_trip(tz, trip, trip_type);
-	}
-
-	dev_dbg(&tz->device, "Trip%d[type=%d,temp=%d]:trend=%d,throttle=%d\n",
-				trip, trip_type, trip_temp, trend, throttle);
+	dev_dbg(&tz->device,
+		"Trip%d[type=%d,temp=%d,hyst=%d]:trend=%d,throttle=%d\n",
+		trip, trip_type, trip_temp, hyst_temp, trend, throttle);
 
 	mutex_lock(&tz->lock);
 
@@ -159,6 +160,18 @@ static void thermal_zone_trip_update(struct thermal_zone_device *tz, int trip)
 			continue;
 
 		old_target = instance->target;
+		throttle = false;
+		/*
+		 * Lower the mitigation only if the temperature
+		 * goes below the hysteresis temperature.
+		 */
+		if (tz->temperature >= trip_temp ||
+		   (tz->temperature >= hyst_temp &&
+		   old_target != THERMAL_NO_TARGET)) {
+			throttle = true;
+			trace_thermal_zone_trip(tz, trip, trip_type);
+		}
+
 		instance->target = get_target_state(instance, trend, throttle);
 		dev_dbg(&instance->cdev->device, "old_target=%d, target=%d\n",
 					old_target, (int)instance->target);

--- a/drivers/thermal/step_wise.c
+++ b/drivers/thermal/step_wise.c
@@ -167,7 +167,7 @@ static void thermal_zone_trip_update(struct thermal_zone_device *tz, int trip)
 		 */
 		if (tz->temperature >= trip_temp ||
 		   (tz->temperature >= hyst_temp &&
-		   old_target != THERMAL_NO_TARGET)) {
+		   old_target == instance->upper)) {
 			throttle = true;
 			trace_thermal_zone_trip(tz, trip, trip_type);
 		}


### PR DESCRIPTION
Currently, the step_wise thermal scaling governor ping pongs around the trip point and ignores the hysteresis value.

This PR steals step_wise hysteresis support from https://patchwork.kernel.org/patch/10384571/. This still results in some bounce at the hysteresis temperature if the 'trend' is rising, which is addressed by the second commit.

In the PoE HAT overlay, a cooling level has been removed and hysteresis values were increased to 5C.