### PR TITLE
pisound: Added reading Pisound board hardware revision and exposing it

### DIFF
--- a/sound/soc/bcm/pisound.c
+++ b/sound/soc/bcm/pisound.c
@@ -591,6 +591,8 @@ static int spi_read_info(void)
 				buffer[0],
 				buffer[1]
 				);
+
+			g_fw_version[MAX_VERSION_STR_LEN-1] = '\0';
 			break;
 		case 3:
 			if (n != 2)
@@ -603,6 +605,8 @@ static int spi_read_info(void)
 				buffer[0],
 				buffer[1]
 			);
+
+			g_hw_version[MAX_VERSION_STR_LEN-1] = '\0';
 			break;
 		case 1:
 			if (n >= sizeof(g_serial_num))
@@ -612,12 +616,14 @@ static int spi_read_info(void)
 			break;
 		case 2:
 			{
-				if (n >= sizeof(g_id))
+				if (n*2 >= sizeof(g_id))
 					return -EINVAL;
 
 				p = g_id;
 				for (j = 0; j < n; ++j)
 					p += sprintf(p, "%02x", buffer[j]);
+
+				*p = '\0';
 			}
 			break;
 		default:

--- a/sound/soc/bcm/pisound.c
+++ b/sound/soc/bcm/pisound.c
@@ -51,7 +51,8 @@ static void pisnd_spi_set_callback(pisnd_spi_recv_cb cb, void *data);
 
 static const char *pisnd_spi_get_serial(void);
 static const char *pisnd_spi_get_id(void);
-static const char *pisnd_spi_get_version(void);
+static const char *pisnd_spi_get_fw_version(void);
+static const char *pisnd_spi_get_hw_version(void);
 
 static int pisnd_midi_init(struct snd_card *card);
 static void pisnd_midi_uninit(void);
@@ -222,7 +223,9 @@ static pisnd_spi_recv_cb g_recvCallback;
 
 static char g_serial_num[11];
 static char g_id[25];
-static char g_version[5];
+enum { MAX_VERSION_STR_LEN = 6 };
+static char g_fw_version[MAX_VERSION_STR_LEN];
+static char g_hw_version[MAX_VERSION_STR_LEN];
 
 static uint8_t g_ledFlashDuration;
 static bool    g_ledFlashDurationChanged;
@@ -558,7 +561,8 @@ static int spi_read_info(void)
 	char *p;
 
 	memset(g_serial_num, 0, sizeof(g_serial_num));
-	memset(g_version, 0, sizeof(g_version));
+	memset(g_fw_version, 0, sizeof(g_fw_version));
+	strcpy(g_hw_version, "1.0"); // Assume 1.0 hw version.
 	memset(g_id, 0, sizeof(g_id));
 
 	tmp = spi_transfer16(0);
@@ -581,12 +585,24 @@ static int spi_read_info(void)
 				return -EINVAL;
 
 			snprintf(
-				g_version,
-				sizeof(g_version),
+				g_fw_version,
+				MAX_VERSION_STR_LEN,
 				"%x.%02x",
 				buffer[0],
 				buffer[1]
 				);
+			break;
+		case 3:
+			if (n != 2)
+				return -EINVAL;
+
+			snprintf(
+				g_hw_version,
+				MAX_VERSION_STR_LEN,
+				"%x.%x",
+				buffer[0],
+				buffer[1]
+			);
 			break;
 		case 1:
 			if (n >= sizeof(g_serial_num))
@@ -619,7 +635,8 @@ static int pisnd_spi_init(struct device *dev)
 
 	memset(g_serial_num, 0, sizeof(g_serial_num));
 	memset(g_id, 0, sizeof(g_id));
-	memset(g_version, 0, sizeof(g_version));
+	memset(g_fw_version, 0, sizeof(g_fw_version));
+	memset(g_hw_version, 0, sizeof(g_hw_version));
 
 	spi = pisnd_spi_find_device();
 
@@ -743,10 +760,18 @@ static const char *pisnd_spi_get_id(void)
 	return "";
 }
 
-static const char *pisnd_spi_get_version(void)
+static const char *pisnd_spi_get_fw_version(void)
 {
-	if (strlen(g_version))
-		return g_version;
+	if (strlen(g_fw_version))
+		return g_fw_version;
+
+	return "";
+}
+
+static const char *pisnd_spi_get_hw_version(void)
+{
+	if (strlen(g_hw_version))
+		return g_hw_version;
 
 	return "";
 }
@@ -1054,13 +1079,22 @@ static ssize_t pisnd_id_show(
 	return sprintf(buf, "%s\n", pisnd_spi_get_id());
 }
 
-static ssize_t pisnd_version_show(
+static ssize_t pisnd_fw_version_show(
 	struct kobject *kobj,
 	struct kobj_attribute *attr,
 	char *buf
 	)
 {
-	return sprintf(buf, "%s\n", pisnd_spi_get_version());
+	return sprintf(buf, "%s\n", pisnd_spi_get_fw_version());
+}
+
+static ssize_t pisnd_hw_version_show(
+	struct kobject *kobj,
+	struct kobj_attribute *attr,
+	char *buf
+)
+{
+	return sprintf(buf, "%s\n", pisnd_spi_get_hw_version());
 }
 
 static ssize_t pisnd_led_store(
@@ -1085,15 +1119,18 @@ static struct kobj_attribute pisnd_serial_attribute =
 	__ATTR(serial, 0444, pisnd_serial_show, NULL);
 static struct kobj_attribute pisnd_id_attribute =
 	__ATTR(id, 0444, pisnd_id_show, NULL);
-static struct kobj_attribute pisnd_version_attribute =
-	__ATTR(version, 0444, pisnd_version_show, NULL);
+static struct kobj_attribute pisnd_fw_version_attribute =
+	__ATTR(version, 0444, pisnd_fw_version_show, NULL);
+static struct kobj_attribute pisnd_hw_version_attribute =
+__ATTR(hw_version, 0444, pisnd_hw_version_show, NULL);
 static struct kobj_attribute pisnd_led_attribute =
 	__ATTR(led, 0644, NULL, pisnd_led_store);
 
 static struct attribute *attrs[] = {
 	&pisnd_serial_attribute.attr,
 	&pisnd_id_attribute.attr,
-	&pisnd_version_attribute.attr,
+	&pisnd_fw_version_attribute.attr,
+	&pisnd_hw_version_attribute.attr,
 	&pisnd_led_attribute.attr,
 	NULL
 };
@@ -1112,9 +1149,10 @@ static int pisnd_probe(struct platform_device *pdev)
 	}
 
 	printi("Detected Pisound card:\n");
-	printi("\tSerial:  %s\n", pisnd_spi_get_serial());
-	printi("\tVersion: %s\n", pisnd_spi_get_version());
-	printi("\tId:      %s\n", pisnd_spi_get_id());
+	printi("\tSerial:           %s\n", pisnd_spi_get_serial());
+	printi("\tFirmware Version: %s\n", pisnd_spi_get_fw_version());
+	printi("\tHardware Version: %s\n", pisnd_spi_get_hw_version());
+	printi("\tId:               %s\n", pisnd_spi_get_id());
 
 	pisnd_kobj = kobject_create_and_add("pisound", kernel_kobj);
 	if (!pisnd_kobj) {

--- a/sound/soc/bcm/pisound.c
+++ b/sound/soc/bcm/pisound.c
@@ -752,34 +752,22 @@ static void pisnd_spi_set_callback(pisnd_spi_recv_cb cb, void *data)
 
 static const char *pisnd_spi_get_serial(void)
 {
-	if (strlen(g_serial_num))
-		return g_serial_num;
-
-	return "";
+	return g_serial_num;
 }
 
 static const char *pisnd_spi_get_id(void)
 {
-	if (strlen(g_id))
-		return g_id;
-
-	return "";
+	return g_id;
 }
 
 static const char *pisnd_spi_get_fw_version(void)
 {
-	if (strlen(g_fw_version))
-		return g_fw_version;
-
-	return "";
+	return g_fw_version;
 }
 
 static const char *pisnd_spi_get_hw_version(void)
 {
-	if (strlen(g_hw_version))
-		return g_hw_version;
-
-	return "";
+	return g_hw_version;
 }
 
 static const struct of_device_id pisound_of_match[] = {


### PR DESCRIPTION
pisound: Added reading Pisound board hardware revision and exposing it in kernel log and sysfs file:

/sys/kernel/pisound/hw_version

Signed-off-by: Giedrius <giedrius@blokas.io>