### PR TITLE
Fixup rpimem to cleanly unload and reload, and make checkpatch clean.

### DIFF
--- a/drivers/char/broadcom/rpivid-mem.c
+++ b/drivers/char/broadcom/rpivid-mem.c
@@ -66,6 +66,7 @@ static int rpivid_mem_open(struct inode *inode, struct file *file)
 	int dev = iminor(inode);
 	int ret = 0;
 	struct rpivid_mem_priv *priv;
+
 	if (dev != DEVICE_MINOR && dev != DEVICE_MINOR + 1)
 		ret = -ENXIO;
 
@@ -134,7 +135,6 @@ static int rpivid_mem_probe(struct platform_device *pdev)
 	struct device *dev = &pdev->dev;
 	struct resource *ioresource;
 	struct rpivid_mem_priv *priv;
-
 
 	/* Allocate buffers and instance data */
 

--- a/drivers/char/broadcom/rpivid-mem.c
+++ b/drivers/char/broadcom/rpivid-mem.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 /**
  * rpivid-mem.c - character device access to the RPiVid decoder registers
  *

--- a/drivers/char/broadcom/rpivid-mem.c
+++ b/drivers/char/broadcom/rpivid-mem.c
@@ -229,7 +229,7 @@ failed_alloc_chrdev:
 failed_get_resource:
 	kfree(priv);
 failed_inst_alloc:
-	dev_err(priv->dev, "could not load rpivid_mem");
+	dev_err(&pdev->dev, "could not load rpivid_mem");
 	return err;
 }
 

--- a/drivers/char/broadcom/rpivid-mem.c
+++ b/drivers/char/broadcom/rpivid-mem.c
@@ -201,9 +201,14 @@ static int rpivid_mem_probe(struct platform_device *pdev)
 		oldname[3] = 'g';
 		oldname[4] = 'o';
 		oldname[5] = 'n';
-		(void)device_create(priv->class, NULL, priv->devid + 1, NULL,
-				       oldname + 1);
+		dev = device_create(priv->class, NULL, priv->devid + 1, NULL,
+				    oldname + 1);
 		kfree(oldname);
+
+		if (IS_ERR(dev)) {
+			err = PTR_ERR(dev);
+			goto failed_legacy_device_create;
+		}
 	}
 
 	dev_info(priv->dev, "%s initialised: Registers at 0x%08lx length 0x%08lx",
@@ -211,6 +216,8 @@ static int rpivid_mem_probe(struct platform_device *pdev)
 
 	return 0;
 
+failed_legacy_device_create:
+	device_destroy(priv->class, priv->devid);
 failed_device_create:
 	class_destroy(priv->class);
 failed_class_create:

--- a/drivers/char/broadcom/rpivid-mem.c
+++ b/drivers/char/broadcom/rpivid-mem.c
@@ -130,10 +130,8 @@ static const struct of_device_id rpivid_mem_of_match[];
 static int rpivid_mem_probe(struct platform_device *pdev)
 {
 	int err;
-	void *ptr_err;
 	const struct of_device_id *id;
 	struct device *dev = &pdev->dev;
-	struct device *rpivid_mem_dev;
 	struct resource *ioresource;
 	struct rpivid_mem_priv *priv;
 
@@ -183,16 +181,16 @@ static int rpivid_mem_probe(struct platform_device *pdev)
 	/* Create sysfs entries */
 
 	priv->class = class_create(THIS_MODULE, priv->name);
-	ptr_err = priv->class;
-	if (IS_ERR(ptr_err))
+	if (IS_ERR(priv->class)) {
+		err = PTR_ERR(priv->class);
 		goto failed_class_create;
+	}
 
-	rpivid_mem_dev = device_create(priv->class, NULL,
-					priv->devid, NULL,
-					priv->name);
-	ptr_err = rpivid_mem_dev;
-	if (IS_ERR(ptr_err))
+	dev = device_create(priv->class, NULL, priv->devid, NULL, priv->name);
+	if (IS_ERR(dev)) {
+		err = PTR_ERR(dev);
 		goto failed_device_create;
+	}
 
 	/* Legacy alias */
 	{
@@ -217,7 +215,6 @@ failed_device_create:
 	class_destroy(priv->class);
 failed_class_create:
 	cdev_del(&priv->rpivid_mem_cdev);
-	err = PTR_ERR(ptr_err);
 failed_cdev_add:
 	unregister_chrdev_region(priv->devid, 1);
 failed_alloc_chrdev:

--- a/drivers/char/broadcom/rpivid-mem.c
+++ b/drivers/char/broadcom/rpivid-mem.c
@@ -233,6 +233,7 @@ static int rpivid_mem_remove(struct platform_device *pdev)
 	struct device *dev = &pdev->dev;
 	struct rpivid_mem_priv *priv = platform_get_drvdata(pdev);
 
+	device_destroy(priv->class, priv->devid + 1);
 	device_destroy(priv->class, priv->devid);
 	class_destroy(priv->class);
 	cdev_del(&priv->rpivid_mem_cdev);


### PR DESCRIPTION
Issue noted when JC was trying to unload and reload an overlay for the V4L2 HEVC codec.
Made checkpatch clean (other than DT compatible string) whilst I was at it.