### PR TITLE
bcm2708_fb: Fix layout of struct vc4_display_settings_t

### DIFF
--- a/drivers/video/fbdev/bcm2708_fb.c
+++ b/drivers/video/fbdev/bcm2708_fb.c
@@ -88,8 +88,8 @@ struct vc4_display_settings_t {
 	u32 display_num;
 	u32 width;
 	u32 height;
-	u32 pitch;
 	u32 depth;
+	u32 pitch;
 	u32 virtual_width;
 	u32 virtual_height;
 	u32 virtual_width_offset;


### PR DESCRIPTION
The display parameters returned by the VC4 firmware in response to the
RPI_FIRMWARE_FRAMEBUFFER_GET_DISPLAY_SETTINGS tag do not match the
layout of struct vc4_display_settings_t: the colour depth and row
pitch are erroneously swapped in the kernel definition.  This can
trigger a kernel warning from pixel_to_pat(), such as:

  pixel_to_pat(): unsupported pixelformat 7296

Fix by adjusting the layout of struct vc4_display_settings_t to match
the layout as used by the VC4 firmware.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>