### PR TITLE
Allow the headphone output to be disabled

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
@@ -152,6 +152,7 @@
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+	brcm,disable-headphones = <1>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2708-rpi-zero.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero.dts
@@ -106,6 +106,7 @@
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+	brcm,disable-headphones = <1>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
@@ -460,6 +460,7 @@
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+	brcm,disable-headphones = <1>;
 };
 
 &vc4 {

--- a/arch/arm/boot/dts/overlays/audremap-overlay.dts
+++ b/arch/arm/boot/dts/overlays/audremap-overlay.dts
@@ -26,6 +26,13 @@
 		};
 	};
 
+	fragment@3 {
+		target = <&audio>;
+		__overlay__  {
+			brcm,disable-headphones = <0>;
+		};
+	};
+
 	__overrides__ {
 		swap_lr = <&frag0>, "swap_lr?";
 		enable_jack = <&frag0>, "enable_jack?";

--- a/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
+++ b/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
@@ -381,11 +381,16 @@ static int snd_bcm2835_alsa_probe(struct platform_device *pdev)
 	}
 
 	if (!enable_compat_alsa) {
+		// In this mode, enable analog output by default
+		u32 disable_headphones = 0;
+
 		if (!of_property_read_bool(dev->of_node, "brcm,disable-hdmi"))
 			set_hdmi_enables(dev);
 
-		// In this mode, always enable analog output
-		enable_headphones = true;
+		of_property_read_u32(dev->of_node,
+				     "brcm,disable-headphones",
+				     &disable_headphones);
+		enable_headphones = !disable_headphones;
 	} else {
 		enable_hdmi0 = enable_hdmi;
 	}


### PR DESCRIPTION
Pi Zeroes and CM4 have no headphone outputs. Disable the corresponding ALSA device so that it doesn't show up in the GUI and sounds utilities.