### PR TITLE
xen: swiotlb-xen.c Support of DMA transfers for devices which dma_pfn…

### DIFF
--- a/drivers/xen/swiotlb-xen.c
+++ b/drivers/xen/swiotlb-xen.c
@@ -589,7 +589,7 @@ xen_swiotlb_map_sg_attrs(struct device *hwdev, struct scatterlist *sgl,
 						sg->length,
 						dir,
 						attrs);
-			sg->dma_address = dev_addr;
+			sg->dma_address = phys_to_dma(hwdev, dev_addr);
 		} else {
 			/* we are not interested in the dma_addr returned by
 			 * xen_dma_map_page, only in the potential cache flushes executed
@@ -600,7 +600,7 @@ xen_swiotlb_map_sg_attrs(struct device *hwdev, struct scatterlist *sgl,
 						sg->length,
 						dir,
 						attrs);
-			sg->dma_address = dev_addr;
+			sg->dma_address = phys_to_dma(hwdev, dev_addr);
 		}
 		sg_dma_len(sg) = sg->length;
 	}


### PR DESCRIPTION
…_offset != 0 (like 802.11 functionality by BCM43455)

Signed-off-by: Nataliya Korovkina <malus.brandywine@gmail.com>