### PR TITLE
[5.1] switch pcm512x soundcard drivers to set_bclk_ration

### DIFF
--- a/sound/soc/bcm/allo-boss-dac.c
+++ b/sound/soc/bcm/allo-boss-dac.c
@@ -288,12 +288,10 @@ static int snd_allo_boss_hw_params(
 			return ret;
 	}
 
-	ret = snd_soc_dai_set_tdm_slot(rtd->cpu_dai, 0x03, 0x03,
-		channels, width);
+	ret = snd_soc_dai_set_bclk_ratio(rtd->cpu_dai, channels * width);
 	if (ret)
 		return ret;
-	ret = snd_soc_dai_set_tdm_slot(rtd->codec_dai, 0x03, 0x03,
-		channels, width);
+	ret = snd_soc_dai_set_bclk_ratio(rtd->codec_dai, channels * width);
 	return ret;
 }
 

--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -236,12 +236,10 @@ static int snd_rpi_hifiberry_dacplus_hw_params(
 			substream, params);
 	}
 
-	ret = snd_soc_dai_set_tdm_slot(rtd->cpu_dai, 0x03, 0x03,
-		channels, width);
+	ret = snd_soc_dai_set_bclk_ratio(rtd->cpu_dai, channels * width);
 	if (ret)
 		return ret;
-	ret = snd_soc_dai_set_tdm_slot(rtd->codec_dai, 0x03, 0x03,
-		channels, width);
+	ret = snd_soc_dai_set_bclk_ratio(rtd->codec_dai, channels * width);
 	return ret;
 }
 

--- a/sound/soc/bcm/hifiberry_dacplusadc.c
+++ b/sound/soc/bcm/hifiberry_dacplusadc.c
@@ -239,12 +239,10 @@ static int snd_rpi_hifiberry_dacplusadc_hw_params(
 			substream, params);
 	}
 
-	ret = snd_soc_dai_set_tdm_slot(rtd->cpu_dai, 0x03, 0x03,
-		channels, width);
+	ret = snd_soc_dai_set_bclk_ratio(rtd->cpu_dai, channels * width);
 	if (ret)
 		return ret;
-	ret = snd_soc_dai_set_tdm_slot(rtd->codec_dai, 0x03, 0x03,
-		channels, width);
+	ret = snd_soc_dai_set_bclk_ratio(rtd->codec_dai, channels * width);
 	return ret;
 }
 


### PR DESCRIPTION
since kernel 5.1 (commit ccc8d6c7b6d2) the upstream pcm512x driver implements the set_bclk_ratio interface which we should use in the soundcard drivers instead of the set_tdm_slot interface (which I added in downstream RPi kernel 4.14 and has now been removed from RPi kernel 5.1).

Without this PR the Allo Boss DAC and Hifiberry DAC Plus / DAC Plus ADC cards are probably broken as calling snd_soc_dai_set_tdm_slot for the pcm512x DAI returns an error.

@allocom @hifiberry could you do a runtime test with this PR? I don't have any of these cards so can't check myself