### PR TITLE
[5.4] rpi-cirrus-wm5102-overlay: fix pinctrl configuration

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-cirrus-wm5102-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cirrus-wm5102-overlay.dts
@@ -18,19 +18,31 @@
 	fragment@1 {
 		target = <&gpio>;
 		__overlay__ {
-			wlf_pins: wlf_pins {
-				brcm,pins = <17 22 27 8>;
+			wlf_5102_pins: wlf_5102_pins {
+				brcm,pins = <17 22 27>;
 				brcm,function = <
 					BCM2835_FSEL_GPIO_OUT
 					BCM2835_FSEL_GPIO_OUT
 					BCM2835_FSEL_GPIO_IN
-					BCM2835_FSEL_GPIO_OUT
 				>;
+			};
+			wlf_8804_pins: wlf_8804_pins {
+				brcm,pins = <8>;
+				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 			};
 		};
 	};
 
 	fragment@2 {
+		target = <&spi0_cs_pins>;
+		__overlay__ {
+			brcm,pins = <7>;
+			brcm,function = <BCM2835_FSEL_GPIO_OUT>;
+		};
+	};
+
+
+	fragment@3 {
 		target-path = "/";
 		__overlay__ {
 			rpi_cirrus_reg_1v8: rpi_cirrus_reg_1v8 {
@@ -43,30 +55,34 @@
 		};
 	};
 
-	fragment@3 {
+	fragment@4 {
 		target = <&spidev0>;
 		__overlay__ {
 			status = "disabled";
 		};
 	};
 
-	fragment@4 {
+	fragment@5 {
 		target = <&spidev1>;
 		__overlay__ {
 			status = "disabled";
 		};
 	};
 
-	fragment@5 {
+	fragment@6 {
 		target = <&spi0>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
+			cs-gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
 
-			wm5102@1{
+			wm5102@0{
 				compatible = "wlf,wm5102";
-				reg = <1>;
+				reg = <0>;
+
+				pinctrl-names = "default";
+				pinctrl-0 = <&wlf_5102_pins>;
 
 				spi-max-frequency = <500000>;
 
@@ -123,7 +139,7 @@
 		};
 	};
 
-	fragment@6 {
+	fragment@7 {
 		target = <&i2c1>;
 		__overlay__ {
 			status = "okay";
@@ -134,6 +150,10 @@
 				compatible = "wlf,wm8804";
 				reg = <0x3b>;
 				status = "okay";
+
+				pinctrl-names = "default";
+				pinctrl-0 = <&wlf_8804_pins>;
+
 				PVDD-supply = <&vdd_3v3_reg>;
 				DVDD-supply = <&vdd_3v3_reg>;
 				wlf,reset-gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
@@ -141,7 +161,7 @@
 		};
 	};
 
-	fragment@7 {
+	fragment@8 {
 		target = <&sound>;
 		__overlay__ {
 			compatible = "wlf,rpi-cirrus";


### PR DESCRIPTION
Separate GPIOs connected to wm5102 and wm8804 into 2 pinctrl
blocks and properly reference them from the DT nodes to have
correct pinmux owners.

Setup spi0 to use only one CS line on GPIO7 so that GPIO8 is
no longer claimed by spi0 but can be used by wm8804.