### PR TITLE
spi-bcm2835: Always initialize local variable in bcm2835_wr_fifo_count

### DIFF
--- a/drivers/spi/spi-bcm2835.c
+++ b/drivers/spi/spi-bcm2835.c
@@ -183,12 +183,11 @@ static inline void bcm2835_wr_fifo_count(struct bcm2835_spi *bs, int count)
 	bs->tx_len -= count;
 
 	while (count > 0) {
+		val = 0;
 		if (bs->tx_buf) {
 			len = min(count, 4);
 			memcpy(&val, bs->tx_buf, len);
 			bs->tx_buf += len;
-		} else {
-			val = 0;
 		}
 		bcm2835_wr(bs, BCM2835_SPI_FIFO, val);
 		count -= 4;


### PR DESCRIPTION
If count is less than 4 and memcpy copies less than 4 bytes into var,
some bytes remain uninitialized. These uninitialized bytes are taken
from var and written to the BCM2835_SPI_FIFO register.

While the hardware probably is able to ignore these extra bytes, it's
Undefined Behavior to read uninitialized bytes. So don't do that.