### PR TITLE
Relax condition on msg parameter

### DIFF
--- a/drivers/char/broadcom/vc_sm/vc_vchi_sm.c
+++ b/drivers/char/broadcom/vc_sm/vc_vchi_sm.c
@@ -389,7 +389,7 @@ static int vc_vchi_sm_send_msg(struct sm_instance *handle,
 		pr_err("%s: invalid handle", __func__);
 		return -EINVAL;
 	}
-	if (msg == NULL) {
+	if (msg == NULL && msg_size > 0) {
 		pr_err("%s: invalid msg pointer", __func__);
 		return -EINVAL;
 	}


### PR DESCRIPTION
Relax condition on msg parameter or vc_vchi_sm_walk_alloc will fail and that will causevcsm_status (VCSM_STATUS_VC_WALK_ALLOC, -1) to fail.