### PR TITLE
Unicam/OV5647 fixes

### DIFF
--- a/arch/arm/boot/dts/bcm270x.dtsi
+++ b/arch/arm/boot/dts/bcm270x.dtsi
@@ -152,6 +152,13 @@
 		regulator-max-microvolt = <3300000>;
 		regulator-always-on;
 	};
+
+	__overrides__ {
+		cam0-pwdn-ctrl;
+		cam0-pwdn;
+		cam0-led-ctrl;
+		cam0-led;
+	};
 };
 
 &vc4 {

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1366,15 +1366,7 @@ Info:   Omnivision OV5647 camera module.
         Uses Unicam 1, which is the standard camera connector on most Pi
         variants.
 Load:   dtoverlay=ov5647,<param>=<val>
-Params: cam0-pwdn               GPIO used to control the sensor powerdown line.
-
-        cam0-led                GPIO used to control the sensor led
-                                Both these fields should be automatically filled
-                                in by the firmware to reflect the default GPIO
-                                configuration of the particular Pi variant in
-                                use.
-
-        i2c_pins_0_1            Use pins 0&1 for the I2C instead of 44&45.
+Params: i2c_pins_0_1            Use pins 0&1 for the I2C instead of 44&45.
                                 Useful on Compute Modules.
 
         i2c_pins_28_29          Use pins 28&29 for the I2C instead of 44&45.

--- a/arch/arm/boot/dts/overlays/ov5647-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov5647-overlay.dts
@@ -14,7 +14,7 @@
 			status = "okay";
 
 			ov5647: ov5647@36 {
-				compatible = "ov5647";
+				compatible = "ovti,ov5647";
 				reg = <0x36>;
 				status = "okay";
 
@@ -82,10 +82,18 @@
 		};
 	};
 
+	fragment@6 {
+		target-path="/__overrides__";
+		__overlay__ {
+			cam0-pwdn-ctrl = <&ov5647>,"pwdn-gpios:0";
+			cam0-pwdn      = <&ov5647>,"pwdn-gpios:4";
+			cam0-led-ctrl  = <&ov5647>,"pwdn-gpios:12";
+			cam0-led       = <&ov5647>,"pwdn-gpios:16";
+		};
+	};
+
 	__overrides__ {
 		i2c_pins_0_1 = <0>,"-2-3+4";
 		i2c_pins_28_29 = <0>,"+2-3-4";
-		cam0-pwdn = <&ov5647>,"pwdn-gpios:4";
-		cam0-led = <&ov5647>,"pwdn-gpios:16";
 	};
 };

--- a/drivers/media/i2c/ov5647.c
+++ b/drivers/media/i2c/ov5647.c
@@ -373,7 +373,7 @@ static int ov5647_sensor_power(struct v4l2_subdev *sd, int on)
 		dev_dbg(&client->dev, "OV5647 power on\n");
 
 		if (ov5647->pwdn) {
-			gpiod_set_value(ov5647->pwdn, 0);
+			gpiod_set_value_cansleep(ov5647->pwdn, 0);
 			msleep(PWDN_ACTIVE_DELAY_MS);
 		}
 
@@ -415,7 +415,7 @@ static int ov5647_sensor_power(struct v4l2_subdev *sd, int on)
 
 		clk_disable_unprepare(ov5647->xclk);
 
-		gpiod_set_value(ov5647->pwdn, 1);
+		gpiod_set_value_cansleep(ov5647->pwdn, 1);
 	}
 
 	/* Update the power count. */
@@ -649,13 +649,13 @@ static int ov5647_probe(struct i2c_client *client,
 		goto mutex_remove;
 
 	if (sensor->pwdn) {
-		gpiod_set_value(sensor->pwdn, 0);
+		gpiod_set_value_cansleep(sensor->pwdn, 0);
 		msleep(PWDN_ACTIVE_DELAY_MS);
 	}
 
 	ret = ov5647_detect(sd);
 
-	gpiod_set_value(sensor->pwdn, 1);
+	gpiod_set_value_cansleep(sensor->pwdn, 1);
 
 	if (ret < 0)
 		goto error;

--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -1237,11 +1237,6 @@ static int unicam_start_streaming(struct vb2_queue *vq, unsigned int count)
 		unicam_err(dev, "Failed to enable CSI clock: %d\n", ret);
 		goto err_pm_put;
 	}
-	ret = v4l2_subdev_call(dev->sensor, core, s_power, 1);
-	if (ret < 0 && ret != -ENOIOCTLCMD) {
-		unicam_err(dev, "power on failed in subdev\n");
-		goto err_clock_unprepare;
-	}
 	dev->streaming = 1;
 
 	unicam_start_rx(dev, addr);
@@ -1256,8 +1251,6 @@ static int unicam_start_streaming(struct vb2_queue *vq, unsigned int count)
 
 err_disable_unicam:
 	unicam_disable(dev);
-	v4l2_subdev_call(dev->sensor, core, s_power, 0);
-err_clock_unprepare:
 	clk_disable_unprepare(dev->clock);
 err_pm_put:
 	unicam_runtime_put(dev);
@@ -1305,11 +1298,6 @@ static void unicam_stop_streaming(struct vb2_queue *vq)
 	dev->cur_frm = NULL;
 	dev->next_frm = NULL;
 	spin_unlock_irqrestore(&dev->dma_queue_lock, flags);
-
-	if (v4l2_subdev_has_op(dev->sensor, core, s_power)) {
-		if (v4l2_subdev_call(dev->sensor, core, s_power, 0) < 0)
-			unicam_err(dev, "power off failed in subdev\n");
-	}
 
 	clk_disable_unprepare(dev->clock);
 	unicam_runtime_put(dev);
@@ -1543,11 +1531,63 @@ static const struct vb2_ops unicam_video_qops = {
 	.stop_streaming		= unicam_stop_streaming,
 };
 
+/*
+ * unicam_open : This function is based on the v4l2_fh_open helper function.
+ * It has been augmented to handle sensor subdevice power management,
+ */
+static int unicam_open(struct file *file)
+{
+	struct unicam_device *dev = video_drvdata(file);
+	int ret;
+
+	mutex_lock(&dev->lock);
+
+	ret = v4l2_fh_open(file);
+	if (ret) {
+		unicam_err(dev, "v4l2_fh_open failed\n");
+		goto unlock;
+	}
+
+	if (!v4l2_fh_is_singular_file(file))
+		goto unlock;
+
+	ret = v4l2_subdev_call(dev->sensor, core, s_power, 1);
+	if (ret < 0 && ret != -ENOIOCTLCMD) {
+		v4l2_fh_release(file);
+		goto unlock;
+	}
+
+unlock:
+	mutex_unlock(&dev->lock);
+	return ret;
+}
+
+static int unicam_release(struct file *file)
+{
+	struct unicam_device *dev = video_drvdata(file);
+	struct v4l2_subdev *sd = dev->sensor;
+	bool fh_singular;
+	int ret;
+
+	mutex_lock(&dev->lock);
+
+	fh_singular = v4l2_fh_is_singular_file(file);
+
+	ret = _vb2_fop_release(file, NULL);
+
+	if (fh_singular)
+		v4l2_subdev_call(sd, core, s_power, 0);
+
+	mutex_unlock(&dev->lock);
+
+	return ret;
+}
+
 /* unicam capture driver file operations */
 static const struct v4l2_file_operations unicam_fops = {
 	.owner		= THIS_MODULE,
-	.open           = v4l2_fh_open,
-	.release        = vb2_fop_release,
+	.open           = unicam_open,
+	.release        = unicam_release,
 	.read		= vb2_fop_read,
 	.poll		= vb2_fop_poll,
 	.unlocked_ioctl	= video_ioctl2,


### PR DESCRIPTION
First patch was a 4.14 commit that hadn't been cherry-picked forward.

Second is so the GPIO calls don't throw a wobbler on the 3B/3B+ GPIO expander that needs to sleep.

Third is a change to the timing of when the sensor gets powered up/down within the Unicam driver, as discussed on https://www.raspberrypi.org/forums/viewtopic.php?f=43&t=232437