### PR TITLE
RFC: Fix DMA channel and memory leak in vc4

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_dsi.c
+++ b/drivers/gpu/drm/vc4/vc4_dsi.c
@@ -1674,8 +1674,8 @@ static int vc4_dsi_bind(struct device *dev, struct device *master, void *data)
 
 rel_dma_exit:
 	dma_release_channel(dsi->reg_dma_chan);
-	return ret;
 
+	return ret;
 }
 
 static void vc4_dsi_unbind(struct device *dev, struct device *master,


### PR DESCRIPTION
Adding a non-Raspberry DSI display.  Even with panel driver and DTB apparently correct, startup was frequently failling with a dmesg entry:
 [ 4.690030] [drm:vc4_dsi_bind [vc4]] *ERROR* Failed to get DMA channel: mask:0001 chan:-19

The vc4/panel startup 'pas a doble' means vc4 requests EPROBE_DEFER before the panel is ready, sometimes several times.

It was found that each iteration was requesting a new DMA channel, and the system was running out.
It was also noticed that small amounts of memory were being allocated each time.
The attached patch seems to fix the second memory leak and the DMA leak.
The patch file contains a proposal for a third patch to fix the first memory leak, but when applied, breaks something, resulting in a kernel oops.
The patch as offered also includes additional debugging messages which could be removed for production.
I have tested this patch in conjunction with the very recent fixes from pelwell which also address a DMA leak.
PS: this is the first time I've done a pull request, so please forgive me if the etiquette isn't quite right...