### PR TITLE
Kbuild: Allow .dtbo overlays to be built, adjust.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1237,7 +1237,7 @@ ifneq ($(dtstree),)
 %.dtb: include/config/kernel.release scripts_dtc
 	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
 
-%.dtbo: prepare3 scripts_dtc
+%.dtbo: include/config/kernel.release scripts_dtc
 	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
 
 PHONY += dtbs dtbs_install dt_binding_check


### PR DESCRIPTION
This is adjustment to commit
d368ceaacdccd7732dc97d1d7987bdf7149d62e3 "kbuild: Allow .dtbo overlays to be built piecemeal"

prepare3 target has gone from mainline tree in branch 5.4.y

Signed-off-by: Nataliya Korovkina <malus.brandywine@gmail.com>