### PR TITLE
Fix poll rate on touchscreen

### DIFF
--- a/drivers/input/touchscreen/rpi-ft5406.c
+++ b/drivers/input/touchscreen/rpi-ft5406.c
@@ -78,12 +78,12 @@ static int ft5406_thread(void *arg)
 
 	while (!kthread_should_stop()) {
 		/* 60fps polling */
-		msleep_interruptible(17);
+		usleep_range(16600,16700);
+
 		memcpy_fromio(&regs, ts->ts_base, sizeof(struct ft5406_regs));
 		iowrite8(99,
 			 ts->ts_base +
 			 offsetof(struct ft5406_regs, num_points));
-
 		/*
 		 * Do not output if theres no new information (num_points is 99)
 		 * or we have no touch points and don't need to release any

--- a/drivers/input/touchscreen/rpi-ft5406.c
+++ b/drivers/input/touchscreen/rpi-ft5406.c
@@ -79,7 +79,6 @@ static int ft5406_thread(void *arg)
 	while (!kthread_should_stop()) {
 		/* 60fps polling */
 		usleep_range(16600,16700);
-
 		memcpy_fromio(&regs, ts->ts_base, sizeof(struct ft5406_regs));
 		iowrite8(99,
 			 ts->ts_base +

--- a/drivers/input/touchscreen/rpi-ft5406.c
+++ b/drivers/input/touchscreen/rpi-ft5406.c
@@ -84,6 +84,7 @@ static int ft5406_thread(void *arg)
 		iowrite8(99,
 			 ts->ts_base +
 			 offsetof(struct ft5406_regs, num_points));
+
 		/*
 		 * Do not output if theres no new information (num_points is 99)
 		 * or we have no touch points and don't need to release any

--- a/drivers/input/touchscreen/rpi-ft5406.c
+++ b/drivers/input/touchscreen/rpi-ft5406.c
@@ -78,7 +78,7 @@ static int ft5406_thread(void *arg)
 
 	while (!kthread_should_stop()) {
 		/* 60fps polling */
-		usleep_range(16600,16700);
+		usleep_range(16600, 16700);
 		memcpy_fromio(&regs, ts->ts_base, sizeof(struct ft5406_regs));
 		iowrite8(99,
 			 ts->ts_base +


### PR DESCRIPTION
Was running at 25Hz, rather than he expected 60. Only been doing it
for the last 5 years....

Replace msleep_interruptible with usleep_range as the msleep call
is not accurate for times < 20ms.