### PR TITLE
staging: bcm2835-audio: Add missing MODULE_ALIAS

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
+++ b/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
@@ -438,3 +438,4 @@ module_platform_driver(bcm2835_alsa_driver);
 MODULE_AUTHOR("Dom Cobley");
 MODULE_DESCRIPTION("Alsa driver for BCM2835 chip");
 MODULE_LICENSE("GPL");
+MODULE_ALIAS("platform:bcm2835_audio");


### PR DESCRIPTION
After changes introduced by #3448, bcm2835-audio doesn't have modalias `platform:bcm2835_audio` anymore, but it's added as a platform device child of VCHIQ. It leads to a situation where `snd_bcm2825` module is not probed on boot, even with `dtparam=audio=on`. The issue is fixed by this commit.