### PR TITLE
overlays: add hdmi-backlight-hwhack-gpio-overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -51,6 +51,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	gpio-poweroff.dtbo \
 	gpio-shutdown.dtbo \
 	hd44780-lcd.dtbo \
+	hdmi-backlight-hwhack-gpio.dtbo \
 	hifiberry-amp.dtbo \
 	hifiberry-dac.dtbo \
 	hifiberry-dacplus.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -883,6 +883,20 @@ Params: pin_d4                  GPIO pin for data pin D4 (default 6)
         display_width           Width of the display in characters
 
 
+Name:   hdmi-backlight-hwhack-gpio
+Info:   Devicetree overlay for GPIO based backlight on/off capability.
+        Use this if you have one of those HDMI displays whose backlight cannot
+        be controlled via DPMS over HDMI and plan to do a little soldering to
+        use an RPi gpio pin for on/off switching. See:
+        https://www.waveshare.com/wiki/7inch_HDMI_LCD_(C)#Backlight_Control
+Load:   dtoverlay=hdmi-backlight-hwhack-gpio,<param>=<val>
+Params: gpio_pin                GPIO pin used (default 17)
+        active_low              Set this to 1 if the display backlight is
+                                switched on when the wire goes low.
+                                Leave the default (value 0) if the backlight
+                                expects a high to switch it on.
+
+
 Name:   hifiberry-amp
 Info:   Configures the HifiBerry Amp and Amp+ audio cards
 Load:   dtoverlay=hifiberry-amp

--- a/arch/arm/boot/dts/overlays/hdmi-backlight-hwhack-gpio-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hdmi-backlight-hwhack-gpio-overlay.dts
@@ -1,0 +1,47 @@
+/*
+ * Devicetree overlay for GPIO based backlight on/off capability.
+ *
+ * Use this if you have one of those HDMI displays whose backlight cannot be
+ * controlled via DPMS over HDMI and plan to do a little soldering to use an
+ * RPi gpio pin for on/off switching.
+ *
+ * See: https://www.waveshare.com/wiki/7inch_HDMI_LCD_(C)#Backlight_Control
+ *
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			hdmi_backlight_hwhack_gpio_pins: hdmi_backlight_hwhack_gpio_pins {
+				brcm,pins = <17>;
+				brcm,function = <1>; /* out */
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			hdmi_backlight_hwhack_gpio: hdmi_backlight_hwhack_gpio {
+				compatible = "gpio-backlight";
+
+				pinctrl-names = "default";
+				pinctrl-0 = <&hdmi_backlight_hwhack_gpio_pins>;
+
+				gpios = <&gpio 17 0>;
+				default-on;
+			};
+		};
+	};
+
+	__overrides__ {
+		gpio_pin   = <&hdmi_backlight_hwhack_gpio>,"gpios:4",
+		             <&hdmi_backlight_hwhack_gpio_pins>,"brcm,pins:0";
+		active_low = <&hdmi_backlight_hwhack_gpio>,"gpios:8";
+	};
+};


### PR DESCRIPTION
This is a Devicetree overlay for GPIO based backlight on/off capability.

Use this if you have one of those HDMI displays whose backlight cannot be controlled via DPMS over HDMI and plan to do a little soldering to use an RPi gpio pin for on/off switching.

See: https://www.waveshare.com/wiki/7inch_HDMI_LCD_(C)#Backlight_Control

This was tested with a clone of the Waveshare "7 inch HDMI Touch LCD C" where I soldered two mosfets to override the backlight dip-switch.
When the overlay is loaded, a sysfs backlight node appears which can be used to modify the brightness value (0 or 1), and is even used by DPMS to switch the display backlight off after the configured timeout.
(On current Raspbian Buster Desktop, it's also possible to wakeup the display via a tap on the touch display :-) )
