### PR TITLE
UAC audio for quectel modem

### DIFF
--- a/drivers/usb/serial/option.c
+++ b/drivers/usb/serial/option.c
@@ -2064,6 +2064,10 @@ static int option_probe(struct usb_serial *serial,
 	 */
 	if (device_flags & NUMEP2 && iface_desc->bNumEndpoints != 2)
 		return -ENODEV;
+	
+	/* Quectel interface 4 can be used as UAC */
+	if (serial->dev->descriptor.idVendor == cpu_to_le16(QUECTEL_VENDOR_ID) && serial->interface->cur_altsetting->desc.bInterfaceNumber >= 4)
+	return -ENODEV;
 
 	/* Store the device flags so we can use them during attach. */
 	usb_set_serial_data(serial, (void *)device_flags);


### PR DESCRIPTION
To complete quectel modems drivers, this enable usb audio UAC, from quectel docs.
NOTES:
- Can be a security problem ? As far as I know, the uac audio mode still need something like alsaloop to recieve and send audio. But can an uac device "enable it self" and listen from microphone ?
- I found the same code to also help QMI drivers along with other code (already?) in the qmi_wwan.c file.