### PR TITLE
kconfig fixes

### DIFF
--- a/drivers/media/platform/bcm2835/Kconfig
+++ b/drivers/media/platform/bcm2835/Kconfig
@@ -2,8 +2,10 @@
 
 config VIDEO_BCM2835_UNICAM
 	tristate "Broadcom BCM2835 Unicam video capture driver"
-	depends on VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API && MEDIA_CONTROLLER
+	depends on VIDEO_V4L2
 	depends on ARCH_BCM2835 || COMPILE_TEST
+	select VIDEO_V4L2_SUBDEV_API
+	select MEDIA_CONTROLLER
 	select VIDEOBUF2_DMA_CONTIG
 	select V4L2_FWNODE
 	help

--- a/drivers/staging/media/rpivid/Kconfig
+++ b/drivers/staging/media/rpivid/Kconfig
@@ -3,9 +3,9 @@
 config VIDEO_RPIVID
 	tristate "Rpi H265 driver"
 	depends on VIDEO_DEV && VIDEO_V4L2
-	depends on MEDIA_CONTROLLER
 	depends on OF
-	depends on MEDIA_CONTROLLER_REQUEST_API
+	select MEDIA_CONTROLLER
+	select MEDIA_CONTROLLER_REQUEST_API
 	select VIDEOBUF2_DMA_CONTIG
 	select V4L2_MEM2MEM_DEV
 	help

--- a/drivers/staging/vc04_services/bcm2835-codec/Kconfig
+++ b/drivers/staging/vc04_services/bcm2835-codec/Kconfig
@@ -1,7 +1,7 @@
 config VIDEO_CODEC_BCM2835
 	tristate "BCM2835 Video codec support"
-	depends on MEDIA_SUPPORT && MEDIA_CONTROLLER
 	depends on VIDEO_V4L2 && (ARCH_BCM2835 || COMPILE_TEST)
+	select MEDIA_CONTROLLER
 	select BCM2835_VCHIQ_MMAL
 	select VIDEOBUF2_DMA_CONTIG
 	select V4L2_MEM2MEM_DEV

--- a/drivers/staging/vc04_services/bcm2835-isp/Kconfig
+++ b/drivers/staging/vc04_services/bcm2835-isp/Kconfig
@@ -2,7 +2,7 @@ config VIDEO_ISP_BCM2835
 	tristate "BCM2835 ISP support"
 	depends on MEDIA_SUPPORT
 	depends on VIDEO_V4L2 && (ARCH_BCM2835 || COMPILE_TEST)
-	depends on MEDIA_CONTROLLER
+	select MEDIA_CONTROLLER
 	select BCM2835_VCHIQ_MMAL
 	select VIDEOBUF2_DMA_CONTIG
 	help


### PR DESCRIPTION
Since 016baa59bf9f6c2550480b73f18100285e3a4fd2 (part of 5.8), MEDIA_CONTROLLER_REQUEST_API has to be selected rather than depended upon. Do the same with some other options.