### PR TITLE
ARM: dts: Add UART skip-init properties for U-boot

### DIFF
--- a/arch/arm/boot/dts/bcm270x-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm270x-rpi.dtsi
@@ -102,6 +102,14 @@
 	};
 };
 
+&uart0 {
+	skip-init;
+};
+
+&uart1 {
+	skip-init;
+};
+
 &txp {
 	status = "disabled";
 };


### PR DESCRIPTION
U-boot can get stuck trying to initialise UARTs that aren't mapped
to the pin header. There is no reason for U-boot not to rely on the
initialisation by the firmware, so tag both UARTs with the u-boot
magic boolean property "skip-init".

See: https://github.com/raspberrypi/linux/pull/3731
     https://lists.denx.de/pipermail/u-boot/2017-April/285606.html

Signed-off-by: Phil Elwell <phil@raspberrypi.com>