### PR TITLE
Make bcm2835-mmc compatible with swiotlb that is used on ARM64

### DIFF
--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -38,6 +38,7 @@
 #include <linux/dmaengine.h>
 #include <linux/dma-mapping.h>
 #include <linux/of_dma.h>
+#include <linux/swiotlb.h>
 
 #include "sdhci.h"
 
@@ -1373,8 +1374,15 @@ static int bcm2835_mmc_add_host(struct bcm2835_host *host)
 		}
 	}
 #endif
-	mmc->max_segs = 128;
-	mmc->max_req_size = 524288;
+	if (swiotlb_max_segment()) {
+		mmc->max_req_size = (1 << IO_TLB_SHIFT) * IO_TLB_SEGSIZE;
+		mmc->max_segs = 1;
+	}
+	else
+	{
+		mmc->max_req_size = 524288;
+		mmc->max_segs = 128;
+	}
 	mmc->max_seg_size = mmc->max_req_size;
 	mmc->max_blk_size = 512;
 	mmc->max_blk_count =  65535;


### PR DESCRIPTION
This resolves swiotlb buffer full errors on Wi-Fi bursts on
Raspberry PI4 in 64-bit mode.

Signed-off-by: Yaroslav Rosomakho <yaroslavros@gmail.com>