### PR TITLE
media: i2c: imx477: Return correct result on sensor id verification

### DIFF
--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -1919,7 +1919,7 @@ static int imx477_identify_module(struct imx477 *imx477)
 	if (val != IMX477_CHIP_ID) {
 		dev_err(&client->dev, "chip id mismatch: %x!=%x\n",
 			IMX477_CHIP_ID, val);
-		ret = -EINVAL;
+		return -EIO;
 	}
 
 	return 0;


### PR DESCRIPTION
The test should return -EIO if the register read id does not match
the expected sensor id.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>