### PR TITLE
arch/arm/Makefile: Added dtbo rule

### DIFF
--- a/arch/arm/Makefile
+++ b/arch/arm/Makefile
@@ -343,6 +343,9 @@ $(BOOT_TARGETS): vmlinux
 $(INSTALL_TARGETS):
 	$(Q)$(MAKE) $(build)=$(boot) MACHINE=$(MACHINE) $@
 
+%.dtbo: | scripts
+	$(Q)$(MAKE) $(build)=$(boot)/dts MACHINE=$(MACHINE) $(boot)/dts/$@
+
 PHONY += vdso_install
 vdso_install:
 ifeq ($(CONFIG_VDSO),y)


### PR DESCRIPTION
Device Tree related rules have been moved to the Top of tree Makefile from 4.19 to 5.0.
At that time, dtbo's rule seems to be removed, but I think it is necessary at least in arch/arm, such as when using with yocto.