### PR TITLE
Fix a sh1106-spi, ssd1306-spi, ssd1351-spi overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/sh1106-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sh1106-spi-overlay.dts
@@ -76,9 +76,9 @@
 		fps       = <&sh1106>,"fps:0";
 		debug     = <&sh1106>,"debug:0";
 		dc_pin    = <&sh1106>,"dc-gpios:4",
-		            <&sh1106_pins>,"brcm,pins:4;
+		            <&sh1106_pins>,"brcm,pins:4";
 		reset_pin = <&sh1106>,"reset-gpios:4",
-		            <&sh1106_pins>,"brcm,pins:0;
+		            <&sh1106_pins>,"brcm,pins:0";
 		height    = <&sh1106>,"sinowealth,height:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/ssd1306-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ssd1306-spi-overlay.dts
@@ -75,9 +75,9 @@
 		rotate    = <&ssd1306>,"rotate:0";
 		fps       = <&ssd1306>,"fps:0";
 		debug     = <&ssd1306>,"debug:0";
-		dc_pin    = <&ssd1306>,"dc-gpios:4";
+		dc_pin    = <&ssd1306>,"dc-gpios:4",
 		            <&ssd1306_pins>,"brcm,pins:4";
-		reset_pin = <&ssd1306>,"reset-gpios:4";
+		reset_pin = <&ssd1306>,"reset-gpios:4",
 		            <&ssd1306_pins>,"brcm,pins:0";
 		height    = <&ssd1306>,"solomon,height:0";
 	};

--- a/arch/arm/boot/dts/overlays/ssd1351-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ssd1351-spi-overlay.dts
@@ -77,7 +77,7 @@
 		debug     = <&ssd1351>,"debug:0";
 		dc_pin    = <&ssd1351>,"dc-gpios:4",
 		            <&ssd1351_pins>,"brcm,pins:4";
-		reset_pin = <&ssd1351>,"reset-gpios:4";
+		reset_pin = <&ssd1351>,"reset-gpios:4",
 		            <&ssd1351_pins>,"brcm,pins:0";
 	};
 };


### PR DESCRIPTION
Fix syntax errors occurred from overlay settings in dts