### PR TITLE
Fix DMA leaks in bcm2835-mmc

### DIFF
--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -345,16 +345,17 @@ static void bcm2835_mmc_dma_complete(void *param)
 
 	host->use_dma = false;
 
-	if (host->data && !(host->data->flags & MMC_DATA_WRITE)) {
-		/* otherwise handled in SDHCI IRQ */
+	if (host->data) {
 		dma_chan = host->dma_chan_rxtx;
-		dir_data = DMA_FROM_DEVICE;
-
+		if (host->data->flags & MMC_DATA_WRITE)
+			dir_data = DMA_TO_DEVICE;
+		else
+			dir_data = DMA_FROM_DEVICE;
 		dma_unmap_sg(dma_chan->device->dev,
 		     host->data->sg, host->data->sg_len,
 		     dir_data);
-
-		bcm2835_mmc_finish_data(host);
+		if (! (host->data->flags & MMC_DATA_WRITE))
+			bcm2835_mmc_finish_data(host);
 	} else if (host->wait_for_dma) {
 		host->wait_for_dma = false;
 		tasklet_schedule(&host->finish_tasklet);
@@ -540,6 +541,8 @@ static void bcm2835_mmc_transfer_dma(struct bcm2835_host *host)
 		spin_unlock_irqrestore(&host->lock, flags);
 		dmaengine_submit(desc);
 		dma_async_issue_pending(dma_chan);
+	} else {
+		dma_unmap_sg(dma_chan->device->dev, host->data->sg, len, dir_data);
 	}
 
 }

--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -38,6 +38,7 @@
 #include <linux/dmaengine.h>
 #include <linux/dma-mapping.h>
 #include <linux/of_dma.h>
+#include <linux/swiotlb.h>
 
 #include "sdhci.h"
 
@@ -1374,7 +1375,10 @@ static int bcm2835_mmc_add_host(struct bcm2835_host *host)
 	}
 #endif
 	mmc->max_segs = 128;
-	mmc->max_req_size = 524288;
+	if (swiotlb_max_segment())
+		mmc->max_req_size = (1 << IO_TLB_SHIFT) * IO_TLB_SEGSIZE;
+	else
+		mmc->max_req_size = 524288;
 	mmc->max_seg_size = mmc->max_req_size;
 	mmc->max_blk_size = 512;
 	mmc->max_blk_count =  65535;


### PR DESCRIPTION
DMA leaks caused swiotlb bounce buffer overflow errors under heavy wifi usage reported in #3157 and #3114 

This patch introduces two missing dma_unmap_sg calls for swiotlb to free relevant bounce buffers and adjusts max_req_size to match swiotlb maximum buffer size.

Signed-off-by: Yaroslav Rosomakho <yaroslavros@gmail.com>