### PR TITLE
add mcp251xfd overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -108,6 +108,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	mcp23s17.dtbo \
 	mcp2515-can0.dtbo \
 	mcp2515-can1.dtbo \
+	mcp251xfd.dtbo \
 	mcp3008.dtbo \
 	mcp3202.dtbo \
 	mcp342x.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1779,6 +1779,28 @@ Params: oscillator              Clock frequency for the CAN controller (Hz)
         interrupt               GPIO for interrupt signal
 
 
+Name:   mcp251xfd
+Info:   Configures the MCP251XFD CAN controller family
+        For devices on spi1 or spi2, the interfaces should be enabled
+        with one of the spi1-1/2/3cs and/or spi2-1/2/3cs overlays.
+Load:   dtoverlay=mcp251xfd,<param>=<val>
+Params: spi<n>-<m>              Configure device at spi<n>, cs<m>
+                                (boolean, required)
+
+        oscillator              Clock frequency for the CAN controller (Hz)
+
+        speed                   Maximum SPI frequence (Hz)
+
+        interrupt               GPIO for interrupt signal
+
+        rx_interrupt            GPIO for RX interrupt signal (nINT1) (optional)
+
+        xceiver_enable          GPIO for CAN transceiver enable (optional)
+
+        xceiver_active_high     specifiy if CAN transceiver enable pin is
+                                active high (optional, default: active low)
+
+
 Name:   mcp3008
 Info:   Configures MCP3008 A/D converters
         For devices on spi1 or spi2, the interfaces should be enabled

--- a/arch/arm/boot/dts/overlays/mcp251xfd-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp251xfd-overlay.dts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/pinctrl/bcm2835.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev1>;
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target-path = "spi1/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target-path = "spi1/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target-path = "spi1/spidev@2";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@5 {
+		target-path = "spi2/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@6 {
+		target-path = "spi2/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@7 {
+		target-path = "spi2/spidev@2";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@8 {
+		target = <&gpio>;
+		__overlay__ {
+			mcp251xfd_pins: mcp251xfd_pins {
+				brcm,pins = <25>;
+				brcm,function = <BCM2835_FSEL_GPIO_IN>;
+			};
+		};
+	};
+
+	fragment@9 {
+		target-path = "/clocks";
+		__overlay__ {
+			clk_mcp251xfd_osc: mcp251xfd-osc {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <40000000>;
+			};
+		};
+	};
+
+	mcp251xfd_frag: fragment@10 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mcp251xfd: mcp251xfd@0 {
+				compatible = "microchip,mcp251xfd";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&mcp251xfd_pins>;
+				spi-max-frequency = <20000000>;
+				interrupt-parent = <&gpio>;
+				interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
+				clocks = <&clk_mcp251xfd_osc>;
+			};
+		};
+	};
+
+	fragment@11 {
+		target = <&mcp251xfd>;
+		mcp251xfd_rx_int_gpios: __dormant__ {
+			microchip,rx-int-gpios = <&gpio 255 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	fragment@12 {
+		target = <&gpio>;
+		__dormant__ {
+			mcp251xfd_xceiver_pins: mcp251xfd_xceiver_pins {
+				brcm,pins = <255>;
+				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
+			};
+		};
+	};
+
+	fragment@13 {
+		target-path = "/";
+		__dormant__ {
+			reg_mcp251xfd_xceiver: reg_mcp251xfd_xceiver {
+				compatible = "regulator-fixed";
+				regulator-name = "mcp251xfd_xceiver";
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				gpio = <&gpio 4 GPIO_ACTIVE_HIGH>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&mcp251xfd_xceiver_pins>;
+			};
+		};
+	};
+
+	fragment@14 {
+		target = <&mcp251xfd>;
+		__dormant__ {
+			xceiver-supply = <&reg_mcp251xfd_xceiver>;
+		};
+	};
+
+	__overrides__ {
+		spi0-0 = <0>, "+0",
+			<&mcp251xfd_frag>, "target:0=", <&spi0>,
+			<&mcp251xfd>, "reg:0=0",
+			<&mcp251xfd_pins>, "name=mcp251xfd_spi0_0_pins",
+			<&clk_mcp251xfd_osc>, "name=mcp251xfd-spi0-0-osc",
+			<&mcp251xfd_xceiver_pins>, "name=mcp251xfd_spi0_0_xceiver_pins",
+			<&reg_mcp251xfd_xceiver>, "name=reg-mcp251xfd-spi0-0-xceiver",
+			<&reg_mcp251xfd_xceiver>, "regulator-name=mcp251xfd-spi0-0-xceiver";
+		spi0-1 = <0>, "+1",
+			<&mcp251xfd_frag>, "target:0=", <&spi0>,
+			<&mcp251xfd>, "reg:0=1",
+			<&mcp251xfd_pins>, "name=mcp251xfd_spi0_1_pins",
+			<&clk_mcp251xfd_osc>, "name=mcp251xfd-spi0-1-osc",
+			<&mcp251xfd_xceiver_pins>, "name=mcp251xfd_spi0_1_xceiver_pins",
+			<&reg_mcp251xfd_xceiver>, "name=reg-mcp251xfd-spi0-1-xceiver",
+			<&reg_mcp251xfd_xceiver>, "regulator-name=mcp251xfd-spi0-1-xceiver";
+		spi1-0 = <0>, "+2",
+			<&mcp251xfd_frag>, "target:0=", <&spi1>,
+			<&mcp251xfd>, "reg:0=0",
+			<&mcp251xfd_pins>, "name=mcp251xfd_spi1_0_pins",
+			<&clk_mcp251xfd_osc>, "name=mcp251xfd-spi1-0-osc",
+			<&mcp251xfd_xceiver_pins>, "name=mcp251xfd_spi1_0_xceiver_pins",
+			<&reg_mcp251xfd_xceiver>, "name=reg-mcp251xfd-spi1-0-xceiver",
+			<&reg_mcp251xfd_xceiver>, "regulator-name=mcp251xfd-spi1-0-xceiver";
+		spi1-1 = <0>, "+3",
+			<&mcp251xfd_frag>, "target:0=", <&spi1>,
+			<&mcp251xfd>, "reg:0=1",
+			<&mcp251xfd_pins>, "name=mcp251xfd_spi1_1_pins",
+			<&clk_mcp251xfd_osc>, "name=mcp251xfd-spi1-1-osc",
+			<&mcp251xfd_xceiver_pins>, "name=mcp251xfd_spi1_1_xceiver_pins",
+			<&reg_mcp251xfd_xceiver>, "name=reg-mcp251xfd-spi1-1-xceiver",
+			<&reg_mcp251xfd_xceiver>, "regulator-name=mcp251xfd-spi1-1-xceiver";
+		spi1-2 = <0>, "+4",
+			<&mcp251xfd_frag>, "target:0=", <&spi1>,
+			<&mcp251xfd>, "reg:0=2",
+			<&mcp251xfd_pins>, "name=mcp251xfd_spi1_2_pins",
+			<&clk_mcp251xfd_osc>, "name=mcp251xfd-spi1-2-osc",
+			<&mcp251xfd_xceiver_pins>, "name=mcp251xfd_spi1_2_xceiver_pins",
+			<&reg_mcp251xfd_xceiver>, "name=reg-mcp251xfd-spi1-2-xceiver",
+			<&reg_mcp251xfd_xceiver>, "regulator-name=mcp251xfd-spi1-2-xceiver";
+		spi2-0 = <0>, "+5",
+			<&mcp251xfd_frag>, "target:0=", <&spi2>,
+			<&mcp251xfd>, "reg:0=0",
+			<&mcp251xfd_pins>, "name=mcp251xfd_spi2_0_pins",
+			<&clk_mcp251xfd_osc>, "name=mcp251xfd-spi2-0-osc",
+			<&mcp251xfd_xceiver_pins>, "name=mcp251xfd_spi2_0_xceiver_pins",
+			<&reg_mcp251xfd_xceiver>, "name=reg-mcp251xfd-spi2-0-xceiver",
+			<&reg_mcp251xfd_xceiver>, "regulator-name=mcp251xfd-spi2-0-xceiver";
+		spi2-1 = <0>, "+6",
+			<&mcp251xfd_frag>, "target:0=", <&spi2>,
+			<&mcp251xfd>, "reg:0=1",
+			<&mcp251xfd_pins>, "name=mcp251xfd_spi2_1_pins",
+			<&clk_mcp251xfd_osc>, "name=mcp251xfd-spi2-1-osc",
+			<&mcp251xfd_xceiver_pins>, "name=mcp251xfd_spi2_1_xceiver_pins",
+			<&reg_mcp251xfd_xceiver>, "name=reg-mcp251xfd-spi2-1-xceiver",
+			<&reg_mcp251xfd_xceiver>, "regulator-name=mcp251xfd-spi2-1-xceiver";
+		spi2-2 = <0>, "+7",
+			<&mcp251xfd_frag>, "target:0=", <&spi2>,
+			<&mcp251xfd>, "reg:0=2",
+			<&mcp251xfd_pins>, "name=mcp251xfd_spi2_2_pins",
+			<&clk_mcp251xfd_osc>, "name=mcp251xfd-spi2-2-osc",
+			<&mcp251xfd_xceiver_pins>, "name=mcp251xfd_spi2_2_xceiver_pins",
+			<&reg_mcp251xfd_xceiver>, "name=reg-mcp251xfd-spi2-2-xceiver",
+			<&reg_mcp251xfd_xceiver>, "regulator-name=mcp251xfd-spi2-2-xceiver";
+		oscillator = <&clk_mcp251xfd_osc>, "clock-frequency:0";
+		speed = <&mcp251xfd>, "spi-max-frequency:0";
+		interrupt = <&mcp251xfd_pins>, "brcm,pins:0",
+			<&mcp251xfd>, "interrupts:0";
+		rx_interrupt = <0>, "+11",
+			<&mcp251xfd_pins>, "brcm,pins:4",
+			<&mcp251xfd_rx_int_gpios>, "microchip,rx-int-gpios:4";
+		xceiver_enable = <0>, "+12+13+14",
+			<&mcp251xfd_xceiver_pins>, "brcm,pins:0",
+			<&reg_mcp251xfd_xceiver>, "gpio:4";
+		xceiver_active_high = <&reg_mcp251xfd_xceiver>, "enable-active-high?";
+	};
+};


### PR DESCRIPTION
The mcp251xfd is a CAN-FD SPI controller found on many rpi add-on modules. The driver is mainline with v5.10 and this patch adds the overlay.

This is the forward-port of the overlay that has been recently added to the rpi-5.4.y branch in https://github.com/raspberrypi/linux/pull/3949.