### PR TITLE
staging: vc04_services: Fix vcsm overflow bug when counting transactions

### DIFF
--- a/drivers/staging/vc04_services/vc-sm-cma/vc_sm_cma_vchi.c
+++ b/drivers/staging/vc04_services/vc-sm-cma/vc_sm_cma_vchi.c
@@ -34,7 +34,7 @@ struct sm_cmd_rsp_blk {
 	/* To be signaled when the response is there */
 	struct completion cmplt;
 
-	u16 id;
+	u32 id;
 	u16 length;
 
 	u8 msg[VC_SM_MAX_MSG_LEN];


### PR DESCRIPTION
The response block and local state were using u16 and u32 respectively
to represent transaction id.  When the former would wrap, there is a
mismatch and subsequent transactions will be marked as failures.
