### PR TITLE
RFC Restore V3D power domain

### DIFF
--- a/arch/arm/boot/dts/bcm2835-common.dtsi
+++ b/arch/arm/boot/dts/bcm2835-common.dtsi
@@ -36,6 +36,7 @@
 			compatible = "brcm,bcm2835-v3d";
 			reg = <0x7ec00000 0x1000>;
 			interrupts = <1 10>;
+			power-domains = <&pm BCM2835_POWER_DOMAIN_GRAFX_V3D>;
 		};
 	};
 };


### PR DESCRIPTION
The commit ARM: dts: bcm283x: Move BCM2835/6/7 specific to
bcm2835-common.dtsi hasn't ported properly to the newer kernel versions 5.1
and newer. It accidentially drops the V3D power domain, which could lead to
firmware hangups.

This has only been compile tested, because i'm too busy with RPi 4 mainlining.