### PR TITLE
softirq: Fix compiling errors when choosing schedule policies other than Fully Preemptible

### DIFF
--- a/include/linux/interrupt.h
+++ b/include/linux/interrupt.h
@@ -648,6 +648,31 @@ extern void tasklet_kill_immediate(struct tasklet_struct *t, unsigned int cpu);
 extern void tasklet_init(struct tasklet_struct *t,
 			 void (*func)(unsigned long), unsigned long data);
 
+struct tasklet_hrtimer {
+	struct hrtimer          timer;
+	struct tasklet_struct   tasklet;
+	enum hrtimer_restart    (*function)(struct hrtimer *);
+};
+
+extern void
+tasklet_hrtimer_init(struct tasklet_hrtimer *ttimer,
+			enum hrtimer_restart (*function)(struct hrtimer *),
+			clockid_t which_clock, enum hrtimer_mode mode);
+
+static inline
+void tasklet_hrtimer_start(struct tasklet_hrtimer *ttimer, ktime_t time,
+			const enum hrtimer_mode mode)
+{
+	hrtimer_start(&ttimer->timer, time, mode);
+}
+
+static inline
+void tasklet_hrtimer_cancel(struct tasklet_hrtimer *ttimer)
+{
+	hrtimer_cancel(&ttimer->timer);
+	tasklet_kill(&ttimer->tasklet);
+}
+
 #ifdef CONFIG_PREEMPT_RT_FULL
 extern void softirq_early_init(void);
 #else


### PR DESCRIPTION
if choose no-rt schedule policies other than fully preemptible, such as Low Latency Desktop, the kernel will NOT compile. Define struct tasklet_hrtimer and function ksoftirqd_running to avoid compiling errors.