### PR TITLE
arm: dt: For 2711 move vc4 gpu node under soc to get correct dma-ranges

### DIFF
--- a/arch/arm/boot/dts/bcm2711.dtsi
+++ b/arch/arm/boot/dts/bcm2711.dtsi
@@ -12,11 +12,6 @@
 
 	interrupt-parent = <&gicv2>;
 
-	vc4: gpu {
-		compatible = "brcm,bcm2711-vc5";
-		status = "disabled";
-	};
-
 	clk_108MHz: clk-108M {
 		#clock-cells = <0>;
 		compatible = "fixed-clock";
@@ -385,6 +380,12 @@
 			clock-frequency = <97500>;
 			status = "disabled";
 		};
+
+		vc4: gpu {
+			compatible = "brcm,bcm2711-vc5";
+			status = "disabled";
+		};
+
 	};
 
 	arm-pmu {


### PR DESCRIPTION
The vc4: gpu / "brcm,bcm2711-vc5" DT node was under the root node,
therefore didn't get the soc dma-ranges to choose the uncached
cache alias. Buffers were therefore allocated and passed to the
HVS in both full and fake KMS modes with incorrect addresses.

Move the node under /soc to get the correct addresses.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>