### PR TITLE
rpi-5.4.y: Fixes for V3D DRM timeout issues

### DIFF
--- a/drivers/gpu/drm/v3d/v3d_sched.c
+++ b/drivers/gpu/drm/v3d/v3d_sched.c
@@ -226,6 +226,17 @@ v3d_csd_job_run(struct drm_sched_job *sched_job)
 	struct dma_fence *fence;
 	int i;
 
+	/* This error is set to -ECANCELED by drm_sched_resubmit_jobs() if this
+	 * job timed out more than sched_job->sched->hang_limit times.
+	 */
+	int error = sched_job->s_fence->finished.error;
+
+	if (unlikely(error < 0)) {
+		DRM_WARN("Skipping CSD job resubmission due to previous error (%d)\n",
+			 error);
+		return ERR_PTR(error);
+	}
+
 	v3d->csd_job = job;
 
 	v3d_invalidate_caches(v3d);

--- a/drivers/gpu/drm/v3d/v3d_sched.c
+++ b/drivers/gpu/drm/v3d/v3d_sched.c
@@ -19,10 +19,16 @@
  */
 
 #include <linux/kthread.h>
+#include <linux/moduleparam.h>
 
 #include "v3d_drv.h"
 #include "v3d_regs.h"
 #include "v3d_trace.h"
+
+static uint timeout = 500;
+module_param(timeout, uint, 0444);
+MODULE_PARM_DESC(timeout,
+	"Timeout for a job in ms (0 means infinity and default is 500 ms)");
 
 static struct v3d_job *
 to_v3d_job(struct drm_sched_job *sched_job)
@@ -405,13 +411,13 @@ v3d_sched_init(struct v3d_dev *v3d)
 {
 	int hw_jobs_limit = 1;
 	int job_hang_limit = 0;
-	int hang_limit_ms = 500;
+	long timeout_jiffies = timeout ?
+			msecs_to_jiffies(timeout) : MAX_SCHEDULE_TIMEOUT;
 	int ret;
 
 	ret = drm_sched_init(&v3d->queue[V3D_BIN].sched,
 			     &v3d_bin_sched_ops,
-			     hw_jobs_limit, job_hang_limit,
-			     msecs_to_jiffies(hang_limit_ms),
+			     hw_jobs_limit, job_hang_limit, timeout_jiffies,
 			     "v3d_bin");
 	if (ret) {
 		dev_err(v3d->dev, "Failed to create bin scheduler: %d.", ret);
@@ -420,8 +426,7 @@ v3d_sched_init(struct v3d_dev *v3d)
 
 	ret = drm_sched_init(&v3d->queue[V3D_RENDER].sched,
 			     &v3d_render_sched_ops,
-			     hw_jobs_limit, job_hang_limit,
-			     msecs_to_jiffies(hang_limit_ms),
+			     hw_jobs_limit, job_hang_limit, timeout_jiffies,
 			     "v3d_render");
 	if (ret) {
 		dev_err(v3d->dev, "Failed to create render scheduler: %d.",
@@ -432,8 +437,7 @@ v3d_sched_init(struct v3d_dev *v3d)
 
 	ret = drm_sched_init(&v3d->queue[V3D_TFU].sched,
 			     &v3d_tfu_sched_ops,
-			     hw_jobs_limit, job_hang_limit,
-			     msecs_to_jiffies(hang_limit_ms),
+			     hw_jobs_limit, job_hang_limit, timeout_jiffies,
 			     "v3d_tfu");
 	if (ret) {
 		dev_err(v3d->dev, "Failed to create TFU scheduler: %d.",
@@ -445,8 +449,7 @@ v3d_sched_init(struct v3d_dev *v3d)
 	if (v3d_has_csd(v3d)) {
 		ret = drm_sched_init(&v3d->queue[V3D_CSD].sched,
 				     &v3d_csd_sched_ops,
-				     hw_jobs_limit, job_hang_limit,
-				     msecs_to_jiffies(hang_limit_ms),
+				     hw_jobs_limit, job_hang_limit, timeout_jiffies,
 				     "v3d_csd");
 		if (ret) {
 			dev_err(v3d->dev, "Failed to create CSD scheduler: %d.",
@@ -457,8 +460,7 @@ v3d_sched_init(struct v3d_dev *v3d)
 
 		ret = drm_sched_init(&v3d->queue[V3D_CACHE_CLEAN].sched,
 				     &v3d_cache_clean_sched_ops,
-				     hw_jobs_limit, job_hang_limit,
-				     msecs_to_jiffies(hang_limit_ms),
+				     hw_jobs_limit, job_hang_limit, timeout_jiffies,
 				     "v3d_cache_clean");
 		if (ret) {
 			dev_err(v3d->dev, "Failed to create CACHE_CLEAN scheduler: %d.",


### PR DESCRIPTION
The current V3D DRM driver in `rpi-5.4.y` kernel has two issues:

1. Return value `NULL` from `v3d_cache_clean_job_run()` is mis-treated as an error by the DRM scheduler, which results in the following warning:
```
[  653.831148] ------------[ cut here ]------------
[  653.836262] WARNING: CPU: 1 PID: 259 at ./include/linux/dma-fence.h:533 drm_sched_main+0x238/0x31c [gpu_sched]
[  653.847204] Modules linked in: <snip>
[  653.902464] CPU: 1 PID: 259 Comm: v3d_cache_clean Tainted: G         C        5.4.51-v7l+ #1327
[  653.912189] Hardware name: BCM2711
[  653.916085] Backtrace:
[  653.919026] [<c020d46c>] (dump_backtrace) from [<c020d768>] (show_stack+0x20/0x24)
[  653.927584]  r6:e8418000 r5:00000000 r4:c129c8f8 r3:31a472ee
[  653.933747] [<c020d748>] (show_stack) from [<c0a39a24>] (dump_stack+0xe0/0x124)
[  653.942062] [<c0a39944>] (dump_stack) from [<c0221c50>] (__warn+0xec/0x104)
[  653.949548]  r8:00000215 r7:00000009 r6:bf158610 r5:00000000 r4:00000000 r3:31a472ee
[  653.958350] [<c0221b64>] (__warn) from [<c0221d20>] (warn_slowpath_fmt+0xb8/0xc0)
[  653.966933]  r9:bf158610 r8:00000215 r7:bf1566a0 r6:00000009 r5:00000000 r4:c1204f88
[  653.975826] [<c0221c6c>] (warn_slowpath_fmt) from [<bf1566a0>] (drm_sched_main+0x238/0x31c [gpu_sched])
[  653.986377]  r9:00000000 r8:c1204f88 r7:efa9a300 r6:00000000 r5:e8fc8700 r4:ef3b58a0
[  653.995297] [<bf156468>] (drm_sched_main [gpu_sched]) from [<c0244e70>] (kthread+0x13c/0x168)
[  654.004996]  r10:e8f126dc r9:ef3c3ae4 r8:bf156468 r7:ef3b58a0 r6:00000000 r5:e8bd4b80
[  654.013994]  r4:e8f126c0
[  654.017095] [<c0244d34>] (kthread) from [<c02010ac>] (ret_from_fork+0x14/0x28)
[  654.025452] Exception stack(0xe8419fb0 to 0xe8419ff8)
[  654.031067] 9fa0:                                     00000000 00000000 00000000 00000000
[  654.040363] 9fc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[  654.049671] 9fe0: 00000000 00000000 00000000 00000000 00000013 00000000
[  654.056876]  r10:00000000 r9:00000000 r8:00000000 r7:00000000 r6:00000000 r5:c0244d34
[  654.065856]  r4:e8bd4b80 r3:c0204648
[  654.070019] ---[ end trace 9b7e1a26f0895ac5 ]---
```

It takes some time to print the warning and thus the execution time of CL/CSD programs will get longer.
This warning can be ceased with 3c37926, and this commit requires 93db7d6.
However, 93db7d6 is [known to break the behavior](https://patchwork.freedesktop.org/patch/342356/) where `v3d_{cl,csd}_job_timedout()` expect the timer to be rearmed.
Since workarounds for this issue are not available yet, we changed the codes not to expect the timer rearming in b465bea.

The non-rearming timer issue should be fixed in the DRM scheduler itself (as said by Daniel Vetter in the thread) because the Etnaviv DRM driver also expects the behavior.
Therefore, we think these commits are appropriate only for the rpi tree.

2. `v3d_csd_job_run()` ignores timeout error flag which results in an infinite GPU reset loop if once a timeout occurs:
```
[  178.799106] v3d fec00000.v3d: [drm:v3d_reset [v3d]] *ERROR* Resetting GPU for hang.
[  178.807836] v3d fec00000.v3d: [drm:v3d_reset [v3d]] *ERROR* V3D_ERR_STAT: 0x00001000
[  179.839132] v3d fec00000.v3d: [drm:v3d_reset [v3d]] *ERROR* Resetting GPU for hang.
[  179.847865] v3d fec00000.v3d: [drm:v3d_reset [v3d]] *ERROR* V3D_ERR_STAT: 0x00001000
[  180.879146] v3d fec00000.v3d: [drm:v3d_reset [v3d]] *ERROR* Resetting GPU for hang.
[  180.887925] v3d fec00000.v3d: [drm:v3d_reset [v3d]] *ERROR* V3D_ERR_STAT: 0x00001000
[  181.919188] v3d fec00000.v3d: [drm:v3d_reset [v3d]] *ERROR* Resetting GPU for hang.
[  181.928002] v3d fec00000.v3d: [drm:v3d_reset [v3d]] *ERROR* V3D_ERR_STAT: 0x00001000
...
```

This issue is fixed with 410a046 by correctly referring to the timed-out flag.
We also added a function to set the timeout milliseconds through kernel's cmdline in 69af0ae.
Because these patches depend on the timeout behavior described in 1, and `bcm2711_defconfig` is not available in drm-next for now, we choose not to post these patches to dri-devel yet.

We tested these patches with [Piglit](https://piglit.freedesktop.org/) and [SaschaWillems/Vulkan](https://github.com/SaschaWillems/Vulkan) with [Igalia's Vulkan driver](https://blogs.igalia.com/apinheiro/2020/06/v3dv-quick-guide-to-build-and-run-some-demos/), and our CSD programs in [Idein/py-videocore6](https://github.com/Idein/py-videocore6).
The programs run peacefully with each other even if a timeout occurs.

Note that the first two drm/sched commits are from linux-5.6.y tree, so you may cherry-pick the other three commits by us to rpi-5.8.y if we are moving to there.

@anholt Is there any reason that the timeout flag is referred to in `v3d_{bin,render}_job_run()` but is ignored in `v3d_csd_job_run()`?