### PR TITLE
vcio 64bit kernel/32bit user compat ioctl handling.

### DIFF
--- a/drivers/char/broadcom/vcio.c
+++ b/drivers/char/broadcom/vcio.c
@@ -126,10 +126,9 @@ static int __init vcio_init(void)
 
 	np = of_find_compatible_node(NULL, NULL,
 				     "raspberrypi,bcm2835-firmware");
-/* Uncomment this when we only boot with Device Tree
 	if (!of_device_is_available(np))
 		return -ENODEV;
-*/
+
 	vcio.fw = rpi_firmware_get(np);
 	if (!vcio.fw)
 		return -ENODEV;

--- a/drivers/char/broadcom/vcio.c
+++ b/drivers/char/broadcom/vcio.c
@@ -24,6 +24,9 @@
 
 #define VCIO_IOC_MAGIC 100
 #define IOCTL_MBOX_PROPERTY _IOWR(VCIO_IOC_MAGIC, 0, char *)
+#ifdef CONFIG_COMPAT
+#define IOCTL_MBOX_PROPERTY32 _IOWR(VCIO_IOC_MAGIC, 0, compat_uptr_t)
+#endif
 
 static struct {
 	dev_t devt;
@@ -87,13 +90,30 @@ static long vcio_device_ioctl(struct file *file, unsigned int ioctl_num,
 	case IOCTL_MBOX_PROPERTY:
 		return vcio_user_property_list((void *)ioctl_param);
 	default:
-		pr_err("unknown ioctl: %d\n", ioctl_num);
+		pr_err("unknown ioctl: %x\n", ioctl_num);
 		return -EINVAL;
 	}
 }
 
+#ifdef CONFIG_COMPAT
+static long vcio_device_compat_ioctl(struct file *file, unsigned int ioctl_num,
+				     unsigned long ioctl_param)
+{
+	switch (ioctl_num) {
+	case IOCTL_MBOX_PROPERTY32:
+		return vcio_user_property_list(compat_ptr(ioctl_param));
+	default:
+		pr_err("unknown ioctl: %x\n", ioctl_num);
+		return -EINVAL;
+	}
+}
+#endif
+
 const struct file_operations vcio_fops = {
 	.unlocked_ioctl = vcio_device_ioctl,
+#ifdef CONFIG_COMPAT
+	.compat_ioctl = vcio_device_compat_ioctl,
+#endif
 	.open = vcio_device_open,
 	.release = vcio_device_release,
 };


### PR DESCRIPTION
Equivalent tweaks to vcio as #2823 provides for vc-mem.

Adds compat_ioctl handling as IOCTL_MBOX_PROPERTY changes due to char* being of a different size.
Tested with https://github.com/6by9/rpi3-gpiovirtbuf, with ```rpi3-gpiovertbuf s 130 [0|1]``` to toggle the power LED on/off on a 3B+.