### PR TITLE
bcm2835_smi: fix dma transfers

### DIFF
--- a/drivers/misc/bcm2835_smi.c
+++ b/drivers/misc/bcm2835_smi.c
@@ -879,7 +879,7 @@ static int bcm2835_smi_probe(struct platform_device *pdev)
 		goto err;
 	}
 	addr = of_get_address(node, 0, NULL, NULL);
-	inst->smi_regs_busaddr = be32_to_cpu(addr);
+	inst->smi_regs_busaddr = be32_to_cpu(*addr);
 
 	err = bcm2835_smi_dma_setup(inst);
 	if (err)


### PR DESCRIPTION
Commit [bef1575](https://github.com/raspberrypi/linux/pull/1629/commits/bef1575246ac3ddee7b5e20c8f07ba80ea1fc685) (part of #1629) removed a dereference in the original code leading to smi_bus_address being wrong - this restores the original code, fixing DMA transfers (anything larger than 128 bytes when using smi-dev).
I'm not sure what tree I should submit against as it's broken since [somewhere in 4.7], but this patch is against rpi-4.14-y.