### PR TITLE
pcie-brcmstb-bounce64.c: dev_err() -> dev_info() for info messages

### DIFF
--- a/drivers/pci/controller/pcie-brcmstb-bounce64.c
+++ b/drivers/pci/controller/pcie-brcmstb-bounce64.c
@@ -524,7 +524,7 @@ int brcm_pcie_bounce_init(struct device *dev,
 
 	g_dmabounce_device_info = device_info;
 
-	dev_err(dev, "dmabounce: initialised - %ld kB, threshold %pad\n",
+	dev_info(dev, "dmabounce: initialised - %ld kB, threshold %pad\n",
 		 buffer_size / 1024, &threshold);
 
 	return 0;


### PR DESCRIPTION
"dmabounce: initialised" is not an error, so do not log it as such.
Prevents screen polution on OS with "quiet" as kernel parameter.

Closes #3266