### PR TITLE
bcm2835-pcm: Fix up multichannel pcm audio

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-audio/bcm2835-pcm.c
+++ b/drivers/staging/vc04_services/bcm2835-audio/bcm2835-pcm.c
@@ -14,14 +14,14 @@ static const struct snd_pcm_hardware snd_bcm2835_playback_hw = {
 		 SNDRV_PCM_INFO_MMAP | SNDRV_PCM_INFO_MMAP_VALID |
 		 SNDRV_PCM_INFO_SYNC_APPLPTR),
 	.formats = SNDRV_PCM_FMTBIT_U8 | SNDRV_PCM_FMTBIT_S16_LE,
-	.rates = SNDRV_PCM_RATE_CONTINUOUS |  SNDRV_PCM_RATE_8000_192000,
+	.rates = SNDRV_PCM_RATE_CONTINUOUS | SNDRV_PCM_RATE_8000_192000,
 	.rate_min = 8000,
 	.rate_max = 192000,
 	.channels_min = 1,
-	.channels_max = 2,
-	.buffer_bytes_max = 128 * 1024,
+	.channels_max = 8,
+	.buffer_bytes_max = 512 * 1024,
 	.period_bytes_min = 1 * 1024,
-	.period_bytes_max = 128 * 1024,
+	.period_bytes_max = 512 * 1024,
 	.periods_min = 1,
 	.periods_max = 128,
 };
@@ -31,16 +31,15 @@ static const struct snd_pcm_hardware snd_bcm2835_playback_spdif_hw = {
 		 SNDRV_PCM_INFO_MMAP | SNDRV_PCM_INFO_MMAP_VALID |
 		 SNDRV_PCM_INFO_SYNC_APPLPTR),
 	.formats = SNDRV_PCM_FMTBIT_S16_LE,
-	.rates = SNDRV_PCM_RATE_44100 | SNDRV_PCM_RATE_48000 |
-	SNDRV_PCM_RATE_88200 | SNDRV_PCM_RATE_96000 |
-	SNDRV_PCM_RATE_176400 | SNDRV_PCM_RATE_192000,
+	.rates = SNDRV_PCM_RATE_CONTINUOUS | SNDRV_PCM_RATE_44100 |
+	SNDRV_PCM_RATE_48000,
 	.rate_min = 44100,
-	.rate_max = 192000,
+	.rate_max = 48000,
 	.channels_min = 2,
-	.channels_max = 8,
-	.buffer_bytes_max = 512 * 1024,
+	.channels_max = 2,
+	.buffer_bytes_max = 128 * 1024,
 	.period_bytes_min = 1 * 1024,
-	.period_bytes_max = 512 * 1024,
+	.period_bytes_max = 128 * 1024,
 	.periods_min = 1,
 	.periods_max = 128,
 };


### PR DESCRIPTION
Fixes: a9c1660ff5f02d048c5f31abf1fd1108ccf9ef87
Signed-off-by: Dom Cobley <popcornmix@gmail.com>