### PR TITLE
bcm2835-codec / mmal-vchiq fixes

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -605,8 +605,8 @@ static void setup_mmal_port_format(struct bcm2835_codec_ctx *ctx,
 
 	if (!(q_data->fmt->flags & V4L2_FMT_FLAG_COMPRESSED)) {
 		/* Raw image format - set width/height */
-		port->es.video.width = q_data->bytesperline /
-						(q_data->fmt->depth >> 3);
+		port->es.video.width = (q_data->bytesperline << 3) /
+						q_data->fmt->depth;
 		port->es.video.height = q_data->height;
 		port->es.video.crop.width = q_data->crop_width;
 		port->es.video.crop.height = q_data->crop_height;

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1015,7 +1015,8 @@ static int vidioc_g_fmt_vid_cap(struct file *file, void *priv,
 	return vidioc_g_fmt(file2ctx(file), f);
 }
 
-static int vidioc_try_fmt(struct v4l2_format *f, struct bcm2835_codec_fmt *fmt)
+static int vidioc_try_fmt(struct bcm2835_codec_ctx *ctx, struct v4l2_format *f,
+			  struct bcm2835_codec_fmt *fmt)
 {
 	/*
 	 * The V4L2 specification requires the driver to correct the format
@@ -1034,11 +1035,13 @@ static int vidioc_try_fmt(struct v4l2_format *f, struct bcm2835_codec_fmt *fmt)
 			f->fmt.pix.height = MIN_H;
 
 		/*
-		 * Buffer must have a vertical alignment of 16 lines.
+		 * For codecs the buffer must have a vertical alignment of 16
+		 * lines.
 		 * The selection will reflect any cropping rectangle when only
 		 * some of the pixels are active.
 		 */
-		f->fmt.pix.height = ALIGN(f->fmt.pix.height, 16);
+		if (ctx->dev->role != ISP)
+			f->fmt.pix.height = ALIGN(f->fmt.pix.height, 16);
 	}
 	f->fmt.pix.bytesperline = get_bytesperline(f->fmt.pix.width,
 						   fmt);
@@ -1065,7 +1068,7 @@ static int vidioc_try_fmt_vid_cap(struct file *file, void *priv,
 		fmt = find_format(f, ctx->dev, true);
 	}
 
-	return vidioc_try_fmt(f, fmt);
+	return vidioc_try_fmt(ctx, f, fmt);
 }
 
 static int vidioc_try_fmt_vid_out(struct file *file, void *priv,
@@ -1084,7 +1087,7 @@ static int vidioc_try_fmt_vid_out(struct file *file, void *priv,
 	if (!f->fmt.pix.colorspace)
 		f->fmt.pix.colorspace = ctx->colorspace;
 
-	return vidioc_try_fmt(f, fmt);
+	return vidioc_try_fmt(ctx, f, fmt);
 }
 
 static int vidioc_s_fmt(struct bcm2835_codec_ctx *ctx, struct v4l2_format *f,

--- a/drivers/staging/vc04_services/vchiq-mmal/mmal-vchiq.c
+++ b/drivers/staging/vc04_services/vchiq-mmal/mmal-vchiq.c
@@ -1981,6 +1981,8 @@ int vchiq_mmal_component_finalise(struct vchiq_mmal_instance *instance,
 	for (idx = 0; idx < component->clocks; idx++)
 		free_event_context(&component->clock[idx]);
 
+	free_event_context(&component->control);
+
 	mutex_unlock(&instance->vchiq_mutex);
 
 	return ret;

--- a/drivers/staging/vc04_services/vchiq-mmal/mmal-vchiq.c
+++ b/drivers/staging/vc04_services/vchiq-mmal/mmal-vchiq.c
@@ -185,7 +185,8 @@ struct vchiq_mmal_instance {
 	void *bulk_scratch;
 
 	struct idr context_map;
-	spinlock_t context_map_lock;
+	/* protect accesses to context_map */
+	struct mutex context_map_lock;
 
 	struct vchiq_mmal_component component[VCHIQ_MMAL_MAX_COMPONENTS];
 
@@ -209,10 +210,10 @@ get_msg_context(struct vchiq_mmal_instance *instance)
 	 * that when we service the VCHI reply, we can look up what
 	 * message is being replied to.
 	 */
-	spin_lock(&instance->context_map_lock);
+	mutex_lock(&instance->context_map_lock);
 	handle = idr_alloc(&instance->context_map, msg_context,
 			   0, 0, GFP_KERNEL);
-	spin_unlock(&instance->context_map_lock);
+	mutex_unlock(&instance->context_map_lock);
 
 	if (handle < 0) {
 		kfree(msg_context);
@@ -236,9 +237,9 @@ release_msg_context(struct mmal_msg_context *msg_context)
 {
 	struct vchiq_mmal_instance *instance = msg_context->instance;
 
-	spin_lock(&instance->context_map_lock);
+	mutex_lock(&instance->context_map_lock);
 	idr_remove(&instance->context_map, msg_context->handle);
-	spin_unlock(&instance->context_map_lock);
+	mutex_unlock(&instance->context_map_lock);
 	kfree(msg_context);
 }
 
@@ -2143,7 +2144,7 @@ int vchiq_mmal_init(struct vchiq_mmal_instance **out_instance)
 
 	instance->bulk_scratch = vmalloc(PAGE_SIZE);
 
-	spin_lock_init(&instance->context_map_lock);
+	mutex_init(&instance->context_map_lock);
 	idr_init_base(&instance->context_map, 1);
 
 	params.callback_param = instance;


### PR DESCRIPTION
4 minor fixes for the V4L2 drivers and support framework.