### PR TITLE
overlays: sdio: Add enhanced 1-bit support

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -469,8 +469,7 @@ Params: <None>
 
 Name:   bmp085_i2c-sensor
 Info:   This overlay is now deprecated - see i2c-sensor
-Load:   dtoverlay=bmp085_i2c-sensor
-Params: <None>
+Load:   <Deprecated>
 
 
 Name:   dht11
@@ -1737,7 +1736,8 @@ Params: overclock_50            Clock (in MHz) to use when the MMC framework
 
 Name:   sdio
 Info:   Selects the bcm2835-sdhost SD/MMC driver, optionally with overclock,
-        and enables SDIO via GPIOs 22-27.
+        and enables SDIO via GPIOs 22-27. An example of use in 1-bit mode is
+        "dtoverlay=sdio,bus_width=1,gpios_22_25"
 Load:   dtoverlay=sdio,<param>=<val>
 Params: sdio_overclock          SDIO Clock (in MHz) to use when the MMC
                                 framework requests 50MHz
@@ -1747,16 +1747,18 @@ Params: sdio_overclock          SDIO Clock (in MHz) to use when the MMC
 
         bus_width               Set the SDIO host bus width (default 4 bits)
 
+        gpios_22_25             Select GPIOs 22-25 for 1-bit mode. Must be used
+                                with bus_width=1. This replaces the sdio-1bit
+                                overlay, which is now deprecated.
+
+        gpios_34_37             Select GPIOs 34-37 for 1-bit mode. Must be used
+                                with bus_width=1.
+
 
 Name:   sdio-1bit
-Info:   Selects the bcm2835-sdhost SD/MMC driver, optionally with overclock,
-        and enables 1-bit SDIO via GPIOs 22-25.
-Load:   dtoverlay=sdio-1bit,<param>=<val>
-Params: sdio_overclock          SDIO Clock (in MHz) to use when the MMC
-                                framework requests 50MHz
-
-        poll_once               Disable SDIO-device polling every second
-                                (default on: polling once at boot-time)
+Info:   This overlay is now deprecated. Use
+        "dtoverlay=sdio,bus_width=1,gpios_22_25" instead.
+Load:   <Deprecated>
 
 
 Name:   sdtweak

--- a/arch/arm/boot/dts/overlays/sdio-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sdio-overlay.dts
@@ -49,6 +49,22 @@
 	};
 
 	fragment@3 {
+		target = <&sdio_ovl_pins>;
+		__dormant__ {
+			brcm,pins = <22 23 24 25>;
+			brcm,pull = <0 2 2 2>;
+		};
+	};
+
+	fragment@4 {
+		target = <&sdio_ovl_pins>;
+		__dormant__ {
+			brcm,pins = <34 35 36 37>;
+			brcm,pull = <0 2 2 2>;
+		};
+	};
+
+	fragment@6 {
 		target-path = "/aliases";
 		__overlay__ {
 			mmc1 = "/soc/sdio@7e300000";
@@ -59,5 +75,7 @@
 		poll_once = <&sdio_ovl>,"non-removable?";
 		bus_width = <&sdio_ovl>,"bus-width:0";
 		sdio_overclock = <&sdio_ovl>,"brcm,overclock-50:0";
+		gpios_22_25 = <0>,"=3";
+		gpios_34_37 = <0>,"=4";
 	};
 };


### PR DESCRIPTION
"dtoverlay=sdio,bus_width=1,gpios_22_25" is equivalent to the sdio-1bit
overlay, which is now deprecated.

"dtoverlay=sdio,bus_width=1,gpios_34_37" enables 1-bit mode on GPIOs 34-37.

Signed-off-by: Phil Elwell <phil@raspberrypi.org>