### PR TITLE
Amend init order of TPM and IMA modules

### DIFF
--- a/drivers/clk/bcm/clk-bcm2835.c
+++ b/drivers/clk/bcm/clk-bcm2835.c
@@ -2414,7 +2414,7 @@ static int __init __bcm2835_clk_driver_init(void)
 {
 	return platform_driver_register(&bcm2835_clk_driver);
 }
-core_initcall(__bcm2835_clk_driver_init);
+subsys_initcall(__bcm2835_clk_driver_init);
 
 MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
 MODULE_DESCRIPTION("BCM2835 clock driver");

--- a/drivers/clk/bcm/clk-bcm2835.c
+++ b/drivers/clk/bcm/clk-bcm2835.c
@@ -2414,7 +2414,7 @@ static int __init __bcm2835_clk_driver_init(void)
 {
 	return platform_driver_register(&bcm2835_clk_driver);
 }
-subsys_initcall(__bcm2835_clk_driver_init);
+postcore_initcall(__bcm2835_clk_driver_init);
 
 MODULE_AUTHOR("Eric Anholt <eric@anholt.net>");
 MODULE_DESCRIPTION("BCM2835 clock driver");

--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -394,7 +394,7 @@ out2:
 out1:
 	return ret;
 }
-subsys_initcall(rpi_firmware_init);
+core_initcall(rpi_firmware_init);
 
 static void __init rpi_firmware_exit(void)
 {


### PR DESCRIPTION
This change seeks to correct the load order of a TPM and
IMA (Integrity Measurement Architecture).

Currently IMA loads first, which results in it not seeing the TPM
and using the TPM as a means to store measurements.

The order of `core_initcall` and `subsys_initcall` are reversed
within `drivers/clk/bcm/clk-bcm2835.c` and
`drivers/firmware/raspberrypi.c` to achieve this.

Resolves: #3291
Signed-off-by: Luke Hinds <lhinds@redhat.com>