### PR TITLE
dtoverlays: Fixup imx219 and imx477 overlays due to parsing failures

### DIFF
--- a/arch/arm/boot/dts/overlays/imx219-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx219-overlay.dts
@@ -49,6 +49,9 @@
 			port {
 				csi1_ep: endpoint {
 					remote-endpoint = <&imx219_0>;
+					clock-lanes = <0>;
+					data-lanes = <1 2>;
+					clock-noncontinuous;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/overlays/imx477-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx477-overlay.dts
@@ -49,7 +49,9 @@
 			port {
 				csi1_ep: endpoint {
 					remote-endpoint = <&imx477_0>;
+					clock-lanes = <0>;
 					data-lanes = <1 2>;
+					clock-noncontinuous;
 				};
 			};
 		};


### PR DESCRIPTION
imx219 overlay failed to detect as CSI2 as it was missing any
of the CSI2 properties on the Unicam end of the configuration.
Clean up imx477 as well to include all the relevant properties.

Fixes: "dt/dtoverlays: Fix up base DT and overlays for updated Unicam driver"

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>