### PR TITLE
overlays: smi: fix typo in comment

### DIFF
--- a/arch/arm/boot/dts/overlays/smi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/smi-overlay.dts
@@ -24,7 +24,7 @@
 				   these are already used as ID_SD and ID_SC */
 				brcm,pins = <2 3 4 5 6 7 8 9 10 11 12 13 14 15
 					     16 17 18 19 20 21 22 23 24 25>;
-				/* Alt 0: SMI */
+				/* Alt 1: SMI */
 				brcm,function = <5 5 5 5 5 5 5 5 5 5 5 5 5 5 5
 						 5 5 5 5 5 5 5 5 5>;
 				/* /CS, /WE and /OE are pulled high, as they are


### PR DESCRIPTION
5 represent alt1 function not alt0.

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>