### PR TITLE
WIP: dt: overlays: Correct compatible string for ds1307

### DIFF
--- a/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
@@ -30,7 +30,7 @@
 			status = "okay";
 
 			ds1307: ds1307@68 {
-				compatible = "maxim,ds1307";
+				compatible = "dallas,ds1307";
 				reg = <0x68>;
 				status = "okay";
 			};


### PR DESCRIPTION
The overlay was requesting maxim,ds1307, which after
af50371 i2c: core: report OF style module alias for devices registered via OF
means that it doesn't match.
Correct the string to dallas,ds1307

https://www.raspberrypi.org/forums/viewtopic.php?f=44&t=242902

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>