### PR TITLE
Revert "USB: hub: Don't record a connect-change event during reset-resume"

### DIFF
--- a/drivers/usb/core/hub.c
+++ b/drivers/usb/core/hub.c
@@ -1222,6 +1222,11 @@ static void hub_activate(struct usb_hub *hub, enum hub_activation_type type)
 #ifdef CONFIG_PM
 			udev->reset_resume = 1;
 #endif
+			/* Don't set the change_bits when the device
+			 * was powered off.
+			 */
+			if (test_bit(port1, hub->power_bits))
+				set_bit(port1, hub->change_bits);
 
 		} else {
 			/* The power session is gone; tell hub_wq */


### PR DESCRIPTION
The offending commit is also on 4.19, so please cherry-pick there if there's going to be another 4.19 stable release.

I assume the lengthy description in the original commit means it's eventually going to be part of a larger cleanup, but for now this fixes Pi 4 downstream.