### PR TITLE
overlays: Add ssd1306-spi overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -168,6 +168,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	spi6-1cs.dtbo \
 	spi6-2cs.dtbo \
 	ssd1306.dtbo \
+	ssd1306-spi.dtbo \
 	superaudioboard.dtbo \
 	sx150x.dtbo \
 	tc358743.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2427,6 +2427,17 @@ Params: address                 Location in display memory of first character.
         For more information refer to the device datasheet at:
         https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf
 
+        
+Name:   ssd1306-spi
+Info:   Overlay for SSD1306 OLED via SPI using fbtft staging driver.
+Load:   dtoverlay=ssd1306-spi,<param>=<val>
+Params: speed                   SPI bus speed (default 10000000)
+        rotate                  Display rotation (0, 90, 180 or 270; default 0)
+        fps                     Delay between frame updates (default 25)
+        debug                   Debug output level (0-7; default 0)
+        dc_pin                  GPIO pin for D/C (default 24)
+        reset_pin               GPIO pin for RESET (default 25)
+
 
 Name:   superaudioboard
 Info:   Configures the SuperAudioBoard sound card

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2427,7 +2427,7 @@ Params: address                 Location in display memory of first character.
         For more information refer to the device datasheet at:
         https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf
 
-        
+
 Name:   ssd1306-spi
 Info:   Overlay for SSD1306 OLED via SPI using fbtft staging driver.
 Load:   dtoverlay=ssd1306-spi,<param>=<val>
@@ -2437,6 +2437,7 @@ Params: speed                   SPI bus speed (default 10000000)
         debug                   Debug output level (0-7; default 0)
         dc_pin                  GPIO pin for D/C (default 24)
         reset_pin               GPIO pin for RESET (default 25)
+        height                  Display height (32 or 64; default 64)
 
 
 Name:   superaudioboard

--- a/arch/arm/boot/dts/overlays/ssd1306-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ssd1306-spi-overlay.dts
@@ -73,7 +73,7 @@
 	__overrides__ {
 		speed		= <&ssd1306>,"spi-max-frequency:0";
 		rotate		= <&ssd1306>,"rotate:0";
-		fps			= <&ssd1306>,"fps:0";
+		fps		= <&ssd1306>,"fps:0";
 		debug		= <&ssd1306>,"debug:0";
 		dc_pin		= <&ssd1306>,"dc-gpios:4>";
 		reset_pin	= <&ssd1306>,"reset-gpios:4>";

--- a/arch/arm/boot/dts/overlays/ssd1306-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ssd1306-spi-overlay.dts
@@ -1,0 +1,81 @@
+/*
+ * Device Tree overlay for SSD1306 based SPI OLED display
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&gpio>;
+		__overlay__ {
+			ssd1306_pins: ssd1306_pins {
+                                brcm,pins = <25 24>;
+                                brcm,function = <1 1>; /* out out */
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ssd1306: ssd1306@0{
+				compatible = "solomon,ssd1306";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&ssd1306_pins>;
+
+				spi-max-frequency = <10000000>;
+				bgr = <0>;
+				bpp = <1>;
+				rotate = <0>;
+				fps = <25>;
+				buswidth = <8>;
+				reset-gpios = <&gpio 25 0>;
+				dc-gpios = <&gpio 24 0>;
+				debug = <0>;
+
+				solomon,height = <64>;
+				solomon,width = <128>;
+				solomon,page-offset = <0>;
+			};
+		};
+	};
+
+	__overrides__ {
+		speed		= <&ssd1306>,"spi-max-frequency:0";
+		rotate		= <&ssd1306>,"rotate:0";
+		fps		= <&ssd1306>,"fps:0";
+		debug		= <&ssd1306>,"debug:0";
+		dc_pin		= <&ssd1306>,"dc-gpios:4>";
+		reset_pin	= <&ssd1306>,"reset-gpios:4>";
+	};
+};

--- a/arch/arm/boot/dts/overlays/ssd1306-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ssd1306-spi-overlay.dts
@@ -73,9 +73,10 @@
 	__overrides__ {
 		speed		= <&ssd1306>,"spi-max-frequency:0";
 		rotate		= <&ssd1306>,"rotate:0";
-		fps		= <&ssd1306>,"fps:0";
+		fps			= <&ssd1306>,"fps:0";
 		debug		= <&ssd1306>,"debug:0";
 		dc_pin		= <&ssd1306>,"dc-gpios:4>";
 		reset_pin	= <&ssd1306>,"reset-gpios:4>";
+		height		= <&ssd1306>,"solomon,height:0>";
 	};
 };


### PR DESCRIPTION
Add an overlay for SSD1306 based OLED boards using SPI.
This will load the staging fbtft driver.

Signed-off-by: Michael Kaplan <m.kaplan@evva.com>