### PR TITLE
[bcm2835-codec] bytesperline was wrong if width is aligned.

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -755,7 +755,7 @@ static void handle_fmt_changed(struct bcm2835_codec_ctx *ctx,
 	q_data = get_q_data(ctx, V4L2_BUF_TYPE_VIDEO_CAPTURE);
 	q_data->crop_width = format->es.video.crop.width;
 	q_data->crop_height = format->es.video.crop.height;
-	q_data->bytesperline = format->es.video.crop.width;
+	q_data->bytesperline = format->es.video.width;
 	q_data->height = format->es.video.height;
 	q_data->sizeimage = format->buffer_size_min;
 	if (format->es.video.color_space)

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1106,9 +1106,9 @@ static int vidioc_s_fmt(struct bcm2835_codec_ctx *ctx, struct v4l2_format *f,
 	bool update_capture_port = false;
 	int ret;
 
-	v4l2_dbg(1, debug, &ctx->dev->v4l2_dev,	"Setting format for type %d, wxh: %dx%d, fmt: %08x, size %u\n",
+	v4l2_dbg(1, debug, &ctx->dev->v4l2_dev,	"Setting format for type %d, wxh: %dx%d, fmt: %.4s, size %u\n",
 		 f->type, f->fmt.pix.width, f->fmt.pix.height,
-		 f->fmt.pix.pixelformat, f->fmt.pix.sizeimage);
+		 (char*)&f->fmt.pix.pixelformat, f->fmt.pix.sizeimage);
 
 	vq = v4l2_m2m_get_vq(ctx->fh.m2m_ctx, f->type);
 	if (!vq)


### PR DESCRIPTION
bytesperline was wrong if width is aligned. bytesperline is defined: Distance in bytes between the leftmost pixels in two adjacent lines.