### PR TITLE
Update hy28b-overlay.dts

### DIFF
--- a/arch/arm/boot/dts/overlays/hy28b-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hy28b-overlay.dts
@@ -61,7 +61,7 @@
 				fps = <50>;
 				buswidth = <8>;
 				startbyte = <0x70>;
-				reset-gpios = <&gpio 25 0>;
+				reset-gpios = <&gpio 25 1>;
 				led-gpios = <&gpio 18 1>;
 
 				gamma = "04 1F 4 7 7 0 7 7 6 0\n0F 00 1 7 4 0 0 0 6 7";


### PR DESCRIPTION
My hy28b TFT stopped working on upgrade to 5.4 kernel.  I had a whitescreen but no obvious errors when using 'sudo vcdbg log msg' or 'dmesg'.  Both /dev/fb0 and /dev/fb1 were present.  Followed this article on waveshare32b that 'reset_gpios needed to be 0 0 1 instead of 0 0 0' (https://forum.armbian.com/topic/13233-any-clues-for-the-creation-of-a-dtoverlay-for-fbtft-on-54y/).  I applied a similar change to this dts file and compiled a new dtbo: 'dtc -O dtb -o hy28b.dtbo hy28b-overlay.dts'.  Fixed my issue - may help others?  I got from the 5.4 upgrade thread that other tft users are having issues with small tfts... https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=269769&p=1706597&hilit=gpio#p1706597