### PR TITLE
overlays: fix compatible for RPi4

### DIFF
--- a/arch/arm/boot/dts/overlays/i2c3-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c3-overlay.dts
@@ -2,7 +2,7 @@
 /plugin/;
 
 /{
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&i2c3>;

--- a/arch/arm/boot/dts/overlays/i2c4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c4-overlay.dts
@@ -2,7 +2,7 @@
 /plugin/;
 
 /{
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&i2c4>;

--- a/arch/arm/boot/dts/overlays/i2c5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c5-overlay.dts
@@ -2,7 +2,7 @@
 /plugin/;
 
 /{
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&i2c5>;

--- a/arch/arm/boot/dts/overlays/i2c6-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c6-overlay.dts
@@ -2,7 +2,7 @@
 /plugin/;
 
 /{
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&i2c6>;

--- a/arch/arm/boot/dts/overlays/spi3-1cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi3-1cs-overlay.dts
@@ -3,7 +3,7 @@
 
 
 / {
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&spi3_cs_pins>;

--- a/arch/arm/boot/dts/overlays/spi3-2cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi3-2cs-overlay.dts
@@ -3,7 +3,7 @@
 
 
 / {
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&spi3_cs_pins>;

--- a/arch/arm/boot/dts/overlays/spi4-1cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi4-1cs-overlay.dts
@@ -3,7 +3,7 @@
 
 
 / {
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&spi4_cs_pins>;

--- a/arch/arm/boot/dts/overlays/spi4-2cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi4-2cs-overlay.dts
@@ -3,7 +3,7 @@
 
 
 / {
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&spi4_cs_pins>;

--- a/arch/arm/boot/dts/overlays/spi5-1cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi5-1cs-overlay.dts
@@ -3,7 +3,7 @@
 
 
 / {
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&spi5_cs_pins>;

--- a/arch/arm/boot/dts/overlays/spi5-2cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi5-2cs-overlay.dts
@@ -3,7 +3,7 @@
 
 
 / {
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&spi5_cs_pins>;

--- a/arch/arm/boot/dts/overlays/spi6-1cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi6-1cs-overlay.dts
@@ -3,7 +3,7 @@
 
 
 / {
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&spi6_cs_pins>;

--- a/arch/arm/boot/dts/overlays/spi6-2cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi6-2cs-overlay.dts
@@ -3,7 +3,7 @@
 
 
 / {
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&spi6_cs_pins>;

--- a/arch/arm/boot/dts/overlays/uart2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart2-overlay.dts
@@ -2,7 +2,7 @@
 /plugin/;
 
 /{
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&uart2>;

--- a/arch/arm/boot/dts/overlays/uart3-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart3-overlay.dts
@@ -2,7 +2,7 @@
 /plugin/;
 
 /{
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&uart3>;

--- a/arch/arm/boot/dts/overlays/uart4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart4-overlay.dts
@@ -2,7 +2,7 @@
 /plugin/;
 
 /{
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&uart4>;

--- a/arch/arm/boot/dts/overlays/uart5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart5-overlay.dts
@@ -2,7 +2,7 @@
 /plugin/;
 
 /{
-	compatible = "brcm,bcm2838";
+	compatible = "brcm,bcm2711";
 
 	fragment@0 {
 		target = <&uart5>;


### PR DESCRIPTION
RPi4 compatible is now bcm2711, but some overlays refer to the SoC as
bcm2838. Fix this overlays as they otherwise won't apply.

This should also go into rpi-5.2.y and rpi-5.3.y