### PR TITLE
bcm2835-mmc: Fix DMA channel leak

### DIFF
--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -1441,7 +1441,8 @@ static int bcm2835_mmc_probe(struct platform_device *pdev)
 	addr = of_get_address(node, 0, NULL, NULL);
 	if (!addr) {
 		dev_err(dev, "could not get DMA-register address\n");
-		return -ENODEV;
+		ret = -ENODEV;
+		goto err;
 	}
 	host->bus_addr = be32_to_cpup(addr);
 	pr_debug(" - ioaddr %lx, iomem->start %lx, bus_addr %lx\n",

--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -1400,10 +1400,16 @@ static int bcm2835_mmc_add_host(struct bcm2835_host *host)
 	}
 
 	mmiowb();
-	mmc_add_host(mmc);
+	ret = mmc_add_host(mmc);
+	if (ret) {
+		dev_err(dev, "could not add MMC host\n");
+		goto free_irq;
+	}
 
 	return 0;
 
+free_irq:
+	free_irq(host->irq, host);
 untasklet:
 	tasklet_kill(&host->finish_tasklet);
 

--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -1391,9 +1391,9 @@ static int bcm2835_mmc_add_host(struct bcm2835_host *host)
 	init_waitqueue_head(&host->buf_ready_int);
 
 	bcm2835_mmc_init(host, 0);
-	ret = devm_request_threaded_irq(dev, host->irq, bcm2835_mmc_irq,
-					bcm2835_mmc_thread_irq, IRQF_SHARED,
-					mmc_hostname(mmc), host);
+	ret = request_threaded_irq(host->irq, bcm2835_mmc_irq,
+				   bcm2835_mmc_thread_irq, IRQF_SHARED,
+				   mmc_hostname(mmc), host);
 	if (ret) {
 		dev_err(dev, "Failed to request IRQ %d: %d\n", host->irq, ret);
 		goto untasklet;

--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -1505,6 +1505,8 @@ static int bcm2835_mmc_probe(struct platform_device *pdev)
 
 	return 0;
 err:
+	if (host->dma_chan_rxtx)
+		dma_release_channel(host->dma_chan_rxtx);
 	mmc_free_host(mmc);
 
 	return ret;
@@ -1549,6 +1551,9 @@ static int bcm2835_mmc_remove(struct platform_device *pdev)
 	del_timer_sync(&host->timer);
 
 	tasklet_kill(&host->finish_tasklet);
+
+	if (host->dma_chan_rxtx)
+		dma_release_channel(host->dma_chan_rxtx);
 
 	mmc_free_host(host->mmc);
 	platform_set_drvdata(pdev, NULL);

--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -1563,7 +1563,6 @@ static int bcm2835_mmc_remove(struct platform_device *pdev)
 		dma_release_channel(host->dma_chan_rxtx);
 
 	mmc_free_host(host->mmc);
-	platform_set_drvdata(pdev, NULL);
 
 	return 0;
 }


### PR DESCRIPTION
The BCM2835 MMC host driver requests a DMA channel on probe but neglects
to release the channel in the probe error path and on driver unbind.

I'm seeing this happen on every boot of the Compute Module 3: On first
driver probe, DMA channel 2 is allocated and then leaked with a "could
not get clk, deferring probe" message. On second driver probe, channel 4
is allocated.

Fix it.

Signed-off-by: Lukas Wunner <lukas@wunner.de>
Cc: @pavlic244