### PR TITLE
dts: Increase default coherent pool size

### DIFF
--- a/arch/arm/boot/dts/bcm270x.dtsi
+++ b/arch/arm/boot/dts/bcm270x.dtsi
@@ -3,7 +3,7 @@
 
 / {
 	chosen {
-		bootargs = "";
+		bootargs = "coherent_pool=1M";
 		/delete-property/ stdout-path;
 	};
 


### PR DESCRIPTION
dwc_otg allocates DMA-coherent buffers in atomic context for misaligned
transfer buffers. The pool that these allocations come from is set up
at boot-time but can be overridden by a commandline parameter -
increase this for now to prevent failures seen on 4.19 with multiple
USB Ethernet devices.

see: https://github.com/raspberrypi/linux/issues/2924

There's a series of patches to come after this, namely:
- dwc_otg properly returning failure to URB submitters instead of failing silently (WIP)
- Getting the lan95xx driver to submit aligned tx buffers (working but needs more testing)
- Getting the lan78xx driver to submit aligned tx buffers (may or may not be possible)