### PR TITLE
ARM: dts: Expand PCIe space on BCM2711

### DIFF
--- a/arch/arm/boot/dts/bcm2711.dtsi
+++ b/arch/arm/boot/dts/bcm2711.dtsi
@@ -503,8 +503,8 @@
 			msi-controller;
 			msi-parent = <&pcie0>;
 
-			ranges = <0x02000000 0x0 0xf8000000 0x6 0x00000000
-				  0x0 0x04000000>;
+			ranges = <0x02000000 0x0 0xc0000000 0x6 0x00000000
+				  0x0 0x40000000>;
 			/*
 			 * The wrapper around the PCIe block has a bug
 			 * preventing it from accessing beyond the first 3GB of


### PR DESCRIPTION
Attempts to connect external GPUs to Compute Module 4's PCIe bus have
highlighted that the existing "outbound window" - the fraction of the
PCI address base that is appears in the host's memory map - is
restrictively small. Expand the window to a full 1GB.

See: https://www.raspberrypi.org/forums/viewtopic.php?f=98&t=288902

Signed-off-by: Phil Elwell <phil@raspberrypi.com>