### PR TITLE
drm/vc4: Add missing NULL check to vc4_crtc_consume_event

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -969,6 +969,9 @@ static void vc4_crtc_consume_event(struct drm_crtc *crtc)
 	struct drm_device *dev = crtc->dev;
 	unsigned long flags;
 
+	if (!crtc->state->event)
+		return;
+
 	crtc->state->event->pipe = drm_crtc_index(crtc);
 
 	WARN_ON(drm_crtc_vblank_get(crtc) != 0);


### PR DESCRIPTION
vc4_crtc_consume_event wasn't checking crtc->state->event was
set before dereferencing it, leading to an OOPS.

Fixes "a5b534b drm/vc4: Resolve the vblank warnings on mode switching"

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>