### PR TITLE
[5.4] pick bcmgenet upstream fix for non-functional network when netbooting

### DIFF
--- a/drivers/net/ethernet/broadcom/genet/bcmmii.c
+++ b/drivers/net/ethernet/broadcom/genet/bcmmii.c
@@ -292,6 +292,7 @@ int bcmgenet_mii_config(struct net_device *dev, bool init)
 	 */
 	if (priv->ext_phy) {
 		reg = bcmgenet_ext_readl(priv, EXT_RGMII_OOB_CTRL);
+		reg &= ~ID_MODE_DIS;
 		reg |= id_mode_dis;
 		if (GENET_IS_V1(priv) || GENET_IS_V2(priv) || GENET_IS_V3(priv))
 			reg |= RGMII_MODE_EN_V123;


### PR DESCRIPTION
As reported on the forum https://www.raspberrypi.org/forums/viewtopic.php?p=1629200#p1629200 upstream commit 402482a6a78e5c61d8a2ec6311fc5b4aca392cd6 is needed to have working network when netbooting RPi4.

The upstream commit contains a Fixes tag so should eventually find it's way into stable kernels