### PR TITLE
staging: bcm2835-codec: remove unnecessary padding on encoder input

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1050,12 +1050,12 @@ static int vidioc_try_fmt(struct bcm2835_codec_ctx *ctx, struct v4l2_format *f,
 			f->fmt.pix_mp.height = MIN_H;
 
 		/*
-		 * For codecs the buffer must have a vertical alignment of 16
+		 * For decoders the buffer must have a vertical alignment of 16
 		 * lines.
 		 * The selection will reflect any cropping rectangle when only
 		 * some of the pixels are active.
 		 */
-		if (ctx->dev->role != ISP)
+		if (ctx->dev->role == DECODE)
 			f->fmt.pix_mp.height = ALIGN(f->fmt.pix_mp.height, 16);
 	}
 	f->fmt.pix_mp.num_planes = 1;


### PR DESCRIPTION
The ISP and ENCODE roles have the same underlying hardware. Neither requires vertical alignment.

Originally pointed out by @6by9 in https://github.com/tmm1/FFmpeg/commit/55380ac7bd20fc764b14d282f2f3899b44059c13#r34807642

>Actually the encoder has to internally format convert the buffer for the hardware, so I'm not sure that there actually is a height alignment requirement. There isn't for the ISP role, and the format convert is being done by the same hardware.
>
>See https://github.com/raspberrypi/linux/blob/rpi-4.19.y/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c#L1052. I'm suspecting that things should still be happy with ```if (ctx->dev->role == DECODE)```

I tested this and it works as expected.