### PR TITLE
vcsm: rpi-5.0.y - gcc-v8 fixes

### DIFF
--- a/drivers/char/broadcom/vc_sm/Makefile
+++ b/drivers/char/broadcom/vc_sm/Makefile
@@ -1,5 +1,5 @@
 ccflags-$(CONFIG_BCM_VC_SM) += -Werror -Wall -Wstrict-prototypes -Wno-trigraphs -O2
-ccflags-$(CONFIG_BCM_VC_SM) += -I"drivers/staging/vc04_services" -I"drivers/staging/vc04_services/interface/vchi" -I"drivers/staging/vc04_services/interface/vchiq_arm" -I"$(srctree)/fs/"
+ccflags-$(CONFIG_BCM_VC_SM) += -I"drivers/staging/vc04_services" -I"drivers/staging/vc04_services/interface/vchi" -I"drivers/staging/vc04_services/interface/vchiq_arm" -I"fs"
 ccflags-$(CONFIG_BCM_VC_SM) += -DOS_ASSERT_FAILURE -D__STDC_VERSION=199901L -D__STDC_VERSION__=199901L -D__VCCOREVER__=0 -D__KERNEL__ -D__linux__
 
 obj-$(CONFIG_BCM_VC_SM) := vc-sm.o

--- a/drivers/char/broadcom/vc_sm/vc_vchi_sm.c
+++ b/drivers/char/broadcom/vc_sm/vc_vchi_sm.c
@@ -361,7 +361,7 @@ lock:
 	return -EINVAL;
 }
 
-int vc_vchi_sm_send_msg(struct sm_instance *handle,
+static int vc_vchi_sm_send_msg(struct sm_instance *handle,
 			enum vc_sm_msg_type msg_id,
 			void *msg, uint32_t msg_size,
 			void *result, uint32_t result_size,

--- a/drivers/char/broadcom/vc_sm/vc_vchi_sm.c
+++ b/drivers/char/broadcom/vc_sm/vc_vchi_sm.c
@@ -347,11 +347,9 @@ int vc_vchi_sm_stop(struct sm_instance **handle)
 
 	/* Close all VCHI service connections */
 	for (i = 0; i < instance->num_connections; i++) {
-		int32_t success;
-
 		vchi_service_use(instance->vchi_handle[i]);
 
-		success = vchi_service_close(instance->vchi_handle[i]);
+		vchi_service_close(instance->vchi_handle[i]);
 	}
 
 	kfree(instance);

--- a/drivers/char/broadcom/vc_sm/vmcs_sm.c
+++ b/drivers/char/broadcom/vc_sm/vmcs_sm.c
@@ -1558,8 +1558,8 @@ error:
 }
 
 /* Allocate a shared memory handle and block. */
-int vc_sm_ioctl_alloc(struct sm_priv_data_t *private,
-		      struct vmcs_sm_ioctl_alloc *ioparam)
+static int vc_sm_ioctl_alloc(struct sm_priv_data_t *private,
+			     struct vmcs_sm_ioctl_alloc *ioparam)
 {
 	int ret = 0;
 	int status;
@@ -1669,8 +1669,8 @@ error:
 }
 
 /* Share an allocate memory handle and block.*/
-int vc_sm_ioctl_alloc_share(struct sm_priv_data_t *private,
-			    struct vmcs_sm_ioctl_alloc_share *ioparam)
+static int vc_sm_ioctl_alloc_share(struct sm_priv_data_t *private,
+				   struct vmcs_sm_ioctl_alloc_share *ioparam)
 {
 	struct sm_resource_t *resource, *shared_resource;
 	int ret = 0;
@@ -2184,9 +2184,9 @@ error:
 }
 
 /* Import a contiguous block of memory to be shared with VC. */
-int vc_sm_ioctl_import_dmabuf(struct sm_priv_data_t *private,
-			      struct vmcs_sm_ioctl_import_dmabuf *ioparam,
-			      struct dma_buf *src_dma_buf)
+static int vc_sm_ioctl_import_dmabuf(struct sm_priv_data_t *private,
+				     struct vmcs_sm_ioctl_import_dmabuf *ioparam,
+				     struct dma_buf *src_dma_buf)
 {
 	int ret = 0;
 	int status;


### PR DESCRIPTION
Three fix up commits for when building the 5.0.y tree with a GCC v8 compiler
arm-linux-gnueabihf-gcc (Ubuntu 8.2.0-7ubuntu1) 8.2.0

I suspect the warnings were enabled by default in recent compilers, and the VC_SM module enables -Werror which fails the build.

These issues are on the 4.19.y branch too - so could likely be cherry-picked there as well.
