### PR TITLE
adds LED OFF feature to HiFiBerry DAC+/DAC+PRO sound cards

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -906,6 +906,8 @@ Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
                                 that does not result in clipping/distortion!)
         slave                   Force DAC+ Pro into slave mode, using Pi as
                                 master for bit clock and frame clock.
+        leds_off                If set to 'true' the onboard indicator LEDs
+                                are switched off at all times.
 
 
 Name:   hifiberry-dacplusadc

--- a/arch/arm/boot/dts/overlays/hifiberry-dacplus-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dacplus-overlay.dts
@@ -55,5 +55,6 @@
 		24db_digital_gain =
 			<&hifiberry_dacplus>,"hifiberry,24db_digital_gain?";
 		slave = <&hifiberry_dacplus>,"hifiberry-dacplus,slave?";
+		leds_off = <&hifiberry_dacplus>,"hifiberry-dacplus,leds_off?";
 	};
 };

--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -50,6 +50,7 @@ struct pcm512x_priv {
 static bool slave;
 static bool snd_rpi_hifiberry_is_dacpro;
 static bool digital_gain_0db_limit = true;
+static bool leds_off;
 
 static void snd_rpi_hifiberry_dacplus_select_clk(struct snd_soc_component *component,
 	int clk_id)
@@ -171,7 +172,10 @@ static int snd_rpi_hifiberry_dacplus_init(struct snd_soc_pcm_runtime *rtd)
 
 	snd_soc_component_update_bits(component, PCM512x_GPIO_EN, 0x08, 0x08);
 	snd_soc_component_update_bits(component, PCM512x_GPIO_OUTPUT_4, 0x0f, 0x02);
-	snd_soc_component_update_bits(component, PCM512x_GPIO_CONTROL_1, 0x08, 0x08);
+	if (leds_off)
+		snd_soc_component_update_bits(component, PCM512x_GPIO_CONTROL_1, 0x08, 0x00);
+	else
+		snd_soc_component_update_bits(component, PCM512x_GPIO_CONTROL_1, 0x08, 0x08);
 
 	if (digital_gain_0db_limit)
 	{
@@ -251,6 +255,8 @@ static int snd_rpi_hifiberry_dacplus_startup(
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	struct snd_soc_component *component = rtd->codec_dai->component;
 
+	if (leds_off)
+		return 0;
 	snd_soc_component_update_bits(component, PCM512x_GPIO_CONTROL_1, 0x08, 0x08);
 	return 0;
 }
@@ -319,6 +325,8 @@ static int snd_rpi_hifiberry_dacplus_probe(struct platform_device *pdev)
 			pdev->dev.of_node, "hifiberry,24db_digital_gain");
 		slave = of_property_read_bool(pdev->dev.of_node,
 						"hifiberry-dacplus,slave");
+		leds_off = of_property_read_bool(pdev->dev.of_node,
+						"hifiberry-dacplus,leds_off");
 	}
 
 	ret = devm_snd_soc_register_card(&pdev->dev,


### PR DESCRIPTION
This adds a DT overlay parameter 'leds_off' which allows
to switch off the onboard activity LEDs at all times
which has been requested by some users.

Signed-off-by: Joerg Schambacher <joerg@i2audio.com>