### PR TITLE
staging: bcm2835-codec: publish component name via querycap.card

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -947,8 +947,9 @@ static void device_run(void *priv)
 static int vidioc_querycap(struct file *file, void *priv,
 			   struct v4l2_capability *cap)
 {
+	struct bcm2835_codec_ctx *ctx = file2ctx(file);
 	strncpy(cap->driver, MEM2MEM_NAME, sizeof(cap->driver) - 1);
-	strncpy(cap->card, MEM2MEM_NAME, sizeof(cap->card) - 1);
+	strncpy(cap->card, components[ctx->dev->role], sizeof(cap->card) - 1);
 	snprintf(cap->bus_info, sizeof(cap->bus_info), "platform:%s",
 		 MEM2MEM_NAME);
 	return 0;


### PR DESCRIPTION
this makes it much more obvious what each of the v4l2 devices does, and helps reading debug output in ffmpeg.

before:
```
[h264_v4l2_m2m_decoder @ 0x1c8fa70] probing device /dev/video12
[h264_v4l2_m2m_decoder @ 0x1c8fa70] driver 'bcm2835-codec' on card 'bcm2835-codec' in mplane mode
[h264_v4l2_m2m_decoder @ 0x1c8fa70] v4l2 output format not supported
[h264_v4l2_m2m_decoder @ 0x1c8fa70] probing device /dev/video11
[h264_v4l2_m2m_decoder @ 0x1c8fa70] driver 'bcm2835-codec' on card 'bcm2835-codec' in mplane mode
[h264_v4l2_m2m_decoder @ 0x1c8fa70] v4l2 output format not supported
[h264_v4l2_m2m_decoder @ 0x1c8fa70] probing device /dev/video10
[h264_v4l2_m2m_decoder @ 0x1c8fa70] driver 'bcm2835-codec' on card 'bcm2835-codec' in mplane mode
[h264_v4l2_m2m_decoder @ 0x1c8fa70] Using device /dev/video10
```

after:
```
[h264_v4l2_m2m_decoder @ 0x12a4a60] probing device /dev/video12
[h264_v4l2_m2m_decoder @ 0x12a4a60] driver 'bcm2835-codec' on card 'ril.isp' in mplane mode
[h264_v4l2_m2m_decoder @ 0x12a4a60] v4l2 output format not supported
[h264_v4l2_m2m_decoder @ 0x12a4a60] probing device /dev/video11
[h264_v4l2_m2m_decoder @ 0x12a4a60] driver 'bcm2835-codec' on card 'ril.video_encode' in mplane mode
[h264_v4l2_m2m_decoder @ 0x12a4a60] v4l2 output format not supported
[h264_v4l2_m2m_decoder @ 0x12a4a60] probing device /dev/video10
[h264_v4l2_m2m_decoder @ 0x12a4a60] driver 'bcm2835-codec' on card 'ril.video_decode' in mplane mode
[h264_v4l2_m2m_decoder @ 0x12a4a60] Using device /dev/video10
```

cc @6by9 @popcornmix 