### PR TITLE
clk-raspberrypi: Allow cpufreq driver to also adjust gpu clocks

### DIFF
--- a/drivers/clk/bcm/clk-raspberrypi.c
+++ b/drivers/clk/bcm/clk-raspberrypi.c
@@ -76,7 +76,7 @@ static int raspberrypi_clock_property(struct rpi_firmware *firmware,
 	struct raspberrypi_firmware_prop msg = {
 		.id = cpu_to_le32(data->id),
 		.val = cpu_to_le32(*val),
-		.disable_turbo = cpu_to_le32(1),
+		.disable_turbo = cpu_to_le32(0),
 	};
 	int ret;
 


### PR DESCRIPTION
Cherry-pick from rpi-4.19.y.
Without this we don't boost core and other gpu clocks when arm requests turbo mode.