### PR TITLE
dtoverlays: Add i2c on 0&1 option to TC358743, ADV7282 and OV5647

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -277,7 +277,9 @@ Info:   Analog Devices ADV7282M analogue video to CSI2 bridge.
         Uses Unicam1, which is the standard camera connector on most Pi
         variants.
 Load:   dtoverlay=adv7282m,<param>=<val>
-Params: i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
+Params: i2c_pins_0_1            Use pins 0&1 for the I2C instead of 44&45.
+                                Useful on Compute Modules.
+        i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
                                 This is required for Pi B+, 2, 0, and 0W.
         addr                    Overrides the I2C address (default 0x21)
 
@@ -286,7 +288,9 @@ Name:   adv728x-m
 Info:   Analog Devices ADV728[0|1|2]-M analogue video to CSI2 bridges.
         This is a wrapper for adv7282m, and defaults to ADV7282M.
 Load:   dtoverlay=adv728x-m,<param>=<val>
-Params: i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
+Params: i2c_pins_0_1            Use pins 0&1 for the I2C instead of 44&45.
+                                Useful on Compute Modules.
+        i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
                                 This is required for Pi B+, 2, 0, and 0W.
         addr                    Overrides the I2C address (default 0x21)
         adv7280m                Select ADV7280-M.
@@ -1324,6 +1328,9 @@ Params: cam0-pwdn               GPIO used to control the sensor powerdown line.
                                 configuration of the particular Pi variant in
                                 use.
 
+        i2c_pins_0_1            Use pins 0&1 for the I2C instead of 44&45.
+                                Useful on Compute Modules.
+
         i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
                                 This is required for Pi B+, 2, 0, and 0W.
 
@@ -1948,6 +1955,9 @@ Params: 4lane                   Use 4 lanes (only applicable to Compute Modules
         link-frequency          Set the link frequency. Only values of 297000000
                                 (574Mbit/s) and 486000000 (972Mbit/s - default)
                                 are supported by the driver.
+
+        i2c_pins_0_1            Use pins 0&1 for the I2C instead of 44&45.
+                                Useful on Compute Modules.
 
         i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.
                                 This is required for Pi B+, 2, 0, and 0W.

--- a/arch/arm/boot/dts/overlays/adv7282m-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adv7282m-overlay.dts
@@ -60,6 +60,13 @@
 		};
 	};
 	fragment@4 {
+		target = <&i2c0_pins>;
+		__dormant__ {
+			brcm,pins = <0 1>;
+			brcm,function = <4>; /* alt0 */
+		};
+	};
+	fragment@5 {
 		target = <&i2c_vc>;
 		__overlay__ {
 			status = "okay";
@@ -67,7 +74,8 @@
 	};
 
 	__overrides__ {
-		i2c_pins_28_29 =	<0>,"+2-3";
+		i2c_pins_0_1 =		<0>,"-2-3+4";
+		i2c_pins_28_29 =	<0>,"+2-3-4";
 		addr =			<&adv728x>,"reg:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/ov5647-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov5647-overlay.dts
@@ -69,6 +69,13 @@
 		};
 	};
 	fragment@4 {
+		target = <&i2c0_pins>;
+		__dormant__ {
+			brcm,pins = <0 1>;
+			brcm,function = <4>; /* alt0 */
+		};
+	};
+	fragment@5 {
 		target = <&i2c_vc>;
 		__overlay__ {
 			status = "okay";
@@ -76,7 +83,8 @@
 	};
 
 	__overrides__ {
-		i2c_pins_28_29 = <0>,"+4-5";
+		i2c_pins_0_1 = <0>,"-2-3+4";
+		i2c_pins_28_29 = <0>,"+2-3-4";
 		cam0-pwdn = <&ov5647>,"pwdn-gpios:4";
 		cam0-led = <&ov5647>,"pwdn-gpios:16";
 	};

--- a/arch/arm/boot/dts/overlays/tc358743-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tc358743-overlay.dts
@@ -94,6 +94,13 @@
 		};
 	};
 	fragment@6 {
+		target = <&i2c0_pins>;
+		__dormant__ {
+			brcm,pins = <0 1>;
+			brcm,function = <4>; /* alt0 */
+		};
+	};
+	fragment@7 {
 		target = <&i2c_vc>;
 		__overlay__ {
 			status = "okay";
@@ -101,7 +108,8 @@
 	};
 
 	__overrides__ {
-		i2c_pins_28_29 = <0>,"+4-5";
+		i2c_pins_0_1 = <0>,"-4-5+6";
+		i2c_pins_28_29 = <0>,"+4-5-6";
 		4lane = <0>, "-2+3";
 		link-frequency = <&tc358743>,"link-frequencies#0";
 	};


### PR DESCRIPTION
Adds the option of configuring i2c0 to be on GPIOs 0&1 as
this is of use on the Compute Module.

Also fixes the ov5647 overlay where the override enabled the wrong
fragments.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>