### PR TITLE
dtoverlays: Correct CSI2 settings for ov9281

### DIFF
--- a/arch/arm/boot/dts/overlays/ov9281-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov9281-overlay.dts
@@ -34,7 +34,7 @@
 						data-lanes = <1 2>;
 						clock-noncontinuous;
 						link-frequencies =
-							/bits/ 64 <456000000>;
+							/bits/ 64 <400000000>;
 					};
 				};
 			};
@@ -50,6 +50,7 @@
 				csi1_ep: endpoint {
 					remote-endpoint = <&ov9281_0>;
 					data-lanes = <1 2>;
+					clock-noncontinuous;
 				};
 			};
 		};


### PR DESCRIPTION
OV9281 appears to drop the clock to LP mode between frames, but
the overlay didn't define this at both ends of the CSI2 link.
The overlay also had an incorrect link frequency defined, not that
the driver ever checked for one.

Fix both issues.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>