### PR TITLE
staging: bcm2835-codec: Replace deprecated V4L2_PIX_FMT_BGR32

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -207,7 +207,7 @@ static const struct bcm2835_codec_fmt supported_formats[] = {
 		.mmal_fmt		= MMAL_ENCODING_BGR24,
 		.size_multiplier_x2	= 2,
 	}, {
-		.fourcc			= V4L2_PIX_FMT_BGR32,
+		.fourcc			= V4L2_PIX_FMT_BGRX32,
 		.depth			= 32,
 		.bytesperline_align	= 32,
 		.flags			= 0,


### PR DESCRIPTION
Sorry, was about to update the previous PR with this just at the point you'd hit merge. The ISP driver is using V4L2_PIX_FMT_ABGR32 for some reason.

V4L2_PIX_FMT_BGR32 is deprecated as it is ambiguous over where
the alpha byte is.

Swap to the newer V4L2_PIX_FMT_BGRX32 format.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>

