### PR TITLE
bcm2835_codec: Add role to video device name

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -77,7 +77,7 @@ enum bcm2835_codec_role {
 	ISP,
 };
 
-const static char *roles[] = {
+static const char * const roles[] = {
 	"decode",
 	"encode",
 	"isp"

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -2587,8 +2587,8 @@ static int bcm2835_codec_create(struct platform_device *pdev,
 	}
 
 	video_set_drvdata(vfd, dev);
-	snprintf(vfd->name, sizeof(vfd->name), "%s",
-		 bcm2835_codec_videodev.name);
+	snprintf(vfd->name, sizeof(vfd->name), "%s-%s",
+		 bcm2835_codec_videodev.name, roles[role]);
 	v4l2_info(&dev->v4l2_dev, "Device registered as /dev/video%d\n",
 		  vfd->num);
 


### PR DESCRIPTION
Hi  @6by9 ,

The first patch fixes up the roles[] array declaration, and then the second patch is more of a proposal. I've added the role to the video node name to distinguish them, producing:

video10: bcm2835-codec-decode
video11: bcm2835-codec-encode
video12: bcm2835-codec-isp

Perhaps as ISP is not directly a 'codec' the codec reference could be removed, but i thought that was more of a point for discussion so I've simply appended the role.
