### PR TITLE
Add Micro Crystal RV-1805 to i2c-rtc overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1196,6 +1196,8 @@ Params: abx80x                  Select one of the ABx80x family:
 
         pcf8563                 Select the PCF8563 device
 
+        rv1805                  Select the Micro Crystal RV1805 device
+
         rv3028                  Select the Micro Crystal RV3028 device
 
         addr                    Sets the address for the RTC. Note that the
@@ -1203,10 +1205,10 @@ Params: abx80x                  Select one of the ABx80x family:
                                 address.
 
         trickle-diode-type      Diode type for trickle charge - "standard" or
-                                "schottky" (ABx80x only)
+                                "schottky" (ABx80x and RV1805 only)
 
         trickle-resistor-ohms   Resistor value for trickle charge (DS1339,
-                                ABx80x, RV3028)
+                                ABx80x, RV1805, RV3028)
 
         wakeup-source           Specify that the RTC can be used as a wakeup
                                 source
@@ -1243,6 +1245,8 @@ Params: abx80x                  Select one of the ABx80x family:
 
         pcf8563                 Select the PCF8563 device
 
+        rv1805                  Select the Micro Crystal RV1805 device
+
         rv3028                  Select the Micro Crystal RV3028 device
 
         addr                    Sets the address for the RTC. Note that the
@@ -1250,10 +1254,10 @@ Params: abx80x                  Select one of the ABx80x family:
                                 address.
 
         trickle-diode-type      Diode type for trickle charge - "standard" or
-                                "schottky" (ABx80x only)
+                                "schottky" (ABx80x and RV1805 only)
 
         trickle-resistor-ohms   Resistor value for trickle charge (DS1339,
-                                ABx80x, RV3028)
+                                ABx80x, RV1805, RV3028)
 
         wakeup-source           Specify that the RTC can be used as a wakeup
                                 source

--- a/arch/arm/boot/dts/overlays/i2c-rtc-gpio-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-rtc-gpio-overlay.dts
@@ -204,6 +204,23 @@
 		};
 	};
 
+	fragment@13 {
+		target = <&i2c_gpio>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			rv1805: rv1805@69 {
+				compatible = "microcrystal,rv1805";
+				reg = <0x69>;
+				abracon,tc-diode = "standard";
+				abracon,tc-resistor = <0>;
+				status = "okay";
+			};
+		};
+	};
+
 	__overrides__ {
 		abx80x = <0>,"+1";
 		ds1307 = <0>,"+2";
@@ -217,6 +234,7 @@
 		m41t62 = <0>,"+10";
 		rv3028 = <0>,"+11";
 		pcf2129 = <0>,"+12";
+		rv1805 = <0>,"+13";
 
 		addr = <&abx80x>, "reg:0",
 		       <&ds1307>, "reg:0",
@@ -226,12 +244,14 @@
 		       <&mcp7941x>, "reg:0",
 		       <&pcf8523>, "reg:0",
 		       <&pcf8563>, "reg:0",
-		       <&m41t62>, "reg:0";
-
-		trickle-diode-type = <&abx80x>,"abracon,tc-diode";
+		       <&m41t62>, "reg:0",
+		       <&rv1805>, "reg:0";
+		trickle-diode-type = <&abx80x>,"abracon,tc-diode",
+				     <&rv1805>,"abracon,tc-diode";
 		trickle-resistor-ohms = <&ds1339>,"trickle-resistor-ohms:0",
 					<&abx80x>,"abracon,tc-resistor:0",
-					<&rv3028>,"trickle-resistor-ohms:0";
+					<&rv3028>,"trickle-resistor-ohms:0",
+					<&rv1805>,"abracon,tc-resistor:0";
 		backup-switchover-mode = <&rv3028>,"backup-switchover-mode:0";
 		wakeup-source = <&ds1339>,"wakeup-source?",
 				<&ds3231>,"wakeup-source?",

--- a/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
@@ -203,6 +203,23 @@
 		};
 	};
 
+	fragment@13 {
+		target = <&i2c_arm>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			rv1805: rv1805@69 {
+				compatible = "microcrystal,rv1805";
+				reg = <0x69>;
+				abracon,tc-diode = "standard";
+				abracon,tc-resistor = <0>;
+				status = "okay";
+			};
+		};
+	};
+
 	__overrides__ {
 		abx80x = <0>,"+0";
 		ds1307 = <0>,"+1";
@@ -217,6 +234,7 @@
 		rv3028 = <0>,"+10";
 		pcf2129 = <0>,"+11";
 		pcf85363 = <0>,"+12";
+		rv1805 = <0>,"+13";
 
 		addr = <&abx80x>, "reg:0",
 		       <&ds1307>, "reg:0",
@@ -226,11 +244,14 @@
 		       <&mcp7941x>, "reg:0",
 		       <&pcf8523>, "reg:0",
 		       <&pcf8563>, "reg:0",
-		       <&m41t62>, "reg:0";
-		trickle-diode-type = <&abx80x>,"abracon,tc-diode";
+		       <&m41t62>, "reg:0",
+		       <&rv1805>, "reg:0";
+		trickle-diode-type = <&abx80x>,"abracon,tc-diode",
+				     <&rv1805>,"abracon,tc-diode";
 		trickle-resistor-ohms = <&ds1339>,"trickle-resistor-ohms:0",
 					<&abx80x>,"abracon,tc-resistor:0",
-					<&rv3028>,"trickle-resistor-ohms:0";
+					<&rv3028>,"trickle-resistor-ohms:0",
+					<&rv1805>,"abracon,tc-resistor:0";
 		backup-switchover-mode = <&rv3028>,"backup-switchover-mode:0";
 		wakeup-source = <&ds1339>,"wakeup-source?",
 				<&ds3231>,"wakeup-source?",


### PR DESCRIPTION
In discussions with one of the maintainers about the rtc-abx80x driver and support of the RV-1805 device, it was made clear that relying on the auto-detection behavior in the driver will result in this device being improperly initialized. The maintainer would actually prefer to remove the auto-detection logic completely, but it at least works properly for the Abracon-branded devices originally supported by the driver.

This patch adds an explicit rv1805 entry to the i2c-rtc overlays so that the user can specify it in config.txt. It has been produced (and tested) against the rpi-5.4.y branch but should apply cleanly to the other branches as well.

Note that there is an existing difference between these overlays: i2c-rtc-overlay has support for the pcf85363, but the i2c-rtc-gpio-overlay does not. This results in numbering differences between some of the fragments.