### PR TITLE
build,ci: add minimal Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: c
+
+os: linux
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+
+env:
+  matrix:
+  - DEFCONFIG=bcm2709_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+  - DEFCONFIG=bcm2711_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+  - DEFCONFIG=bcm2835_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+  - DEFCONFIG=bcm2711_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
+
+script:
+  - ./ci/travis/run-build-docker.sh

--- a/ci/travis/lib.sh
+++ b/ci/travis/lib.sh
@@ -1,0 +1,51 @@
+#!/bin/sh -e
+
+echo_red()   { printf "\033[1;31m$*\033[m\n"; }
+echo_green() { printf "\033[1;32m$*\033[m\n"; }
+echo_blue()  { printf "\033[1;34m$*\033[m\n"; }
+
+command_exists() {
+	local cmd=$1
+	[ -n "$cmd" ] || return 1
+	type "$cmd" >/dev/null 2>&1
+}
+
+prepare_docker_image() {
+	local DOCKER_IMAGE="$1"
+	sudo apt-get -qq update
+	echo 'DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock -s devicemapper"' | sudo tee /etc/default/docker > /dev/null
+	sudo service docker restart
+	sudo docker pull "$DOCKER_IMAGE"
+}
+
+run_docker_script() {
+	local DOCKER_SCRIPT="$1"
+	local DOCKER_IMAGE="$2"
+	local OS_TYPE="$3"
+	local MOUNTPOINT="${4:-docker_build_dir}"
+	sudo docker run --rm=true \
+		-v "$(pwd):/${MOUNTPOINT}:rw" \
+		$DOCKER_IMAGE \
+		/bin/bash -e "/${MOUNTPOINT}/${DOCKER_SCRIPT}" "${MOUNTPOINT}" "${OS_TYPE}"
+}
+
+ensure_command_exists() {
+	local cmd="$1"
+	local package="$2"
+	[ -n "$cmd" ] || return 1
+	[ -n "$package" ] || package="$cmd"
+	! command_exists "$cmd" || return 0
+	# go through known package managers
+	for pacman in apt-get brew yum ; do
+		command_exists $pacman || continue
+		$pacman install -y $package || {
+			# Try an update if install doesn't work the first time
+			$pacman -y update && \
+				$pacman install -y $package
+		}
+		return $?
+	done
+	return 1
+}
+
+ensure_command_exists sudo

--- a/ci/travis/run-build-docker.sh
+++ b/ci/travis/run-build-docker.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+. ./ci/travis/lib.sh
+
+# Env-vars to pass to the docker image, should they be defined
+ENV_VARS="BUILD_TYPE DEFCONFIG ARCH CROSS_COMPILE DTS_FILES IMAGE"
+
+if [ "$DO_NOT_DOCKERIZE" = "1" ] ; then
+	. ./ci/travis/run-build.sh
+else
+	TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR:-.}"
+
+	# cd to docker build dir if it exists
+	if [ -d /docker_build_dir ] ; then
+		cd /docker_build_dir
+		TRAVIS_BUILD_DIR="/docker_build_dir"
+	fi
+
+	cat /dev/null > "${TRAVIS_BUILD_DIR}/env"
+	BUILD_TYPE=${BUILD_TYPE:-default}
+	for env in $ENV_VARS ; do
+		val="$(eval echo "\$${env}")"
+		if [ -n "$val" ] ; then
+			echo "export ${env}=${val}" >> "${TRAVIS_BUILD_DIR}/env"
+		fi
+	done
+	prepare_docker_image "ubuntu:rolling"
+	run_docker_script "./ci/travis/run-build.sh" "ubuntu:rolling"
+fi

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+
+TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR:-.}"
+
+# cd to docker build dir if it exists
+if [ -d /docker_build_dir ] ; then
+	cd /docker_build_dir
+	TRAVIS_BUILD_DIR="/docker_build_dir"
+fi
+
+. ./ci/travis/lib.sh
+
+if [ -f "${TRAVIS_BUILD_DIR}/env" ] ; then
+	echo_blue "Loading environment variables"
+	cat "${TRAVIS_BUILD_DIR}/env"
+	. "${TRAVIS_BUILD_DIR}/env"
+fi
+
+KCFLAGS="-Werror"
+export KCFLAGS
+
+APT_LIST="build-essential bc u-boot-tools flex bison libssl-dev"
+
+if [ "$ARCH" == "arm64" ] ; then
+	APT_LIST="$APT_LIST gcc-aarch64-linux-gnu"
+else
+	APT_LIST="$APT_LIST gcc-arm-linux-gnueabihf"
+fi
+
+adjust_kcflags_against_gcc() {
+	# FIXME: remove this function once kernel gets upgrade and
+	#        these have been fixed upstream. Currently, these are
+	#	 for kernel 4.19
+	GCC="${CROSS_COMPILE}gcc"
+	if [ "$($GCC -dumpversion | cut -d. -f1)" -ge "8" ]; then
+		KCFLAGS="$KCFLAGS -Wno-error=stringop-truncation"
+		KCFLAGS="$KCFLAGS -Wno-error=packed-not-aligned"
+		KCFLAGS="$KCFLAGS -Wno-error=stringop-overflow= -Wno-error=sizeof-pointer-memaccess"
+		KCFLAGS="$KCFLAGS -Wno-error=missing-attributes"
+	fi
+
+	if [ "$($GCC -dumpversion | cut -d. -f1)" -ge "9" ]; then
+		KCFLAGS="$KCFLAGS -Wno-error=address-of-packed-member -Wno-error=stringop-truncation"
+	fi
+	export KCFLAGS
+}
+
+apt_update_install() {
+	sudo -s <<-EOF
+		apt-get -qq update
+		apt-get -y install $@
+	EOF
+	adjust_kcflags_against_gcc
+}
+
+build_default() {
+	apt_update_install $APT_LIST
+	make ${DEFCONFIG}
+	make -j`getconf _NPROCESSORS_ONLN`
+}
+
+ORIGIN=${ORIGIN:-origin}
+
+BUILD_TYPE=${BUILD_TYPE:-${1}}
+BUILD_TYPE=${BUILD_TYPE:-default}
+
+build_${BUILD_TYPE}


### PR DESCRIPTION
This change adds a minimal build via Travis-CI. Lately, when
upstreaming patches, we get a lot of reports back (from Kernel-CI and
Intel's lkp bot) about [valid] faults in the code we submit. A lot of them
are caught by newer GCC compilers (GCC 8 & 9).

We also have a branch with rpi-4.19.y, on top of which we add our own
patches:
  https://github.com/analogdevicesinc/linux/tree/rpi-4.19.y

When enabling warnings-as-errors, some of the warnings [caught by GCC] are
not our own, and on the rpi-4.x.y branches the code differs from upstream.

This proposal, adds Travis-CI build with the newest Ubuntu (currently
19.10) docker image; but, since it's the rolling version, this should
update as time goes by, and should have a pretty new GCC compiler.
Travis-CI is a popular CI integration on Github, and helps with
build-visibility.

The intent is to have these warnings handled by the RPi project, so that we
don't have to patch too much downstream. Many of the warnings [that GCC
reports] are reasonable.

This change is an adaption from the scripts we use here:
  https://github.com/analogdevicesinc/linux/tree/master/ci/travis
  https://github.com/analogdevicesinc/libiio/blob/master/CI/travis/lib.sh

Note that this change adds the build stuff. It doesn't do any fixes to the
warnings. That is subject to another set of discussions/proposals, should
this be accepted.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>