### PR TITLE
Rpi 5.3.y: alsa/soc/bcm: change to use modern dai_link style otherwise there is building error for v5.3 

### DIFF
--- a/sound/soc/bcm/allo-boss-dac.c
+++ b/sound/soc/bcm/allo-boss-dac.c
@@ -346,19 +346,21 @@ static struct snd_soc_ops snd_allo_boss_ops = {
 	.prepare = snd_allo_boss_prepare,
 };
 
+SND_SOC_DAILINK_DEFS(allo_boss,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("pcm512x.1-004d", "pcm512x-hifi")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
+
 static struct snd_soc_dai_link snd_allo_boss_dai[] = {
 {
 	.name		= "Boss DAC",
 	.stream_name	= "Boss DAC HiFi",
-	.cpu_dai_name	= "bcm2708-i2s.0",
-	.codec_dai_name	= "pcm512x-hifi",
-	.platform_name	= "bcm2708-i2s.0",
-	.codec_name	= "pcm512x.1-004d",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S |
 			  SND_SOC_DAIFMT_NB_NF |
 			  SND_SOC_DAIFMT_CBS_CFS,
 	.ops		= &snd_allo_boss_ops,
 	.init		= snd_allo_boss_init,
+	SND_SOC_DAILINK_REG(allo_boss),
 },
 };
 
@@ -385,10 +387,10 @@ static int snd_allo_boss_probe(struct platform_device *pdev)
 					    "i2s-controller", 0);
 
 		if (i2s_node) {
-			dai->cpu_dai_name = NULL;
-			dai->cpu_of_node = i2s_node;
-			dai->platform_name = NULL;
-			dai->platform_of_node = i2s_node;
+			dai->cpus->dai_name = NULL;
+			dai->cpus->of_node = i2s_node;
+			dai->platforms->name = NULL;
+			dai->platforms->of_node = i2s_node;
 		}
 
 		digital_gain_0db_limit = !of_property_read_bool(

--- a/sound/soc/bcm/allo-piano-dac-plus.c
+++ b/sound/soc/bcm/allo-piano-dac-plus.c
@@ -867,19 +867,22 @@ static struct snd_soc_dai_link_component allo_piano_2_1_codecs[] = {
 	},
 };
 
+SND_SOC_DAILINK_DEFS(allo_piano_dai_plus,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC(NULL, "pcm512x-hifi"),
+			   COMP_CODEC(NULL, "pcm512x-hifi")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
+
 static struct snd_soc_dai_link snd_allo_piano_dac_dai[] = {
 	{
 		.name		= "PianoDACPlus",
 		.stream_name	= "PianoDACPlus",
-		.cpu_dai_name	= "bcm2708-i2s.0",
-		.platform_name	= "bcm2708-i2s.0",
-		.codecs		= allo_piano_2_1_codecs,
-		.num_codecs	= 2,
 		.dai_fmt	= SND_SOC_DAIFMT_I2S |
 				SND_SOC_DAIFMT_NB_NF |
 				SND_SOC_DAIFMT_CBS_CFS,
 		.ops		= &snd_allo_piano_dac_ops,
 		.init		= snd_allo_piano_dac_init,
+		SND_SOC_DAILINK_REG(allo_piano_dai_plus),
 	},
 };
 
@@ -910,10 +913,10 @@ static int snd_allo_piano_dac_probe(struct platform_device *pdev)
 						"i2s-controller", 0);
 		if (i2s_node) {
 			for (i = 0; i < card->num_links; i++) {
-				dai->cpu_dai_name = NULL;
-				dai->cpu_of_node = i2s_node;
-				dai->platform_name = NULL;
-				dai->platform_of_node = i2s_node;
+				dai->cpus->dai_name = NULL;
+				dai->cpus->of_node = i2s_node;
+				dai->platforms->name = NULL;
+				dai->platforms->of_node = i2s_node;
 			}
 		}
 		digital_gain_0db_limit =

--- a/sound/soc/bcm/allo-piano-dac.c
+++ b/sound/soc/bcm/allo-piano-dac.c
@@ -42,18 +42,20 @@ static int snd_allo_piano_dac_init(struct snd_soc_pcm_runtime *rtd)
 	return 0;
 }
 
+SND_SOC_DAILINK_DEFS(allo_piano_dai,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("pcm512x.1-004c", "pcm512x-hifi")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
+
 static struct snd_soc_dai_link snd_allo_piano_dac_dai[] = {
 {
 	.name		= "Piano DAC",
 	.stream_name	= "Piano DAC HiFi",
-	.cpu_dai_name	= "bcm2708-i2s.0",
-	.codec_dai_name	= "pcm512x-hifi",
-	.platform_name	= "bcm2708-i2s.0",
-	.codec_name	= "pcm512x.1-004c",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S |
 			  SND_SOC_DAIFMT_NB_NF |
 			  SND_SOC_DAIFMT_CBS_CFS,
 	.init		= snd_allo_piano_dac_init,
+	SND_SOC_DAILINK_REG(allo_piano_dai),
 },
 };
 
@@ -80,10 +82,10 @@ static int snd_allo_piano_dac_probe(struct platform_device *pdev)
 					    "i2s-controller", 0);
 
 		if (i2s_node) {
-			dai->cpu_dai_name = NULL;
-			dai->cpu_of_node = i2s_node;
-			dai->platform_name = NULL;
-			dai->platform_of_node = i2s_node;
+			dai->cpus->dai_name = NULL;
+			dai->cpus->of_node = i2s_node;
+			dai->platforms->name = NULL;
+			dai->platforms->of_node = i2s_node;
 		}
 
 		digital_gain_0db_limit = !of_property_read_bool(

--- a/sound/soc/bcm/audioinjector-octo-soundcard.c
+++ b/sound/soc/bcm/audioinjector-octo-soundcard.c
@@ -198,15 +198,20 @@ static struct snd_soc_ops audioinjector_octo_ops = {
 	.trigger = audioinjector_octo_trigger,
 };
 
+SND_SOC_DAILINK_DEFS(audioinjector_octo,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_CODEC(NULL, "cs42448")),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static struct snd_soc_dai_link audioinjector_octo_dai[] = {
 	{
 		.name = "AudioInjector Octo",
 		.stream_name = "AudioInject-HIFI",
-		.codec_dai_name = "cs42448",
 		.ops = &audioinjector_octo_ops,
 		.init = audioinjector_octo_dai_init,
 		.symmetric_rates = 1,
 		.symmetric_channels = 1,
+		SND_SOC_DAILINK_REG(audioinjector_octo),
 	},
 };
 
@@ -290,12 +295,12 @@ static int audioinjector_octo_probe(struct platform_device *pdev)
 		msleep(500);
 
 		if (i2s_node && codec_node) {
-			dai->cpu_dai_name = NULL;
-			dai->cpu_of_node = i2s_node;
-			dai->platform_name = NULL;
-			dai->platform_of_node = i2s_node;
-			dai->codec_name = NULL;
-			dai->codec_of_node = codec_node;
+			dai->cpus->dai_name = NULL;
+			dai->cpus->of_node = i2s_node;
+			dai->platforms->name = NULL;
+			dai->platforms->of_node = i2s_node;
+			dai->codecs->name = NULL;
+			dai->codecs->of_node = codec_node;
 		} else
 			if (!i2s_node) {
 				dev_err(&pdev->dev,

--- a/sound/soc/bcm/audioinjector-pi-soundcard.c
+++ b/sound/soc/bcm/audioinjector-pi-soundcard.c
@@ -84,17 +84,19 @@ static int audioinjector_pi_soundcard_dai_init(struct snd_soc_pcm_runtime *rtd)
 	return snd_soc_dai_set_sysclk(rtd->codec_dai, WM8731_SYSCLK_XTAL, 12000000, SND_SOC_CLOCK_IN);
 }
 
+SND_SOC_DAILINK_DEFS(audioinjector_pi,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("wm8731.1-001a", "wm8731-hifi")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2835-i2s.0")));
+
 static struct snd_soc_dai_link audioinjector_pi_soundcard_dai[] = {
 	{
 		.name = "AudioInjector audio",
 		.stream_name = "AudioInjector audio",
-		.cpu_dai_name	= "bcm2708-i2s.0",
-		.codec_dai_name = "wm8731-hifi",
-		.platform_name	= "bcm2835-i2s.0",
-		.codec_name = "wm8731.1-001a",
 		.ops = &snd_audioinjector_pi_soundcard_ops,
 		.init = audioinjector_pi_soundcard_dai_init,
 		.dai_fmt = SND_SOC_DAIFMT_CBM_CFM|SND_SOC_DAIFMT_I2S|SND_SOC_DAIFMT_NB_NF,
+		SND_SOC_DAILINK_REG(audioinjector_pi),
 	},
 };
 
@@ -145,12 +147,12 @@ static int audioinjector_pi_soundcard_probe(struct platform_device *pdev)
 								"i2s-controller", 0);
 
 		if (i2s_node) {
-			dai->cpu_dai_name = NULL;
-			dai->cpu_of_node = i2s_node;
-			dai->platform_name = NULL;
-			dai->platform_of_node = i2s_node;
+			dai->cpus->dai_name = NULL;
+			dai->cpus->of_node = i2s_node;
+			dai->platforms->name = NULL;
+			dai->platforms->of_node = i2s_node;
 		} else
-			if (!dai->cpu_of_node) {
+			if (!dai->cpus->of_node) {
 				dev_err(&pdev->dev, "Property 'i2s-controller' missing or invalid\n");
 				return -EINVAL;
 			}

--- a/sound/soc/bcm/audiosense-pi.c
+++ b/sound/soc/bcm/audiosense-pi.c
@@ -150,18 +150,20 @@ static struct snd_soc_ops audiosense_pi_card_ops = {
 	.hw_params = audiosense_pi_card_hw_params,
 };
 
+SND_SOC_DAILINK_DEFS(audiosense_pi,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("tlv320aic32x4.1-0018", "tlv320aic32x4-hifi")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
+
 static struct snd_soc_dai_link audiosense_pi_card_dai[] = {
 	{
 		.name           = "TLV320AIC3204 Audio",
 		.stream_name    = "TLV320AIC3204 Hifi Audio",
-		.cpu_dai_name   = "bcm2708-i2s.0",
-		.codec_dai_name = "tlv320aic32x4-hifi",
-		.platform_name  = "bcm2708-i2s.0",
-		.codec_name     = "tlv320aic32x4.1-0018",
 		.dai_fmt        = SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
 			SND_SOC_DAIFMT_CBM_CFM,
 		.ops            = &audiosense_pi_card_ops,
 		.init           = audiosense_pi_card_init,
+		SND_SOC_DAILINK_REG(audiosense_pi),
 	},
 };
 
@@ -198,10 +200,10 @@ static int audiosense_pi_card_probe(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
-	dai->cpu_dai_name = NULL;
-	dai->cpu_of_node = i2s_node;
-	dai->platform_name = NULL;
-	dai->platform_of_node = i2s_node;
+	dai->cpus->dai_name = NULL;
+	dai->cpus->of_node = i2s_node;
+	dai->platforms->name = NULL;
+	dai->platforms->of_node = i2s_node;
 
 	of_node_put(i2s_node);
 

--- a/sound/soc/bcm/digidac1-soundcard.c
+++ b/sound/soc/bcm/digidac1-soundcard.c
@@ -332,28 +332,33 @@ static struct snd_soc_ops digidac1_soundcard_ops = {
 	.shutdown	= digidac1_soundcard_shutdown,
 };
 
+SND_SOC_DAILINK_DEFS(digidac1,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("wm8804.1-003b", "wm8804-spdif")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2835-i2s.0")));
+
+SND_SOC_DAILINK_DEFS(digidac11,
+	DAILINK_COMP_ARRAY(COMP_CPU("wm8804-spdif")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("wm8741.1-001a", "wm8741")),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static struct snd_soc_dai_link digidac1_soundcard_dai[] = {
 	{
 	.name		= "RRA DigiDAC1",
 	.stream_name	= "RRA DigiDAC1 HiFi",
-	.cpu_dai_name	= "bcm2708-i2s.0",
-	.codec_dai_name	= "wm8804-spdif",
-	.platform_name	= "bcm2708-i2s.0",
-	.codec_name	= "wm8804.1-003b",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
 				SND_SOC_DAIFMT_CBM_CFM,
 	.ops		= &digidac1_soundcard_ops,
 	.init		= digidac1_soundcard_init,
+	SND_SOC_DAILINK_REG(digidac1),
 	},
 	{
 	.name		= "RRA DigiDAC11",
 	.stream_name	= "RRA DigiDAC11 HiFi",
-	.cpu_dai_name	= "wm8804-spdif",
-	.codec_dai_name	= "wm8741",
-	.codec_name	= "wm8741.1-001a",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S
 			| SND_SOC_DAIFMT_NB_NF
 			| SND_SOC_DAIFMT_CBS_CFS,
+	SND_SOC_DAILINK_REG(digidac11),
 	},
 };
 
@@ -379,10 +384,10 @@ static int digidac1_soundcard_probe(struct platform_device *pdev)
 					"i2s-controller", 0);
 
 		if (i2s_node) {
-			dai->cpu_dai_name = NULL;
-			dai->cpu_of_node = i2s_node;
-			dai->platform_name = NULL;
-			dai->platform_of_node = i2s_node;
+			dai->cpus->dai_name = NULL;
+			dai->cpus->of_node = i2s_node;
+			dai->platforms->name = NULL;
+			dai->platforms->of_node = i2s_node;
 		}
 	}
 

--- a/sound/soc/bcm/dionaudio_loco-v2.c
+++ b/sound/soc/bcm/dionaudio_loco-v2.c
@@ -41,17 +41,19 @@ static int snd_rpi_dionaudio_loco_v2_init(struct snd_soc_pcm_runtime *rtd)
 	return 0;
 }
 
+SND_SOC_DAILINK_DEFS(dionaudio_loco_v2,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("pcm512x.1-004d", "pcm512x-hifi")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
+
 static struct snd_soc_dai_link snd_rpi_dionaudio_loco_v2_dai[] = {
 {
 	.name		= "DionAudio LOCO-V2",
 	.stream_name	= "DionAudio LOCO-V2 DAC-AMP",
-	.cpu_dai_name	= "bcm2708-i2s.0",
-	.codec_dai_name	= "pcm512x-hifi",
-	.platform_name	= "bcm2708-i2s.0",
-	.codec_name	= "pcm512x.1-004d",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
 			  SND_SOC_DAIFMT_CBS_CFS,
 	.init		= snd_rpi_dionaudio_loco_v2_init,
+	SND_SOC_DAILINK_REG(dionaudio_loco_v2),
 },};
 
 /* audio machine driver */
@@ -75,10 +77,10 @@ static int snd_rpi_dionaudio_loco_v2_probe(struct platform_device *pdev)
 		i2s_node = of_parse_phandle(pdev->dev.of_node,
 					    "i2s-controller", 0);
 		if (i2s_node) {
-			dai->cpu_dai_name = NULL;
-			dai->cpu_of_node = i2s_node;
-			dai->platform_name = NULL;
-			dai->platform_of_node = i2s_node;
+			dai->cpus->dai_name = NULL;
+			dai->cpus->of_node = i2s_node;
+			dai->platforms->name = NULL;
+			dai->platforms->of_node = i2s_node;
 		}
 
 		digital_gain_0db_limit = !of_property_read_bool(

--- a/sound/soc/bcm/dionaudio_loco.c
+++ b/sound/soc/bcm/dionaudio_loco.c
@@ -42,18 +42,20 @@ static struct snd_soc_ops snd_rpi_dionaudio_loco_ops = {
 	.hw_params = snd_rpi_dionaudio_loco_hw_params,
 };
 
+SND_SOC_DAILINK_DEFS(dionaudio_loco,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("pcm5102a-codec", "pcm5102a-hifi")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
+
 static struct snd_soc_dai_link snd_rpi_dionaudio_loco_dai[] = {
 {
 	.name		= "DionAudio LOCO",
 	.stream_name	= "DionAudio LOCO DAC-AMP",
-	.cpu_dai_name	= "bcm2708-i2s.0",
-	.codec_dai_name	= "pcm5102a-hifi",
-	.platform_name	= "bcm2708-i2s.0",
-	.codec_name	= "pcm5102a-codec",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S |
 			  SND_SOC_DAIFMT_NB_NF |
 			  SND_SOC_DAIFMT_CBS_CFS,
 	.ops		= &snd_rpi_dionaudio_loco_ops,
+	SND_SOC_DAILINK_REG(dionaudio_loco),
 },
 };
 
@@ -78,10 +80,10 @@ static int snd_rpi_dionaudio_loco_probe(struct platform_device *pdev)
 
 		i2s_np = of_parse_phandle(np, "i2s-controller", 0);
 		if (i2s_np) {
-			dai->cpu_dai_name = NULL;
-			dai->cpu_of_node = i2s_np;
-			dai->platform_name = NULL;
-			dai->platform_of_node = i2s_np;
+			dai->cpus->dai_name = NULL;
+			dai->cpus->of_node = i2s_np;
+			dai->platforms->name = NULL;
+			dai->platforms->of_node = i2s_np;
 		}
 	}
 

--- a/sound/soc/bcm/fe-pi-audio.c
+++ b/sound/soc/bcm/fe-pi-audio.c
@@ -67,18 +67,20 @@ static struct snd_soc_ops snd_fe_pi_audio_ops = {
 	.hw_params = snd_fe_pi_audio_hw_params,
 };
 
+SND_SOC_DAILINK_DEFS(fe_pi,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("sgtl5000.1-000a", "sgtl5000")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
+
 static struct snd_soc_dai_link snd_fe_pi_audio_dai[] = {
 	{
 		.name		= "FE-PI",
 		.stream_name	= "Fe-Pi HiFi",
-		.cpu_dai_name	= "bcm2708-i2s.0",
-		.codec_dai_name	= "sgtl5000",
-		.platform_name	= "bcm2708-i2s.0",
-		.codec_name	= "sgtl5000.1-000a",
 		.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
 					SND_SOC_DAIFMT_CBM_CFM,
 		.ops		= &snd_fe_pi_audio_ops,
 		.init		= snd_fe_pi_audio_init,
+		SND_SOC_DAILINK_REG(fe_pi),
 	},
 };
 
@@ -113,10 +115,10 @@ static int snd_fe_pi_audio_probe(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
-	dai->cpu_dai_name = NULL;
-	dai->cpu_of_node = i2s_node;
-	dai->platform_name = NULL;
-	dai->platform_of_node = i2s_node;
+	dai->cpus->dai_name = NULL;
+	dai->cpus->of_node = i2s_node;
+	dai->platforms->name = NULL;
+	dai->platforms->of_node = i2s_node;
 
 	of_node_put(i2s_node);
 

--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -269,18 +269,20 @@ static struct snd_soc_ops snd_rpi_hifiberry_dacplus_ops = {
 	.shutdown = snd_rpi_hifiberry_dacplus_shutdown,
 };
 
+SND_SOC_DAILINK_DEFS(rpi_hifiberry_dacplus,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("pcm512x.1-004d", "pcm512x-hifi")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
+
 static struct snd_soc_dai_link snd_rpi_hifiberry_dacplus_dai[] = {
 {
 	.name		= "HiFiBerry DAC+",
 	.stream_name	= "HiFiBerry DAC+ HiFi",
-	.cpu_dai_name	= "bcm2708-i2s.0",
-	.codec_dai_name	= "pcm512x-hifi",
-	.platform_name	= "bcm2708-i2s.0",
-	.codec_name	= "pcm512x.1-004d",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
 				SND_SOC_DAIFMT_CBS_CFS,
 	.ops		= &snd_rpi_hifiberry_dacplus_ops,
 	.init		= snd_rpi_hifiberry_dacplus_init,
+	SND_SOC_DAILINK_REG(rpi_hifiberry_dacplus),
 },
 };
 
@@ -307,10 +309,10 @@ static int snd_rpi_hifiberry_dacplus_probe(struct platform_device *pdev)
 			"i2s-controller", 0);
 
 		if (i2s_node) {
-			dai->cpu_dai_name = NULL;
-			dai->cpu_of_node = i2s_node;
-			dai->platform_name = NULL;
-			dai->platform_of_node = i2s_node;
+			dai->cpus->dai_name = NULL;
+			dai->cpus->of_node = i2s_node;
+			dai->platforms->name = NULL;
+			dai->platforms->of_node = i2s_node;
 		}
 
 		digital_gain_0db_limit = !of_property_read_bool(

--- a/sound/soc/bcm/i-sabre-q2m.c
+++ b/sound/soc/bcm/i-sabre-q2m.c
@@ -63,19 +63,20 @@ static struct snd_soc_ops snd_rpi_i_sabre_q2m_ops = {
 	.hw_params = snd_rpi_i_sabre_q2m_hw_params,
 };
 
+SND_SOC_DAILINK_DEFS(rpi_i_sabre_q2m,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("i-sabre-codec-i2c.1-0048", "i-sabre-codec-dai")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
 
 static struct snd_soc_dai_link snd_rpi_i_sabre_q2m_dai[] = {
 	{
 		.name           = "I-Sabre Q2M",
 		.stream_name    = "I-Sabre Q2M DAC",
-		.cpu_dai_name   = "bcm2708-i2s.0",
-		.codec_dai_name = "i-sabre-codec-dai",
-		.platform_name  = "bcm2708-i2s.0",
-		.codec_name     = "i-sabre-codec-i2c.1-0048",
 		.dai_fmt        = SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF
 						| SND_SOC_DAIFMT_CBS_CFS,
 		.init           = snd_rpi_i_sabre_q2m_init,
 		.ops            = &snd_rpi_i_sabre_q2m_ops,
+		SND_SOC_DAILINK_REG(rpi_i_sabre_q2m),
 	}
 };
 
@@ -101,10 +102,10 @@ static int snd_rpi_i_sabre_q2m_probe(struct platform_device *pdev)
 		i2s_node = of_parse_phandle(pdev->dev.of_node,
 							"i2s-controller", 0);
 		if (i2s_node) {
-			dai->cpu_dai_name     = NULL;
-			dai->cpu_of_node      = i2s_node;
-			dai->platform_name    = NULL;
-			dai->platform_of_node = i2s_node;
+			dai->cpus->dai_name     = NULL;
+			dai->cpus->of_node      = i2s_node;
+			dai->platforms->name    = NULL;
+			dai->platforms->of_node = i2s_node;
 		} else {
 			dev_err(&pdev->dev,
 			    "Property 'i2s-controller' missing or invalid\n");

--- a/sound/soc/bcm/iqaudio-codec.c
+++ b/sound/soc/bcm/iqaudio-codec.c
@@ -167,13 +167,13 @@ static const struct snd_soc_ops snd_rpi_iqaudio_codec_ops = {
 	.hw_params = snd_rpi_iqaudio_codec_hw_params,
 };
 
+SND_SOC_DAILINK_DEFS(rpi_iqaudio,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("da7213.1-001a", "da7213-hifi")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2835-i2s.0")));
 
 static struct snd_soc_dai_link snd_rpi_iqaudio_codec_dai[] = {
 {
-	.cpu_dai_name 		= "bcm2708-i2s.0",
-	.codec_dai_name 	= "da7213-hifi",
-	.platform_name 		= "bmc2708-i2s.0",
-	.codec_name 		= "da7213.1-001a",
 	.dai_fmt 		= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
 				  SND_SOC_DAIFMT_CBM_CFM,
 	.init			= snd_rpi_iqaudio_codec_init,
@@ -181,6 +181,7 @@ static struct snd_soc_dai_link snd_rpi_iqaudio_codec_dai[] = {
 	.symmetric_rates	= 1,
 	.symmetric_channels	= 1,
 	.symmetric_samplebits	= 1,
+	SND_SOC_DAILINK_REG(rpi_iqaudio),
 },
 };
 
@@ -211,10 +212,10 @@ static int snd_rpi_iqaudio_codec_probe(struct platform_device *pdev)
 		i2s_node = of_parse_phandle(pdev->dev.of_node,
 					    "i2s-controller", 0);
 		if (i2s_node) {
-			dai->cpu_dai_name = NULL;
-			dai->cpu_of_node = i2s_node;
-			dai->platform_name = NULL;
-			dai->platform_of_node = i2s_node;
+			dai->cpus->dai_name = NULL;
+			dai->cpus->of_node = i2s_node;
+			dai->platforms->name = NULL;
+			dai->platforms->of_node = i2s_node;
 		}
 
 		if (of_property_read_string(pdev->dev.of_node, "card_name",

--- a/sound/soc/bcm/pisound.c
+++ b/sound/soc/bcm/pisound.c
@@ -930,19 +930,21 @@ static struct snd_soc_ops pisnd_ops = {
 	.hw_params = pisnd_hw_params,
 };
 
+SND_SOC_DAILINK_DEFS(pisnd,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_DUMMY()),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
+
 static struct snd_soc_dai_link pisnd_dai[] = {
 	{
 		.name           = "pisound",
 		.stream_name    = "pisound",
-		.cpu_dai_name   = "bcm2708-i2s.0",
-		.codec_dai_name = "snd-soc-dummy-dai",
-		.platform_name  = "bcm2708-i2s.0",
-		.codec_name     = "snd-soc-dummy",
 		.dai_fmt        =
 			SND_SOC_DAIFMT_I2S |
 			SND_SOC_DAIFMT_NB_NF |
 			SND_SOC_DAIFMT_CBM_CFM,
 		.ops            = &pisnd_ops,
+		SND_SOC_DAILINK_REG(pisnd),
 	},
 };
 
@@ -1140,10 +1142,10 @@ static int pisnd_probe(struct platform_device *pdev)
 			struct snd_soc_dai_link *dai = &pisnd_dai[i];
 
 			if (i2s_node) {
-				dai->cpu_dai_name = NULL;
-				dai->cpu_of_node = i2s_node;
-				dai->platform_name = NULL;
-				dai->platform_of_node = i2s_node;
+				dai->cpus->dai_name = NULL;
+				dai->cpus->of_node = i2s_node;
+				dai->platforms->name = NULL;
+				dai->platforms->of_node = i2s_node;
 				dai->stream_name = pisnd_spi_get_serial();
 			}
 		}

--- a/sound/soc/bcm/pisound.c
+++ b/sound/soc/bcm/pisound.c
@@ -371,7 +371,7 @@ static int spi_read_bytes(char *dst, size_t length, uint8_t *bytesRead)
 	return 0;
 }
 
-static int spi_device_match(struct device *dev, void *data)
+static int spi_device_match(struct device *dev, const void *data)
 {
 	struct spi_device *spi = container_of(dev, struct spi_device, dev);
 

--- a/sound/soc/bcm/rpi-proto.c
+++ b/sound/soc/bcm/rpi-proto.c
@@ -72,18 +72,20 @@ static struct snd_soc_ops snd_rpi_proto_ops = {
 	.hw_params = snd_rpi_proto_hw_params,
 };
 
+SND_SOC_DAILINK_DEFS(rpi_proto,
+	DAILINK_COMP_ARRAY(COMP_CPU("bcm2708-i2s.0")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("wm8731.1-001a", "wm8731-hifi")),
+	DAILINK_COMP_ARRAY(COMP_PLATFORM("bcm2708-i2s.0")));
+
 static struct snd_soc_dai_link snd_rpi_proto_dai[] = {
 {
 	.name		= "WM8731",
 	.stream_name	= "WM8731 HiFi",
-	.cpu_dai_name	= "bcm2708-i2s.0",
-	.codec_dai_name	= "wm8731-hifi",
-	.platform_name	= "bcm2708-i2s.0",
-	.codec_name	= "wm8731.1-001a",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S
 				| SND_SOC_DAIFMT_NB_NF
 				| SND_SOC_DAIFMT_CBM_CFM,
 	.ops		= &snd_rpi_proto_ops,
+	SND_SOC_DAILINK_REG(rpi_proto),
 },
 };
 
@@ -108,10 +110,10 @@ static int snd_rpi_proto_probe(struct platform_device *pdev)
 				            "i2s-controller", 0);
 
 		if (i2s_node) {
-			dai->cpu_dai_name = NULL;
-			dai->cpu_of_node = i2s_node;
-			dai->platform_name = NULL;
-			dai->platform_of_node = i2s_node;
+			dai->cpus->dai_name = NULL;
+			dai->cpus->of_node = i2s_node;
+			dai->platforms->name = NULL;
+			dai->platforms->of_node = i2s_node;
 		}
 	}
 

--- a/sound/soc/bcm/rpi-simple-soundcard.c
+++ b/sound/soc/bcm/rpi-simple-soundcard.c
@@ -102,16 +102,20 @@ static int adau1977_init(struct snd_soc_pcm_runtime *rtd)
 			11289600, SND_SOC_CLOCK_IN);
 }
 
+SND_SOC_DAILINK_DEFS(adau1977,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_CODEC("adau1977.1-0011", "adau1977-hifi")),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static struct snd_soc_dai_link snd_rpi_adau1977_dai[] = {
 	{
 	.name           = "adau1977",
 	.stream_name    = "ADAU1977",
-	.codec_dai_name = "adau1977-hifi",
-	.codec_name     = "adau1977.1-0011",
 	.init           = adau1977_init,
 	.dai_fmt = SND_SOC_DAIFMT_I2S |
 		SND_SOC_DAIFMT_NB_NF |
 		SND_SOC_DAIFMT_CBM_CFM,
+	SND_SOC_DAILINK_REG(adau1977),
 	},
 };
 
@@ -120,14 +124,18 @@ static struct snd_rpi_simple_drvdata drvdata_adau1977 = {
 	.dai       = snd_rpi_adau1977_dai,
 };
 
+SND_SOC_DAILINK_DEFS(gvchat,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_CODEC("voicehat-codec", "voicehat-hifi")),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static struct snd_soc_dai_link snd_googlevoicehat_soundcard_dai[] = {
 {
 	.name           = "Google voiceHAT SoundCard",
 	.stream_name    = "Google voiceHAT SoundCard HiFi",
-	.codec_dai_name = "voicehat-hifi",
-	.codec_name     = "voicehat-codec",
 	.dai_fmt        =  SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
 				SND_SOC_DAIFMT_CBS_CFS,
+	SND_SOC_DAILINK_REG(gvchat),
 },
 };
 
@@ -136,15 +144,19 @@ static struct snd_rpi_simple_drvdata drvdata_googlevoicehat = {
 	.dai       = snd_googlevoicehat_soundcard_dai,
 };
 
+SND_SOC_DAILINK_DEFS(hifiberry_amp,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_CODEC("tas5713.1-001b", "tas5713-hifi")),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static struct snd_soc_dai_link snd_hifiberry_amp_dai[] = {
 	{
 		.name           = "HifiBerry AMP",
 		.stream_name    = "HifiBerry AMP HiFi",
-		.codec_dai_name = "tas5713-hifi",
-		.codec_name     = "tas5713.1-001b",
 		.dai_fmt        = SND_SOC_DAIFMT_I2S |
 					SND_SOC_DAIFMT_NB_NF |
 					SND_SOC_DAIFMT_CBS_CFS,
+		SND_SOC_DAILINK_REG(hifiberry_amp),
 	},
 };
 
@@ -154,15 +166,19 @@ static struct snd_rpi_simple_drvdata drvdata_hifiberry_amp = {
 	.fixed_bclk_ratio = 64,
 };
 
+SND_SOC_DAILINK_DEFS(hifiberry_dac,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_CODEC("pcm5102a-codec", "pcm5102a-hifi")),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static struct snd_soc_dai_link snd_hifiberry_dac_dai[] = {
 	{
 		.name           = "HifiBerry DAC",
 		.stream_name    = "HifiBerry DAC HiFi",
-		.codec_dai_name = "pcm5102a-hifi",
-		.codec_name     = "pcm5102a-codec",
 		.dai_fmt        = SND_SOC_DAIFMT_I2S |
 					SND_SOC_DAIFMT_NB_NF |
 					SND_SOC_DAIFMT_CBS_CFS,
+		SND_SOC_DAILINK_REG(hifiberry_dac),
 	},
 };
 
@@ -171,14 +187,18 @@ static struct snd_rpi_simple_drvdata drvdata_hifiberry_dac = {
 	.dai       = snd_hifiberry_dac_dai,
 };
 
+SND_SOC_DAILINK_DEFS(rpi_dac,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_CODEC("pcm1794a-codec", "pcm1794a-hifi")),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static struct snd_soc_dai_link snd_rpi_dac_dai[] = {
 {
 	.name		= "RPi-DAC",
 	.stream_name	= "RPi-DAC HiFi",
-	.codec_dai_name	= "pcm1794a-hifi",
-	.codec_name	= "pcm1794a-codec",
 	.dai_fmt	= SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
 				SND_SOC_DAIFMT_CBS_CFS,
+	SND_SOC_DAILINK_REG(rpi_dac),
 },
 };
 
@@ -240,8 +260,8 @@ static int snd_rpi_simple_probe(struct platform_device *pdev)
 			return -ENODEV;
 		}
 
-		dai->cpu_of_node = i2s_node;
-		dai->platform_of_node = i2s_node;
+		dai->cpus->of_node = i2s_node;
+		dai->platforms->of_node = i2s_node;
 	}
 
 	ret = devm_snd_soc_register_card(&pdev->dev, &snd_rpi_simple);


### PR DESCRIPTION
There are some build errors in the sound/soc/bcm/ when building the 5.3 kernel.  In the v5.3, the kernel dropped all legacy dai_link stuff, so those drivers can't be built anymore, let us fix them.