### PR TITLE
USB Audio: generic DSD detection for XMOS-based implemtations

### DIFF
--- a/sound/usb/card.h
+++ b/sound/usb/card.h
@@ -32,6 +32,7 @@ struct audioformat {
 	struct snd_pcm_chmap_elem *chmap; /* (optional) channel map */
 	bool dsd_dop;			/* add DOP headers in case of DSD samples */
 	bool dsd_bitrev;		/* reverse the bits of each DSD sample */
+	bool dsd_raw;			/* altsetting is raw DSD */
 };
 
 struct snd_usb_substream;

--- a/sound/usb/format.c
+++ b/sound/usb/format.c
@@ -63,9 +63,11 @@ static u64 parse_audio_format_i_type(struct snd_usb_audio *chip,
 		sample_width = fmt->bBitResolution;
 		sample_bytes = fmt->bSubslotSize;
 
-		if (format & UAC2_FORMAT_TYPE_I_RAW_DATA)
+		if (format & UAC2_FORMAT_TYPE_I_RAW_DATA) {
 			pcm_formats |= SNDRV_PCM_FMTBIT_SPECIAL;
-
+			/* flag potentially raw DSD capable altsettings */
+			fp->dsd_raw = true;
+		}
 		format <<= 1;
 		break;
 	}

--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -1442,9 +1442,7 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
 	case 0x20b1:  /* XMOS based devices */
 	case 0x152a:  /* Thesycon devices */
 	case 0x25ce:  /* Mytek devices */
-printk(KERN_DEBUG "XMOS USB Audio device: checking altsetting %d\n",fp->altsetting);
 		if (fp->dsd_raw) {
-printk(KERN_DEBUG "DSD Direct capable!\n");
 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
 		}
 		break;

--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -1355,20 +1355,44 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
 
 	/* XMOS based USB DACs */
 	switch (chip->usb_id) {
-	case USB_ID(0x20b1, 0x3008): /* iFi Audio micro/nano iDSD */
+	case USB_ID(0x1511, 0x0037): /* AURALiC VEGA */
+	case USB_ID(0x20b1, 0x0002): /* Wyred 4 Sound DAC-2 DSD */
+	case USB_ID(0x20b1, 0x2004): /* Matrix Audio X-SPDIF 2 */
 	case USB_ID(0x20b1, 0x2008): /* Matrix Audio X-Sabre */
 	case USB_ID(0x20b1, 0x300a): /* Matrix Audio Mini-i Pro */
 	case USB_ID(0x22d9, 0x0416): /* OPPO HA-1 */
+	case USB_ID(0x22d9, 0x0436): /* OPPO Sonica */
+	case USB_ID(0x22d9, 0x0461): /* OPPO UDP-205 */
+	case USB_ID(0x2522, 0x0012): /* LH Labs VI DAC Infinity */
 	case USB_ID(0x2772, 0x0230): /* Pro-Ject Pre Box S2 Digital */
 		if (fp->altsetting == 2)
 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
 		break;
 
+	case USB_ID(0x152a, 0x85de): /* SMSL D1 DAC */
+	case USB_ID(0x16d0, 0x09dd): /* Encore mDSD */
+	case USB_ID(0x0d8c, 0x0316): /* Hegel HD12 DSD */
+	case USB_ID(0x16b0, 0x06b2): /* NuPrime DAC-10 */
+	case USB_ID(0x16d0, 0x0733): /* Furutech ADL Stratos */
+	case USB_ID(0x16d0, 0x09db): /* NuPrime Audio DAC-9 */
+	case USB_ID(0x1db5, 0x0003): /* Bryston BDA3 */
 	case USB_ID(0x20b1, 0x000a): /* Gustard DAC-X20U */
+	case USB_ID(0x20b1, 0x2005): /* Denafrips Ares DAC */
 	case USB_ID(0x20b1, 0x2009): /* DIYINHK DSD DXD 384kHz USB to I2S/DSD */
 	case USB_ID(0x20b1, 0x2023): /* JLsounds I2SoverUSB */
+	case USB_ID(0x20b1, 0x3021): /* Eastern El. MiniMax Tube DAC Supreme */
 	case USB_ID(0x20b1, 0x3023): /* Aune X1S 32BIT/384 DSD DAC */
+	case USB_ID(0x20b1, 0x302d): /* Unison Research Unico CD Due */
+	case USB_ID(0x20b1, 0x307b): /* CH Precision C1 DAC */
+	case USB_ID(0x20b1, 0x3086): /* Singxer F-1 converter board */
+	case USB_ID(0x22d9, 0x0426): /* OPPO HA-2 */
+	case USB_ID(0x22e1, 0xca01): /* HDTA Serenade DSD */
+	case USB_ID(0x249c, 0x9326): /* M2Tech Young MkIII */
 	case USB_ID(0x2616, 0x0106): /* PS Audio NuWave DAC */
+	case USB_ID(0x2622, 0x0041): /* Audiolab M-DAC+ */
+	case USB_ID(0x27f7, 0x3002): /* W4S DAC-2v2SE */
+	case USB_ID(0x29a2, 0x0086): /* Mutec MC3+ USB */
+	case USB_ID(0x6b42, 0x0042): /* MSB Technology */
 		if (fp->altsetting == 3)
 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
 		break;
@@ -1411,5 +1435,22 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
 	}
 
+	/* Mostly generic method to detect many DSD-capable implementations -
+	 * from XMOS/Thesycon
+	 */
+	switch (USB_ID_VENDOR(chip->usb_id)) {
+	case 0x20b1:  /* XMOS based devices */
+	case 0x152a:  /* Thesycon devices */
+	case 0x25ce:  /* Mytek devices */
+printk(KERN_DEBUG "XMOS USB Audio device: checking altsetting %d\n",fp->altsetting);
+		if (fp->dsd_raw) {
+printk(KERN_DEBUG "DSD Direct capable!\n");
+			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
+		}
+		break;
+	default:
+		break;
+
+	}
 	return 0;
 }


### PR DESCRIPTION
The purpose of this backport is to implement the generic method to detect many DSD-capable implementations from XMOS/ Thesycon and Mytek as found in kernel 4.19 LTS.
This simple patch makes it available for kernel version 4.14.y

Additionally the patch implements support for the following DSD-capable devices:

AURALiC VEGA
Wyred 4 Sound DAC-2 DSD
Matrix Audio X-SPDIF 2
OPPO Sonica
OPPO UDP-205
OPPO HA-2
LH Labs VI DAC Infinity
SMSL D1 DAC
Encore mDSD
Hegel HD12 DSD
NuPrime Audio DAC-9
NuPrime DAC-10
Furutech ADL Stratos
Bryston BDA3
Denafrips Ares DAC
Eastern El. MiniMax Tube DAC Supreme
Unison Research Unico CD Due
CH Precision C1 DAC
Singxer F-1 converter board
HDTA Serenade DSD
M2Tech Young MkIII
PS Audio NuWave DAC
Audiolab M-DAC+
W4S DAC-2v2SE
Mutec MC3+ USB
MSB Technology