### PR TITLE
Rpi 5.2.y: fix compiling in separate directory (O=...)

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-camera/Makefile
+++ b/drivers/staging/vc04_services/bcm2835-camera/Makefile
@@ -7,6 +7,6 @@ obj-$(CONFIG_VIDEO_BCM2835) += bcm2835-v4l2.o
 
 ccflags-y += \
 	-I $(srctree)/$(src)/.. \
-	-Idrivers/staging/vc04_services \
-	-Idrivers/staging/vc04_services/vchiq-mmal \
+	-I$(srctree)/drivers/staging/vc04_services \
+	-I$(srctree)/drivers/staging/vc04_services/vchiq-mmal \
 	-D__VCCOREVER__=0x04000000

--- a/drivers/staging/vc04_services/bcm2835-codec/Makefile
+++ b/drivers/staging/vc04_services/bcm2835-codec/Makefile
@@ -4,5 +4,5 @@ bcm2835-codec-objs := bcm2835-v4l2-codec.o
 obj-$(CONFIG_VIDEO_CODEC_BCM2835) += bcm2835-codec.o
 
 ccflags-y += \
-	-Idrivers/staging/vc04_services \
+	-I$(srctree)/drivers/staging/vc04_services \
 	-D__VCCOREVER__=0x04000000

--- a/drivers/staging/vc04_services/vc-sm-cma/Makefile
+++ b/drivers/staging/vc04_services/vc-sm-cma/Makefile
@@ -1,4 +1,4 @@
-ccflags-y += -Idrivers/staging/vc04_services -Idrivers/staging/vc04_services/interface/vchi -Idrivers/staging/vc04_services/interface/vchiq_arm
+ccflags-y += -I$(srctree)/drivers/staging/vc04_services -I$(srctree)/drivers/staging/vc04_services/interface/vchi -I$(srctree)/drivers/staging/vc04_services/interface/vchiq_arm
 # -I"drivers/staging/android/ion/" -I"$(srctree)/fs/"
 ccflags-y += -D__VCCOREVER__=0
 

--- a/drivers/staging/vc04_services/vchiq-mmal/Makefile
+++ b/drivers/staging/vc04_services/vchiq-mmal/Makefile
@@ -4,5 +4,5 @@ bcm2835-mmal-vchiq-objs := mmal-vchiq.o
 obj-$(CONFIG_BCM2835_VCHIQ_MMAL) += bcm2835-mmal-vchiq.o
 
 ccflags-y += \
-	-Idrivers/staging/vc04_services \
+	-I$(srctree)/drivers/staging/vc04_services \
 	-D__VCCOREVER__=0x04000000

--- a/drivers/usb/host/dwc_otg/Makefile
+++ b/drivers/usb/host/dwc_otg/Makefile
@@ -22,7 +22,7 @@ endif
 
 ccflags-y	+= -Dlinux -DDWC_HS_ELECT_TST
 #ccflags-y	+= -DDWC_EN_ISOC
-ccflags-y   	+= -I$(obj)/../dwc_common_port
+ccflags-y   	+= -I$(srctree)/drivers/usb/host/dwc_common_port
 #ccflags-y   	+= -I$(PORTLIB)
 ccflags-y   	+= -DDWC_LINUX
 ccflags-y   	+= $(CFI)


### PR DESCRIPTION
Some Makefiles in raspberry pi specific drivers use include paths that are relative to compiled objects, not to the sources. This obviously does not work when compiling in separate directory, with O=path variable.

This pull request only fixes this for the 5.2.y branch which I work on.