### PR TITLE
[RFC] dts: bcm2838: add missing properties for pmu and gic nodes

### DIFF
--- a/arch/arm/boot/dts/bcm2838.dtsi
+++ b/arch/arm/boot/dts/bcm2838.dtsi
@@ -35,6 +35,8 @@
 				<0x40042000 0x2000>,
 				<0x40044000 0x2000>,
 				<0x40046000 0x2000>;
+			interrupts = <GIC_PPI 9 (GIC_CPU_MASK_SIMPLE(4) |
+						 IRQ_TYPE_LEVEL_HIGH)>;
 		};
 
 		thermal: thermal@7d5d2200 {
@@ -222,15 +224,12 @@
 	};
 
 	arm-pmu {
-		/*
-		 * N.B. the A72 PMU support only exists in arch/arm64, hence
-		 * the fallback to the A53 version.
-		 */
-		compatible = "arm,cortex-a72-pmu", "arm,cortex-a53-pmu";
+		compatible = "arm,cortex-a72-pmu";
 		interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL_HIGH>,
 			<GIC_SPI 17 IRQ_TYPE_LEVEL_HIGH>,
 			<GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>,
 			<GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-affinity = <&cpu0>, <&cpu1>, <&cpu2>, <&cpu3>;
 	};
 
 	timer {


### PR DESCRIPTION
The GIC has a virtual interface maintenance interrupt and the PMU
interrupts need affinity mappings as they are wired to generic SPIs.

Also, delete incorrect PMU compatible string.

Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>