### PR TITLE
dts: bcm2711: Disable DVP by default

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2711-rpi.dtsi
@@ -46,6 +46,7 @@
 			clocks = <&clk_108MHz>;
 			#clock-cells = <1>;
 			#reset-cells = <1>;
+			status = "disabled";
 		};
 
 		hdmi0: hdmi@7ef00700 {

--- a/arch/arm/boot/dts/overlays/vc4-kms-v3d-pi4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-v3d-pi4-overlay.dts
@@ -145,6 +145,13 @@
 		};
 	};
 
+	fragment@20 {
+		target = <&dvp>;
+		__overlay__  {
+			status = "okay";
+		};
+	};
+
 	__overrides__ {
 		audio   = <0>,"!17";
 		audio1   = <0>,"!18";


### PR DESCRIPTION
The HDMI DVP should be disabled by default as is the case for other
display related drivers. This changes resolves an issue when using
the legacy firmware display driver where the DVP caused the 108 MHz
clock in HDMI TX to be gated off when Linux started. This effectively
stopped the firmware from being able to change the HDMI analog PHY
registers.