### PR TITLE
arm: dts: overlays: pitft35-resistive: add upstream compatible

### DIFF
--- a/arch/arm/boot/dts/overlays/pitft35-resistive-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pitft35-resistive-overlay.dts
@@ -49,7 +49,7 @@
 			#size-cells = <0>;
 
 			pitft: pitft@0{
-				compatible = "himax,hx8357d";
+				compatible = "himax,hx8357d", "adafruit,yx350hv15";
 				reg = <0>;
 				pinctrl-names = "default";
 				pinctrl-0 = <&pitft_pins>;


### PR DESCRIPTION
The upstream hx8357d driver uses "adafruit,yx350hv15" for the compatible
string explicitly for this screen config and not a hx8357d generic for
the controller so add that in as well so it will work with an unmodified
upstream kernel driver. We leave the downstream as the priority.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>