### PR TITLE
5.4: V4L2 codecs fixes

### DIFF
--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -3195,6 +3195,12 @@ vchiq_register_child(struct platform_device *pdev, const char *name)
 		child = NULL;
 	}
 
+	/*
+	 * We want the dma-ranges etc to be copied from the parent VCHIQ device
+	 * to be passed on to the children too.
+	 */
+	of_dma_configure(&new_dev->dev, pdev->dev.of_node, true);
+
 	return child;
 }
 

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -3181,6 +3181,7 @@ vchiq_register_child(struct platform_device *pdev, const char *name)
 {
 	struct platform_device_info pdevinfo;
 	struct platform_device *child;
+	struct device_node *np;
 
 	memset(&pdevinfo, 0, sizeof(pdevinfo));
 
@@ -3196,10 +3197,20 @@ vchiq_register_child(struct platform_device *pdev, const char *name)
 	}
 
 	/*
-	 * We want the dma-ranges etc to be copied from the parent VCHIQ device
-	 * to be passed on to the children too.
+	 * We want the dma-ranges etc to be copied from a device with the
+	 * correct dma-ranges for the VPU.
+	 * VCHIQ on Pi4 is now under scb which doesn't get those dma-ranges.
+	 * Take the "dma" node as going to be suitable as it sees the world
+	 * through the same eyes as the VPU.
 	 */
-	of_dma_configure(&new_dev->dev, pdev->dev.of_node, true);
+	np = of_find_node_by_path("dma");
+	if (!np)
+		np = pdev->dev.of_node;
+
+	of_dma_configure(&child->dev, np, true);
+
+	if (np != pdev->dev.of_node)
+		of_node_put(np);
 
 	return child;
 }

--- a/drivers/staging/vc04_services/vchiq-mmal/mmal-vchiq.c
+++ b/drivers/staging/vc04_services/vchiq-mmal/mmal-vchiq.c
@@ -268,8 +268,6 @@ static void buffer_work_cb(struct work_struct *work)
 	if (!buffer->cmd)
 		atomic_dec(&msg_context->u.bulk.port->buffers_with_vpu);
 
-	atomic_dec(&msg_context->u.bulk.port->buffers_with_vpu);
-
 	msg_context->u.bulk.port->buffer_cb(msg_context->u.bulk.instance,
 					    msg_context->u.bulk.port,
 					    msg_context->u.bulk.status,


### PR DESCRIPTION
Two changes to fix the dma-ranages (I thought these had been merged to 5.3, but it appears not).

One which reverts a bad merge.