### PR TITLE
WIP: drm/vc4: Pass an update_id to the fw to return on completion

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -766,12 +766,6 @@ static int unicam_all_nodes_streaming(struct unicam_device *dev)
 	return ret;
 }
 
-static int unicam_all_nodes_disabled(struct unicam_device *dev)
-{
-	return !dev->node[IMAGE_PAD].streaming &&
-	       !dev->node[METADATA_PAD].streaming;
-}
-
 static void unicam_queue_event_sof(struct unicam_device *unicam)
 {
 	struct v4l2_event event = {
@@ -800,15 +794,6 @@ static irqreturn_t unicam_isr(int irq, void *dev)
 	int ista, sta;
 	u64 ts;
 	int i;
-
-	/*
-	 * Don't service interrupts if not streaming.
-	 * Avoids issues if the VPU should enable the
-	 * peripheral without the kernel knowing (that
-	 * shouldn't happen, but causes issues if it does).
-	 */
-	if (unicam_all_nodes_disabled(unicam))
-		return IRQ_HANDLED;
 
 	sta = reg_read(cfg, UNICAM_STA);
 	/* Write value back to clear the interrupts */


### PR DESCRIPTION
This should allow KMS to return the events correctly for
page flip completions.

ISSUE SEEN: On quiting X there appears to be a mode change
that is timing out because we aren't returning a completion.
I'm wondering if this is due to kicking off the mode change
when the update is still active, resulting in the fw never
giving us the appropriate callback.
DRM has a 10sec timeout which clears the issue, but it isn't
clean at present.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>