### PR TITLE
Fix i2c-pwm-pca9685a overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/i2c-pwm-pca9685a-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-pwm-pca9685a-overlay.dts
@@ -13,7 +13,7 @@
 			status = "okay";
 
 			pca: pca@40 {
-				compatible = "nxp,pca9685";
+				compatible = "nxp,pca9685-pwm";
 				#pwm-cells = <2>;
 				reg = <0x40>;
 				status = "okay";


### PR DESCRIPTION
Overlay was using wrong compatible string - now using the one defined in the driver source.