### PR TITLE
staging: vc04_services: ISP: Fix dmabuf error check in S_CTRL

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
@@ -733,7 +733,7 @@ static int bcm2835_isp_s_ctrl(struct v4l2_ctrl *ctrl)
 		       sizeof(struct bcm2835_isp_lens_shading));
 
 		dmabuf = dma_buf_get(ls.dmabuf);
-		if (!dmabuf)
+		if (IS_ERR_OR_NULL(dmabuf))
 			return -EINVAL;
 
 		ret = vc_sm_cma_import_dmabuf(dmabuf,


### PR DESCRIPTION
In bcm2835_isp_s_ctrl, the error check for dma_buf_get() is incorrect,
and considers ERR_PTR pointers as valid dmabufs. Fix this error check.

Signed-off-by: Paul Elder <paul.elder@ideasonboard.com>