### PR TITLE
mcp23017 overlay updates

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1427,6 +1427,7 @@ Params: gpiopin                 Gpio pin connected to the INTA output of the
         addr                    I2C address of the MCP23017 (default: 0x20)
 
         mcp23008                Configure an MCP23008 instead.
+        noints                  Disable the interrupt GPIO line.
 
 
 Name:   mcp23s17

--- a/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
@@ -34,11 +34,6 @@
 				reg = <0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				#interrupt-cells=<2>;
-				interrupt-parent = <&gpio>;
-				interrupts = <4 2>;
-				interrupt-controller;
-				microchip,irq-mirror;
 
 				status = "okay";
 			};
@@ -52,11 +47,25 @@
 		};
 	};
 
+	fragment@4 {
+		target = <&i2c1>;
+		__overlay__ {
+			mcp23017_irq: mcp@20 {
+				#interrupt-cells=<2>;
+				interrupt-parent = <&gpio>;
+				interrupts = <4 2>;
+				interrupt-controller;
+				microchip,irq-mirror;
+			};
+		};
+	};
+
 	__overrides__ {
 		gpiopin = <&mcp23017_pins>,"brcm,pins:0",
-				<&mcp23017>,"interrupts:0";
+				<&mcp23017_irq>,"interrupts:0";
 		addr = <&mcp23017>,"reg:0", <&mcp23017_pins>,"reg:0";
 		mcp23008 = <0>,"=3";
+		noints = <0>,"!1!4";
 	};
 };
 

--- a/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
@@ -16,7 +16,7 @@
 	fragment@1 {
 		target = <&gpio>;
 		__overlay__ {
-			mcp23017_pins: mcp23017_pins {
+			mcp23017_pins: mcp23017_pins@20 {
 				brcm,pins = <4>;
 				brcm,function = <0>;
 			};
@@ -55,7 +55,7 @@
 	__overrides__ {
 		gpiopin = <&mcp23017_pins>,"brcm,pins:0",
 				<&mcp23017>,"interrupts:0";
-		addr = <&mcp23017>,"reg:0";
+		addr = <&mcp23017>,"reg:0", <&mcp23017_pins>,"reg:0";
 		mcp23008 = <0>,"=3";
 	};
 };


### PR DESCRIPTION
Renames the mcp23017_pins node so that we don't get collisions if trying to load it multiple times.

Adds an option for disabling the interrupt GPIO line.