### PR TITLE
audioinjector-octo: revert to dummy supplies

### DIFF
--- a/arch/arm/boot/dts/overlays/audioinjector-addons-overlay.dts
+++ b/arch/arm/boot/dts/overlays/audioinjector-addons-overlay.dts
@@ -25,10 +25,6 @@
 				reg = <0x48>;
 				clocks = <&cs42448_mclk>;
 				clock-names = "mclk";
-				VA-supply = <&vdd_5v0_reg>;
-				VD-supply = <&vdd_3v3_reg>;
-				VLS-supply = <&vdd_3v3_reg>;
-				VLC-supply = <&vdd_3v3_reg>;
 				status = "okay";
 			};
 


### PR DESCRIPTION
The Audio Injector Octo has had a lot of reports of not coming up on power cycles. By reverting to dummy supplies, the card comes up reliably.