### PR TITLE
dtoverlays: Add overlay for the PCA953x family of GPIO expanders

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -119,6 +119,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	ov7251.dtbo \
 	ov9281.dtbo \
 	papirus.dtbo \
+	pca953x.dtbo \
 	pibell.dtbo \
 	piglow.dtbo \
 	piscreen.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1873,6 +1873,42 @@ Params: panel                   Display panel (required):
         speed                   Display SPI bus speed
 
 
+Name:   pca953x
+Info:   TI PCA953x family of I2C GPIO expanders. Default is for NXP PCA9534.
+Load:   dtoverlay=pca953x,<param>=<val>
+Params: addr                    I2C address of expander. Default 0x20.
+        pca6416                 Select the NXP PCA6416 (16 bit)
+        pca9505                 Select the NXP PCA9505 (40 bit)
+        pca9535                 Select the NXP PCA9535 (16 bit)
+        pca9536                 Select the NXP PCA9536 or TI PCA9536 (4 bit)
+        pca9537                 Select the NXP PCA9537 (4 bit)
+        pca9538                 Select the NXP PCA9538 (8 bit)
+        pca9539                 Select the NXP PCA9539 (16 bit)
+        pca9554                 Select the NXP PCA9554 (8 bit)
+        pca9555                 Select the NXP PCA9555 (16 bit)
+        pca9556                 Select the NXP PCA9556 (8 bit)
+        pca9557                 Select the NXP PCA9557 (8 bit)
+        pca9574                 Select the NXP PCA9574 (8 bit)
+        pca9575                 Select the NXP PCA9575 (16 bit)
+        pca9698                 Select the NXP PCA9698 (40 bit)
+        pca16416                Select the NXP PCA16416 (16 bit)
+        pca16524                Select the NXP PCA16524 (24 bit)
+        pca19555a               Select the NXP PCA19555A (16 bit)
+        max7310                 Select the Maxim MAX7310 (8 bit)
+        max7312                 Select the Maxim MAX7312 (16 bit)
+        max7313                 Select the Maxim MAX7313 (16 bit)
+        max7315                 Select the Maxim MAX7315 (8 bit)
+        pca6107                 Select the TI PCA6107 (8 bit)
+        tca6408                 Select the TI TCA6408 (8 bit)
+        tca6416                 Select the TI TCA6416 (16 bit)
+        tca6424                 Select the TI TCA6424 (24 bit)
+        tca9539                 Select the TI TCA9539 (16 bit)
+        tca9554                 Select the TI TCA9554 (8 bit)
+        cat9554                 Select the Onnn CAT9554 (8 bit)
+        pca9654                 Select the Onnn PCA9654 (8 bit)
+        xra1202                 Select the Exar XRA1202 (8 bit)
+
+
 [ The pcf2127-rtc overlay has been deleted. See i2c-rtc. ]
 
 

--- a/arch/arm/boot/dts/overlays/pca953x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pca953x-overlay.dts
@@ -1,0 +1,240 @@
+// Definitions for NXP PCA953x family of I2C GPIO controllers on ARM I2C bus.
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			pca: pca@20 {
+				compatible = "nxp,pca9534";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca6416";
+		};
+	};
+	fragment@2 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9505";
+		};
+	};
+	fragment@3 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9535";
+		};
+	};
+	fragment@4 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9536";
+		};
+	};
+	fragment@5 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9537";
+		};
+	};
+	fragment@6 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9538";
+		};
+	};
+	fragment@7 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9539";
+		};
+	};
+	fragment@8 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9554";
+		};
+	};
+	fragment@9 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9555";
+		};
+	};
+	fragment@10 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9556";
+		};
+	};
+	fragment@11 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9557";
+		};
+	};
+	fragment@12 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9574";
+		};
+	};
+	fragment@13 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9575";
+		};
+	};
+	fragment@14 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca9698";
+		};
+	};
+	fragment@15 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca16416";
+		};
+	};
+	fragment@16 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca16524";
+		};
+	};
+	fragment@17 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "nxp,pca19555a";
+		};
+	};
+	fragment@18 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "maxim,max7310";
+		};
+	};
+	fragment@19 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "maxim,max7312";
+		};
+	};
+	fragment@20 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "maxim,max7313";
+		};
+	};
+	fragment@21 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "maxim,max7315";
+		};
+	};
+	fragment@22 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "ti,pca6107";
+		};
+	};
+	fragment@23 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "ti,tca6408";
+		};
+	};
+	fragment@24 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "ti,tca6416";
+		};
+	};
+	fragment@25 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "ti,tca6424";
+		};
+	};
+	fragment@26 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "ti,tca9539";
+		};
+	};
+	fragment@27 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "ti,tca9554";
+		};
+	};
+	fragment@28 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "onnn,cat9554";
+		};
+	};
+	fragment@29 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "onnn,pca9654";
+		};
+	};
+	fragment@30 {
+		target = <&pca>;
+		__dormant__ {
+			compatible = "exar,xra1202";
+		};
+	};
+
+	__overrides__ {
+		addr = <&pca>,"reg:0";
+		pca6416 = <0>, "+1";
+		pca9505 = <0>, "+2";
+		pca9535 = <0>, "+3";
+		pca9536 = <0>, "+4";
+		pca9537 = <0>, "+5";
+		pca9538 = <0>, "+6";
+		pca9539 = <0>, "+7";
+		pca9554 = <0>, "+8";
+		pca9555 = <0>, "+9";
+		pca9556 = <0>, "+10";
+		pca9557 = <0>, "+11";
+		pca9574 = <0>, "+12";
+		pca9575 = <0>, "+13";
+		pca9698 = <0>, "+14";
+		pca16416 = <0>, "+15";
+		pca16524 = <0>, "+16";
+		pca19555a = <0>, "+17";
+		max7310 = <0>, "+18";
+		max7312 = <0>, "+19";
+		max7313 = <0>, "+20";
+		max7315 = <0>, "+21";
+		pca6107 = <0>, "+22";
+		tca6408 = <0>, "+23";
+		tca6416 = <0>, "+24";
+		tca6424 = <0>, "+25";
+		tca9539 = <0>, "+26";
+		tca9554 = <0>, "+27";
+		cat9554 = <0>, "+28";
+		pca9654 = <0>, "+29";
+		xra1202 = <0>, "+30";
+	};
+};


### PR DESCRIPTION
Adds an overlay for configuring all the GPIO expanders supported
by the driver under GPIO_PCA953X.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>