### PR TITLE
net: account for the srctree rtl8192 cflags

### DIFF
--- a/drivers/net/wireless/realtek/rtl8192cu/Makefile
+++ b/drivers/net/wireless/realtek/rtl8192cu/Makefile
@@ -16,7 +16,7 @@ EXTRA_CFLAGS += -Wno-unused
 
 EXTRA_CFLAGS += -Wno-uninitialized
 
-EXTRA_CFLAGS += -I$(src)/include
+EXTRA_CFLAGS += -I$(srctree)/$(src)/include
 
 CONFIG_AUTOCFG_CP = n
 


### PR DESCRIPTION
Account for the srctree in the rtl8192 non-mainline driver.
See cdd750bfb1f76fe9be8cfb53cbe77b2e811081ab for details.

Fixes: #3199 