### PR TITLE
bcm2835-dma: only reserve channel 0 if legacy dma driver is enabled

### DIFF
--- a/drivers/dma/bcm2835-dma.c
+++ b/drivers/dma/bcm2835-dma.c
@@ -1286,6 +1286,7 @@ static int bcm2835_dma_probe(struct platform_device *pdev)
 		goto err_no_dma;
 	}
 
+#ifdef CONFIG_DMA_BCM2708
 	/* One channel is reserved for the legacy API */
 	if (chans_available & BCM2835_DMA_BULK_MASK) {
 		rc = bcm_dmaman_probe(pdev, base,
@@ -1296,6 +1297,7 @@ static int bcm2835_dma_probe(struct platform_device *pdev)
 
 		chans_available &= ~BCM2835_DMA_BULK_MASK;
 	}
+#endif
 
 	/* And possibly one for the 40-bit DMA memcpy API */
 	if (chans_available & od->cfg_data->chan_40bit_mask &


### PR DESCRIPTION
If CONFIG_DMA_BCM2708 isn't enabled there's no need to mask out
one of the already scarce DMA channels.