### PR TITLE
media: bcm2835-isp: fix bytes per line calculations for some image fo…

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
@@ -676,7 +676,11 @@ struct bcm2835_isp_fmt *get_default_format(struct bcm2835_isp_node *node)
 static inline unsigned int get_bytesperline(int width,
 					    const struct bcm2835_isp_fmt *fmt)
 {
-	return ALIGN((width * fmt->depth) >> 3, fmt->bytesperline_align);
+	/* GPU aligns 24bpp images to a multiple of 32 pixels (not bytes). */
+	if (fmt->depth == 24)
+		return ALIGN(width, 32) * 3;
+	else
+		return ALIGN((width * fmt->depth) >> 3, fmt->bytesperline_align);
 }
 
 static inline unsigned int get_sizeimage(int bpl, int width, int height,

--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835_isp_fmts.h
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835_isp_fmts.h
@@ -71,7 +71,7 @@ static const struct bcm2835_isp_fmt supported_formats[] = {
 	}, {
 		.fourcc		    = V4L2_PIX_FMT_YUYV,
 		.depth		    = 16,
-		.bytesperline_align = 32,
+		.bytesperline_align = 64,
 		.flags		    = 0,
 		.mmal_fmt	    = MMAL_ENCODING_YUYV,
 		.size_multiplier_x2 = 2,
@@ -80,7 +80,7 @@ static const struct bcm2835_isp_fmt supported_formats[] = {
 	}, {
 		.fourcc		    = V4L2_PIX_FMT_UYVY,
 		.depth		    = 16,
-		.bytesperline_align = 32,
+		.bytesperline_align = 64,
 		.flags		    = 0,
 		.mmal_fmt	    = MMAL_ENCODING_UYVY,
 		.size_multiplier_x2 = 2,
@@ -89,7 +89,7 @@ static const struct bcm2835_isp_fmt supported_formats[] = {
 	}, {
 		.fourcc		    = V4L2_PIX_FMT_YVYU,
 		.depth		    = 16,
-		.bytesperline_align = 32,
+		.bytesperline_align = 64,
 		.flags		    = 0,
 		.mmal_fmt	    = MMAL_ENCODING_YVYU,
 		.size_multiplier_x2 = 2,
@@ -98,7 +98,7 @@ static const struct bcm2835_isp_fmt supported_formats[] = {
 	}, {
 		.fourcc		    = V4L2_PIX_FMT_VYUY,
 		.depth		    = 16,
-		.bytesperline_align = 32,
+		.bytesperline_align = 64,
 		.flags		    = 0,
 		.mmal_fmt	    = MMAL_ENCODING_VYUY,
 		.size_multiplier_x2 = 2,
@@ -135,7 +135,7 @@ static const struct bcm2835_isp_fmt supported_formats[] = {
 	}, {
 		.fourcc		    = V4L2_PIX_FMT_ABGR32,
 		.depth		    = 32,
-		.bytesperline_align = 32,
+		.bytesperline_align = 64,
 		.flags		    = 0,
 		.mmal_fmt	    = MMAL_ENCODING_BGRA,
 		.size_multiplier_x2 = 2,


### PR DESCRIPTION
…rmats

The bytes per line numbers calculated by get_bytesperline was not
matching the equivalent calculation being performed by the VideoCore
(mostly by the calculate_pitch function there), resulting in failures
to set the image format with some image width values. This patches up
the RGB24 and YUYV type formats to match the VideoCore calculation.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>