### PR TITLE
Add universal device tree overlay for SPI devices

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -15,6 +15,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	allo-katana-dac-audio.dtbo \
 	allo-piano-dac-pcm512x-audio.dtbo \
 	allo-piano-dac-plus-pcm512x-audio.dtbo \
+	anyspi.dtbo \
 	apds9960.dtbo \
 	applepi-dac.dtbo \
 	at86rf233.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -441,6 +441,29 @@ Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
                                 better voice quality. (default Off)
 
 
+Name:   anyspi
+Info:   Universal device tree overlay for SPI devices
+
+        Just specify the SPI address and device name ("compatible" property).
+        This overlay lacks any device-specific parameter support!
+
+        For devices on spi1 or spi2, the interfaces should be enabled
+        with one of the spi1-1/2/3cs and/or spi2-1/2/3cs overlays.
+
+        Examples:
+        1. SPI NOR flash on spi0.1, maximum SPI clock frequency 45MHz:
+            dtoverlay=anyspi:spi0-1,dev="jedec,spi-nor",hz=45000000
+        2. MCP3204 ADC on spi1.2, maximum SPI clock frequency 500kHz:
+            dtoverlay=anyspi:spi1-2,dev="microchip,mcp3204"
+Load:   dtoverlay=anyspi,<param>=<val>
+Params: spi<n>-<m>              configure device at spi<n>, cs<m>
+                                (boolean, required)
+        dev                     set device name to search compatible module
+                                (string, required)
+        hz                      maximum SPI clock frequency
+                                (integer, optional, default 500000)
+
+
 Name:   apds9960
 Info:   Configures the AVAGO APDS9960 digital proximity, ambient light, RGB and
         gesture sensor

--- a/arch/arm/boot/dts/overlays/anyspi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/anyspi-overlay.dts
@@ -1,0 +1,205 @@
+/*
+ * Universal device tree overlay for SPI devices
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev1>;
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target-path = "spi1/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target-path = "spi1/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target-path = "spi1/spidev@2";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@5 {
+		target-path = "spi2/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@6 {
+		target-path = "spi2/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@7 {
+		target-path = "spi2/spidev@2";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@8 {
+		target = <&spi0>;
+		__dormant__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			anyspi_00: anyspi@0 {
+				reg = <0>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	fragment@9 {
+		target = <&spi0>;
+		__dormant__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			anyspi_01: anyspi@1 {
+				reg = <1>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	fragment@10 {
+		target = <&spi1>;
+		__dormant__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			anyspi_10: anyspi@0 {
+				reg = <0>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	fragment@11 {
+		target = <&spi1>;
+		__dormant__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			anyspi_11: anyspi@1 {
+				reg = <1>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	fragment@12 {
+		target = <&spi1>;
+		__dormant__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			anyspi_12: anyspi@2 {
+				reg = <2>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	fragment@13 {
+		target = <&spi2>;
+		__dormant__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			anyspi_20: anyspi@0 {
+				reg = <0>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	fragment@14 {
+		target = <&spi2>;
+		__dormant__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			anyspi_21: anyspi@1 {
+				reg = <1>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	fragment@15 {
+		target = <&spi2>;
+		__dormant__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			anyspi_22: anyspi@2 {
+				reg = <2>;
+				spi-max-frequency = <500000>;
+			};
+		};
+	};
+
+	__overrides__ {
+		spi0-0 = <0>, "+0+8";
+		spi0-1 = <0>, "+1+9";
+		spi1-0 = <0>, "+2+10";
+		spi1-1 = <0>, "+3+11";
+		spi1-2 = <0>, "+4+12";
+		spi2-0 = <0>, "+5+13";
+		spi2-1 = <0>, "+6+14";
+		spi2-2 = <0>, "+7+15";
+		hz = <&anyspi_00>, "spi-max-frequency:0",
+		     <&anyspi_01>, "spi-max-frequency:0",
+		     <&anyspi_10>, "spi-max-frequency:0",
+		     <&anyspi_11>, "spi-max-frequency:0",
+		     <&anyspi_12>, "spi-max-frequency:0",
+		     <&anyspi_20>, "spi-max-frequency:0",
+		     <&anyspi_21>, "spi-max-frequency:0",
+		     <&anyspi_22>, "spi-max-frequency:0";
+		dev = <&anyspi_00>,"compatible",
+		      <&anyspi_01>,"compatible",
+		      <&anyspi_10>,"compatible",
+		      <&anyspi_11>,"compatible",
+		      <&anyspi_12>,"compatible",
+		      <&anyspi_20>,"compatible",
+		      <&anyspi_21>,"compatible",
+		      <&anyspi_22>,"compatible";
+	};
+};


### PR DESCRIPTION
Just specify the SPI address and device name ("compatible" property).
This overlay lacks any device-specific parameter support!
(some of them could be added later, e.g. "m25p,fast-read" for spi-nor)

Examples:
1. SPI NOR flash on spi0.1, maximum SPI clock frequency 45MHz:
    `dtoverlay=anyspi:spi0-1,dev="jedec,spi-nor",hz=45000000`
2. MCP3204 ADC on spi1.2, maximum SPI clock frequency 500kHz:
    `dtoverlay=anyspi:spi1-2,dev="microchip,mcp3204"`

I've tested these examples with both config.txt dtoverlay command and standalone dtoverlay utility.