### PR TITLE
vc4_hdmi: Move hdmi reset to bind

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -1023,9 +1023,6 @@ static void vc4_hdmi_encoder_pre_crtc_configure(struct drm_encoder *encoder,
 		return;
 	}
 
-	if (vc4_hdmi->variant->reset)
-		vc4_hdmi->variant->reset(vc4_hdmi);
-
 	if (vc4_hdmi->variant->phy_init)
 		vc4_hdmi->variant->phy_init(vc4_hdmi, mode);
 
@@ -2387,6 +2384,9 @@ static int vc4_hdmi_bind(struct device *dev, struct device *master, void *data)
 
 		vc4_hdmi->hpd_active_low = hpd_gpio_flags & OF_GPIO_ACTIVE_LOW;
 	}
+
+	if (vc4_hdmi->variant->reset)
+		vc4_hdmi->variant->reset(vc4_hdmi);
 
 	pm_runtime_enable(dev);
 


### PR DESCRIPTION
The hdmi reset got moved to a later point in
"drm/vc4: hdmi: Add reset callback"

which now occurs after vc4_hdmi_cec_init
and so tramples the setup of registers like
HDMI_CEC_CNTRL_1

This only affects pi0-3 as on pi4 the cec
resgisters are in a separate block

Fixes: ed9a1f6eb4402b25b8a983dc4bfe40f025176e03
Signed-off-by: Dom Cobley <popcornmix@gmail.com>