### PR TITLE
Backport BCM270X_DT: Rename Pi Zero W DT files

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -5,7 +5,7 @@ dtb-$(CONFIG_ARCH_BCM2835) += \
 	bcm2708-rpi-b.dtb \
 	bcm2708-rpi-b-plus.dtb \
 	bcm2708-rpi-cm.dtb \
-	bcm2708-rpi-0-w.dtb \
+	bcm2708-rpi-zero-w.dtb \
 	bcm2709-rpi-2-b.dtb \
 	bcm2710-rpi-3-b.dtb \
 	bcm2710-rpi-3-b-plus.dtb \

--- a/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
@@ -132,13 +132,8 @@
 };
 
 &i2s {
-	#sound-dai-cells = <0>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2s_pins>;
-};
-
-&random {
-	status = "okay";
 };
 
 &leds {


### PR DESCRIPTION
This patch needed to be backported to series 4.14.y-rt because it is also supported in meta-raspberrypi for Yocto Project.
Unfortunately, the rename affected the correct building of the 4.14 series kernel, which now results broken.
Applying the same renames on the 4.14.y-rt series would fix the issue for those still using that kernel version.

The downtream Pi Zero W dts file uses the digit 0, whereas upstream
chose to spell it out - "zero-w". The firmware has, for a long time,
looked for bcm2708-rpi-zero-w.dtb first before falling back to the
numerical version. Therefore it is better to follow upstream and
make the switch to "bcm2708-rpi-zero-w".

At the same time, remove some overrides that duplicate values
inherited from the shared .dtsi files.

Signed-off-by: Phil Elwell <phil@raspberrypi.org>
Signed-off-by: Francesco Giancane <francescogiancane8@gmail.com>