### PR TITLE
overlays: add better target to rpi-ft5406

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-ft5406-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ft5406-overlay.dts
@@ -5,14 +5,12 @@
 	compatible = "brcm,bcm2708";
 
 	fragment@0 {
-		target-path = "/";
+		target-path = "/soc/firmware";
 		__overlay__ {
-			firmware {
-				ts: touchscreen {
-					compatible = "raspberrypi,firmware-ts";
-					touchscreen-size-x = <800>;
-					touchscreen-size-y = <480>;
-				};
+			ts: touchscreen {
+				compatible = "raspberrypi,firmware-ts";
+				touchscreen-size-x = <800>;
+				touchscreen-size-y = <480>;
 			};
 		};
 	};


### PR DESCRIPTION
The current overlay's target is set to "/firmware". This is worng as the
real firmware node is located at "/soc/firmware". This is not ideal as
the touchcreen didn't appear in the final device tree as a child of the
firmware node.

the overlay still worked fine as the driver uses 'of_get_parent()' to
get the firmware node which in the end pointed to the right place.

Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>