### PR TITLE
vc4_hdmi: Report that 3d/stereo is allowed

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -564,6 +564,7 @@ static int vc4_hdmi_connector_init(struct drm_device *dev,
 
 	connector->interlace_allowed = 1;
 	connector->doublescan_allowed = 0;
+	connector->stereo_allowed = 1;
 
 	drm_connector_attach_encoder(connector, encoder);
 


### PR DESCRIPTION
You can query stereo (3d) modes through DRM, e.g. kodi does here:
https://github.com/xbmc/xbmc/blob/5b06cdf3e64347085484435f2a4963e919edc8ec/xbmc/windowing/gbm/drm/DRMUtils.cpp#L383

currently none are reported as we don't report the capability.