### PR TITLE
overlays: gpio-shutdown: Add information for Raspberry PI 1 rev 1

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -838,6 +838,7 @@ Params: gpiopin                 GPIO for signalling (default 26)
 Name:   gpio-shutdown
 Info:   Initiates a shutdown when GPIO pin changes. The given GPIO pin
         is configured as an input key that generates KEY_POWER events.
+
         This event is handled by systemd-logind by initiating a
         shutdown. Systemd versions older than 225 need an udev rule
         enable listening to the input device:
@@ -845,6 +846,29 @@ Info:   Initiates a shutdown when GPIO pin changes. The given GPIO pin
                 ACTION!="REMOVE", SUBSYSTEM=="input", KERNEL=="event*", \
                         SUBSYSTEMS=="platform", DRIVERS=="gpio-keys", \
                         ATTRS{keys}=="116", TAG+="power-switch"
+
+        Alternatively this event can be handled also on systems without
+        systemd, just by traditional SysV init daemon. KEY_POWER event
+        (keycode 116) needs to be mapped to KeyboardSignal on console
+        and then kb::kbrequest inittab action which is triggered by
+        KeyboardSignal from console can be configured to issue system
+        shutdown. Steps for this configuration are:
+
+            Add following lines to the /etc/console-setup/remap.inc file:
+
+                # Key Power as special keypress
+                keycode 116 = KeyboardSignal
+
+            Then add following lines to /etc/inittab file:
+
+                # Action on special keypress (Key Power)
+                kb::kbrequest:/sbin/shutdown -t1 -a -h -P now
+
+            And finally reload configuration by calling following commands:
+
+                # dpkg-reconfigure console-setup
+                # service console-setup reload
+                # init q
 
         This overlay only handles shutdown. After shutdown, the system
         can be powered up again by driving GPIO3 low. The default

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -874,9 +874,14 @@ Info:   Initiates a shutdown when GPIO pin changes. The given GPIO pin
         can be powered up again by driving GPIO3 low. The default
         configuration uses GPIO3 with a pullup, so if you connect a
         button between GPIO3 and GND (pin 5 and 6 on the 40-pin header),
-        you get a shutdown and power-up button.
+        you get a shutdown and power-up button. Please note that
+        Raspberry Pi 1 Model B rev 1 uses GPIO1 instead of GPIO3.
 Load:   dtoverlay=gpio-shutdown,<param>=<val>
 Params: gpio_pin                GPIO pin to trigger on (default 3)
+                                For Raspberry Pi 1 Model B rev 1 set this
+                                explicitly to value 1, e.g.:
+
+                                    dtoverlay=gpio-shutdown,gpio_pin=1
 
         active_low              When this is 1 (active low), a falling
                                 edge generates a key down event and a
@@ -888,7 +893,8 @@ Params: gpio_pin                GPIO pin to trigger on (default 3)
                                 Default is "up".
 
                                 Note that the default pin (GPIO3) has an
-                                external pullup.
+                                external pullup. Same applies for GPIO1
+                                on Raspberry Pi 1 Model B rev 1.
 
         debounce                Specify the debounce interval in milliseconds
                                 (default 100)

--- a/arch/arm/boot/dts/overlays/gpio-shutdown-overlay.dts
+++ b/arch/arm/boot/dts/overlays/gpio-shutdown-overlay.dts
@@ -4,7 +4,9 @@
 
 // This overlay sets up an input device that generates KEY_POWER events
 // when a given GPIO pin changes. It defaults to using GPIO3, which can
-// also be used to wake up (start) the Rpi again after shutdown. Since
+// also be used to wake up (start) the Rpi again after shutdown.
+// Raspberry Pi 1 Model B rev 1 can be wake up only by GPIO1 pin, so for
+// these boards change default GPIO pin to 1 via gpio_pin parameter. Since
 // wakeup is active-low, this defaults to active-low with a pullup
 // enabled, but all of this can be changed using overlay parameters (but
 // note that GPIO3 has an external pullup on at least some boards).
@@ -71,7 +73,7 @@
 
 		// Allow changing the internal pullup/down state. 0 = none, 1 = pulldown, 2 = pullup
 		// Note that GPIO3 and GPIO2 are the I2c pins and have an external pullup (at least
-                // on some boards).
+		// on some boards). Same applies for GPIO1 on Raspberry Pi 1 Model B rev 1.
 		gpio_pull = <&pin_state>,"brcm,pull:0";
 
 		// Allow setting the active_low flag. 0 = active high, 1 = active low


### PR DESCRIPTION
Older Raspberry PI 1 rev 1 uses GPIO1 for power-up instead of GPIO3.

See discussion: https://github.com/raspberrypi/linux/pull/2103#issuecomment-502347710
CC: @matthijskooijman