### PR TITLE
VCHIQ audio Device Tree support

### DIFF
--- a/arch/arm/boot/dts/bcm270x-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm270x-rpi.dtsi
@@ -70,13 +70,6 @@
 			status = "okay";
 		};
 
-		/* Onboard audio */
-		audio: audio {
-			compatible = "brcm,bcm2835-audio";
-			brcm,pwm-channels = <8>;
-			status = "disabled";
-		};
-
 		/* External sound card */
 		sound: sound {
 			status = "disabled";
@@ -136,4 +129,13 @@
 
 &vec {
 	status = "disabled";
+};
+
+&vchiq {
+	/* Onboard audio */
+	audio: audio {
+		compatible = "brcm,bcm2835-audio";
+		brcm,pwm-channels = <8>;
+		status = "disabled";
+	};
 };

--- a/arch/arm/boot/dts/bcm2711-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2711-rpi.dtsi
@@ -54,6 +54,8 @@
 		compatible = "brcm,bcm2835-vc4";
 		status = "disabled";
 	};
+
+	/delete-node/ audio;
 };
 
 &scb {
@@ -156,6 +158,18 @@
 		compatible = "raspberrypi,rpivid-vp9-decoder";
 		reg = <0x0 0x7eb30000 0x10000>;
 		status = "okay";
+	};
+};
+
+&vchiq {
+	/* Onboard audio
+	 * This node is replicated because the original from bcm270x-rpi.dtsi
+	 * was deleted when the vchiq node was deleted above.
+	 */
+	audio: bcm2835_audio {
+		compatible = "brcm,bcm2835-audio";
+		brcm,pwm-channels = <8>;
+		status = "disabled";
 	};
 };
 

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -3303,6 +3303,7 @@ failed_platform_init:
 
 static int vchiq_remove(struct platform_device *pdev)
 {
+	platform_device_unregister(bcm2835_audio);
 	platform_device_unregister(bcm2835_camera);
 	platform_device_unregister(bcm2835_codec);
 	platform_device_unregister(vcsm_cma);

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -139,6 +139,7 @@ static struct vchiq_state g_state;
 static struct class  *vchiq_class;
 static DEFINE_SPINLOCK(msg_queue_spinlock);
 static struct platform_device *bcm2835_camera;
+static struct platform_device *bcm2835_audio;
 static struct platform_device *bcm2835_codec;
 static struct platform_device *vcsm_cma;
 
@@ -3281,6 +3282,7 @@ static int vchiq_probe(struct platform_device *pdev)
 	vcsm_cma = vchiq_register_child(pdev, "vcsm-cma");
 	bcm2835_codec = vchiq_register_child(pdev, "bcm2835-codec");
 	bcm2835_camera = vchiq_register_child(pdev, "bcm2835-camera");
+	bcm2835_audio = vchiq_register_child(pdev, "bcm2835_audio");
 
 	return 0;
 

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -3200,11 +3200,19 @@ vchiq_register_child(struct platform_device *pdev, const char *name)
 	pdevinfo.id = PLATFORM_DEVID_NONE;
 	pdevinfo.dma_mask = DMA_BIT_MASK(32);
 
+	np = of_get_child_by_name(pdev->dev.of_node, name);
+
+	/* Skip the child if it is explicitly disabled */
+	if (np && !of_device_is_available(np))
+		return NULL;
+
 	child = platform_device_register_full(&pdevinfo);
 	if (IS_ERR(child)) {
 		dev_warn(&pdev->dev, "%s not registered\n", name);
 		child = NULL;
 	}
+
+	child->dev.of_node = np;
 
 	/*
 	 * We want the dma-ranges etc to be copied from a device with the


### PR DESCRIPTION
This is an attempt to solve the problem of the BCM2835 audio driver - a client of VCHIQ - which in its downstream incarnation makes use of Device Tree properties. Until a recent reversion the audio device was being instantiated twice - once via DT and once directly by the VCHIQ parent.

VCHIQ kernel client drivers have been transformed into platform drivers instantiated explicitly by the parent. This solves the issue of device creation order, but it poses a problem for downstream use - the clients lose their Device Tree nodes. I understand that use of DT by "devices" that don't directly address hardware is against some of the DT principles, but the VCHIQ clients do control hardware - they just present proxies for services running on the RPi firmware. I therefore don't think it's unreasonable to use DT to describe them, allowing them to benefit from automatic pin configuration etc.

The solution is to give each child device an optional DT node, identified by name, and initialise the platform device object with a pointer to it. In this way the device creation is still controlled by the vchiq "bus" driver, but the children are free to use DT.