### PR TITLE
arm64: make CONFIG_ARCH_BCM2835 select CONFIG_MFD_CORE

### DIFF
--- a/arch/arm64/Kconfig.platforms
+++ b/arch/arm64/Kconfig.platforms
@@ -25,6 +25,7 @@ config ARCH_BCM2835
 	select ARM_AMBA
 	select ARM_TIMER_SP804
 	select HAVE_ARM_ARCH_TIMER
+	select MFD_CORE
 	help
 	  This enables support for the Broadcom BCM2837 SoC.
 	  This SoC is used in the Raspberry Pi 3 device.


### PR DESCRIPTION
The bcm2835-pm.c driver is compiled as a built-in for
CONFIG_ARCH_BCM2835, and its probe function calls devm_mfd_add_devices,
which comes from the MFD core.

A missing Kconfig dependency/selection means it's possible to select
CONFIG_MFD_CORE=m with CONFIG_ARCH_BCM2835=y, leading to build failures.

Fix by making CONFIG_ARCH_BCM2835 select CONFIG_MFD_CORE, which will
pull in the MFD core as a built-in rather than a module.

Signed-off-by: Allen Wild <allenwild93@gmail.com>