### PR TITLE
[5.3] justboom-dac, rpi-wm8804-soundcard: use modern dai_link style

### DIFF
--- a/sound/soc/bcm/justboom-dac.c
+++ b/sound/soc/bcm/justboom-dac.c
@@ -68,18 +68,20 @@ static struct snd_soc_ops snd_rpi_justboom_dac_ops = {
 	.shutdown = snd_rpi_justboom_dac_shutdown,
 };
 
+SND_SOC_DAILINK_DEFS(hifi,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("pcm512x.1-004d", "pcm512x-hifi")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
+
 static struct snd_soc_dai_link snd_rpi_justboom_dac_dai[] = {
 {
 	.name		= "JustBoom DAC",
 	.stream_name	= "JustBoom DAC HiFi",
-	.cpu_dai_name	= "bcm2708-i2s.0",
-	.codec_dai_name	= "pcm512x-hifi",
-	.platform_name	= "bcm2708-i2s.0",
-	.codec_name	= "pcm512x.1-004d",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
 				SND_SOC_DAIFMT_CBS_CFS,
 	.ops		= &snd_rpi_justboom_dac_ops,
 	.init		= snd_rpi_justboom_dac_init,
+	SND_SOC_DAILINK_REG(hifi),
 },
 };
 
@@ -105,10 +107,10 @@ static int snd_rpi_justboom_dac_probe(struct platform_device *pdev)
 					"i2s-controller", 0);
 
 	    if (i2s_node) {
-			dai->cpu_dai_name = NULL;
-			dai->cpu_of_node = i2s_node;
-			dai->platform_name = NULL;
-			dai->platform_of_node = i2s_node;
+			dai->cpus->dai_name = NULL;
+			dai->cpus->of_node = i2s_node;
+			dai->platforms->name = NULL;
+			dai->platforms->of_node = i2s_node;
 	    }
 
 	    digital_gain_0db_limit = !of_property_read_bool(

--- a/sound/soc/bcm/rpi-wm8804-soundcard.c
+++ b/sound/soc/bcm/rpi-wm8804-soundcard.c
@@ -183,10 +183,16 @@ static struct snd_soc_ops snd_rpi_wm8804_ops = {
 	.hw_params = snd_rpi_wm8804_hw_params,
 };
 
+SND_SOC_DAILINK_DEFS(justboom_digi,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static struct snd_soc_dai_link snd_justboom_digi_dai[] = {
 {
 	.name        = "JustBoom Digi",
 	.stream_name = "JustBoom Digi HiFi",
+	SND_SOC_DAILINK_REG(justboom_digi),
 },
 };
 
@@ -195,10 +201,16 @@ static struct snd_rpi_wm8804_drvdata drvdata_justboom_digi = {
 	.dai                  = snd_justboom_digi_dai,
 };
 
+SND_SOC_DAILINK_DEFS(iqaudio_digi,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static struct snd_soc_dai_link snd_iqaudio_digi_dai[] = {
 {
 	.name        = "IQAudIO Digi",
 	.stream_name = "IQAudIO Digi HiFi",
+	SND_SOC_DAILINK_REG(iqaudio_digi),
 },
 };
 
@@ -221,10 +233,16 @@ static int snd_allo_digione_probe(struct platform_device *pdev)
 	return 0;
 }
 
+SND_SOC_DAILINK_DEFS(allo_digione,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static struct snd_soc_dai_link snd_allo_digione_dai[] = {
 {
 	.name        = "Allo DigiOne",
 	.stream_name = "Allo DigiOne HiFi",
+	SND_SOC_DAILINK_REG(allo_digione),
 },
 };
 
@@ -234,10 +252,16 @@ static struct snd_rpi_wm8804_drvdata drvdata_allo_digione = {
 	.probe     = snd_allo_digione_probe,
 };
 
+SND_SOC_DAILINK_DEFS(hifiberry_digi,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static struct snd_soc_dai_link snd_hifiberry_digi_dai[] = {
 {
 	.name        = "HifiBerry Digi",
 	.stream_name = "HifiBerry Digi HiFi",
+	SND_SOC_DAILINK_REG(hifiberry_digi),
 },
 };
 
@@ -296,10 +320,10 @@ static int snd_rpi_wm8804_probe(struct platform_device *pdev)
 
 		if (!dai->ops)
 			dai->ops = &snd_rpi_wm8804_ops;
-		if (!dai->codec_dai_name)
-			dai->codec_dai_name = "wm8804-spdif";
-		if (!dai->codec_name)
-			dai->codec_name = "wm8804.1-003b";
+		if (!dai->codecs->dai_name)
+			dai->codecs->dai_name = "wm8804-spdif";
+		if (!dai->codecs->name)
+			dai->codecs->name = "wm8804.1-003b";
 		if (!dai->dai_fmt)
 			dai->dai_fmt = SND_SOC_DAIFMT_I2S |
 				SND_SOC_DAIFMT_NB_NF |
@@ -331,8 +355,8 @@ static int snd_rpi_wm8804_probe(struct platform_device *pdev)
 					drvdata->dai_stream_name_dt,
 					&dai->stream_name);
 
-		dai->cpu_of_node = i2s_node;
-		dai->platform_of_node = i2s_node;
+		dai->cpus->of_node = i2s_node;
+		dai->platforms->of_node = i2s_node;
 
 		/*
 		 * clk44gpio and clk48gpio are not required by all cards so


### PR DESCRIPTION
Runtime tested on RPi4 with Justboom DAC, Justboom Digi and HifiBerry Digi-Pro

That's it from my side, I think I'm through all the I2S cards I have here