### PR TITLE
ALSA: usb-audio: Add Gustard U16/X26 to quirks for native DSD support

### DIFF
--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -1369,6 +1369,7 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
 	case USB_ID(0x22d9, 0x0461): /* OPPO UDP-205 */
 	case USB_ID(0x2522, 0x0012): /* LH Labs VI DAC Infinity */
 	case USB_ID(0x2772, 0x0230): /* Pro-Ject Pre Box S2 Digital */
+ 	case USB_ID(0x292b, 0xc4b3): /* Gustard U16/X26 USB Interface */	
 		if (fp->altsetting == 2)
 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
 		break;


### PR DESCRIPTION
ALSA: usb-audio: Add Gustard U16/X26 to quirks for native DSD support