### PR TITLE
overlays: Updated MCP3008 compatible strings.

### DIFF
--- a/arch/arm/boot/dts/overlays/mcp3008-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp3008-overlay.dts
@@ -72,7 +72,7 @@
 			#size-cells = <0>;
 
 			mcp3008_00: mcp3008@0 {
-				compatible = "mcp3008";
+				compatible = "microchip,mcp3008";
 				reg = <0>;
 				spi-max-frequency = <1600000>;
 			};
@@ -87,7 +87,7 @@
 			#size-cells = <0>;
 
 			mcp3008_01: mcp3008@1 {
-				compatible = "mcp3008";
+				compatible = "microchip,mcp3008";
 				reg = <1>;
 				spi-max-frequency = <1600000>;
 			};
@@ -102,7 +102,7 @@
 			#size-cells = <0>;
 
 			mcp3008_10: mcp3008@0 {
-				compatible = "mcp3008";
+				compatible = "microchip,mcp3008";
 				reg = <0>;
 				spi-max-frequency = <1600000>;
 			};
@@ -117,7 +117,7 @@
 			#size-cells = <0>;
 
 			mcp3008_11: mcp3008@1 {
-				compatible = "mcp3008";
+				compatible = "microchip,mcp3008";
 				reg = <1>;
 				spi-max-frequency = <1600000>;
 			};
@@ -132,7 +132,7 @@
 			#size-cells = <0>;
 
 			mcp3008_12: mcp3008@2 {
-				compatible = "mcp3008";
+				compatible = "microchip,mcp3008";
 				reg = <2>;
 				spi-max-frequency = <1600000>;
 			};
@@ -147,7 +147,7 @@
 			#size-cells = <0>;
 
 			mcp3008_20: mcp3008@0 {
-				compatible = "mcp3008";
+				compatible = "microchip,mcp3008";
 				reg = <0>;
 				spi-max-frequency = <1600000>;
 			};
@@ -162,7 +162,7 @@
 			#size-cells = <0>;
 
 			mcp3008_21: mcp3008@1 {
-				compatible = "mcp3008";
+				compatible = "microchip,mcp3008";
 				reg = <1>;
 				spi-max-frequency = <1600000>;
 			};
@@ -177,7 +177,7 @@
 			#size-cells = <0>;
 
 			mcp3008_22: mcp3008@2 {
-				compatible = "mcp3008";
+				compatible = "microchip,mcp3008";
 				reg = <2>;
 				spi-max-frequency = <1600000>;
 			};


### PR DESCRIPTION
Used recommended ones from Documentation/devicetree/bindings/iio/adc/mcp320x.txt.