### PR TITLE
arm: dts: add missing Raspberry Pi model names

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
@@ -6,6 +6,7 @@
 #include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
+	compatible = "raspberrypi,model-b-plus", "brcm,bcm2835";
 	model = "Raspberry Pi Model B+";
 };
 

--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -6,6 +6,7 @@
 #include "bcm283x-rpi-csi1-2lane.dtsi"
 
 / {
+	compatible = "raspberrypi,model-b", "brcm,bcm2835";
 	model = "Raspberry Pi Model B";
 };
 

--- a/arch/arm/boot/dts/bcm2708-rpi-cm.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-cm.dts
@@ -5,6 +5,7 @@
 #include "bcm283x-rpi-csi1-4lane.dtsi"
 
 / {
+	compatible = "raspberrypi,compute-module", "brcm,bcm2835";
 	model = "Raspberry Pi Compute Module";
 };
 

--- a/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
@@ -6,6 +6,7 @@
 #include "bcm283x-rpi-csi1-4lane.dtsi"
 
 / {
+	compatible = "raspberrypi,3-compute-module", "brcm,bcm2837";
 	model = "Raspberry Pi Compute Module 3";
 };
 


### PR DESCRIPTION
This is needed to identify the different models on distributions like OpenWrt.

Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>