### PR TITLE
raspberrypi firmware driver to log build variant and hash during probe.

### DIFF
--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -227,21 +227,39 @@ static const struct attribute_group rpi_firmware_dev_group = {
 static void
 rpi_firmware_print_firmware_revision(struct rpi_firmware *fw)
 {
+	static const char * const variant_strs[] = {
+		"unknown",
+		"start",
+		"start_x",
+		"start_db",
+		"start_cd",
+	};
+	const char *variant_str = "cmd unsupported";
 	u32 packet;
+	u32 variant;
+	struct tm tm;
 	int ret = rpi_firmware_property(fw,
 					RPI_FIRMWARE_GET_FIRMWARE_REVISION,
 					&packet, sizeof(packet));
 
-	if (ret == 0) {
-		struct tm tm;
+	if (ret)
+		return;
 
-		time64_to_tm(packet, 0, &tm);
+	ret = rpi_firmware_property(fw, RPI_FIRMWARE_GET_FIRMWARE_VARIANT,
+				    &variant, sizeof(variant));
 
-		dev_info(fw->cl.dev,
-			 "Attached to firmware from %04ld-%02d-%02d %02d:%02d\n",
-			 tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-			 tm.tm_hour, tm.tm_min);
+	if (!ret) {
+		if (variant >= ARRAY_SIZE(variant_strs))
+			variant = 0;
+		variant_str = variant_strs[variant];
 	}
+
+	time64_to_tm(packet, 0, &tm);
+
+	dev_info(fw->cl.dev,
+		 "Attached to firmware from %04ld-%02d-%02d %02d:%02d, variant %s\n",
+		 tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour,
+		 tm.tm_min, variant_str);
 }
 
 static void

--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -263,6 +263,22 @@ rpi_firmware_print_firmware_revision(struct rpi_firmware *fw)
 }
 
 static void
+rpi_firmware_print_firmware_hash(struct rpi_firmware *fw)
+{
+	u32 hash[5];
+	int ret = rpi_firmware_property(fw,
+					RPI_FIRMWARE_GET_FIRMWARE_HASH,
+					hash, sizeof(hash));
+
+	if (ret)
+		return;
+
+	dev_info(fw->cl.dev,
+		 "Firmware hash is %08x%08x%08x%08x%08x\n",
+		 hash[0], hash[1], hash[2], hash[3], hash[4]);
+}
+
+static void
 rpi_register_hwmon_driver(struct device *dev, struct rpi_firmware *fw)
 {
 	u32 packet;
@@ -308,6 +324,7 @@ static int rpi_firmware_probe(struct platform_device *pdev)
 	g_pdev = pdev;
 
 	rpi_firmware_print_firmware_revision(fw);
+	rpi_firmware_print_firmware_hash(fw);
 	rpi_register_hwmon_driver(dev, fw);
 
 	return 0;

--- a/include/soc/bcm2835/raspberrypi-firmware.h
+++ b/include/soc/bcm2835/raspberrypi-firmware.h
@@ -42,6 +42,7 @@ enum rpi_firmware_property_tag {
 	RPI_FIRMWARE_PROPERTY_END =                           0,
 	RPI_FIRMWARE_GET_FIRMWARE_REVISION =                  0x00000001,
 	RPI_FIRMWARE_GET_FIRMWARE_VARIANT =                   0x00000002,
+	RPI_FIRMWARE_GET_FIRMWARE_HASH =                      0x00000003,
 
 	RPI_FIRMWARE_SET_CURSOR_INFO =                        0x00008010,
 	RPI_FIRMWARE_SET_CURSOR_STATE =                       0x00008011,

--- a/include/soc/bcm2835/raspberrypi-firmware.h
+++ b/include/soc/bcm2835/raspberrypi-firmware.h
@@ -41,6 +41,7 @@ struct rpi_firmware_property_tag_header {
 enum rpi_firmware_property_tag {
 	RPI_FIRMWARE_PROPERTY_END =                           0,
 	RPI_FIRMWARE_GET_FIRMWARE_REVISION =                  0x00000001,
+	RPI_FIRMWARE_GET_FIRMWARE_VARIANT =                   0x00000002,
 
 	RPI_FIRMWARE_SET_CURSOR_INFO =                        0x00008010,
 	RPI_FIRMWARE_SET_CURSOR_STATE =                       0x00008011,


### PR DESCRIPTION
Requires the associated firmware change to work, but will behave sensibly if it is absent.