### PR TITLE
dtoverlays: fe-pi-audio: fix sgtl5000 compatible string

### DIFF
--- a/arch/arm/boot/dts/overlays/fe-pi-audio-overlay.dts
+++ b/arch/arm/boot/dts/overlays/fe-pi-audio-overlay.dts
@@ -39,7 +39,7 @@
 
 			sgtl5000@0a {
 				#sound-dai-cells = <0>;
-				compatible = "fepi,sgtl5000";
+				compatible = "fsl,sgtl5000";
 				reg = <0x0a>;
 				clocks = <&sgtl5000_mclk>;
 				micbias-resistor-k-ohms = <2>;


### PR DESCRIPTION
The compatible string was set to "fepi,sgtl5000", which worked for some reason in 4.14, but does not work in 4.19, presumably due to some change in the kernel matching logic. The correct string is "fsl,sgtl5000". This overlay still works correctly with 4.14 with this change.