### PR TITLE
Power Switchover Mode support for the RV3028 RTC

### DIFF
--- a/Documentation/devicetree/bindings/rtc/rtc.txt
+++ b/Documentation/devicetree/bindings/rtc/rtc.txt
@@ -26,6 +26,7 @@ below.
 - trickle-diode-disable :   Do not use internal trickle charger diode Should be
                             given if internal trickle charger diode should be
                             disabled
+- backup-switchover-mode :  Configure RTC backup power supply switch behaviour
 - wakeup-source :           Enables wake up of host system on alarm
 - quartz-load-femtofarads : The capacitive load of the quartz(x-tal),
                             expressed in femto Farad (fF).

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1013,6 +1013,9 @@ Params: abx80x                  Select one of the ABx80x family:
         wakeup-source           Specify that the RTC can be used as a wakeup
                                 source
 
+        backup-switchover-mode  Backup power supply switch mode. Must be 0 for
+                                off or 1 for Vdd < VBackup (RV3028 only)
+
 
 Name:   i2c-rtc-gpio
 Info:   Adds support for a number of I2C Real Time Clock devices

--- a/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
@@ -200,6 +200,7 @@
 		trickle-resistor-ohms = <&ds1339>,"trickle-resistor-ohms:0",
 					<&abx80x>,"abracon,tc-resistor",
 					<&rv3028>,"trickle-resistor-ohms:0";
+		backup-switchover-mode = <&rv3028>,"backup-switchover-mode:0";
 		wakeup-source = <&ds1339>,"wakeup-source?",
 				<&ds3231>,"wakeup-source?",
 				<&mcp7940x>,"wakeup-source?",

--- a/drivers/rtc/rtc-rv3028.c
+++ b/drivers/rtc/rtc-rv3028.c
@@ -74,6 +74,7 @@
 
 #define RV3028_BACKUP_TCE		BIT(5)
 #define RV3028_BACKUP_TCR_MASK		GENMASK(1,0)
+#define RV3028_BACKUP_BSM_MASK		0x0C
 
 #define OFFSET_STEP_PPT			953674
 
@@ -601,6 +602,7 @@ static int rv3028_probe(struct i2c_client *client)
 	struct rv3028_data *rv3028;
 	int ret, status;
 	u32 ohms;
+	u8 bsm;
 	struct nvmem_config nvmem_cfg = {
 		.name = "rv3028_nvram",
 		.word_size = 1,
@@ -670,6 +672,21 @@ static int rv3028_probe(struct i2c_client *client)
 				 RV3028_CTRL2_EIE | RV3028_CTRL2_TSE);
 	if (ret)
 		return ret;
+
+	/* setup backup switchover mode */
+	if (!device_property_read_u8(&client->dev, "backup-switchover-mode",
+				     &bsm))  {
+		if (bsm <= 3) {
+			ret = regmap_update_bits(rv3028->regmap, RV3028_BACKUP,
+				RV3028_BACKUP_BSM_MASK,
+				(bsm & 0x03) << 2);
+
+			if (ret)
+				return ret;
+		} else {
+			dev_warn(&client->dev, "invalid backup switchover mode value\n");
+		}
+	}
 
 	/* setup trickle charger */
 	if (!device_property_read_u32(&client->dev, "trickle-resistor-ohms",


### PR DESCRIPTION
Adds support for the "BSM" bits of the EEPROM Backup register documented on page 37 of the RV3028 datasheet- https://www.microcrystal.com/fileadmin/Media/Products/RTC/App.Manual/RV-3028-C7_App-Manual.pdf

The backup switchover mode has 4 possible settings governing the behaviour of the RTC under certain power conditions:

* 00 - Switchover Disabled. The automatic backup switchover function is
disabled. Used when only one power supply is available (VDD). VBACKUP pin
should be connected to ground. – Default value on delivery
* 01 Enables the Direct Switching Mode (DSM).
Switchover when VDD < VBACKUP.
* 10 -Standby Mode. When VDD < VBACKUP the device enters the standby mode
and does not draw any current from the backup source before it is powered
up again from main supply VDD.
* 11 - Enables the Level Switching Mode (LSM).
Switchover when VDD < VBACKUP AND VDD < VDDSW (AND VBACKUP > VDDSW)

This change is required for a battery backed-up RTC board to successfully switch over when the main power supply is lost.

