### PR TITLE
smsc95xx: dynamically fix up TX buffer alignment with padding bytes

### DIFF
--- a/drivers/net/usb/smsc95xx.h
+++ b/drivers/net/usb/smsc95xx.h
@@ -21,7 +21,7 @@
 #define _SMSC95XX_H
 
 /* Tx command words */
-#define TX_CMD_A_DATA_OFFSET_	(0x001F0000)	/* Data Start Offset */
+#define TX_CMD_A_DATA_OFFSET_	(0x00030000)	/* Data Start Offset */
 #define TX_CMD_A_FIRST_SEG_	(0x00002000)	/* First Segment */
 #define TX_CMD_A_LAST_SEG_	(0x00001000)	/* Last Segment */
 #define TX_CMD_A_BUF_SIZE_	(0x000007FF)	/* Buffer Size */


### PR DESCRIPTION
dwc_otg requires a 32-bit aligned buffer start address, otherwise
expensive bounce buffers are used. The LAN951x hardware can skip up to
3 bytes between the TX header and the start of frame data, which can
be used to force alignment of the URB passed to dwc_otg.

As found in https://github.com/raspberrypi/linux/issues/2924