### PR TITLE
Pisound: Remove spinlock usage around spi_sync

### DIFF
--- a/sound/soc/bcm/pisound.c
+++ b/sound/soc/bcm/pisound.c
@@ -286,9 +286,6 @@ static irqreturn_t data_available_interrupt_handler(int irq, void *dev_id)
 	return IRQ_HANDLED;
 }
 
-static DEFINE_SPINLOCK(spilock);
-static unsigned long spilockflags;
-
 static uint16_t spi_transfer16(uint16_t val)
 {
 	uint8_t txbuf[2];
@@ -333,9 +330,7 @@ static void spi_transfer(const uint8_t *txbuf, uint8_t *rxbuf, int len)
 	transfer.delay_usecs = 10;
 	spi_message_add_tail(&transfer, &msg);
 
-	spin_lock_irqsave(&spilock, spilockflags);
 	err = spi_sync(pisnd_spi_device, &msg);
-	spin_unlock_irqrestore(&spilock, spilockflags);
 
 	if (err < 0) {
 		printe("spi_sync error %d\n", err);


### PR DESCRIPTION
Removed spinlock usage around `spi_sync`. `spi_sync` must not be called from a context that cannot sleep, and being in a spinlock ends up making such a context. Below is the kernel warning that gets produced.

This was detected on ARCH Linux kernel builds for Raspberry Pi, but the warning wasn't getting printed on regular, nor real time default Raspberry Pi configs.

```
[  184.195296] Preemption disabled at:
[  184.195301] [<00000000>]   (null)
[  184.202747] CPU: 3 PID: 2114 Comm: modprobe Tainted: G        WC O      4.19.57-ARCH+ #1
[  184.210001] Hardware name: BCM2835
[  184.213542] [<80110c38>] (unwind_backtrace) from [<8010c6c8>] (show_stack+0x10/0x14)
[  184.220690] [<8010c6c8>] (show_stack) from [<80b54f5c>] (dump_stack+0xb8/0xe0)
[  184.224287] [<80b54f5c>] (dump_stack) from [<80155770>] (__schedule_bug+0x98/0xd4)
[  184.231200] [<80155770>] (__schedule_bug) from [<80b6a7a0>] (__schedule+0x800/0xa58)
[  184.238291] [<80b6a7a0>] (__schedule) from [<80b6aa3c>] (schedule+0x44/0xb0)
[  184.241833] [<80b6aa3c>] (schedule) from [<80b6e4ac>] (schedule_timeout+0x1c0/0x474)
[  184.248368] [<80b6e4ac>] (schedule_timeout) from [<80b6b740>] (wait_for_common+0x130/0x168)
[  184.254955] [<80b6b740>] (wait_for_common) from [<8088db38>] (spi_transfer_one_message+0x134/0x534)
[  184.261737] [<8088db38>] (spi_transfer_one_message) from [<8088e2a8>] (__spi_pump_messages+0x370/0x744)
[  184.268675] [<8088e2a8>] (__spi_pump_messages) from [<8088e8c8>] (__spi_sync+0x240/0x25c)
[  184.275760] [<8088e8c8>] (__spi_sync) from [<8088e908>] (spi_sync+0x24/0x3c)
[  184.279304] [<8088e908>] (spi_sync) from [<7f748480>] (spi_transfer+0xb4/0x114 [snd_soc_pisound])
[  184.286287] [<7f748480>] (spi_transfer [snd_soc_pisound]) from [<7f748c2c>] (spi_transfer16+0x58/0x8c [snd_soc_pisound])
[  184.293538] [<7f748c2c>] (spi_transfer16 [snd_soc_pisound]) from [<7f748d38>] (spi_read_info+0xd8/0x1f0 [snd_soc_pisound])
[  184.300543] [<7f748d38>] (spi_read_info [snd_soc_pisound]) from [<7f748f64>] (pisnd_probe+0x114/0x4e0 [snd_soc_pisound])
[  184.307581] [<7f748f64>] (pisnd_probe [snd_soc_pisound]) from [<8084325c>] (platform_drv_probe+0x48/0x98)
[  184.314405] [<8084325c>] (platform_drv_probe) from [<8084191c>] (really_probe+0x1f8/0x2bc)
[  184.321326] [<8084191c>] (really_probe) from [<80841b40>] (driver_probe_device+0x5c/0x164)
[  184.328224] [<80841b40>] (driver_probe_device) from [<80841d24>] (__driver_attach+0xdc/0xe0)
[  184.335203] [<80841d24>] (__driver_attach) from [<8083fc2c>] (bus_for_each_dev+0x70/0xb4)
[  184.342278] [<8083fc2c>] (bus_for_each_dev) from [<80840da4>] (bus_add_driver+0x198/0x1fc)
[  184.349317] [<80840da4>] (bus_add_driver) from [<808423f4>] (driver_register+0x74/0x108)
[  184.356464] [<808423f4>] (driver_register) from [<80102d50>] (do_one_initcall+0x3c/0x280)
[  184.363545] [<80102d50>] (do_one_initcall) from [<801be2d0>] (do_init_module+0x5c/0x214)
[  184.370734] [<801be2d0>] (do_init_module) from [<801c05a4>] (load_module+0x20b4/0x2400)
[  184.378007] [<801c05a4>] (load_module) from [<801c0a2c>] (sys_init_module+0x13c/0x170)
[  184.385392] [<801c0a2c>] (sys_init_module) from [<801011c8>] (__sys_trace_return+0x0/0x10)
[  184.393015] Exception stack(0xb5e4bfa8 to 0xb5e4bff0)
[  184.396775] bfa0:                   01342d58 75ddc008 75ddc008 00006dfc 0047fc10 28d82e00
[  184.404515] bfc0: 01342d58 75ddc008 00040000 00000080 01342cd0 00000000 00000000 01342c70
[  184.412558] bfe0: 00492dd4 7eb8f958 00475e94 76c39550
[  184.416744] BUG: scheduling while atomic: modprobe/2114/0x00000002
```

The fix was tested on ARCH Linux as well as Raspbian.