### PR TITLE
overlays: Move "fixed-clock" nodes to the root

### DIFF
--- a/arch/arm/boot/dts/overlays/audiosense-pi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/audiosense-pi-overlay.dts
@@ -24,6 +24,13 @@
 				regulator-max-microvolt = <1800000>;
 				regulator-always-on;
 			};
+
+			/* audio external oscillator */
+			codec_osc: codec_osc {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <12000000>;	/* 12 MHz */
+			};
 		};
 	};
 
@@ -43,13 +50,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
-
-			/* audio external oscillator */
-			codec_osc: codec_osc {
-				compatible = "fixed-clock";
-				#clock-cells = <0>;
-				clock-frequency = <12000000>;	/* 12 MHz */
-			};
 
 			codec: tlv320aic32x4@18 {
 				#sound-dai-cells = <0>;

--- a/arch/arm/boot/dts/overlays/draws-overlay.dts
+++ b/arch/arm/boot/dts/overlays/draws-overlay.dts
@@ -30,6 +30,12 @@
                     regulator-max-microvolt = <3300000>;
                     regulator-always-on;
                 };
+
+                sc16is752_clk: sc16is752_draws_clk {
+                    compatible = "fixed-clock";
+                    #clock-cells = <0>;
+                    clock-frequency = <1843200>;
+                };
             };
 
             pps: pps {
@@ -78,12 +84,6 @@
 
                 pinctrl-names = "default";
                 pinctrl-0 = <&sc16is752_irq>;
-
-                sc16is752_clk: sc16is752_clk {
-                    compatible = "fixed-clock";
-                    #clock-cells = <0>;
-                    clock-frequency = <1843200>;
-                };
             };
 
             tla2024: tla2024@48 {

--- a/arch/arm/boot/dts/overlays/fe-pi-audio-overlay.dts
+++ b/arch/arm/boot/dts/overlays/fe-pi-audio-overlay.dts
@@ -6,7 +6,7 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&clocks>;
+		target-path = "/";
 		__overlay__ {
 			sgtl5000_mclk: sgtl5000_mclk {
 				compatible = "fixed-clock";

--- a/arch/arm/boot/dts/overlays/imx219-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx219-overlay.dts
@@ -27,12 +27,6 @@
 				VDIG-supply = <&imx219_vdig>;	/* 1.8v */
 				VDDL-supply = <&imx219_vddl>;	/* 1.2v */
 
-				imx219_clk: camera-clk {
-					compatible = "fixed-clock";
-					#clock-cells = <0>;
-					clock-frequency = <24000000>;
-				};
-
 				port {
 					imx219_0: endpoint {
 						remote-endpoint = <&csi1_ep>;
@@ -89,6 +83,12 @@
 				regulator-name = "imx219_vddl";
 				regulator-min-microvolt = <1200000>;
 				regulator-max-microvolt = <1200000>;
+			};
+
+			imx219_clk: camera-clk {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <24000000>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/irs1125-overlay.dts
+++ b/arch/arm/boot/dts/overlays/irs1125-overlay.dts
@@ -21,12 +21,6 @@
 				pwdn-gpios = <&gpio 5 0>;
 				clocks = <&irs1125_clk>;
 
-				irs1125_clk: camera-clk {
-					compatible = "fixed-clock";
-					#clock-cells = <0>;
-					clock-frequency = <26000000>;
-				};
-
 				port {
 					irs1125_0: endpoint {
 						remote-endpoint = <&csi1_ep>;
@@ -73,6 +67,17 @@
 		__overlay__ {
 			cam0-pwdn-ctrl = <&irs1125>,"pwdn-gpios:0";
 			cam0-pwdn      = <&irs1125>,"pwdn-gpios:4";
+		};
+	};
+
+	fragment@5 {
+		target-path = "/";
+		__overlay__ {
+			irs1125_clk: camera-clk {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <26000000>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/overlays/mcp2515-can0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp2515-can0-overlay.dts
@@ -35,7 +35,7 @@
 
     /* the clock/oscillator of the can-controller */
     fragment@3 {
-        target-path = "/clocks";
+        target-path = "/";
         __overlay__ {
             /* external oscillator of mcp2515 on SPI0.0 */
             can0_osc: can0_osc {

--- a/arch/arm/boot/dts/overlays/mcp2515-can1-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp2515-can1-overlay.dts
@@ -35,7 +35,7 @@
 
     /* the clock/oscillator of the can-controller */
     fragment@3 {
-        target-path = "/clocks";
+        target-path = "/";
         __overlay__ {
             /* external oscillator of mcp2515 on spi0.1 */
             can1_osc: can1_osc {

--- a/arch/arm/boot/dts/overlays/midi-uart0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart0-overlay.dts
@@ -15,7 +15,7 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target-path = "/clocks";
+		target-path = "/";
 		__overlay__ {
 			midi_clk: midi_clk {
 				compatible = "fixed-clock";

--- a/arch/arm/boot/dts/overlays/ov5647-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov5647-overlay.dts
@@ -21,12 +21,6 @@
 				pwdn-gpios = <&gpio 41 1>, <&gpio 32 1>;
 				clocks = <&ov5647_clk>;
 
-				ov5647_clk: camera-clk {
-					compatible = "fixed-clock";
-					#clock-cells = <0>;
-					clock-frequency = <25000000>;
-				};
-
 				port {
 					ov5647_0: endpoint {
 						remote-endpoint = <&csi1_ep>;
@@ -75,6 +69,17 @@
 			cam0-pwdn      = <&ov5647>,"pwdn-gpios:4";
 			cam0-led-ctrl  = <&ov5647>,"pwdn-gpios:12";
 			cam0-led       = <&ov5647>,"pwdn-gpios:16";
+		};
+	};
+
+	fragment@5 {
+		target-path = "/";
+		__overlay__ {
+			ov5647_clk: camera-clk {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <25000000>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/overlays/rpivid-v4l2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpivid-v4l2-overlay.dts
@@ -26,12 +26,6 @@
 
 				clocks = <&hevc_clk>;
 				clock-names = "hevc";
-
-				hevc_clk: hevc_clk {
-					compatible = "fixed-clock";
-					#clock-cells = <0>;
-					clock-frequency = <500000000>;
-				};
 			};
 		};
 	};
@@ -50,6 +44,17 @@
 			};
 			vp9-decoder@7eb30000 {
 				status = "disabled";
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			hevc_clk: hevc_clk {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <500000000>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/sc16is752-spi1-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is752-spi1-overlay.dts
@@ -38,12 +38,6 @@
 				#gpio-controller;
 				#gpio-cells = <2>;
 				spi-max-frequency = <4000000>;
-
-				sc16is752_clk: sc16is752_clk {
-					compatible = "fixed-clock";
-					#clock-cells = <0>;
-					clock-frequency = <14745600>;
-				};
 			};
 		};
 	};
@@ -55,8 +49,19 @@
 		};
 	};
 
-    __overrides__ {
+	fragment@3 {
+		target-path = "/";
+		__overlay__ {
+			sc16is752_clk: sc16is752_spi1_clk {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <14745600>;
+			};
+		};
+	};
+
+	__overrides__ {
 		int_pin = <&sc16is752>,"interrupts:0";
 		xtal = <&sc16is752_clk>,"clock-frequency:0";
-    };
+	};
 };

--- a/arch/arm/boot/dts/overlays/tc358743-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tc358743-overlay.dts
@@ -21,12 +21,6 @@
 				clocks = <&tc358743_clk>;
 				clock-names = "refclk";
 
-				tc358743_clk: bridge-clk {
-					compatible = "fixed-clock";
-					#clock-cells = <0>;
-					clock-frequency = <27000000>;
-				};
-
 				port {
 					tc358743: endpoint {
 						remote-endpoint = <&csi1_ep>;
@@ -78,6 +72,17 @@
 		target = <&i2c0mux>;
 		__overlay__ {
 			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target-path = "/";
+		__overlay__ {
+			tc358743_clk: bridge-clk {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <27000000>;
+			};
 		};
 	};
 


### PR DESCRIPTION
Apart from some special cases, device objects are only created for
nodes if they are children of a bus or the root node. "fixed-clock"
is one of the exceptions that will be instantiated wherever it is
found, but only during kernel initialisation - ruling out loading the
overlay at runtime.

Move most of the affected clocks to be children of the root, only
leaving those in overlays that could be multiply instantiated, to avoid
a potential name clash.

See: https://github.com/raspberrypi/linux/issues/3602

Signed-off-by: Phil Elwell <phil@raspberrypi.com>