### PR TITLE
overlays: TPM SLB9670 overlay compatible updated for RPi 3

### DIFF
--- a/arch/arm/boot/dts/overlays/tpm-slb9670-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tpm-slb9670-overlay.dts
@@ -8,7 +8,7 @@
 /plugin/;
 
 / {
-	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+	compatible = "brcm,bcm2835", "brcm,bcm2837", "brcm,bcm2708", "brcm,bcm2709";
 
 	fragment@0 {
 		target = <&spi0>;


### PR DESCRIPTION
List bcm2837 as compatible for the TPM SLB9670 so this works as expected
on the newer Raspberry Pi 3 models