### PR TITLE
staging: bcm2835-codec: NULL component handle on queue_setup failure

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1776,13 +1776,21 @@ static int bcm2835_codec_create_component(struct bcm2835_codec_ctx *ctx)
 
 	ret = vchiq_mmal_port_set_format(dev->instance,
 					 &ctx->component->input[0]);
-	if (ret < 0)
+	if (ret < 0) {
+		v4l2_dbg(1, debug, &dev->v4l2_dev,
+			 "%s: vchiq_mmal_port_set_format ip port failed\n",
+			 __func__);
 		goto destroy_component;
+	}
 
 	ret = vchiq_mmal_port_set_format(dev->instance,
 					 &ctx->component->output[0]);
-	if (ret < 0)
+	if (ret < 0) {
+		v4l2_dbg(1, debug, &dev->v4l2_dev,
+			 "%s: vchiq_mmal_port_set_format op port failed\n",
+			 __func__);
 		goto destroy_component;
+	}
 
 	if (dev->role == ENCODE) {
 		u32 param = 1;
@@ -1812,11 +1820,14 @@ static int bcm2835_codec_create_component(struct bcm2835_codec_ctx *ctx)
 				 ctx->q_data[V4L2_M2M_DST].sizeimage,
 				 ctx->component->output[0].minimum_buffer.size);
 	}
+	v4l2_dbg(2, debug, &dev->v4l2_dev, "%s: component created as %s\n",
+		 __func__, components[dev->role]);
 
 	return 0;
 
 destroy_component:
 	vchiq_mmal_component_finalise(ctx->dev->instance, ctx->component);
+	ctx->component = NULL;
 
 	return ret;
 }


### PR DESCRIPTION
queue_setup tries creating the relevant MMAL component and configures
the input and output ports as we're expecting to start streaming.
If the port configuration failed then it destroyed the component,
but failed to clear the component handle, therefore release tried
destroying the component again.
Adds some logging should the port config fail as well.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>