### PR TITLE
Maxim MAX98357A I2S DAC overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -75,6 +75,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	justboom-dac.dtbo \
 	justboom-digi.dtbo \
 	ltc294x.dtbo \
+	max98357a.dtbo \
 	mbed-dac.dtbo \
 	mcp23017.dtbo \
 	mcp23s17.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1276,6 +1276,14 @@ Params: ltc2941                 Select the ltc2941 device
                                 See the datasheet for more information.
 
 
+Name:   max98357a
+Info:   Configures the Maxim MAX98357A I2S DAC
+Load:   dtoverlay=max98357a,<param>=<val>
+Params: sdmode-pin              GPIO pin connected to the SD_MODE input of the
+                                MAX98357A.  If omitted, driver does not manage
+                                the pin state (i.e. chip is always on).
+
+
 Name:   mbed-dac
 Info:   Configures the mbed AudioCODEC (TLV320AIC23B)
 Load:   dtoverlay=mbed-dac

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1281,7 +1281,7 @@ Info:   Configures the Maxim MAX98357A I2S DAC
 Load:   dtoverlay=max98357a,<param>=<val>
 Params: no-sdmode               Driver does not manage the state of the DAC's
                                 SD_MODE pin (i.e. chip is always on).
-Params: sdmode-pin              integer, GPIO pin connected to the SD_MODE input
+        sdmode-pin              integer, GPIO pin connected to the SD_MODE input
                                 of the DAC (default GPIO4 if parameter omitted).
 
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1279,9 +1279,10 @@ Params: ltc2941                 Select the ltc2941 device
 Name:   max98357a
 Info:   Configures the Maxim MAX98357A I2S DAC
 Load:   dtoverlay=max98357a,<param>=<val>
-Params: sdmode-pin              GPIO pin connected to the SD_MODE input of the
-                                MAX98357A.  If omitted, driver does not manage
-                                the pin state (i.e. chip is always on).
+Params: no-sdmode               Driver does not manage the state of the DAC's
+                                SD_MODE pin (i.e. chip is always on).
+Params: sdmode-pin              integer, GPIO pin connected to the SD_MODE input
+                                of the DAC (default GPIO4 if parameter omitted).
 
 
 Name:   mbed-dac

--- a/arch/arm/boot/dts/overlays/max98357a-overlay.dts
+++ b/arch/arm/boot/dts/overlays/max98357a-overlay.dts
@@ -1,7 +1,8 @@
-/ Overlay for Maxim MAX98357A audio DAC
+// Overlay for Maxim MAX98357A audio DAC
 
 // dtparams:
-//     sdmode-pin - GPIO pin to which SD_MODE is connected.
+//     no-sdmode  - SD_MODE pin not managed by driver.
+//     sdmode-pin - Specify GPIO pin to which SD_MODE is connected (default 4).
 
 /dts-v1/;
 /plugin/;
@@ -9,6 +10,7 @@
 / {
 	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
 
+	/* Enable I2S */
 	fragment@0 {
 		target = <&i2s>;
 		__overlay__ {
@@ -16,19 +18,33 @@
 		};
 	};
 
+	/* DAC whose SD_MODE pin is managed by driver (via GPIO pin) */
 	fragment@1 {
 		target-path = "/";
 		__overlay__ {
 			max98357a_dac: max98357a {
 				compatible = "maxim,max98357a";
 				#sound-dai-cells = <0>;
-				sdmode-gpios = <&gpio 0 0>;   /* 2nd word overwritten by sdmode-pin parameter */
+				sdmode-gpios = <&gpio 4 0>;   /* 2nd word overwritten by sdmode-pin parameter */
 				status = "okay";
 			};
 		};
 	};
 
+	/* DAC whose SD_MODE pin is not managed by driver */ 
 	fragment@2 {
+		target-path = "/";
+		__dormant__ {
+			max98357a_nsd: max98357a {
+				compatible = "maxim,max98357a";
+				#sound-dai-cells = <0>;
+				status = "okay";
+			};
+		};
+	};
+
+	/* Soundcard connecting I2S to DAC with SD_MODE */
+	fragment@3 {
 		target = <&sound>;
 		__overlay__ {
 			compatible = "simple-audio-card";
@@ -44,8 +60,25 @@
 		};
 	};
 
+	/* Soundcard connecting I2S to DAC without SD_MODE */
+	fragment@4 {
+		target = <&sound>;
+		__dormant__ {
+			compatible = "simple-audio-card";
+			simple-audio-card,format = "i2s";
+			simple-audio-card,name = "MAX98357A";
+			status = "okay";
+			simple-audio-card,cpu {
+				sound-dai = <&i2s>;
+			};
+			simple-audio-card,codec {
+				sound-dai = <&max98357a_nsd>;
+			};
+		};
+	};
+
 	__overrides__ {
+		no-sdmode  = <0>,"-1+2-3+4";
 		sdmode-pin = <&max98357a_dac>,"sdmode-gpios:4";
 	};
 };
-

--- a/arch/arm/boot/dts/overlays/max98357a-overlay.dts
+++ b/arch/arm/boot/dts/overlays/max98357a-overlay.dts
@@ -1,0 +1,51 @@
+/ Overlay for Maxim MAX98357A audio DAC
+
+// dtparams:
+//     sdmode-pin - GPIO pin to which SD_MODE is connected.
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target = <&i2s>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			max98357a_dac: max98357a {
+				compatible = "maxim,max98357a";
+				#sound-dai-cells = <0>;
+				sdmode-gpios = <&gpio 0 0>;   /* 2nd word overwritten by sdmode-pin parameter */
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&sound>;
+		__overlay__ {
+			compatible = "simple-audio-card";
+			simple-audio-card,format = "i2s";
+			simple-audio-card,name = "MAX98357A";
+			status = "okay";
+			simple-audio-card,cpu {
+				sound-dai = <&i2s>;
+			};
+			simple-audio-card,codec {
+				sound-dai = <&max98357a_dac>;
+			};
+		};
+	};
+
+	__overrides__ {
+		sdmode-pin = <&max98357a_dac>,"sdmode-gpios:4";
+	};
+};
+

--- a/arch/arm/boot/dts/overlays/max98357a-overlay.dts
+++ b/arch/arm/boot/dts/overlays/max98357a-overlay.dts
@@ -31,7 +31,7 @@
 		};
 	};
 
-	/* DAC whose SD_MODE pin is not managed by driver */ 
+	/* DAC whose SD_MODE pin is not managed by driver */
 	fragment@2 {
 		target-path = "/";
 		__dormant__ {


### PR DESCRIPTION
An overlay for the max98357a kernel driver.  Tested on a Pi 1B connected to a MAX98357A breakout board (Adafruit, I think).