### PR TITLE
dwc_otg: fix bug with port_addr assignment for single-TT hubs

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
@@ -232,7 +232,7 @@ static int _hub_info(dwc_otg_hcd_t * hcd, void *urb_handle, uint32_t * hub_addr,
 		else
 			*hub_addr = urb->dev->tt->hub->devnum;
 	}
-	*port_addr = urb->dev->tt->multi ? urb->dev->ttport : 1;
+	*port_addr = urb->dev->ttport;
    } else {
         *hub_addr = 0;
 	*port_addr = urb->dev->ttport;


### PR DESCRIPTION
See https://github.com/raspberrypi/linux/issues/2734

The "Hub Port" field in the split transaction packet was always set
to 1 for single-TT hubs. The majority of single-TT hub products
apparently ignore this field and broadcast to all downstream enabled
ports, which masked the issue. A subset of hub devices apparently
need the port number to be exact or split transactions will fail.