### PR TITLE
drm/vc4: Remove UIF from the list of modifiers returned by format_mod…

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -718,7 +718,6 @@ static bool vc4_fkms_format_mod_supported(struct drm_plane *plane,
 		switch (modifier) {
 		case DRM_FORMAT_MOD_BROADCOM_VC4_T_TILED:
 		case DRM_FORMAT_MOD_LINEAR:
-		case DRM_FORMAT_MOD_BROADCOM_UIF:
 			return true;
 		default:
 			return false;


### PR DESCRIPTION
…_supported

FKMS was listing UIF in the supported modifiers from format_mod_supported
when actually the pipeline doesn't support it. X was then choosing to
use it, and that then failed to render.

Remove references to UIF.

https://github.com/raspberrypi/linux/issues/3665

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>