### PR TITLE
pi: add skip-init flag to disable-bt overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/disable-bt-overlay.dts
+++ b/arch/arm/boot/dts/overlays/disable-bt-overlay.dts
@@ -17,6 +17,7 @@
 		target = <&uart1>;
 		__overlay__ {
 			status = "disabled";
+			skip-init;
 		};
 	};
 
@@ -26,6 +27,7 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&uart0_pins>;
 			status = "okay";
+			skip-init;
 		};
 	};
 


### PR DESCRIPTION
If this flag is not set, u-boot will fail while trying to (re)init the
uart devices when the disable-bt overlay is used.

Signed-off-by: Florian Wickert <fw@ferncast.de>