### PR TITLE
vcsm: Fix an NULL dereference in the import_dmabuf error path

### DIFF
--- a/drivers/char/broadcom/vc_sm/vmcs_sm.c
+++ b/drivers/char/broadcom/vc_sm/vmcs_sm.c
@@ -2315,8 +2315,8 @@ int vc_sm_ioctl_import_dmabuf(struct sm_priv_data_t *private,
 	return 0;
 
 error:
-	resource->res_stats[IMPORT_FAIL]++;
 	if (resource) {
+		resource->res_stats[IMPORT_FAIL]++;
 		vc_sm_resource_deceased(resource, 1);
 		kfree(resource);
 	}


### PR DESCRIPTION
Same as #2752 but for 4.14.