### PR TITLE
RESET_CONTROLLER needs to be activated to compile Broadcom BCM2835 clk

### DIFF
--- a/drivers/clk/bcm/Kconfig
+++ b/drivers/clk/bcm/Kconfig
@@ -5,6 +5,7 @@ config CLK_BCM2835
 	depends on COMMON_CLK
 	default ARCH_BCM2835 || ARCH_BRCMSTB
 	select RESET_SIMPLE
+	select RESET_CONTROLLER
 	help
 	  Enable common clock framework support for Broadcom BCM2835
 	  SoCs.


### PR DESCRIPTION
RESET_CONTROLLER needs to be activated to compile Broadcom BCM2835 clock support