### PR TITLE
gpio-ir: change default pull configuration to up

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -611,7 +611,7 @@ Load:   dtoverlay=gpio-ir,<param>=<val>
 Params: gpio_pin                Input pin number. Default is 18.
 
         gpio_pull               Desired pull-up/down state (off, down, up)
-                                Default is "down".
+                                Default is "up".
 
         rc-map-name             Default rc keymap (can also be changed by
                                 ir-keytable), defaults to "rc-rc6-mce"

--- a/arch/arm/boot/dts/overlays/gpio-ir-overlay.dts
+++ b/arch/arm/boot/dts/overlays/gpio-ir-overlay.dts
@@ -30,7 +30,7 @@
                         gpio_ir_pins: gpio_ir_pins@12 {
                                 brcm,pins = <18>;                       // pin 18
                                 brcm,function = <0>;                    // in
-                                brcm,pull = <1>;                        // down
+                                brcm,pull = <2>;                        // up
                         };
                 };
         };


### PR DESCRIPTION
IR receivers like the TSOP series from Vishay and compatible ones
have active-low open collector outputs with an internal pull up of
about 30k (according to the TSOP datasheets).

Activating a pull-down resistor on the GPIO will make it work against
the pull-up in the IR receiver and brings the idle input voltage down
to about 1.9V (measured on a RPi3B+ with a TSOP4438). While that's
usually enough to make the RPi see a high signal it's certainly not
optimal and may even fail when using an IR receiver with a weaker pull-up.

Switching the default GPIO pull to "up" results in an input voltage
level of about 3.3V and ensures that an idle state (high signal) will
be detected if no IR receiver is attached.