### PR TITLE
arm: dts: overlays: rpi-sense: add upstream humidity compatible

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-sense-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-sense-overlay.dts
@@ -38,7 +38,7 @@
 			};
 
 			hts221-humid@5f {
-				compatible = "st,hts221-humid";
+				compatible = "st,hts221-humid", "st,hts221";
 				reg = <0x5f>;
 				status = "okay";
 			};


### PR DESCRIPTION
The upstream humidiity driver uses "st,hts221" for the compatible
string so add that in as well so it will work with an unmodified
upstream kernel driver. We leave the downstream as the priority.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>