### PR TITLE
[5.4] rpi-cirrus-wm5102-overlay: use reset-gpios instead of wlf,reset

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-cirrus-wm5102-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cirrus-wm5102-overlay.dts
@@ -104,7 +104,7 @@
 				SPKVDDR-supply = <&vdd_5v0_reg>;
 				DCVDD-supply = <&arizona_ldo1>;
 
-				wlf,reset = <&gpio 17 GPIO_ACTIVE_HIGH>;
+				reset-gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
 				wlf,ldoena = <&gpio 22 GPIO_ACTIVE_HIGH>;
 				wlf,gpio-defaults = <
 					ARIZONA_GP_DEFAULT


### PR DESCRIPTION
wlf,reset has been deprecated in favour of the standard reset-gpios
DT property in commit fced2963d84b44990f4aa99ed7268223c294c0df so
let's use that instead of the old property.
