### PR TITLE
Revert "drm/vc4: Allocate binner bo when starting to use the V3D"

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_bo.c
+++ b/drivers/gpu/drm/vc4/vc4_bo.c
@@ -793,35 +793,12 @@ vc4_prime_import_sg_table(struct drm_device *dev,
 	return obj;
 }
 
-static int vc4_grab_bin_bo(struct vc4_dev *vc4, struct vc4_file *vc4file)
-{
-	int ret;
-
-	if (!vc4->v3d)
-		return -ENODEV;
-
-	if (vc4file->bin_bo_used)
-		return 0;
-
-	ret = vc4_v3d_bin_bo_get(vc4, &vc4file->bin_bo_used);
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
 int vc4_create_bo_ioctl(struct drm_device *dev, void *data,
 			struct drm_file *file_priv)
 {
 	struct drm_vc4_create_bo *args = data;
-	struct vc4_file *vc4file = file_priv->driver_priv;
-	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct vc4_bo *bo = NULL;
 	int ret;
-
-	ret = vc4_grab_bin_bo(vc4, vc4file);
-	if (ret)
-		return ret;
 
 	/*
 	 * We can't allocate from the BO cache, because the BOs don't
@@ -863,8 +840,6 @@ vc4_create_shader_bo_ioctl(struct drm_device *dev, void *data,
 			   struct drm_file *file_priv)
 {
 	struct drm_vc4_create_shader_bo *args = data;
-	struct vc4_file *vc4file = file_priv->driver_priv;
-	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct vc4_bo *bo = NULL;
 	int ret;
 
@@ -883,10 +858,6 @@ vc4_create_shader_bo_ioctl(struct drm_device *dev, void *data,
 		DRM_INFO("Pad set: 0x%08x\n", args->pad);
 		return -EINVAL;
 	}
-
-	ret = vc4_grab_bin_bo(vc4, vc4file);
-	if (ret)
-		return ret;
 
 	bo = vc4_bo_create(dev, args->size, true, VC4_BO_TYPE_V3D_SHADER);
 	if (IS_ERR(bo))
@@ -917,7 +888,7 @@ vc4_create_shader_bo_ioctl(struct drm_device *dev, void *data,
 	 */
 	ret = drm_gem_handle_create(file_priv, &bo->base.base, &args->handle);
 
-fail:
+ fail:
 	drm_gem_object_put_unlocked(&bo->base.base);
 
 	return ret;

--- a/drivers/gpu/drm/vc4/vc4_drv.c
+++ b/drivers/gpu/drm/vc4/vc4_drv.c
@@ -130,11 +130,7 @@ static int vc4_open(struct drm_device *dev, struct drm_file *file)
 
 static void vc4_close(struct drm_device *dev, struct drm_file *file)
 {
-	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct vc4_file *vc4file = file->driver_priv;
-
-	if (vc4file->bin_bo_used)
-		vc4_v3d_bin_bo_put(vc4);
 
 	vc4_perfmon_close_file(vc4file);
 	kfree(vc4file);
@@ -295,8 +291,6 @@ static int vc4_drm_bind(struct device *dev)
 	vc4->dev = drm;
 	drm->dev_private = vc4;
 	INIT_LIST_HEAD(&vc4->debugfs_list);
-
-	mutex_init(&vc4->bin_bo_lock);
 
 	ret = vc4_bo_cache_init(drm);
 	if (ret)

--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -228,11 +228,6 @@ struct vc4_dev {
 	 * the minor is available (after drm_dev_register()).
 	 */
 	struct list_head debugfs_list;
-
-	/* Mutex for binner bo allocation. */
-	struct mutex bin_bo_lock;
-	/* Reference count for our binner bo. */
-	struct kref bin_bo_kref;
 };
 
 static inline struct vc4_dev *
@@ -634,11 +629,6 @@ struct vc4_exec_info {
 	 * NULL otherwise.
 	 */
 	struct vc4_perfmon *perfmon;
-
-	/* Whether the exec has taken a reference to the binner BO, which should
-	 * happen with a VC4_PACKET_TILE_BINNING_MODE_CONFIG packet.
-	 */
-	bool bin_bo_used;
 };
 
 /* Per-open file private data. Any driver-specific resource that has to be
@@ -649,8 +639,6 @@ struct vc4_file {
 		struct idr idr;
 		struct mutex lock;
 	} perfmon;
-
-	bool bin_bo_used;
 };
 
 static inline struct vc4_exec_info *
@@ -893,8 +881,6 @@ void vc4_plane_async_set_fb(struct drm_plane *plane,
 extern struct platform_driver vc4_v3d_driver;
 extern const struct of_device_id vc4_v3d_dt_match[];
 int vc4_v3d_get_bin_slot(struct vc4_dev *vc4);
-int vc4_v3d_bin_bo_get(struct vc4_dev *vc4, bool *used);
-void vc4_v3d_bin_bo_put(struct vc4_dev *vc4);
 int vc4_v3d_pm_get(struct vc4_dev *vc4);
 void vc4_v3d_pm_put(struct vc4_dev *vc4);
 

--- a/drivers/gpu/drm/vc4/vc4_gem.c
+++ b/drivers/gpu/drm/vc4/vc4_gem.c
@@ -822,7 +822,6 @@ static int
 vc4_get_bcl(struct drm_device *dev, struct vc4_exec_info *exec)
 {
 	struct drm_vc4_submit_cl *args = exec->args;
-	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	void *temp = NULL;
 	void *bin;
 	int ret = 0;
@@ -921,12 +920,6 @@ vc4_get_bcl(struct drm_device *dev, struct vc4_exec_info *exec)
 	if (ret)
 		goto fail;
 
-	if (exec->found_tile_binning_mode_config_packet) {
-		ret = vc4_v3d_bin_bo_get(vc4, &exec->bin_bo_used);
-		if (ret)
-			goto fail;
-	}
-
 	/* Block waiting on any previous rendering into the CS's VBO,
 	 * IB, or textures, so that pixels are actually written by the
 	 * time we try to read them.
@@ -974,10 +967,6 @@ vc4_complete_exec(struct drm_device *dev, struct vc4_exec_info *exec)
 	spin_lock_irqsave(&vc4->job_lock, irqflags);
 	vc4->bin_alloc_used &= ~exec->bin_slots;
 	spin_unlock_irqrestore(&vc4->job_lock, irqflags);
-
-	/* Release the reference on the binner BO if needed. */
-	if (exec->bin_bo_used)
-		vc4_v3d_bin_bo_put(vc4);
 
 	/* Release the reference we had on the perf monitor. */
 	vc4_perfmon_put(exec->perfmon);

--- a/drivers/gpu/drm/vc4/vc4_irq.c
+++ b/drivers/gpu/drm/vc4/vc4_irq.c
@@ -59,22 +59,18 @@ vc4_overflow_mem_work(struct work_struct *work)
 {
 	struct vc4_dev *vc4 =
 		container_of(work, struct vc4_dev, overflow_mem_work);
-	struct vc4_bo *bo;
+	struct vc4_bo *bo = vc4->bin_bo;
 	int bin_bo_slot;
 	struct vc4_exec_info *exec;
 	unsigned long irqflags;
 
-	mutex_lock(&vc4->bin_bo_lock);
-
-	if (!vc4->bin_bo)
-		goto complete;
-
-	bo = vc4->bin_bo;
+	if (!bo)
+		return;
 
 	bin_bo_slot = vc4_v3d_get_bin_slot(vc4);
 	if (bin_bo_slot < 0) {
 		DRM_ERROR("Couldn't allocate binner overflow mem\n");
-		goto complete;
+		return;
 	}
 
 	spin_lock_irqsave(&vc4->job_lock, irqflags);
@@ -105,9 +101,6 @@ vc4_overflow_mem_work(struct work_struct *work)
 	V3D_WRITE(V3D_INTCTL, V3D_INT_OUTOMEM);
 	V3D_WRITE(V3D_INTENA, V3D_INT_OUTOMEM);
 	spin_unlock_irqrestore(&vc4->job_lock, irqflags);
-
-complete:
-	mutex_unlock(&vc4->bin_bo_lock);
 }
 
 static void
@@ -259,10 +252,8 @@ vc4_irq_postinstall(struct drm_device *dev)
 	if (!vc4->v3d)
 		return 0;
 
-	/* Enable the render done interrupts. The out-of-memory interrupt is
-	 * enabled as soon as we have a binner BO allocated.
-	 */
-	V3D_WRITE(V3D_INTENA, V3D_INT_FLDONE | V3D_INT_FRDONE);
+	/* Enable both the render done and out of memory interrupts. */
+	V3D_WRITE(V3D_INTENA, V3D_DRIVER_IRQS);
 
 	return 0;
 }

--- a/drivers/gpu/drm/vc4/vc4_v3d.c
+++ b/drivers/gpu/drm/vc4/vc4_v3d.c
@@ -287,14 +287,6 @@ static int bin_bo_alloc(struct vc4_dev *vc4)
 			WARN_ON_ONCE(sizeof(vc4->bin_alloc_used) * 8 !=
 				     bo->base.base.size / vc4->bin_alloc_size);
 
-			kref_init(&vc4->bin_bo_kref);
-
-			/* Enable the out-of-memory interrupt to set our
-			 * newly-allocated binner BO, potentially from an
-			 * already-pending-but-masked interrupt.
-			 */
-			V3D_WRITE(V3D_INTENA, V3D_INT_OUTOMEM);
-
 			break;
 		}
 
@@ -314,47 +306,6 @@ static int bin_bo_alloc(struct vc4_dev *vc4)
 	return ret;
 }
 
-int vc4_v3d_bin_bo_get(struct vc4_dev *vc4, bool *used)
-{
-	int ret = 0;
-
-	mutex_lock(&vc4->bin_bo_lock);
-
-	if (used && *used)
-		goto complete;
-
-	if (vc4->bin_bo)
-		kref_get(&vc4->bin_bo_kref);
-	else
-		ret = bin_bo_alloc(vc4);
-
-	if (ret == 0 && used)
-		*used = true;
-
-complete:
-	mutex_unlock(&vc4->bin_bo_lock);
-
-	return ret;
-}
-
-static void bin_bo_release(struct kref *ref)
-{
-	struct vc4_dev *vc4 = container_of(ref, struct vc4_dev, bin_bo_kref);
-
-	if (WARN_ON_ONCE(!vc4->bin_bo))
-		return;
-
-	drm_gem_object_put_unlocked(&vc4->bin_bo->base.base);
-	vc4->bin_bo = NULL;
-}
-
-void vc4_v3d_bin_bo_put(struct vc4_dev *vc4)
-{
-	mutex_lock(&vc4->bin_bo_lock);
-	kref_put(&vc4->bin_bo_kref, bin_bo_release);
-	mutex_unlock(&vc4->bin_bo_lock);
-}
-
 #ifdef CONFIG_PM
 static int vc4_v3d_runtime_suspend(struct device *dev)
 {
@@ -362,6 +313,9 @@ static int vc4_v3d_runtime_suspend(struct device *dev)
 	struct vc4_dev *vc4 = v3d->vc4;
 
 	vc4_irq_uninstall(vc4->dev);
+
+	drm_gem_object_put_unlocked(&vc4->bin_bo->base.base);
+	vc4->bin_bo = NULL;
 
 	clk_disable_unprepare(v3d->clk);
 
@@ -373,6 +327,10 @@ static int vc4_v3d_runtime_resume(struct device *dev)
 	struct vc4_v3d *v3d = dev_get_drvdata(dev);
 	struct vc4_dev *vc4 = v3d->vc4;
 	int ret;
+
+	ret = bin_bo_alloc(vc4);
+	if (ret)
+		return ret;
 
 	ret = clk_prepare_enable(v3d->clk);
 	if (ret != 0)
@@ -439,6 +397,12 @@ static int vc4_v3d_bind(struct device *dev, struct device *master, void *data)
 	ret = clk_prepare_enable(v3d->clk);
 	if (ret != 0)
 		return ret;
+
+	ret = bin_bo_alloc(vc4);
+	if (ret) {
+		clk_disable_unprepare(v3d->clk);
+		return ret;
+	}
 
 	/* Reset the binner overflow address/size at setup, to be sure
 	 * we don't reuse an old one.


### PR DESCRIPTION
This reverts commit 35c8b4b2c0fed637d2b30a8ec8e5d7f4c19c8d9d.

Fixes issues with minigbm on 5.4.