### PR TITLE
Revert "net: pskb_trim_rcsum() and CHECKSUM_COMPLETE are friends"

### DIFF
--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -3139,7 +3139,6 @@ static inline void *skb_push_rcsum(struct sk_buff *skb, unsigned int len)
 	return skb->data;
 }
 
-int pskb_trim_rcsum_slow(struct sk_buff *skb, unsigned int len);
 /**
  *	pskb_trim_rcsum - trim received skb and update checksum
  *	@skb: buffer to trim
@@ -3153,7 +3152,9 @@ static inline int pskb_trim_rcsum(struct sk_buff *skb, unsigned int len)
 {
 	if (likely(len >= skb->len))
 		return 0;
-	return pskb_trim_rcsum_slow(skb, len);
+	if (skb->ip_summed == CHECKSUM_COMPLETE)
+		skb->ip_summed = CHECKSUM_NONE;
+	return __pskb_trim(skb, len);
 }
 
 static inline int __skb_trim_rcsum(struct sk_buff *skb, unsigned int len)

--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -1836,20 +1836,6 @@ done:
 }
 EXPORT_SYMBOL(___pskb_trim);
 
-/* Note : use pskb_trim_rcsum() instead of calling this directly
- */
-int pskb_trim_rcsum_slow(struct sk_buff *skb, unsigned int len)
-{
-	if (skb->ip_summed == CHECKSUM_COMPLETE) {
-		int delta = skb->len - len;
-
-		skb->csum = csum_sub(skb->csum,
-				     skb_checksum(skb, len, delta, 0));
-	}
-	return __pskb_trim(skb, len);
-}
-EXPORT_SYMBOL(pskb_trim_rcsum_slow);
-
 /**
  *	__pskb_pull_tail - advance tail of skb header
  *	@skb: buffer to reallocate


### PR DESCRIPTION
This reverts commit 6bf32cda46ebfbaf13da3c48a0a009adae925703.

Various people have been reporting seeing "eth0: hw csum failure"
and callstacks dumped in the kernel log on 4.18, and since 4.14.71,
on both SMSC9514 and LAN7800 adapters.
This commit appears to be the reason, but potentially due to an
issue further down the stack. Revert whilst investigating the
trigger.

https://github.com/raspberrypi/linux/issues/2713
https://github.com/raspberrypi/linux/issues/2659
https://github.com/raspberrypi/linux/issues/2712

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>