### PR TITLE
media: bcm2835-unicam: Always service interrupts

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -766,12 +766,6 @@ static int unicam_all_nodes_streaming(struct unicam_device *dev)
 	return ret;
 }
 
-static int unicam_all_nodes_disabled(struct unicam_device *dev)
-{
-	return !dev->node[IMAGE_PAD].streaming &&
-	       !dev->node[METADATA_PAD].streaming;
-}
-
 static void unicam_queue_event_sof(struct unicam_device *unicam)
 {
 	struct v4l2_event event = {
@@ -800,15 +794,6 @@ static irqreturn_t unicam_isr(int irq, void *dev)
 	int ista, sta;
 	u64 ts;
 	int i;
-
-	/*
-	 * Don't service interrupts if not streaming.
-	 * Avoids issues if the VPU should enable the
-	 * peripheral without the kernel knowing (that
-	 * shouldn't happen, but causes issues if it does).
-	 */
-	if (unicam_all_nodes_disabled(unicam))
-		return IRQ_HANDLED;
 
 	sta = reg_read(cfg, UNICAM_STA);
 	/* Write value back to clear the interrupts */


### PR DESCRIPTION
From when bringing up the driver, there was a check in the isr
to ignore interrupts (claiming them handled) should the driver
not be streaming.

The VPU now will not register a camera driver if it finds a
CSI2 node enabled in device tree, therefore this flawed check is
redundant.

https://github.com/raspberrypi/linux/issues/3602

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>