### PR TITLE
arm64: bcm2835: select MFD_CORE

### DIFF
--- a/arch/arm64/Kconfig.platforms
+++ b/arch/arm64/Kconfig.platforms
@@ -26,6 +26,7 @@ config ARCH_BCM2835
 	select ARM_AMBA
 	select ARM_TIMER_SP804
 	select HAVE_ARM_ARCH_TIMER
+	select MFD_CORE
 	help
 	  This enables support for the Broadcom BCM2837 SoC.
 	  This SoC is used in the Raspberry Pi 3 device.


### PR DESCRIPTION
This is selected by default on arm bcm2835.
Not having it selected may cause build errors on some distributions.

Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>