### PR TITLE
SPI Chip Select tidy-up

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
@@ -18,8 +18,6 @@
 	};
 
 	spi0_cs_pins: spi0_cs_pins {
-		brcm,pins = <8 7>;
-		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {

--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -18,8 +18,6 @@
 	};
 
 	spi0_cs_pins: spi0_cs_pins {
-		brcm,pins = <8 7>;
-		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {

--- a/arch/arm/boot/dts/bcm2708-rpi-cm.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-cm.dts
@@ -21,8 +21,6 @@
 	};
 
 	spi0_cs_pins: spi0_cs_pins {
-		brcm,pins = <8 7>;
-		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {

--- a/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
@@ -27,8 +27,6 @@
 	};
 
 	spi0_cs_pins: spi0_cs_pins {
-		brcm,pins = <8 7>;
-		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {

--- a/arch/arm/boot/dts/bcm2708-rpi-zero.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero.dts
@@ -21,8 +21,6 @@
 	};
 
 	spi0_cs_pins: spi0_cs_pins {
-		brcm,pins = <8 7>;
-		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {

--- a/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
@@ -18,8 +18,6 @@
 	};
 
 	spi0_cs_pins: spi0_cs_pins {
-		brcm,pins = <8 7>;
-		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {

--- a/arch/arm/boot/dts/bcm2710-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-2-b.dts
@@ -18,8 +18,6 @@
 	};
 
 	spi0_cs_pins: spi0_cs_pins {
-		brcm,pins = <8 7>;
-		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
@@ -28,8 +28,6 @@
 	};
 
 	spi0_cs_pins: spi0_cs_pins {
-		brcm,pins = <8 7>;
-		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
@@ -28,8 +28,6 @@
 	};
 
 	spi0_cs_pins: spi0_cs_pins {
-		brcm,pins = <8 7>;
-		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {

--- a/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
@@ -21,8 +21,6 @@
 	};
 
 	spi0_cs_pins: spi0_cs_pins {
-		brcm,pins = <8 7>;
-		brcm,function = <1>; /* output */
 	};
 
 	i2c0_pins: i2c0 {

--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
@@ -287,8 +287,6 @@
 	};
 
 	spi0_cs_pins: spi0_cs_pins {
-		brcm,pins = <8 7>;
-		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 	};
 
 	spi3_pins: spi3_pins {
@@ -297,8 +295,6 @@
 	};
 
 	spi3_cs_pins: spi3_cs_pins {
-		brcm,pins = <0 24>;
-		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 	};
 
 	spi4_pins: spi4_pins {
@@ -307,8 +303,6 @@
 	};
 
 	spi4_cs_pins: spi4_cs_pins {
-		brcm,pins = <4 25>;
-		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 	};
 
 	spi5_pins: spi5_pins {
@@ -317,8 +311,6 @@
 	};
 
 	spi5_cs_pins: spi5_cs_pins {
-		brcm,pins = <12 26>;
-		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 	};
 
 	spi6_pins: spi6_pins {
@@ -327,8 +319,6 @@
 	};
 
 	spi6_cs_pins: spi6_cs_pins {
-		brcm,pins = <18 27>;
-		brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 	};
 
 	i2c0_pins: i2c0 {

--- a/arch/arm/boot/dts/overlays/sc16is752-spi1-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is752-spi1-overlay.dts
@@ -11,11 +11,6 @@
 				brcm,pins = <19 20 21>;
 				brcm,function = <3>; /* alt4 */
 			};
-
-			spi1_cs_pins: spi1_cs_pins {
-				brcm,pins = <18>;
-				brcm,function = <1>; /* output */
-			};
 		};
 	};
 
@@ -25,7 +20,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&spi1_pins &spi1_cs_pins>;
+			pinctrl-0 = <&spi1_pins>;
 			cs-gpios = <&gpio 18 1>;
 			status = "okay";
 

--- a/arch/arm/boot/dts/overlays/spi-gpio35-39-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi-gpio35-39-overlay.dts
@@ -16,13 +16,6 @@
 	};
 
 	fragment@1 {
-		target = <&spi0_cs_pins>;
-		__overlay__ {
-			brcm,pins = <36 35>;
-		};
-	};
-
-	fragment@2 {
 		target = <&spi0_pins>;
 		__overlay__ {
 			brcm,pins = <37 38 39>;

--- a/arch/arm/boot/dts/overlays/spi-gpio40-45-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi-gpio40-45-overlay.dts
@@ -17,20 +17,10 @@
 	};
 
 	fragment@1 {
-		target = <&spi0_cs_pins>;
-		__overlay__ {
-			brcm,pins = <45 44 43>;
-			brcm,function = <1>; /* output */
-			status = "okay";
-		};
-	};
-
-	fragment@2 {
 		target = <&spi0_pins>;
 		__overlay__ {
 			brcm,pins = <40 41 42>;
 			brcm,function = <3>; /* alt4 */
-			status = "okay";
 		};
 	};
 };

--- a/arch/arm/boot/dts/overlays/spi0-cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi0-cs-overlay.dts
@@ -6,24 +6,15 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&spi0_cs_pins>;
-		frag0: __overlay__ {
-			brcm,pins = <8 7>;
-		};
-	};
-
-	fragment@1 {
 		target = <&spi0>;
-		frag1: __overlay__ {
+		frag0: __overlay__ {
 			cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
 			status = "okay";
 		};
 	};
 
 	__overrides__ {
-		cs0_pin  = <&frag0>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
-		cs1_pin  = <&frag0>,"brcm,pins:4",
-			   <&frag1>,"cs-gpios:16";
+		cs0_pin  = <&frag0>,"cs-gpios:4";
+		cs1_pin  = <&frag0>,"cs-gpios:16";
 	};
 };

--- a/arch/arm/boot/dts/overlays/spi1-1cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi1-1cs-overlay.dts
@@ -12,11 +12,6 @@
 				brcm,pins = <19 20 21>;
 				brcm,function = <3>; /* alt4 */
 			};
-
-			spi1_cs_pins: spi1_cs_pins {
-				brcm,pins = <18>;
-				brcm,function = <1>; /* output */
-			};
 		};
 	};
 
@@ -27,7 +22,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&spi1_pins &spi1_cs_pins>;
+			pinctrl-0 = <&spi1_pins>;
 			cs-gpios = <&gpio 18 1>;
 			status = "okay";
 
@@ -50,8 +45,7 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&spi1_cs_pins>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
+		cs0_pin  = <&frag1>,"cs-gpios:4";
 		cs0_spidev = <&spidev1_0>,"status";
 	};
 };

--- a/arch/arm/boot/dts/overlays/spi1-2cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi1-2cs-overlay.dts
@@ -12,11 +12,6 @@
 				brcm,pins = <19 20 21>;
 				brcm,function = <3>; /* alt4 */
 			};
-
-			spi1_cs_pins: spi1_cs_pins {
-				brcm,pins = <18 17>;
-				brcm,function = <1>; /* output */
-			};
 		};
 	};
 
@@ -27,7 +22,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&spi1_pins &spi1_cs_pins>;
+			pinctrl-0 = <&spi1_pins>;
 			cs-gpios = <&gpio 18 1>, <&gpio 17 1>;
 			status = "okay";
 
@@ -59,10 +54,8 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&spi1_cs_pins>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
-		cs1_pin  = <&spi1_cs_pins>,"brcm,pins:4",
-			   <&frag1>,"cs-gpios:16";
+		cs0_pin  = <&frag1>,"cs-gpios:4";
+		cs1_pin  = <&frag1>,"cs-gpios:16";
 		cs0_spidev = <&spidev1_0>,"status";
 		cs1_spidev = <&spidev1_1>,"status";
 	};

--- a/arch/arm/boot/dts/overlays/spi1-3cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi1-3cs-overlay.dts
@@ -12,11 +12,6 @@
 				brcm,pins = <19 20 21>;
 				brcm,function = <3>; /* alt4 */
 			};
-
-			spi1_cs_pins: spi1_cs_pins {
-				brcm,pins = <18 17 16>;
-				brcm,function = <1>; /* output */
-			};
 		};
 	};
 
@@ -27,7 +22,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&spi1_pins &spi1_cs_pins>;
+			pinctrl-0 = <&spi1_pins>;
 			cs-gpios = <&gpio 18 1>, <&gpio 17 1>, <&gpio 16 1>;
 			status = "okay";
 
@@ -68,12 +63,9 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&spi1_cs_pins>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
-		cs1_pin  = <&spi1_cs_pins>,"brcm,pins:4",
-			   <&frag1>,"cs-gpios:16";
-		cs2_pin  = <&spi1_cs_pins>,"brcm,pins:8",
-			   <&frag1>,"cs-gpios:28";
+		cs0_pin  = <&frag1>,"cs-gpios:4";
+		cs1_pin  = <&frag1>,"cs-gpios:16";
+		cs2_pin  = <&frag1>,"cs-gpios:28";
 		cs0_spidev = <&spidev1_0>,"status";
 		cs1_spidev = <&spidev1_1>,"status";
 		cs2_spidev = <&spidev1_2>,"status";

--- a/arch/arm/boot/dts/overlays/spi2-1cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi2-1cs-overlay.dts
@@ -12,11 +12,6 @@
 				brcm,pins = <40 41 42>;
 				brcm,function = <3>; /* alt4 */
 			};
-
-			spi2_cs_pins: spi2_cs_pins {
-				brcm,pins = <43>;
-				brcm,function = <1>; /* output */
-			};
 		};
 	};
 
@@ -27,7 +22,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&spi2_pins &spi2_cs_pins>;
+			pinctrl-0 = <&spi2_pins>;
 			cs-gpios = <&gpio 43 1>;
 			status = "okay";
 
@@ -50,8 +45,7 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&spi2_cs_pins>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
+		cs0_pin  = <&frag1>,"cs-gpios:4";
 		cs0_spidev = <&spidev2_0>,"status";
 	};
 };

--- a/arch/arm/boot/dts/overlays/spi2-2cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi2-2cs-overlay.dts
@@ -12,11 +12,6 @@
 				brcm,pins = <40 41 42>;
 				brcm,function = <3>; /* alt4 */
 			};
-
-			spi2_cs_pins: spi2_cs_pins {
-				brcm,pins = <43 44>;
-				brcm,function = <1>; /* output */
-			};
 		};
 	};
 
@@ -27,7 +22,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&spi2_pins &spi2_cs_pins>;
+			pinctrl-0 = <&spi2_pins>;
 			cs-gpios = <&gpio 43 1>, <&gpio 44 1>;
 			status = "okay";
 
@@ -59,10 +54,8 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&spi2_cs_pins>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
-		cs1_pin  = <&spi2_cs_pins>,"brcm,pins:4",
-			   <&frag1>,"cs-gpios:16";
+		cs0_pin  = <&frag1>,"cs-gpios:4";
+		cs1_pin  = <&frag1>,"cs-gpios:16";
 		cs0_spidev = <&spidev2_0>,"status";
 		cs1_spidev = <&spidev2_1>,"status";
 	};

--- a/arch/arm/boot/dts/overlays/spi2-3cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi2-3cs-overlay.dts
@@ -12,11 +12,6 @@
 				brcm,pins = <40 41 42>;
 				brcm,function = <3>; /* alt4 */
 			};
-
-			spi2_cs_pins: spi2_cs_pins {
-				brcm,pins = <43 44 45>;
-				brcm,function = <1>; /* output */
-			};
 		};
 	};
 
@@ -27,7 +22,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&spi2_pins &spi2_cs_pins>;
+			pinctrl-0 = <&spi2_pins>;
 			cs-gpios = <&gpio 43 1>, <&gpio 44 1>, <&gpio 45 1>;
 			status = "okay";
 
@@ -68,12 +63,9 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&spi2_cs_pins>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
-		cs1_pin  = <&spi2_cs_pins>,"brcm,pins:4",
-			   <&frag1>,"cs-gpios:16";
-		cs2_pin  = <&spi2_cs_pins>,"brcm,pins:8",
-			   <&frag1>,"cs-gpios:28";
+		cs0_pin  = <&frag1>,"cs-gpios:4";
+		cs1_pin  = <&frag1>,"cs-gpios:16";
+		cs2_pin  = <&frag1>,"cs-gpios:28";
 		cs0_spidev = <&spidev2_0>,"status";
 		cs1_spidev = <&spidev2_1>,"status";
 		cs2_spidev = <&spidev2_2>,"status";

--- a/arch/arm/boot/dts/overlays/spi3-1cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi3-1cs-overlay.dts
@@ -6,22 +6,14 @@
 	compatible = "brcm,bcm2711";
 
 	fragment@0 {
-		target = <&spi3_cs_pins>;
-		frag0: __overlay__ {
-			brcm,pins = <0>;
-			brcm,function = <1>; /* output */
-		};
-	};
-
-	fragment@1 {
 		target = <&spi3>;
-		frag1: __overlay__ {
+		frag0: __overlay__ {
 			/* needed to avoid dtc warning */
 			#address-cells = <1>;
 			#size-cells = <0>;
 
 			pinctrl-names = "default";
-		        pinctrl-0 = <&spi3_pins &spi3_cs_pins>;
+		        pinctrl-0 = <&spi3_pins>;
 			cs-gpios = <&gpio 0 1>;
 			status = "okay";
 
@@ -37,8 +29,7 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&frag0>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
+		cs0_pin  = <&frag0>,"cs-gpios:4";
 		cs0_spidev = <&spidev3_0>,"status";
 	};
 };

--- a/arch/arm/boot/dts/overlays/spi3-2cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi3-2cs-overlay.dts
@@ -6,22 +6,14 @@
 	compatible = "brcm,bcm2711";
 
 	fragment@0 {
-		target = <&spi3_cs_pins>;
-		frag0: __overlay__ {
-			brcm,pins = <0 24>;
-			brcm,function = <1>; /* output */
-		};
-	};
-
-	fragment@1 {
 		target = <&spi3>;
-		frag1: __overlay__ {
+		frag0: __overlay__ {
 			/* needed to avoid dtc warning */
 			#address-cells = <1>;
 			#size-cells = <0>;
 
 			pinctrl-names = "default";
-		        pinctrl-0 = <&spi3_pins &spi3_cs_pins>;
+		        pinctrl-0 = <&spi3_pins>;
 			cs-gpios = <&gpio 0 1>, <&gpio 24 1>;
 			status = "okay";
 
@@ -46,10 +38,8 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&frag0>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
-		cs1_pin  = <&frag0>,"brcm,pins:4",
-			   <&frag1>,"cs-gpios:16";
+		cs0_pin  = <&frag0>,"cs-gpios:4";
+		cs1_pin  = <&frag0>,"cs-gpios:16";
 		cs0_spidev = <&spidev3_0>,"status";
 		cs1_spidev = <&spidev3_1>,"status";
 	};

--- a/arch/arm/boot/dts/overlays/spi4-1cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi4-1cs-overlay.dts
@@ -6,22 +6,14 @@
 	compatible = "brcm,bcm2711";
 
 	fragment@0 {
-		target = <&spi4_cs_pins>;
-		frag0: __overlay__ {
-			brcm,pins = <4>;
-			brcm,function = <1>; /* output */
-		};
-	};
-
-	fragment@1 {
 		target = <&spi4>;
-		frag1: __overlay__ {
+		frag0: __overlay__ {
 			/* needed to avoid dtc warning */
 			#address-cells = <1>;
 			#size-cells = <0>;
 
 			pinctrl-names = "default";
-		        pinctrl-0 = <&spi4_pins &spi4_cs_pins>;
+		        pinctrl-0 = <&spi4_pins>;
 			cs-gpios = <&gpio 4 1>;
 			status = "okay";
 
@@ -37,8 +29,7 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&frag0>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
+		cs0_pin  = <&frag0>,"cs-gpios:4";
 		cs0_spidev = <&spidev4_0>,"status";
 	};
 };

--- a/arch/arm/boot/dts/overlays/spi4-2cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi4-2cs-overlay.dts
@@ -6,22 +6,14 @@
 	compatible = "brcm,bcm2711";
 
 	fragment@0 {
-		target = <&spi4_cs_pins>;
-		frag0: __overlay__ {
-			brcm,pins = <4 25>;
-			brcm,function = <1>; /* output */
-		};
-	};
-
-	fragment@1 {
 		target = <&spi4>;
-		frag1: __overlay__ {
+		frag0: __overlay__ {
 			/* needed to avoid dtc warning */
 			#address-cells = <1>;
 			#size-cells = <0>;
 
 			pinctrl-names = "default";
-		        pinctrl-0 = <&spi4_pins &spi4_cs_pins>;
+		        pinctrl-0 = <&spi4_pins>;
 			cs-gpios = <&gpio 4 1>, <&gpio 25 1>;
 			status = "okay";
 
@@ -46,10 +38,8 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&frag0>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
-		cs1_pin  = <&frag0>,"brcm,pins:4",
-			   <&frag1>,"cs-gpios:16";
+		cs0_pin  = <&frag0>,"cs-gpios:4";
+		cs1_pin  = <&frag0>,"cs-gpios:16";
 		cs0_spidev = <&spidev4_0>,"status";
 		cs1_spidev = <&spidev4_1>,"status";
 	};

--- a/arch/arm/boot/dts/overlays/spi5-1cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi5-1cs-overlay.dts
@@ -6,22 +6,14 @@
 	compatible = "brcm,bcm2711";
 
 	fragment@0 {
-		target = <&spi5_cs_pins>;
-		frag0: __overlay__ {
-			brcm,pins = <12>;
-			brcm,function = <1>; /* output */
-		};
-	};
-
-	fragment@1 {
 		target = <&spi5>;
-		frag1: __overlay__ {
+		frag0: __overlay__ {
 			/* needed to avoid dtc warning */
 			#address-cells = <1>;
 			#size-cells = <0>;
 
 			pinctrl-names = "default";
-		        pinctrl-0 = <&spi5_pins &spi5_cs_pins>;
+		        pinctrl-0 = <&spi5_pins>;
 			cs-gpios = <&gpio 12 1>;
 			status = "okay";
 
@@ -37,8 +29,7 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&frag0>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
+		cs0_pin  = <&frag0>,"cs-gpios:4";
 		cs0_spidev = <&spidev5_0>,"status";
 	};
 };

--- a/arch/arm/boot/dts/overlays/spi5-2cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi5-2cs-overlay.dts
@@ -6,22 +6,14 @@
 	compatible = "brcm,bcm2711";
 
 	fragment@0 {
-		target = <&spi5_cs_pins>;
-		frag0: __overlay__ {
-			brcm,pins = <12 26>;
-			brcm,function = <1>; /* output */
-		};
-	};
-
-	fragment@1 {
 		target = <&spi5>;
-		frag1: __overlay__ {
+		frag0: __overlay__ {
 			/* needed to avoid dtc warning */
 			#address-cells = <1>;
 			#size-cells = <0>;
 
 			pinctrl-names = "default";
-		        pinctrl-0 = <&spi5_pins &spi5_cs_pins>;
+		        pinctrl-0 = <&spi5_pins>;
 			cs-gpios = <&gpio 12 1>, <&gpio 26 1>;
 			status = "okay";
 
@@ -46,10 +38,8 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&frag0>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
-		cs1_pin  = <&frag0>,"brcm,pins:4",
-			   <&frag1>,"cs-gpios:16";
+		cs0_pin  = <&frag0>,"cs-gpios:4";
+		cs1_pin  = <&frag0>,"cs-gpios:16";
 		cs0_spidev = <&spidev5_0>,"status";
 		cs1_spidev = <&spidev5_1>,"status";
 	};

--- a/arch/arm/boot/dts/overlays/spi6-1cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi6-1cs-overlay.dts
@@ -6,22 +6,14 @@
 	compatible = "brcm,bcm2711";
 
 	fragment@0 {
-		target = <&spi6_cs_pins>;
-		frag0: __overlay__ {
-			brcm,pins = <18>;
-			brcm,function = <1>; /* output */
-		};
-	};
-
-	fragment@1 {
 		target = <&spi6>;
-		frag1: __overlay__ {
+		frag0: __overlay__ {
 			/* needed to avoid dtc warning */
 			#address-cells = <1>;
 			#size-cells = <0>;
 
 			pinctrl-names = "default";
-		        pinctrl-0 = <&spi6_pins &spi6_cs_pins>;
+		        pinctrl-0 = <&spi6_pins>;
 			cs-gpios = <&gpio 18 1>;
 			status = "okay";
 
@@ -37,8 +29,7 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&frag0>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
+		cs0_pin  = <&frag0>,"cs-gpios:4";
 		cs0_spidev = <&spidev6_0>,"status";
 	};
 };

--- a/arch/arm/boot/dts/overlays/spi6-2cs-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi6-2cs-overlay.dts
@@ -6,22 +6,14 @@
 	compatible = "brcm,bcm2711";
 
 	fragment@0 {
-		target = <&spi6_cs_pins>;
-		frag0: __overlay__ {
-			brcm,pins = <18 27>;
-			brcm,function = <1>; /* output */
-		};
-	};
-
-	fragment@1 {
 		target = <&spi6>;
-		frag1: __overlay__ {
+		frag0: __overlay__ {
 			/* needed to avoid dtc warning */
 			#address-cells = <1>;
 			#size-cells = <0>;
 
 			pinctrl-names = "default";
-		        pinctrl-0 = <&spi6_pins &spi6_cs_pins>;
+		        pinctrl-0 = <&spi6_pins>;
 			cs-gpios = <&gpio 18 1>, <&gpio 27 1>;
 			status = "okay";
 
@@ -46,10 +38,8 @@
 	};
 
 	__overrides__ {
-		cs0_pin  = <&frag0>,"brcm,pins:0",
-			   <&frag1>,"cs-gpios:4";
-		cs1_pin  = <&frag0>,"brcm,pins:4",
-			   <&frag1>,"cs-gpios:16";
+		cs0_pin  = <&frag0>,"cs-gpios:4";
+		cs1_pin  = <&frag0>,"cs-gpios:16";
 		cs0_spidev = <&spidev6_0>,"status";
 		cs1_spidev = <&spidev6_1>,"status";
 	};

--- a/drivers/spi/spi.c
+++ b/drivers/spi/spi.c
@@ -1775,15 +1775,6 @@ static int of_spi_parse_dt(struct spi_controller *ctlr, struct spi_device *spi,
 	}
 	spi->chip_select = value;
 
-	/*
-	 * For descriptors associated with the device, polarity inversion is
-	 * handled in the gpiolib, so all gpio chip selects are "active high"
-	 * in the logical sense, the gpiolib will invert the line if need be.
-	 */
-	if ((ctlr->use_gpio_descriptors) && ctlr->cs_gpiods &&
-	    ctlr->cs_gpiods[spi->chip_select])
-		spi->mode |= SPI_CS_HIGH;
-
 	/* Device speed */
 	rc = of_property_read_u32(nc, "spi-max-frequency", &value);
 	if (rc) {

--- a/drivers/spi/spidev.c
+++ b/drivers/spi/spidev.c
@@ -394,17 +394,12 @@ spidev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		else
 			retval = get_user(tmp, (u32 __user *)arg);
 		if (retval == 0) {
-			struct spi_controller *ctlr = spi->controller;
 			u32	save = spi->mode;
 
 			if (tmp & ~SPI_MODE_MASK) {
 				retval = -EINVAL;
 				break;
 			}
-
-			if (ctlr->use_gpio_descriptors && ctlr->cs_gpiods &&
-			    ctlr->cs_gpiods[spi->chip_select])
-				tmp |= SPI_CS_HIGH;
 
 			tmp |= spi->mode & ~SPI_MODE_MASK;
 			spi->mode = (u16)tmp;


### PR DESCRIPTION
These three commits, together with the previous "spi: Force CS_HIGH if GPIO descriptors are used", tidy up the handling of SPI Chip Select signals, particularly for controllers that use GPIO descriptors. The problems observed since the end of 2019 stem from the setting too early of SPI_CS_HIGH flag for all CS GPIOs managed by descriptors. The earlier commit moves the flag setting later, and two of these commits remove premature settings.

The third commit avoids a glitch on active-low CS lines on GPIOs that naturally pull high by declaring the pins to pinctrl as inputs.