### PR TITLE
clk: clk-bcm2835: Use %zd when printing size_t

### DIFF
--- a/drivers/clk/bcm/clk-bcm2835.c
+++ b/drivers/clk/bcm/clk-bcm2835.c
@@ -2271,7 +2271,7 @@ static int bcm2835_clk_probe(struct platform_device *pdev)
 		return ret;
 
 	/* note that we have registered all the clocks */
-	dev_dbg(dev, "registered %d clocks\n", asize);
+	dev_dbg(dev, "registered %zd clocks\n", asize);
 
 	return 0;
 }


### PR DESCRIPTION
The debug text for how many clocks have been registered
uses "%d" with a size_t. Correct it to "%zd".

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>