### PR TITLE
BCM2710_DT: fix gpio expander bindings

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2708-rpi.dtsi
@@ -50,7 +50,9 @@
 		};
 
 		firmware: firmware {
-			compatible = "raspberrypi,bcm2835-firmware";
+			compatible = "raspberrypi,bcm2835-firmware", "simple-bus";
+			#address-cells = <0>;
+			#size-cells = <0>;
 			mboxes = <&mailbox>;
 		};
 

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
@@ -82,12 +82,11 @@
 	brcm,overclock-50 = <0>;
 };
 
-&soc {
+&firmware {
 	expgpio: expgpio {
 		compatible = "raspberrypi,firmware-gpio";
 		gpio-controller;
 		#gpio-cells = <2>;
-		firmware = <&firmware>;
 		status = "okay";
 	};
 };

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
@@ -91,11 +91,13 @@
 		status = "okay";
 	};
 
+};
+
+&firmware {
 	expgpio: expgpio {
 		compatible = "raspberrypi,firmware-gpio";
 		gpio-controller;
 		#gpio-cells = <2>;
-		firmware = <&firmware>;
 		status = "okay";
 	};
 };

--- a/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
@@ -51,11 +51,13 @@
 		status = "okay";
 	};
 
+};
+
+&firmware {
 	expgpio: expgpio {
 		compatible = "raspberrypi,firmware-gpio";
 		gpio-controller;
 		#gpio-cells = <2>;
-		firmware = <&firmware>;
 		status = "okay";
 	};
 };


### PR DESCRIPTION
The upstreamed driver for the GPIO expander expects to be a children of
the "firmware" node. It won't probe otherwise.

The patch also removes the "firmware" phandle as it's useless.

Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>