### PR TITLE
watchdog: bcm2835: make normal restart detectable

### DIFF
--- a/drivers/watchdog/bcm2835_wdt.c
+++ b/drivers/watchdog/bcm2835_wdt.c
@@ -115,6 +115,14 @@ static void bcm2835_restart(struct bcm2835_wdt *wdt, u8 partition)
 {
 	u32 val, rsts;
 
+	/* Allow code to distinguish a normal reboot from a watchdog reboot
+	 * by setting a magic partition number.
+	 * A partition number higher than the number of partitions on sdcard
+	 * will result in a normal reboot.
+	 */
+	if (partition == 0)
+		partition = 62;
+
 	rsts = (partition & BIT(0)) | ((partition & BIT(1)) << 1) |
 	       ((partition & BIT(2)) << 2) | ((partition & BIT(3)) << 3) |
 	       ((partition & BIT(4)) << 4) | ((partition & BIT(5)) << 5);


### PR DESCRIPTION
Currently PM_RSTS gives the same value for a normal restart as it does for a watchdog lapse (as the restart routine appears to use a watchdog lapse). If we have a watchdog monitored process that crashes, we would like to be able to log the incident at next startup. PM_RSTS Bit 9 is described [in issue 932 as "9 HADSRF Had a software full reset R/W"](https://github.com/raspberrypi/linux/issues/932#issuecomment-93989581) which seems appropriate, and it does not appear to be currently used. The behavior of currently used bits have not been affected, so it should be backwards compatible with anything that might be checking for those bit positions. Any comments, feedback, alternatives, or suggestions are welcome. Thank you for your time.

Example of checking PM_RSTS via script:
```bash
#!/bin/bash
RSTS="$(vcgencmd get_rsts)"
RSTS=${RSTS#*=}
RSTS=$(("0x$RSTS"))
STR="?"
# order is important as multiple bits can be set
if ((RSTS & 0x200)); then
    # software reset
    STR="SoftwareReset"
elif ((RSTS & 0x20)); then
    # dog trip (or software reset if before this patch)
    STR="DogReset"
elif ((RSTS & 0x1000)); then
    # power cycle
    STR="PowerCycle"
fi
printf "RSTS=0x%08X CAUSE=%s\n" $RSTS $STR
```
(This was tested with a yocto (poky) core-image-base build on the rocko branch. We have not tested it in any other distros. Test hardware was the Pi3 B+.)