### PR TITLE
Set DMA coherent pool size to 2MB

### DIFF
--- a/arch/arm/mm/dma-mapping.c
+++ b/arch/arm/mm/dma-mapping.c
@@ -381,7 +381,7 @@ static void __dma_free_remap(void *cpu_addr, size_t size)
 			VM_ARM_DMA_CONSISTENT | VM_USERMAP);
 }
 
-#define DEFAULT_DMA_COHERENT_POOL_SIZE	SZ_256K
+#define DEFAULT_DMA_COHERENT_POOL_SIZE	SZ_2M
 static struct gen_pool *atomic_pool __ro_after_init;
 
 static size_t atomic_pool_size __initdata = DEFAULT_DMA_COHERENT_POOL_SIZE;


### PR DESCRIPTION
This is needed for UAS attached storage (mkfs -V -t ext4 -b 4096 -m 0 -E lazy_itable_init=0,lazy_journal_init=0) and also for some DVB dongles.

Details: https://forum.armbian.com/topic/4811-uas-mainline-kernel-coherent-pool-memory-size/ (in case you'll ever release a 64-bit kernel the same change is needed at arch/arm64/mm/dma-mapping.c)