### PR TITLE
Revert "staging: vchiq_arm: Register a platform device for the audio …

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
+++ b/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
@@ -4,17 +4,15 @@
 #include <linux/platform_device.h>
 
 #include <linux/init.h>
-#include <linux/dma-mapping.h>
-#include <linux/of_device.h>
 #include <linux/slab.h>
 #include <linux/module.h>
+#include <linux/of.h>
 
 #include "bcm2835.h"
 
 static bool enable_hdmi;
 static bool enable_headphones;
 static bool enable_compat_alsa = true;
-static int num_channels = MAX_SUBSTREAMS;
 
 module_param(enable_hdmi, bool, 0444);
 MODULE_PARM_DESC(enable_hdmi, "Enables HDMI virtual audio device");
@@ -23,8 +21,6 @@ MODULE_PARM_DESC(enable_headphones, "Enables Headphones virtual audio device");
 module_param(enable_compat_alsa, bool, 0444);
 MODULE_PARM_DESC(enable_compat_alsa,
 		 "Enables ALSA compatibility virtual audio device");
-module_param(num_channels, int, 0644);
-MODULE_PARM_DESC(num_channels, "Number of audio channels (default: 8)");
 
 static void snd_devm_unregister_child(struct device *dev, void *res)
 {
@@ -411,30 +407,31 @@ static int snd_add_child_devices(struct device *device, u32 numchans)
 	return 0;
 }
 
-static int snd_bcm2835_alsa_probe(struct platform_device *pdev)
+static int snd_bcm2835_alsa_probe_dt(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
+	u32 numchans;
 	int err;
 
-	if (num_channels <= 0 || num_channels > MAX_SUBSTREAMS) {
-		num_channels = MAX_SUBSTREAMS;
-		dev_warn(dev, "Illegal num_channels value, will use %u\n",
-			 num_channels);
+	err = of_property_read_u32(dev->of_node, "brcm,pwm-channels",
+				   &numchans);
+	if (err) {
+		dev_err(dev, "Failed to get DT property 'brcm,pwm-channels'");
+		return err;
 	}
 
-	dev->coherent_dma_mask = DMA_BIT_MASK(32);
-	dev->dma_mask = &dev->coherent_dma_mask;
-	err = of_dma_configure(dev, NULL, true);
-	if (err) {
-		dev_err(dev, "Unable to setup DMA: %d\n", err);
-		return err;
+	if (numchans == 0 || numchans > MAX_SUBSTREAMS) {
+		numchans = MAX_SUBSTREAMS;
+		dev_warn(dev,
+			 "Illegal 'brcm,pwm-channels' value, will use %u\n",
+			 numchans);
 	}
 
 	err = bcm2835_devm_add_vchi_ctx(dev);
 	if (err)
 		return err;
 
-	err = snd_add_child_devices(dev, num_channels);
+	err = snd_add_child_devices(dev, numchans);
 	if (err)
 		return err;
 
@@ -456,14 +453,21 @@ static int snd_bcm2835_alsa_resume(struct platform_device *pdev)
 
 #endif
 
+static const struct of_device_id snd_bcm2835_of_match_table[] = {
+	{ .compatible = "brcm,bcm2835-audio",},
+	{},
+};
+MODULE_DEVICE_TABLE(of, snd_bcm2835_of_match_table);
+
 static struct platform_driver bcm2835_alsa0_driver = {
-	.probe = snd_bcm2835_alsa_probe,
+	.probe = snd_bcm2835_alsa_probe_dt,
 #ifdef CONFIG_PM
 	.suspend = snd_bcm2835_alsa_suspend,
 	.resume = snd_bcm2835_alsa_resume,
 #endif
 	.driver = {
 		.name = "bcm2835_audio",
+		.of_match_table = snd_bcm2835_of_match_table,
 	},
 };
 module_platform_driver(bcm2835_alsa0_driver);
@@ -471,4 +475,3 @@ module_platform_driver(bcm2835_alsa0_driver);
 MODULE_AUTHOR("Dom Cobley");
 MODULE_DESCRIPTION("Alsa driver for BCM2835 chip");
 MODULE_LICENSE("GPL");
-MODULE_ALIAS("platform:bcm2835_audio");

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -170,7 +170,6 @@ static struct class  *vchiq_class;
 static struct device *vchiq_dev;
 static DEFINE_SPINLOCK(msg_queue_spinlock);
 static struct platform_device *bcm2835_camera;
-static struct platform_device *bcm2835_audio;
 static struct platform_device *bcm2835_codec;
 static struct platform_device *vcsm_cma;
 
@@ -3662,9 +3661,6 @@ static int vchiq_probe(struct platform_device *pdev)
 	bcm2835_camera = vchiq_register_child(pdev, "bcm2835-camera");
 	if (IS_ERR(bcm2835_camera))
 		bcm2835_camera = NULL;
-	bcm2835_audio = vchiq_register_child(pdev, "bcm2835_audio");
-	if (IS_ERR(bcm2835_audio))
-		bcm2835_audio = NULL;
 	bcm2835_codec = vchiq_register_child(pdev, "bcm2835-codec");
 	if (IS_ERR(bcm2835_codec))
 		bcm2835_codec = NULL;
@@ -3685,7 +3681,6 @@ failed_platform_init:
 static int vchiq_remove(struct platform_device *pdev)
 {
 	platform_device_unregister(bcm2835_codec);
-	platform_device_unregister(bcm2835_audio);
 	platform_device_unregister(bcm2835_camera);
 	platform_device_unregister(vcsm_cma);
 	vchiq_debugfs_deinit();


### PR DESCRIPTION
…driver"

This reverts commit ab59590ed562b89db51fe46cee5db96b9bc5abd8.

Issues have been observed in LibreElec as this was unconditionally
loading the audio driver instead of having the DT parameter to
enable it.

Includes a partial revert of 2147700eb7a1b9e55e0684f0749114ce35d61571
which fixed up the error handling.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>