### PR TITLE
staging: vchiq_arm: fix msgbufcount in VCHIQ_IOC_AWAIT_COMPLETION compat ioctl

### DIFF
--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -1461,6 +1461,7 @@ vchiq_compat_ioctl_await_completion(struct file *file,
 	struct vchiq_await_completion32 args32;
 	struct vchiq_completion_data32 completion32;
 	unsigned int *msgbufcount32;
+	unsigned int msgbufcount_native;
 	compat_uptr_t msgbuf32;
 	void *msgbuf;
 	void **msgbufptr;
@@ -1572,7 +1573,11 @@ vchiq_compat_ioctl_await_completion(struct file *file,
 			 sizeof(completion32)))
 		return -EFAULT;
 
-	args32.msgbufcount--;
+	if (get_user(msgbufcount_native, &args->msgbufcount))
+		return -EFAULT;
+
+	if (!msgbufcount_native)
+		args32.msgbufcount--;
 
 	msgbufcount32 =
 		&((struct vchiq_await_completion32 __user *)arg)->msgbufcount;


### PR DESCRIPTION
The compatibility ioctl wrapper for `VCHIQ_IOC_AWAIT_COMPLETION` assumes that
the native ioctl always uses a message buffer and decrements `msgbufcount`.
Certain message types do not use a message buffer and in this case
`msgbufcount` is not decremented, and `completion->header` for the message is
`NULL`. Because the wrapper unconditionally decrements msgbufcount, the
calling process may assume that a message buffer has been used even when
it has not.

This bug results in a memory leak in [vchiq_lib](https://github.com/raspberrypi/userland/blob/master/interface/vchiq_arm/vchiq_lib.c#L1540). When msgbufcount is decremented, the code assumes
that the buffer can be freed though the reference in `completion->header`,
which cannot happen when the reference is NULL. In my case, I ran into this bug when attempting to use gst-omx, as described here: https://bugzilla.gnome.org/show_bug.cgi?id=797159

This patch causes the wrapper to only decrement `msgbufcount` when the
native ioctl decrements it. Note that we cannot simply copy the native
ioctl's value of `msgbufcount`, because the wrapper only retrieves messages
from the native ioctl one at a time, while userspace may request multiple
messages.