### PR TITLE
[4.19] RPi wm8804 soundcard driver cleanup and improvements

### DIFF
--- a/sound/soc/bcm/rpi-wm8804-soundcard.c
+++ b/sound/soc/bcm/rpi-wm8804-soundcard.c
@@ -54,8 +54,6 @@ struct snd_rpi_wm8804_drvdata {
 	struct snd_soc_dai_link *dai;
 	/* Required - snd_soc_card name */
 	const char *card_name;
-	/* Optional- Overrides the module paramter */
-	unsigned short auto_shutdown_output;
 	/* Optional DT node names if card info is defined in DT */
 	const char *card_name_dt;
 	const char *dai_name_dt;
@@ -64,50 +62,11 @@ struct snd_rpi_wm8804_drvdata {
 	int (*probe)(struct platform_device *pdev);
 };
 
-static short int auto_shutdown_output;
-module_param(auto_shutdown_output, short, 0660);
-MODULE_PARM_DESC(auto_shutdown_output, "Shutdown SP/DIF output if playback is stopped");
-
 static struct gpio_desc *snd_clk44gpio;
 static struct gpio_desc *snd_clk48gpio;
 
 #define CLK_44EN_RATE 22579200UL
 #define CLK_48EN_RATE 24576000UL
-
-static int snd_rpi_wm8804_init(struct snd_soc_pcm_runtime *rtd)
-{
-	struct snd_soc_component *component = rtd->codec_dai->component;
-	int rc;
-
-	pr_debug("%s\n", __func__);
-
-	rc = snd_soc_component_update_bits(component, WM8804_PWRDN, 0x4, 0x0);
-	return rc < 0 ? rc : 0;
-}
-
-static int snd_rpi_wm8804_digi_startup(struct snd_pcm_substream *substream)
-{
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_component *component = rtd->codec_dai->component;
-	int rc;
-
-	pr_debug("%s\n", __func__);
-
-	rc = snd_soc_component_update_bits(component, WM8804_PWRDN, 0x3c, 0x00);
-	return rc < 0 ? rc : 0;
-}
-
-static void snd_rpi_wm8804_digi_shutdown(struct snd_pcm_substream *substream)
-{
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
-	struct snd_soc_component *component = rtd->codec_dai->component;
-
-	pr_debug("%s %d\n", __func__, auto_shutdown_output);
-
-	if (auto_shutdown_output)
-		snd_soc_component_update_bits(component, WM8804_PWRDN,
-				0x3c, 0x3c);
-}
 
 static unsigned int snd_rpi_wm8804_enable_clock(unsigned int samplerate)
 {
@@ -204,12 +163,6 @@ static int snd_rpi_wm8804_hw_params(struct snd_pcm_substream *substream,
 		return ret;
 	}
 
-	/* Enable TX output */
-	snd_soc_component_update_bits(component, WM8804_PWRDN, 0x4, 0x0);
-
-	/* Power on */
-	snd_soc_component_update_bits(component, WM8804_PWRDN, 0x9, 0);
-
 	/* set sampling frequency status bits */
 	snd_soc_component_update_bits(component, WM8804_SPDTX4, 0x0f,
 			sampling_freq);
@@ -219,8 +172,6 @@ static int snd_rpi_wm8804_hw_params(struct snd_pcm_substream *substream,
 
 static struct snd_soc_ops snd_rpi_wm8804_ops = {
 	.hw_params = snd_rpi_wm8804_hw_params,
-	.startup   = snd_rpi_wm8804_digi_startup,
-	.shutdown  = snd_rpi_wm8804_digi_shutdown,
 };
 
 static struct snd_soc_dai_link snd_justboom_digi_dai[] = {
@@ -233,7 +184,6 @@ static struct snd_soc_dai_link snd_justboom_digi_dai[] = {
 static struct snd_rpi_wm8804_drvdata drvdata_justboom_digi = {
 	.card_name            = "snd_rpi_justboom_digi",
 	.dai                  = snd_justboom_digi_dai,
-	.auto_shutdown_output = 1,
 };
 
 static struct snd_soc_dai_link snd_iqaudio_digi_dai[] = {
@@ -335,8 +285,6 @@ static int snd_rpi_wm8804_probe(struct platform_device *pdev)
 
 		snd_soc_card_set_drvdata(&snd_rpi_wm8804, drvdata);
 
-		if (!dai->init)
-			dai->init = snd_rpi_wm8804_init;
 		if (!dai->ops)
 			dai->ops = &snd_rpi_wm8804_ops;
 		if (!dai->codec_dai_name)
@@ -347,9 +295,6 @@ static int snd_rpi_wm8804_probe(struct platform_device *pdev)
 			dai->dai_fmt = SND_SOC_DAIFMT_I2S |
 				SND_SOC_DAIFMT_NB_NF |
 				SND_SOC_DAIFMT_CBM_CFM;
-
-		if (drvdata->auto_shutdown_output)
-			auto_shutdown_output = 1;
 
 		snd_rpi_wm8804.dai_link = dai;
 		i2s_node = of_parse_phandle(pdev->dev.of_node,

--- a/sound/soc/bcm/rpi-wm8804-soundcard.c
+++ b/sound/soc/bcm/rpi-wm8804-soundcard.c
@@ -64,6 +64,7 @@ struct snd_rpi_wm8804_drvdata {
 
 static struct gpio_desc *snd_clk44gpio;
 static struct gpio_desc *snd_clk48gpio;
+static int wm8804_samplerate = 0;
 
 #define CLK_44EN_RATE 22579200UL
 #define CLK_48EN_RATE 24576000UL
@@ -117,6 +118,12 @@ static int snd_rpi_wm8804_hw_params(struct snd_pcm_substream *substream,
 	struct wm8804_clk_cfg clk_cfg;
 	int samplerate = params_rate(params);
 
+	if (samplerate == wm8804_samplerate)
+		return 0;
+
+	/* clear until all clocks are setup properly */
+	wm8804_samplerate = 0;
+
 	snd_rpi_wm8804_clk_cfg(samplerate, &clk_cfg);
 
 	pr_debug("%s samplerate: %d mclk_freq: %u mclk_div: %u sysclk: %u\n",
@@ -162,6 +169,8 @@ static int snd_rpi_wm8804_hw_params(struct snd_pcm_substream *substream,
 		"Failed to set WM8804 SYSCLK: %d\n", ret);
 		return ret;
 	}
+
+	wm8804_samplerate = samplerate;
 
 	/* set sampling frequency status bits */
 	snd_soc_component_update_bits(component, WM8804_SPDTX4, 0x0f,

--- a/sound/soc/codecs/wm8804.c
+++ b/sound/soc/codecs/wm8804.c
@@ -550,7 +550,6 @@ static const struct snd_soc_component_driver soc_component_dev_wm8804 = {
 	.use_pmdown_time	= 1,
 	.endianness		= 1,
 	.non_legacy_dai_naming	= 1,
-	.idle_bias_on		= true,
 };
 
 const struct regmap_config wm8804_regmap_config = {


### PR DESCRIPTION
This is a followup to #2757 to prevent clicks on stop/start operations

Since kernel 4.0 the DAPM code in the wm8804 driver handles setting up it's PWRDN register and the code in the soundcard driver to do that is no longer needed. Actually that code interfers with DAPM and disables delayed DAPM shutdown handling (which tries to prevent clicks from stop+start operations).

Changing the WM8804 clocks/PLLs can also lead to clicks, so avoid doing that in hwparams when they are already setup properly.

Another change in this PR is the removal of the idle_bias change in the wm8804 driver which seems to have accidentally sneaked back in 4.19 - in 4.14 this change was already dropped and the wm8804 driver was at upstream level.

I tested the change with the Hifiberry Digi+ Pro and Justboom Digi HATs but some more tests would be welcome.

Note: with this change you may see a harmless "I2S SYNC error" message in dmesg on stream startup. This is caused by the clear fifo call in hwparams which is performed before the wm8804 clock has been started. The second clear fifo call from .prepare will succeed though and everything should be fine.

@drestebon can you test if this change works for you, too?

@timg236 a second pair of eyes glancing over these changes would be nice, too

@MilhouseVH could you include this PR in your LE testbuilds?