### PR TITLE
media: bcm2835-unicam: change minimum number of vb2_queue buffers to 1

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -2404,7 +2404,7 @@ static int register_node(struct unicam_device *unicam, struct unicam_node *node,
 	q->buf_struct_size = sizeof(struct unicam_buffer);
 	q->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
 	q->lock = &node->lock;
-	q->min_buffers_needed = 2;
+	q->min_buffers_needed = 1;
 	q->dev = &unicam->pdev->dev;
 
 	ret = vb2_queue_init(q);


### PR DESCRIPTION
Since the unicam driver was modified to write to a dummy buffer when no
user-supplied buffer is available, it can now write to and return a
buffer even when there's only a single one. Enable this by changing the
min_buffers_needed in the vb2_queue; it will be useful for enabling
still captures without allocating more memory than absolutely necessary.