### PR TITLE
Platform driver DMA config, and vcsm-cma fixes for 64 bit

### DIFF
--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -3585,6 +3585,7 @@ static struct platform_device *
 vchiq_register_child(struct platform_device *pdev, const char *name)
 {
 	struct platform_device_info pdevinfo;
+	struct platform_device *new_dev;
 
 	memset(&pdevinfo, 0, sizeof(pdevinfo));
 
@@ -3593,7 +3594,17 @@ vchiq_register_child(struct platform_device *pdev, const char *name)
 	pdevinfo.id = PLATFORM_DEVID_NONE;
 	pdevinfo.dma_mask = DMA_BIT_MASK(32);
 
-	return platform_device_register_full(&pdevinfo);
+	new_dev = platform_device_register_full(&pdevinfo);
+	if (!new_dev)
+		return NULL;
+
+	/*
+	 * We want the dma-ranges etc to be copied from the parent VCHIQ device
+	 * to be passed on to the children too.
+	 */
+	of_dma_configure(&new_dev->dev, pdev->dev.of_node, true);
+
+	return new_dev;
 }
 
 static int vchiq_probe(struct platform_device *pdev)

--- a/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
+++ b/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
@@ -745,7 +745,7 @@ static int bcm2835_vc_sm_cma_remove(struct platform_device *pdev)
 }
 
 /* Get an internal resource handle mapped from the external one. */
-int vc_sm_cma_int_handle(int handle)
+int vc_sm_cma_int_handle(void *handle)
 {
 	struct dma_buf *dma_buf = (struct dma_buf *)handle;
 	struct vc_sm_buffer *res;
@@ -762,7 +762,7 @@ int vc_sm_cma_int_handle(int handle)
 EXPORT_SYMBOL_GPL(vc_sm_cma_int_handle);
 
 /* Free a previously allocated shared memory handle and block. */
-int vc_sm_cma_free(int handle)
+int vc_sm_cma_free(void *handle)
 {
 	struct dma_buf *dma_buf = (struct dma_buf *)handle;
 
@@ -772,7 +772,7 @@ int vc_sm_cma_free(int handle)
 		return -EPERM;
 	}
 
-	pr_debug("%s: handle %08x/dmabuf %p\n", __func__, handle, dma_buf);
+	pr_debug("%s: handle %p/dmabuf %p\n", __func__, handle, dma_buf);
 
 	dma_buf_put(dma_buf);
 
@@ -781,7 +781,7 @@ int vc_sm_cma_free(int handle)
 EXPORT_SYMBOL_GPL(vc_sm_cma_free);
 
 /* Import a dmabuf to be shared with VC. */
-int vc_sm_cma_import_dmabuf(struct dma_buf *src_dmabuf, int *handle)
+int vc_sm_cma_import_dmabuf(struct dma_buf *src_dmabuf, void **handle)
 {
 	struct dma_buf *new_dma_buf;
 	struct vc_sm_buffer *res;
@@ -801,7 +801,7 @@ int vc_sm_cma_import_dmabuf(struct dma_buf *src_dmabuf, int *handle)
 		res = (struct vc_sm_buffer *)new_dma_buf->priv;
 
 		/* Assign valid handle at this time.*/
-		*handle = (int)new_dma_buf;
+		*handle = new_dma_buf;
 	} else {
 		/*
 		 * succeeded in importing the dma_buf, but then

--- a/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
+++ b/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
@@ -703,9 +703,6 @@ err_free_mem:
 /* Driver loading. */
 static int bcm2835_vc_sm_cma_probe(struct platform_device *pdev)
 {
-	struct device *dev = &pdev->dev;
-	int err;
-
 	pr_info("%s: Videocore shared memory driver\n", __func__);
 
 	sm_state = kzalloc(sizeof(*sm_state), GFP_KERNEL);
@@ -714,13 +711,11 @@ static int bcm2835_vc_sm_cma_probe(struct platform_device *pdev)
 	sm_state->pdev = pdev;
 	mutex_init(&sm_state->map_lock);
 
-	dev->coherent_dma_mask = DMA_BIT_MASK(32);
-	dev->dma_mask = &dev->coherent_dma_mask;
-	err = of_dma_configure(dev, NULL, true);
-	if (err) {
-		dev_err(dev, "Unable to setup DMA: %d\n", err);
-		return err;
-	}
+	pdev->dev.dma_parms = devm_kzalloc(&pdev->dev,
+					   sizeof(*pdev->dev.dma_parms),
+					   GFP_KERNEL);
+	/* dma_set_max_seg_size checks if dma_parms is NULL. */
+	dma_set_max_seg_size(&pdev->dev, 0x3FFFFFFF);
 
 	vchiq_add_connected_callback(vc_sm_connected_init);
 	return 0;

--- a/drivers/staging/vc04_services/vc-sm-cma/vc_sm_cma_vchi.c
+++ b/drivers/staging/vc04_services/vc-sm-cma/vc_sm_cma_vchi.c
@@ -356,8 +356,7 @@ struct sm_instance *vc_sm_cma_vchi_init(VCHI_INSTANCE_T vchi_instance,
 	set_user_nice(instance->io_thread, -10);
 	wake_up_process(instance->io_thread);
 
-	pr_debug("%s: success - instance 0x%x", __func__,
-		 (unsigned int)instance);
+	pr_debug("%s: success - instance %p", __func__, instance);
 	return instance;
 
 err_close_services:

--- a/drivers/staging/vc04_services/vc-sm-cma/vc_sm_knl.h
+++ b/drivers/staging/vc04_services/vc-sm-cma/vc_sm_knl.h
@@ -17,12 +17,12 @@
 #endif
 
 /* Free a previously allocated or imported shared memory handle and block. */
-int vc_sm_cma_free(int handle);
+int vc_sm_cma_free(void *handle);
 
 /* Get an internal resource handle mapped from the external one. */
-int vc_sm_cma_int_handle(int handle);
+int vc_sm_cma_int_handle(void *handle);
 
 /* Import a block of memory into the GPU space. */
-int vc_sm_cma_import_dmabuf(struct dma_buf *dmabuf, int *handle);
+int vc_sm_cma_import_dmabuf(struct dma_buf *dmabuf, void **handle);
 
 #endif /* __VC_SM_KNL_H__INCLUDED__ */

--- a/drivers/staging/vc04_services/vchiq-mmal/mmal-common.h
+++ b/drivers/staging/vc04_services/vchiq-mmal/mmal-common.h
@@ -52,7 +52,7 @@ struct mmal_buffer {
 	struct mmal_msg_context *msg_context;
 
 	struct dma_buf *dma_buf;/* Exported dmabuf fd from videobuf2 */
-	int vcsm_handle;	/* VCSM handle having imported the dmabuf */
+	void *vcsm_handle;	/* VCSM handle having imported the dmabuf */
 	u32 vc_handle;		/* VC handle to that dmabuf */
 
 	u32 cmd;		/* MMAL command. 0=data. */

--- a/drivers/staging/vc04_services/vchiq-mmal/mmal-vchiq.c
+++ b/drivers/staging/vc04_services/vchiq-mmal/mmal-vchiq.c
@@ -1793,7 +1793,7 @@ int mmal_vchi_buffer_cleanup(struct mmal_buffer *buf)
 	if (buf->vcsm_handle) {
 		int ret;
 
-		pr_debug("%s: vc_sm_cma_free on handle %08X\n", __func__,
+		pr_debug("%s: vc_sm_cma_free on handle %p\n", __func__,
 			 buf->vcsm_handle);
 		ret = vc_sm_cma_free(buf->vcsm_handle);
 		if (ret)


### PR DESCRIPTION
The dma config stuff is so that we get the correct cache aliases from vc-sm-cma and similar. I do need to bounce it off upstream at some point to get their view.

The 64 bit fixups are:
- logging format specifiers.
- to use an IDR for the kernel id
- changing the in-kernel vc-sm handle to being a void* instead of an int, otherwise we needed yet another IDR to convert from handle to vc-sm structure. The codec driver/mmal-vchiq is the only thing that uses the handle currently and has been updated. Perhaps better would be to declare it as a ```struct dma_buf *``` (which is what it is), but I wouldn't like to guarantee that it will behave sensibly to all dma_buf operations. Thoughts? This isn't an issue as and when we get to userspace being able to make allocations/import with this driver, as that will be giving out genuine dmabuf fds.

This should get the V4L2 codec driver working on 64 bit. I have got a follow up that cleans up some of the dmabuf code ready for VPU allocations.