### PR TITLE
Reduce noise from rpi poe hat fan

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
@@ -14,9 +14,9 @@
 				compatible = "raspberrypi,rpi-poe-fan";
 				firmware = <&firmware>;
 				cooling-min-state = <0>;
-				cooling-max-state = <2>;
+				cooling-max-state = <4>;
 				#cooling-cells = <2>;
-				cooling-levels = <0 150 255>;
+				cooling-levels = <0 31 63 150 255>;
 				status = "okay";
 			};
 		};
@@ -27,12 +27,21 @@
 		__overlay__ {
 			trips {
 				trip0: trip0 {
-					temperature = <50000>;
-					hysteresis = <5000>;
+					temperature = <40000>;
+					hysteresis = <2000>;
 					type = "active";
 				};
 				trip1: trip1 {
-
+					temperature = <45000>;
+					hysteresis = <2000>;
+					type = "active";
+				};
+				trip2: trip2 {
+					temperature = <50000>;
+					hysteresis = <2000>;
+					type = "active";
+				};
+				trip3: trip3 {
 					temperature = <55000>;
 					hysteresis = <5000>;
 					type = "active";
@@ -47,6 +56,14 @@
 					trip = <&trip1>;
 					cooling-device = <&fan0 1 2>;
 				};
+				map2 {
+					trip = <&trip2>;
+					cooling-device = <&fan0 2 3>;
+				};
+				map3 {
+					trip = <&trip3>;
+					cooling-device = <&fan0 3 4>;
+				};
 			};
 		};
 	};
@@ -58,6 +75,10 @@
 			poe_fan_temp0_hyst =	<&trip0>,"hysteresis:0";
 			poe_fan_temp1 =		<&trip1>,"temperature:0";
 			poe_fan_temp1_hyst =	<&trip1>,"hysteresis:0";
+			poe_fan_temp2 =		<&trip2>,"temperature:0";
+			poe_fan_temp2_hyst =	<&trip2>,"hysteresis:0";
+			poe_fan_temp3 =		<&trip3>,"temperature:0";
+			poe_fan_temp3_hyst =	<&trip3>,"hysteresis:0";
 		};
 	};
 
@@ -66,5 +87,9 @@
 		poe_fan_temp0_hyst =	<&trip0>,"hysteresis:0";
 		poe_fan_temp1 =		<&trip1>,"temperature:0";
 		poe_fan_temp1_hyst =	<&trip1>,"hysteresis:0";
+		poe_fan_temp2 =		<&trip2>,"temperature:0";
+		poe_fan_temp2_hyst =	<&trip2>,"hysteresis:0";
+		poe_fan_temp3 =		<&trip3>,"temperature:0";
+		poe_fan_temp3_hyst =	<&trip3>,"hysteresis:0";
 	};
 };


### PR DESCRIPTION
This adds 2 extra states, at 40c and 45c, with PWM of 31 and 63 (out of 255) for the rpi poe hat fan.  This significantly improves user experience by providing a smoother ramp up of the fan, from a pwm 0 to 31 to 63 then finally to 150, and additionally makes it very easy for users to further tweak the values as needed for their specific application.

The possible concerns I have are that a hysteresis of 2000 (2c) could be too narrow, and that running the fan more at a reduced temperature (40000 - 40c) could cause problems.