### PR TITLE
dtoverlays: Fix pi3-disable overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/pi3-disable-bt-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pi3-disable-bt-overlay.dts
@@ -8,7 +8,7 @@
        sudo systemctl disable hciuart
 */
 
-/{
+/ {
 	compatible = "brcm,bcm2708";
 
 	fragment@0 {

--- a/arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pi3-disable-wifi-overlay.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 /plugin/;
 
-/{
+/ {
 	compatible = "brcm,bcm2708";
 
 	fragment@0 {


### PR DESCRIPTION
The root node definition of pi3-disable-wifi and
pi3-disable-bt is not correct. This breaks the
overlays. This patch fixes the root note definition.

Signed-off-by: Matthias Brugger <mbrugger@suse.com>