### PR TITLE
Fix for Pisound kernel module in Real Time kernel configuration.

### DIFF
--- a/sound/soc/bcm/pisound.c
+++ b/sound/soc/bcm/pisound.c
@@ -1,6 +1,6 @@
 /*
  * Pisound Linux kernel module.
- * Copyright (C) 2016-2017  Vilniaus Blokas UAB, https://blokas.io/pisound
+ * Copyright (C) 2016-2019  Vilniaus Blokas UAB, https://blokas.io/pisound
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -532,10 +532,10 @@ static void pisnd_spi_gpio_uninit(void)
 
 static int pisnd_spi_gpio_irq_init(struct device *dev)
 {
-	return request_irq(
-		gpiod_to_irq(data_available),
+	return request_threaded_irq(
+		gpiod_to_irq(data_available), NULL,
 		data_available_interrupt_handler,
-		IRQF_TIMER | IRQF_TRIGGER_RISING,
+		IRQF_TIMER | IRQF_TRIGGER_RISING | IRQF_ONESHOT,
 		"data_available_int",
 		NULL
 		);


### PR DESCRIPTION
When handler of data_available interrupt is fired, queue_work ends up getting called and it can block on a spin lock which is not allowed in interrupt context. The fix was to run the handler from a thread context instead.

Exactly the same fix should be applied to rpi-4.14.y-rt.