### PR TITLE
V4L2 compliance fixes, and 64 bit kernel improvements

### DIFF
--- a/drivers/char/broadcom/vc_mem.c
+++ b/drivers/char/broadcom/vc_mem.c
@@ -1,16 +1,16 @@
-/*****************************************************************************
-* Copyright 2010 - 2011 Broadcom Corporation.  All rights reserved.
-*
-* Unless you and Broadcom execute a separate written software license
-* agreement governing use of this software, this software is licensed to you
-* under the terms of the GNU General Public License version 2, available at
-* http://www.broadcom.com/licenses/GPLv2.php (the "GPL").
-*
-* Notwithstanding the above, under no circumstances may you combine this
-* software in any way with any other Broadcom software provided under a
-* license other than the GPL, without Broadcom's express prior written
-* consent.
-*****************************************************************************/
+/*
+ * Copyright 2010 - 2011 Broadcom Corporation.  All rights reserved.
+ *
+ * Unless you and Broadcom execute a separate written software license
+ * agreement governing use of this software, this software is licensed to you
+ * under the terms of the GNU General Public License version 2, available at
+ * http://www.broadcom.com/licenses/GPLv2.php (the "GPL").
+ *
+ * Notwithstanding the above, under no circumstances may you combine this
+ * software in any way with any other Broadcom software provided under a
+ * license other than the GPL, without Broadcom's express prior written
+ * consent.
+ */
 
 #include <linux/kernel.h>
 #include <linux/module.h>
@@ -26,11 +26,11 @@
 
 #define DRIVER_NAME  "vc-mem"
 
-// Device (/dev) related variables
-static dev_t vc_mem_devnum = 0;
-static struct class *vc_mem_class = NULL;
+/* Device (/dev) related variables */
+static dev_t vc_mem_devnum;
+static struct class *vc_mem_class;
 static struct cdev vc_mem_cdev;
-static int vc_mem_inited = 0;
+static int vc_mem_inited;
 
 #ifdef CONFIG_DEBUG_FS
 static struct dentry *vc_mem_debugfs_entry;
@@ -50,95 +50,54 @@ static struct dentry *vc_mem_debugfs_entry;
  * bootloader (and/or kernel). When that happens, the values of these variables
  * would be calculated and assigned in the init function.
  */
-// in the 2835 VC in mapped above ARM, but ARM has full access to VC space
-unsigned long mm_vc_mem_phys_addr = 0x00000000;
-unsigned int mm_vc_mem_size = 0;
-unsigned int mm_vc_mem_base = 0;
-
+/* In the 2835 VC in mapped above ARM, but ARM has full access to VC space */
+unsigned long mm_vc_mem_phys_addr;
 EXPORT_SYMBOL(mm_vc_mem_phys_addr);
+unsigned int mm_vc_mem_size;
 EXPORT_SYMBOL(mm_vc_mem_size);
+unsigned int mm_vc_mem_base;
 EXPORT_SYMBOL(mm_vc_mem_base);
 
-static uint phys_addr = 0;
-static uint mem_size = 0;
-static uint mem_base = 0;
-
-
-/****************************************************************************
-*
-*   vc_mem_open
-*
-***************************************************************************/
+static uint phys_addr;
+static uint mem_size;
+static uint mem_base;
 
 static int
 vc_mem_open(struct inode *inode, struct file *file)
 {
-	(void) inode;
-	(void) file;
+	(void)inode;
 
 	pr_debug("%s: called file = 0x%p\n", __func__, file);
 
 	return 0;
 }
-
-/****************************************************************************
-*
-*   vc_mem_release
-*
-***************************************************************************/
 
 static int
 vc_mem_release(struct inode *inode, struct file *file)
 {
-	(void) inode;
-	(void) file;
+	(void)inode;
 
 	pr_debug("%s: called file = 0x%p\n", __func__, file);
 
 	return 0;
 }
-
-/****************************************************************************
-*
-*   vc_mem_get_size
-*
-***************************************************************************/
 
 static void
 vc_mem_get_size(void)
 {
 }
 
-/****************************************************************************
-*
-*   vc_mem_get_base
-*
-***************************************************************************/
-
 static void
 vc_mem_get_base(void)
 {
 }
-
-/****************************************************************************
-*
-*   vc_mem_get_current_size
-*
-***************************************************************************/
 
 int
 vc_mem_get_current_size(void)
 {
 	return mm_vc_mem_size;
 }
-
 EXPORT_SYMBOL_GPL(vc_mem_get_current_size);
-
-/****************************************************************************
-*
-*   vc_mem_ioctl
-*
-***************************************************************************/
 
 static long
 vc_mem_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
@@ -154,52 +113,52 @@ vc_mem_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	case VC_MEM_IOC_MEM_PHYS_ADDR:
 		{
 			pr_debug("%s: VC_MEM_IOC_MEM_PHYS_ADDR=0x%p\n",
-				__func__, (void *) mm_vc_mem_phys_addr);
+				__func__, (void *)mm_vc_mem_phys_addr);
 
-			if (copy_to_user((void *) arg, &mm_vc_mem_phys_addr,
-					 sizeof (mm_vc_mem_phys_addr)) != 0) {
+			if (copy_to_user((void *)arg, &mm_vc_mem_phys_addr,
+					 sizeof(mm_vc_mem_phys_addr))) {
 				rc = -EFAULT;
 			}
 			break;
 		}
 	case VC_MEM_IOC_MEM_SIZE:
 		{
-			// Get the videocore memory size first
+			/* Get the videocore memory size first */
 			vc_mem_get_size();
 
 			pr_debug("%s: VC_MEM_IOC_MEM_SIZE=%x\n", __func__,
-				mm_vc_mem_size);
+				 mm_vc_mem_size);
 
-			if (copy_to_user((void *) arg, &mm_vc_mem_size,
-					 sizeof (mm_vc_mem_size)) != 0) {
+			if (copy_to_user((void *)arg, &mm_vc_mem_size,
+					 sizeof(mm_vc_mem_size))) {
 				rc = -EFAULT;
 			}
 			break;
 		}
 	case VC_MEM_IOC_MEM_BASE:
 		{
-			// Get the videocore memory base
+			/* Get the videocore memory base */
 			vc_mem_get_base();
 
 			pr_debug("%s: VC_MEM_IOC_MEM_BASE=%x\n", __func__,
-				mm_vc_mem_base);
+				 mm_vc_mem_base);
 
-			if (copy_to_user((void *) arg, &mm_vc_mem_base,
-					 sizeof (mm_vc_mem_base)) != 0) {
+			if (copy_to_user((void *)arg, &mm_vc_mem_base,
+					 sizeof(mm_vc_mem_base))) {
 				rc = -EFAULT;
 			}
 			break;
 		}
 	case VC_MEM_IOC_MEM_LOAD:
 		{
-			// Get the videocore memory base
+			/* Get the videocore memory base */
 			vc_mem_get_base();
 
 			pr_debug("%s: VC_MEM_IOC_MEM_LOAD=%x\n", __func__,
 				mm_vc_mem_base);
 
-			if (copy_to_user((void *) arg, &mm_vc_mem_base,
-					 sizeof (mm_vc_mem_base)) != 0) {
+			if (copy_to_user((void *)arg, &mm_vc_mem_base,
+					 sizeof(mm_vc_mem_base))) {
 				rc = -EFAULT;
 			}
 			break;
@@ -243,12 +202,6 @@ vc_mem_compat_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 }
 #endif
 
-/****************************************************************************
-*
-*   vc_mem_mmap
-*
-***************************************************************************/
-
 static int
 vc_mem_mmap(struct file *filp, struct vm_area_struct *vma)
 {
@@ -257,32 +210,26 @@ vc_mem_mmap(struct file *filp, struct vm_area_struct *vma)
 	unsigned long offset = vma->vm_pgoff << PAGE_SHIFT;
 
 	pr_debug("%s: vm_start = 0x%08lx vm_end = 0x%08lx vm_pgoff = 0x%08lx\n",
-		__func__, (long) vma->vm_start, (long) vma->vm_end,
-		(long) vma->vm_pgoff);
+		 __func__, (long)vma->vm_start, (long)vma->vm_end,
+		 (long)vma->vm_pgoff);
 
 	if (offset + length > mm_vc_mem_size) {
 		pr_err("%s: length %ld is too big\n", __func__, length);
 		return -EINVAL;
 	}
-	// Do not cache the memory map
+	/* Do not cache the memory map */
 	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
 
 	rc = remap_pfn_range(vma, vma->vm_start,
 			     (mm_vc_mem_phys_addr >> PAGE_SHIFT) +
 			     vma->vm_pgoff, length, vma->vm_page_prot);
-	if (rc != 0) {
+	if (rc)
 		pr_err("%s: remap_pfn_range failed (rc=%d)\n", __func__, rc);
-	}
 
 	return rc;
 }
 
-/****************************************************************************
-*
-*   File Operations for the driver.
-*
-***************************************************************************/
-
+/* File Operations for the driver. */
 static const struct file_operations vc_mem_fops = {
 	.owner = THIS_MODULE,
 	.open = vc_mem_open,
@@ -316,7 +263,7 @@ static int vc_mem_debugfs_init(
 				vc_mem_debugfs_entry,
 				(u32 *)&mm_vc_mem_phys_addr)) {
 		dev_warn(dev, "%s:could not create vc_mem_phys entry\n",
-			__func__);
+			 __func__);
 		goto fail;
 	}
 
@@ -325,7 +272,7 @@ static int vc_mem_debugfs_init(
 				vc_mem_debugfs_entry,
 				(u32 *)&mm_vc_mem_size)) {
 		dev_warn(dev, "%s:could not create vc_mem_size entry\n",
-			__func__);
+			 __func__);
 		goto fail;
 	}
 
@@ -347,12 +294,7 @@ fail:
 
 #endif /* CONFIG_DEBUG_FS */
 
-
-/****************************************************************************
-*
-*   vc_mem_init
-*
-***************************************************************************/
+/* Module load/unload functions */
 
 static int __init
 vc_mem_init(void)
@@ -369,16 +311,19 @@ vc_mem_init(void)
 	vc_mem_get_size();
 
 	pr_info("vc-mem: phys_addr:0x%08lx mem_base=0x%08x mem_size:0x%08x(%u MiB)\n",
-		mm_vc_mem_phys_addr, mm_vc_mem_base, mm_vc_mem_size, mm_vc_mem_size / (1024 * 1024));
+		mm_vc_mem_phys_addr, mm_vc_mem_base, mm_vc_mem_size,
+		mm_vc_mem_size / (1024 * 1024));
 
-	if ((rc = alloc_chrdev_region(&vc_mem_devnum, 0, 1, DRIVER_NAME)) < 0) {
+	rc = alloc_chrdev_region(&vc_mem_devnum, 0, 1, DRIVER_NAME);
+	if (rc < 0) {
 		pr_err("%s: alloc_chrdev_region failed (rc=%d)\n",
 		       __func__, rc);
 		goto out_err;
 	}
 
 	cdev_init(&vc_mem_cdev, &vc_mem_fops);
-	if ((rc = cdev_add(&vc_mem_cdev, vc_mem_devnum, 1)) != 0) {
+	rc = cdev_add(&vc_mem_cdev, vc_mem_devnum, 1);
+	if (rc) {
 		pr_err("%s: cdev_add failed (rc=%d)\n", __func__, rc);
 		goto out_unregister;
 	}
@@ -408,25 +353,19 @@ vc_mem_init(void)
 
 	device_destroy(vc_mem_class, vc_mem_devnum);
 
-      out_class_destroy:
+out_class_destroy:
 	class_destroy(vc_mem_class);
 	vc_mem_class = NULL;
 
-      out_cdev_del:
+out_cdev_del:
 	cdev_del(&vc_mem_cdev);
 
-      out_unregister:
+out_unregister:
 	unregister_chrdev_region(vc_mem_devnum, 1);
 
-      out_err:
+out_err:
 	return -1;
 }
-
-/****************************************************************************
-*
-*   vc_mem_exit
-*
-***************************************************************************/
 
 static void __exit
 vc_mem_exit(void)

--- a/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.c
+++ b/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.c
@@ -242,6 +242,22 @@ static int queue_setup(struct vb2_queue *vq,
 		return -EINVAL;
 	}
 
+	/* Handle CREATE_BUFS situation - *nplanes != 0 */
+	if (*nplanes) {
+		if (*nplanes != 1 ||
+		    sizes[0] < dev->capture.port->current_buffer.size) {
+			v4l2_dbg(1, bcm2835_v4l2_debug, &dev->v4l2_dev,
+				 "%s: dev:%p Invalid buffer request from CREATE_BUFS, size %u < %u, nplanes %u != 1\n",
+				 __func__, dev, sizes[0],
+				 dev->capture.port->current_buffer.size,
+				 *nplanes);
+			return -EINVAL;
+		} else {
+			return 0;
+		}
+	}
+
+	/* Handle REQBUFS situation */
 	size = dev->capture.port->current_buffer.size;
 	if (size == 0) {
 		v4l2_err(&dev->v4l2_dev,

--- a/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.c
+++ b/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.c
@@ -443,6 +443,7 @@ static void buffer_cb(struct vchiq_mmal_instance *instance,
 	}
 	dev->capture.last_timestamp = buf->vb.vb2_buf.timestamp;
 	buf->vb.sequence = dev->capture.sequence++;
+	buf->vb.field = V4L2_FIELD_NONE;
 
 	vb2_set_plane_payload(&buf->vb.vb2_buf, 0, mmal_buf->length);
 	if (mmal_buf->mmal_flags & MMAL_BUFFER_HEADER_FLAG_KEYFRAME)

--- a/drivers/staging/vc04_services/vchiq-mmal/mmal-vchiq.h
+++ b/drivers/staging/vc04_services/vchiq-mmal/mmal-vchiq.h
@@ -97,6 +97,7 @@ struct vchiq_mmal_component {
 	struct vchiq_mmal_port input[MAX_PORT_COUNT]; /* input ports */
 	struct vchiq_mmal_port output[MAX_PORT_COUNT]; /* output ports */
 	struct vchiq_mmal_port clock[MAX_PORT_COUNT]; /* clock ports */
+	u32 client_component;	/* Used to ref back to client struct */
 };
 
 int vchiq_mmal_init(struct vchiq_mmal_instance **out_instance);

--- a/include/linux/broadcom/vc_mem.h
+++ b/include/linux/broadcom/vc_mem.h
@@ -1,16 +1,16 @@
-/*****************************************************************************
-* Copyright 2010 - 2011 Broadcom Corporation.  All rights reserved.
-*
-* Unless you and Broadcom execute a separate written software license
-* agreement governing use of this software, this software is licensed to you
-* under the terms of the GNU General Public License version 2, available at
-* http://www.broadcom.com/licenses/GPLv2.php (the "GPL").
-*
-* Notwithstanding the above, under no circumstances may you combine this
-* software in any way with any other Broadcom software provided under a
-* license other than the GPL, without Broadcom's express prior written
-* consent.
-*****************************************************************************/
+/*
+ * Copyright 2010 - 2011 Broadcom Corporation.  All rights reserved.
+ *
+ * Unless you and Broadcom execute a separate written software license
+ * agreement governing use of this software, this software is licensed to you
+ * under the terms of the GNU General Public License version 2, available at
+ * http://www.broadcom.com/licenses/GPLv2.php (the "GPL").
+ *
+ * Notwithstanding the above, under no circumstances may you combine this
+ * software in any way with any other Broadcom software provided under a
+ * license other than the GPL, without Broadcom's express prior written
+ * consent.
+ */
 
 #ifndef _VC_MEM_H
 #define _VC_MEM_H
@@ -19,17 +19,17 @@
 
 #define VC_MEM_IOC_MAGIC  'v'
 
-#define VC_MEM_IOC_MEM_PHYS_ADDR    _IOR( VC_MEM_IOC_MAGIC, 0, unsigned long )
-#define VC_MEM_IOC_MEM_SIZE         _IOR( VC_MEM_IOC_MAGIC, 1, unsigned int )
-#define VC_MEM_IOC_MEM_BASE         _IOR( VC_MEM_IOC_MAGIC, 2, unsigned int )
-#define VC_MEM_IOC_MEM_LOAD         _IOR( VC_MEM_IOC_MAGIC, 3, unsigned int )
+#define VC_MEM_IOC_MEM_PHYS_ADDR    _IOR(VC_MEM_IOC_MAGIC, 0, unsigned long)
+#define VC_MEM_IOC_MEM_SIZE         _IOR(VC_MEM_IOC_MAGIC, 1, unsigned int)
+#define VC_MEM_IOC_MEM_BASE         _IOR(VC_MEM_IOC_MAGIC, 2, unsigned int)
+#define VC_MEM_IOC_MEM_LOAD         _IOR(VC_MEM_IOC_MAGIC, 3, unsigned int)
 
-#if defined( __KERNEL__ )
+#ifdef __KERNEL__
 #define VC_MEM_TO_ARM_ADDR_MASK 0x3FFFFFFF
 
 extern unsigned long mm_vc_mem_phys_addr;
 extern unsigned int  mm_vc_mem_size;
-extern int vc_mem_get_current_size( void );
+extern int vc_mem_get_current_size(void);
 #endif
 
 #ifdef CONFIG_COMPAT

--- a/include/linux/broadcom/vc_mem.h
+++ b/include/linux/broadcom/vc_mem.h
@@ -32,4 +32,8 @@ extern unsigned int  mm_vc_mem_size;
 extern int vc_mem_get_current_size( void );
 #endif
 
+#ifdef CONFIG_COMPAT
+#define VC_MEM_IOC_MEM_PHYS_ADDR32  _IOR(VC_MEM_IOC_MAGIC, 0, compat_ulong_t)
+#endif
+
 #endif  /* _VC_MEM_H */


### PR DESCRIPTION
Two V4L2 compliance test fixes for the camera driver.

Hopefully fixes mmal-vchiq to support 64 bit kernels. (Fails at present due to dma_alloc_coherent failing, so unable to confirm).

Fixes up vc_mem for 32 bit userspace/64 bit kernel, so vcdbg now works under those conditions. Cleans up checkpatch issues with it too.