### PR TITLE
staging: bcm2835-camera: Replace deprecated V4L2_PIX_FMT_BGR32

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.c
+++ b/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.c
@@ -175,7 +175,7 @@ static struct mmal_fmt formats[] = {
 		.ybbp = 1,
 		.remove_padding = 1,
 	}, {
-		.fourcc = V4L2_PIX_FMT_BGR32,
+		.fourcc = V4L2_PIX_FMT_BGRX32,
 		.mmal = MMAL_ENCODING_BGRA,
 		.depth = 32,
 		.mmal_component = COMP_CAMERA,


### PR DESCRIPTION
V4L2_PIX_FMT_BGR32 is deprecated as it is ambiguous over where
the alpha byte is. Cheese/GStreamer appear to get it wrong for
one, and qv4l2 gets red and blue swapped.

Swap to the newer V4L2_PIX_FMT_BGRX32 format.

https://www.raspberrypi.org/forums/viewtopic.php?f=38&t=267736&p=1738912

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>