### PR TITLE
vc4-fkms fixes on 4.19

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -193,8 +193,8 @@ static void vc4_cursor_plane_atomic_update(struct drm_plane *plane,
 					   struct drm_plane_state *old_state)
 {
 	struct vc4_dev *vc4 = to_vc4_dev(plane->dev);
-	struct vc4_crtc *vc4_crtc = to_vc4_crtc(plane->crtc);
 	struct drm_plane_state *state = plane->state;
+	struct vc4_crtc *vc4_crtc = to_vc4_crtc(state->crtc);
 	struct drm_framebuffer *fb = state->fb;
 	struct drm_gem_cma_object *bo = drm_fb_cma_get_gem_obj(fb, 0);
 	dma_addr_t addr = bo->paddr + fb->offsets[0];
@@ -682,8 +682,6 @@ static int vc4_fkms_bind(struct device *dev, struct device *master, void *data)
 	drm_crtc_init_with_planes(drm, crtc, primary_plane, cursor_plane,
 				  &vc4_crtc_funcs, NULL);
 	drm_crtc_helper_add(crtc, &vc4_crtc_helper_funcs);
-	primary_plane->crtc = crtc;
-	cursor_plane->crtc = crtc;
 
 	vc4_encoder = devm_kzalloc(dev, sizeof(*vc4_encoder), GFP_KERNEL);
 	if (!vc4_encoder)

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -147,7 +147,8 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 
 	drm_atomic_helper_commit_modeset_disables(dev, state);
 
-	vc4_ctm_commit(vc4, state);
+	if (!vc4->firmware_kms)
+		vc4_ctm_commit(vc4, state);
 
 	drm_atomic_helper_commit_planes(dev, state, 0);
 


### PR DESCRIPTION
fkms wasn't booting on 4.19 as it was trying to write to HVS registers when it didn't "own" the HVS.
Make the call to vc4_ctm_commit conditional.

Also fixes a WARN_ON where upstream have moved crtc info from the drm_plane to drm_plane_state for atomic drivers.