### PR TITLE
Increase firmware call buffer size to 48 bytes

### DIFF
--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -22,7 +22,7 @@
 #define MBOX_DATA28(msg)		((msg) & ~0xf)
 #define MBOX_CHAN_PROPERTY		8
 
-#define MAX_RPI_FW_PROP_BUF_SIZE	32
+#define MAX_RPI_FW_PROP_BUF_SIZE	48
 
 static struct platform_device *rpi_hwmon;
 


### PR DESCRIPTION
An assumption was made in commit a1547e0bc that 32 bytes
would be enough data buffer size for all firmware calls. However,
the axi performance monitor driver uses a call with 44 bytes
(RPI_FIRMWARE_GET_PERIPH_REG) to get the VC registers values.

Increase value to 48 to take this in to account.

Signed-off-by: James Hughes <james.hughes@raspberrypi.org>