### PR TITLE
usb/dwc2: Set correct state on gadget disconnect

### DIFF
--- a/drivers/usb/dwc2/core_intr.c
+++ b/drivers/usb/dwc2/core_intr.c
@@ -523,14 +523,11 @@ static void dwc2_handle_usb_suspend_intr(struct dwc2_hsotg *hsotg)
 						__func__);
 			}
 skip_power_saving:
-			/*
-			 * Change to L2 (suspend) state before releasing
-			 * spinlock
-			 */
-			hsotg->lx_state = DWC2_L2;
+			/* Raspberry Pi seems to call the suspend interrupt on gadget disconnect, so instead of setting state to suspend set to not attached */
 
-			/* Call gadget suspend callback */
-			call_gadget(hsotg, suspend);
+			hsotg->lx_state = DWC2_L3;
+
+			usb_gadget_set_state(&hsotg->gadget, USB_STATE_NOTATTACHED);
 		}
 	} else {
 		if (hsotg->op_state == OTG_STATE_A_PERIPHERAL) {


### PR DESCRIPTION
When operating as a USB device, when the device is disconnected the suspend interrupt is called rather than the disconnect interrupt, this results in the state remaining as "configured".  This change changes the state to "not attached" instead when the suspend interrupt is called.

I don't know whether this patch interferes with anything else or whether it's the correct way of "fixing" this issue, there is chatter on the web about similar behaviour a long time ago but patches were submitted, so I don't know whether this is something which is just affecting the hardware implementation on the Pi.

Without the correct state being reflected, it's not possible to detect when a gadget is connected and disconnected from a device as without this patch after enumeration even pulling the the cable the Pi device remains in "configured" state.  With this patch it reverts back to "not attached".