### PR TITLE
Fix two building errors when we build the kernel in the non-src folder

### DIFF
--- a/drivers/char/broadcom/vc_sm/Makefile
+++ b/drivers/char/broadcom/vc_sm/Makefile
@@ -1,5 +1,5 @@
 ccflags-$(CONFIG_BCM_VC_SM) += -Werror -Wall -Wstrict-prototypes -Wno-trigraphs -O2
-ccflags-$(CONFIG_BCM_VC_SM) += -I"drivers/staging/vc04_services" -I"drivers/staging/vc04_services/interface/vchi" -I"drivers/staging/vc04_services/interface/vchiq_arm" -I"fs"
+ccflags-$(CONFIG_BCM_VC_SM) += -I$(srctree)/"drivers/staging/vc04_services" -I$(srctree)/"drivers/staging/vc04_services/interface/vchi" -I$(srctree)/"drivers/staging/vc04_services/interface/vchiq_arm" -I$(srctree)/"fs"
 ccflags-$(CONFIG_BCM_VC_SM) += -DOS_ASSERT_FAILURE -D__STDC_VERSION=199901L -D__STDC_VERSION__=199901L -D__VCCOREVER__=0 -D__KERNEL__ -D__linux__
 
 obj-$(CONFIG_BCM_VC_SM) := vc-sm.o

--- a/drivers/net/wireless/realtek/rtl8192cu/Makefile
+++ b/drivers/net/wireless/realtek/rtl8192cu/Makefile
@@ -16,7 +16,7 @@ EXTRA_CFLAGS += -Wno-unused
 
 EXTRA_CFLAGS += -Wno-uninitialized
 
-EXTRA_CFLAGS += -I$(src)/include
+EXTRA_CFLAGS += -I$(srctree)/$(src)/include
 
 CONFIG_AUTOCFG_CP = n
 


### PR DESCRIPTION
It is because the building process can't find the needed header files. And this already introduced building errors on the branches of 5.2.y and 5.3.y for RPi4, and I guess all branches need these two fixes, it is safe to merge these two patches to base branch then it will apply to all branches automatically?