### PR TITLE
uapi: Update V4L2_CID_USER_BCM2835_ISP_BASE due to upstream change

### DIFF
--- a/include/uapi/linux/v4l2-controls.h
+++ b/include/uapi/linux/v4l2-controls.h
@@ -192,9 +192,15 @@ enum v4l2_colorfx {
  * We reserve 16 controls for this driver. */
 #define V4L2_CID_USER_IMX_BASE			(V4L2_CID_USER_BASE + 0x10b0)
 
+/*
+ * The base for the atmel isc driver controls.
+ * We reserve 32 controls for this driver.
+ */
+#define V4L2_CID_USER_ATMEL_ISC_BASE		(V4L2_CID_USER_BASE + 0x10c0)
+
 /* The base for the bcm2835-isp driver controls.
  * We reserve 16 controls for this driver. */
-#define V4L2_CID_USER_BCM2835_ISP_BASE		(V4L2_CID_USER_BASE + 0x10c0)
+#define V4L2_CID_USER_BCM2835_ISP_BASE		(V4L2_CID_USER_BASE + 0x10e0)
 
 /* MPEG-class control IDs */
 /* The MPEG controls are applicable to all codec controls


### PR DESCRIPTION
Commit "4e52889 media: atmel: atmel-isc-base: expose white
balance as v4l2 controls" in the upstream kernels reserves
(V4L2_CID_USER_BASE + 0x10c0) for use by the Atmel ISC,
therefore we have a control collision with our existing
define for V4L2_CID_USER_BCM2835_ISP_BASE.

Update V4L2_CID_USER_BCM2835_ISP_BASE to + 0x10e0 as the
next available block.

NB ABI breakage for lbcamera (the only user of these controls).

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>