### PR TITLE
arm64/mm: Limit the DMA zone for arm64

### DIFF
--- a/arch/arm64/mm/init.c
+++ b/arch/arm64/mm/init.c
@@ -224,7 +224,7 @@ static void __init reserve_elfcorehdr(void)
 static phys_addr_t __init max_zone_dma_phys(void)
 {
 	phys_addr_t offset = memblock_start_of_DRAM() & GENMASK_ULL(63, 32);
-	return min(offset + (1ULL << 32), memblock_end_of_DRAM());
+	return min(offset + (1ULL << 30), memblock_end_of_DRAM());
 }
 
 #ifdef CONFIG_NUMA


### PR DESCRIPTION
On RaspberryPi, only the first 1Gb can be used for DMA[1].

[1] http://lists.infradead.org/pipermail/linux-arm-kernel/2019-July/665986.html

Signed-off-by: Andrei Gherzan <andrei@balena.io>