### PR TITLE
Fixing some build warnings

### DIFF
--- a/drivers/media/i2c/tc358743.c
+++ b/drivers/media/i2c/tc358743.c
@@ -2002,6 +2002,7 @@ static int tc358743_probe_of(struct tc358743_state *state)
 	switch (bps_pr_lane) {
 	default:
 		dev_warn(dev, "untested bps per lane: %u bps\n", bps_pr_lane);
+		/* fall through */
 	case 594000000U:
 		state->pdata.lineinitcnt = 0xe80;
 		state->pdata.lptxtimecnt = 0x003;

--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -1001,7 +1001,7 @@ const struct unicam_fmt *get_first_supported_format(struct unicam_device *dev)
 {
 	struct v4l2_subdev_mbus_code_enum mbus_code;
 	const struct unicam_fmt *fmt = NULL;
-	int ret;
+	int ret = 0;
 	int j;
 
 	for (j = 0; ret != -EINVAL && ret != -ENOIOCTLCMD; ++j) {


### PR DESCRIPTION
This series of commits fixes some warnings which happen during the building of a kernel for the raspberry pi 4. This does not fix all warnings and only the low-hanging fruit: obvious intentional fallthroughs, misleading indentation and an unitialized variable warning.