### PR TITLE
gpio-ir-overlay: add parameter to configure signal polarity

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -754,6 +754,10 @@ Params: gpio_pin                Input pin number. Default is 18.
         gpio_pull               Desired pull-up/down state (off, down, up)
                                 Default is "up".
 
+        invert                  "1" = invert the input (active-low signalling).
+                                "0" = non-inverted input (active-high signalling).
+                                Default is "1".
+
         rc-map-name             Default rc keymap (can also be changed by
                                 ir-keytable), defaults to "rc-rc6-mce"
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -755,8 +755,8 @@ Params: gpio_pin                Input pin number. Default is 18.
                                 Default is "up".
 
         invert                  "1" = invert the input (active-low signalling).
-                                "0" = non-inverted input (active-high signalling).
-                                Default is "1".
+                                "0" = non-inverted input (active-high
+                                signalling). Default is "1".
 
         rc-map-name             Default rc keymap (can also be changed by
                                 ir-keytable), defaults to "rc-rc6-mce"

--- a/arch/arm/boot/dts/overlays/gpio-ir-overlay.dts
+++ b/arch/arm/boot/dts/overlays/gpio-ir-overlay.dts
@@ -42,6 +42,7 @@
                                 <&gpio_ir_pins>,"brcm,pins:0",
                                 <&gpio_ir_pins>,"reg:0";
                 gpio_pull = <&gpio_ir_pins>,"brcm,pull:0";              // pull-up/down state
+                invert = <&gpio_ir>,"gpios:8";                          // 0 = active high input
 
                 rc-map-name = <&gpio_ir>,"linux,rc-map-name";           // default rc map
         };


### PR DESCRIPTION
Standard IR receivers use inverted / active-low signalling
and the gpio-ir overlay configures the GPIO appropriately
as GPIO_ACTIVE_LOW (1).

In order to support (rather rare) non-inverted / active-high
signalling the GPIO needs to be configured as GPIO_ACTIVE_HIGH (0).

Add an "invert" parameter to override this like in the gpio-ir-tx
overlay.

This should fix the issue reported in this thread https://www.raspberrypi.org/forums/viewtopic.php?f=44&t=264834