### PR TITLE
sound: pcm512x-codec: Adding 352.8kHz samplerate support

### DIFF
--- a/sound/soc/codecs/pcm512x.c
+++ b/sound/soc/codecs/pcm512x.c
@@ -542,7 +542,7 @@ static unsigned long pcm512x_ncp_target(struct pcm512x_priv *pcm512x,
 
 static const u32 pcm512x_dai_rates[] = {
 	8000, 11025, 16000, 22050, 32000, 44100, 48000, 64000,
-	88200, 96000, 176400, 192000, 384000,
+	88200, 96000, 176400, 192000, 352800, 384000,
 };
 
 static const struct snd_pcm_hw_constraint_list constraints_slave = {


### PR DESCRIPTION
352.8kHz support can be added to the pcm512c-codec.

This patch is around for years and usually gets applied in custom kernels (e.g. piCoreplayer). 
It allows to convert DoP-128 straight to 352.8kHz PCM.
And it also allows synchronous upsampling from x*44.1, mainly to bypass the internal DSP.

The datasheet doesn't show that 352.8kHz is supported. That's why it is probably missing in the codec.

