### PR TITLE
arm: fix mmap unlocks in uaccess_with_memcpy.c

### DIFF
--- a/arch/arm/lib/uaccess_with_memcpy.c
+++ b/arch/arm/lib/uaccess_with_memcpy.c
@@ -210,7 +210,7 @@ __copy_from_user_memcpy(void *to, const void __user *from, unsigned long n)
 		while (!pin_page_for_read(from, &pte, &ptl)) {
 			char temp;
 			if (!atomic)
-				mmap_write_unlock(current->mm);
+				mmap_read_unlock(current->mm);
 			if (__get_user(temp, (char __user *)from))
 				goto out;
 			if (!atomic)
@@ -231,7 +231,7 @@ __copy_from_user_memcpy(void *to, const void __user *from, unsigned long n)
 		pte_unmap_unlock(pte, ptl);
 	}
 	if (!atomic)
-		mmap_write_unlock(current->mm);
+		mmap_read_unlock(current->mm);
 
 out:
 	return n;


### PR DESCRIPTION
This is a regression that was added with the commit 192a4e923ef092924dd013e7326f2ec520ee4783 as of rpi-5.8.y, since that is when the move to the mmap locking API was introduced - d8ed45c5dcd455fc5848d47f86883a1b872ac0d0

The issue is that when the patch to improve performance for the __copy_to_user and __copy_from_user functions were added for the Raspberry Pi, some of the mmaps were incorrectly mapped to write instead of read. This would cause a verity of issues, and in my case, prevent the booting of a squashfs filesystem on rpi-5.8-y and above. An example of the panic you would see from this can be seen at https://pastebin.com/raw/jBz5xCzL

Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
Signed-off-by: Christopher Blake <chrisrblake93@gmail.com>