### PR TITLE
Add support for 'tryboot' OS upgrade fallback mechanism on BCM2711

### DIFF
--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -190,6 +190,7 @@ static int rpi_firmware_notify_reboot(struct notifier_block *nb,
 {
 	struct rpi_firmware *fw;
 	struct platform_device *pdev = g_pdev;
+	u32 reboot_flags = 0;
 
 	if (!pdev)
 		return 0;
@@ -198,8 +199,28 @@ static int rpi_firmware_notify_reboot(struct notifier_block *nb,
 	if (!fw)
 		return 0;
 
-	(void)rpi_firmware_property(fw, RPI_FIRMWARE_NOTIFY_REBOOT,
-				    0, 0);
+	// The partition id is the first parameter followed by zero or
+	// more flags separated by spaces indicating the reason for the reboot.
+	//
+	// 'tryboot': Sets a one-shot flag which is cleared upon reboot and
+	//            causes the tryboot.txt to be loaded instead of config.txt
+	//            by the bootloader and the start.elf firmware.
+	//
+	//            This is intended to allow automatic fallback to a known
+	//            good image if an OS/FW upgrade fails.
+	//
+	// N.B. The firmware mechanism for storing reboot flags may vary
+	// on different Raspberry Pi models.
+	if (data && strstr(data, " tryboot"))
+		reboot_flags |= 0x1;
+
+	// The mailbox might have been called earlier, directly via vcmailbox
+	// so only overwrite if reboot flags are passed to the reboot command.
+	if (reboot_flags)
+		(void)rpi_firmware_property(fw, RPI_FIRMWARE_SET_REBOOT_FLAGS,
+				&reboot_flags, sizeof(reboot_flags));
+
+	(void)rpi_firmware_property(fw, RPI_FIRMWARE_NOTIFY_REBOOT, NULL, 0);
 
 	return 0;
 }

--- a/drivers/watchdog/bcm2835_wdt.c
+++ b/drivers/watchdog/bcm2835_wdt.c
@@ -126,10 +126,12 @@ static int bcm2835_restart(struct watchdog_device *wdog,
 {
 	struct bcm2835_wdt *wdt = watchdog_get_drvdata(wdog);
 
-	unsigned long long val;
+	unsigned long val;
 	u8 partition = 0;
 
-	if (data && !kstrtoull(data, 0, &val) && val <= 63)
+	// Allow extra arguments separated by spaces after
+	// the partition number.
+	if (data && sscanf(data, "%lu", &val) && val < 63)
 		partition = val;
 
 	__bcm2835_restart(wdt, partition);

--- a/include/soc/bcm2835/raspberrypi-firmware.h
+++ b/include/soc/bcm2835/raspberrypi-firmware.h
@@ -96,6 +96,8 @@ enum rpi_firmware_property_tag {
 	RPI_FIRMWARE_GET_POE_HAT_VAL =                        0x00030049,
 	RPI_FIRMWARE_SET_POE_HAT_VAL =                        0x00030050,
 	RPI_FIRMWARE_NOTIFY_XHCI_RESET =                      0x00030058,
+	RPI_FIRMWARE_GET_REBOOT_FLAGS =                       0x00030064,
+	RPI_FIRMWARE_SET_REBOOT_FLAGS =                       0x00038064,
 
 	/* Dispmanx TAGS */
 	RPI_FIRMWARE_FRAMEBUFFER_ALLOCATE =                   0x00040001,


### PR DESCRIPTION
Extend parsing of reboot notifier parameters to check for an additional 'tryboot' parameter. This instructs the GPU firmware to set a bit which is read then cleared and boot that causes the bootloader/firmware to read from tryboot.txt instead of config.txt

This alternate configuration file allows the pending updated to be tested. If a watchdog reset or power cycle occurs then the previous configuration will be loaded. 

This change requires an updated GPU firmware and bootloader.

