### PR TITLE
bcm2711: Retain support for old DTBs

### DIFF
--- a/arch/arm/mach-bcm/board_bcm2835.c
+++ b/arch/arm/mach-bcm/board_bcm2835.c
@@ -119,6 +119,8 @@ static const char * const bcm2835_compat[] = {
 	"brcm,bcm2836",
 	"brcm,bcm2837",
 	"brcm,bcm2711",
+	// Temporary, for backwards-compatibility with old DTBs
+	"brcm,bcm2838",
 #endif
 	NULL
 };

--- a/drivers/clk/bcm/clk-bcm2835.c
+++ b/drivers/clk/bcm/clk-bcm2835.c
@@ -2396,6 +2396,8 @@ static const struct cprman_plat_data cprman_bcm2711_plat_data = {
 static const struct of_device_id bcm2835_clk_of_match[] = {
 	{ .compatible = "brcm,bcm2835-cprman", .data = &cprman_bcm2835_plat_data },
 	{ .compatible = "brcm,bcm2711-cprman", .data = &cprman_bcm2711_plat_data },
+	// Temporary, for backwards-compatibility with old DTBs
+	{ .compatible = "brcm,bcm2838-cprman", .data = &cprman_bcm2711_plat_data },
 	{}
 };
 MODULE_DEVICE_TABLE(of, bcm2835_clk_of_match);

--- a/drivers/pinctrl/bcm/pinctrl-bcm2835.c
+++ b/drivers/pinctrl/bcm/pinctrl-bcm2835.c
@@ -1079,6 +1079,11 @@ static const struct of_device_id bcm2835_pinctrl_match[] = {
 		.compatible = "brcm,bcm2711-gpio",
 		.data = &bcm2711_pinconf_ops,
 	},
+	// Temporary, for backwards-compatibility with old DTBs
+	{
+		.compatible = "brcm,bcm2838-gpio",
+		.data = &bcm2711_pinconf_ops,
+	},
 	{}
 };
 


### PR DESCRIPTION
The recent series switching to bcm2711 as the DT identifier broke Pis
running with old DTBs. Add some bcm2838 compatible strings as a
temporary measure, at least until the next full Raspbian image with
bcm2711 DTBs.

Signed-off-by: Phil Elwell <phil@raspberrypi.org>