### PR TITLE
drm:vc4 Added calls for firmware display blank/unblank

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -91,6 +91,12 @@ struct mailbox_blank_display {
 	u32 blank;
 };
 
+struct mailbox_display_pwr {
+	struct rpi_firmware_property_tag_header tag1;
+	u32 display;
+	u32 state;
+};
+
 struct mailbox_get_edid {
 	struct rpi_firmware_property_tag_header tag1;
 	u32 block;
@@ -272,6 +278,7 @@ struct vc4_fkms_encoder {
 	struct drm_encoder base;
 	bool hdmi_monitor;
 	bool rgb_range_selectable;
+	int display_num;
 };
 
 static inline struct vc4_fkms_encoder *
@@ -1613,13 +1620,29 @@ static const struct drm_encoder_funcs vc4_fkms_encoder_funcs = {
 	.destroy = vc4_fkms_encoder_destroy,
 };
 
+static void vc4_fkms_display_power(struct drm_encoder *encoder, bool power)
+{
+	struct vc4_fkms_encoder *vc4_encoder = to_vc4_fkms_encoder(encoder);
+	struct vc4_dev *vc4 = to_vc4_dev(encoder->dev);
+
+	struct mailbox_display_pwr pwr = {
+		.tag1 = {RPI_FIRMWARE_SET_DISPLAY_POWER, 8, 0, },
+		.display = vc4_encoder->display_num,
+		.state = power ? 1 : 0,
+	};
+
+	rpi_firmware_property_list(vc4->firmware, &pwr, sizeof(pwr));
+}
+
 static void vc4_fkms_encoder_enable(struct drm_encoder *encoder)
 {
+	vc4_fkms_display_power(encoder, true);
 	DRM_DEBUG_KMS("Encoder_enable\n");
 }
 
 static void vc4_fkms_encoder_disable(struct drm_encoder *encoder)
 {
+	vc4_fkms_display_power(encoder, false);
 	DRM_DEBUG_KMS("Encoder_disable\n");
 }
 
@@ -1695,6 +1718,8 @@ static int vc4_fkms_create_screen(struct device *dev, struct drm_device *drm,
 	if (!vc4_encoder)
 		return -ENOMEM;
 	vc4_crtc->encoder = &vc4_encoder->base;
+
+	vc4_encoder->display_num = display_ref;
 	vc4_encoder->base.possible_crtcs |= drm_crtc_mask(crtc) ;
 
 	drm_encoder_init(drm, &vc4_encoder->base, &vc4_fkms_encoder_funcs,

--- a/include/soc/bcm2835/raspberrypi-firmware.h
+++ b/include/soc/bcm2835/raspberrypi-firmware.h
@@ -155,7 +155,7 @@ enum rpi_firmware_property_tag {
 	RPI_FIRMWARE_GET_DISPLAY_TIMING =                     0x00040017,
 	RPI_FIRMWARE_SET_TIMING =                             0x00048017,
 	RPI_FIRMWARE_GET_DISPLAY_CFG =                        0x00040018,
-
+	RPI_FIRMWARE_SET_DISPLAY_POWER =		      0x00048019,
 	RPI_FIRMWARE_GET_COMMAND_LINE =                       0x00050001,
 	RPI_FIRMWARE_GET_DMA_CHANNELS =                       0x00060001,
 };


### PR DESCRIPTION
Requires new display power mailbox call to be present.

Signed-off-by: James Hughes <james.hughes@raspberrypi.org>