### PR TITLE
video: bcm2708_fb Add power down to screen blanking

### DIFF
--- a/drivers/video/fbdev/bcm2708_fb.c
+++ b/drivers/video/fbdev/bcm2708_fb.c
@@ -521,6 +521,21 @@ static int bcm2708_fb_blank(int blank_mode, struct fb_info *info)
 	ret = rpi_firmware_property(fb->fbdev->fw, RPI_FIRMWARE_FRAMEBUFFER_BLANK,
 				    &value, sizeof(value));
 
+	if (!ret && (blank_mode == FB_BLANK_POWERDOWN ||
+	    blank_mode == FB_BLANK_UNBLANK)) {
+		u32 buf[2] = {fb->display_settings.display_num,
+			      blank_mode == FB_BLANK_POWERDOWN ? 0 : 1};
+
+		/* Convert display number to a display id in place */
+		ret = rpi_firmware_property(fb->fbdev->fw,
+					    RPI_FIRMWARE_GET_DISPLAY_ID,
+					    buf, sizeof(u32));
+
+		ret = rpi_firmware_property(fb->fbdev->fw,
+					    RPI_FIRMWARE_SET_DISPLAY_POWER,
+					    buf, sizeof(buf));
+	}
+
 	if (ret)
 		dev_err(info->device, "%s(%d) failed: %d\n", __func__,
 			blank_mode, ret);

--- a/include/soc/bcm2835/raspberrypi-firmware.h
+++ b/include/soc/bcm2835/raspberrypi-firmware.h
@@ -152,6 +152,7 @@ enum rpi_firmware_property_tag {
 	RPI_FIRMWARE_VCHIQ_INIT =                             0x00048010,
 
 	RPI_FIRMWARE_SET_PLANE =                              0x00048015,
+	RPI_FIRMWARE_GET_DISPLAY_ID =			      0x00040016,
 	RPI_FIRMWARE_GET_DISPLAY_TIMING =                     0x00040017,
 	RPI_FIRMWARE_SET_TIMING =                             0x00048017,
 	RPI_FIRMWARE_GET_DISPLAY_CFG =                        0x00040018,


### PR DESCRIPTION
The FB_BLANK_POWERDOWN operation now calls the new power
down code in the firmware to correctly power down the specified
display. And conversely FB_BLANK_UNBLANK powers back up.

Signed-off-by: James Hughes <james.hughes@raspberrypi.org>