### PR TITLE
media: bcm2835-unicam: Correctly handle error states on stream on/off

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -426,6 +426,8 @@ struct unicam_device {
 	struct clk *clock;
 	/* vpu clock handle */
 	struct clk *vpu_clock;
+	/* clock status for error handling */
+	bool clocks_enabled;
 	/* V4l2 device */
 	struct v4l2_device v4l2_dev;
 	struct media_device mdev;
@@ -1724,6 +1726,7 @@ static int unicam_start_streaming(struct vb2_queue *vq, unsigned int count)
 		goto err_disable_unicam;
 	}
 
+	dev->clocks_enabled = true;
 	return 0;
 
 err_disable_unicam:
@@ -1750,8 +1753,6 @@ static void unicam_stop_streaming(struct vb2_queue *vq)
 	node->streaming = false;
 
 	if (node->pad_id == IMAGE_PAD) {
-		int ret;
-
 		/*
 		 * Stop streaming the sensor and disable the peripheral.
 		 * We cannot continue streaming embedded data with the
@@ -1762,12 +1763,13 @@ static void unicam_stop_streaming(struct vb2_queue *vq)
 
 		unicam_disable(dev);
 
-		ret = clk_set_min_rate(dev->vpu_clock, 0);
-		if (ret)
-			unicam_err(dev, "failed to reset the min VPU clock\n");
+		if (dev->clocks_enabled) {
+			if (clk_set_min_rate(dev->vpu_clock, 0))
+				unicam_err(dev, "failed to reset the min VPU clock\n");
 
-		clk_disable_unprepare(dev->vpu_clock);
-		clk_disable_unprepare(dev->clock);
+			clk_disable_unprepare(dev->vpu_clock);
+			clk_disable_unprepare(dev->clock);
+		}
 		unicam_runtime_put(dev);
 
 	} else if (node->pad_id == METADATA_PAD) {

--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -1730,8 +1730,7 @@ err_disable_unicam:
 	unicam_disable(dev);
 	clk_disable_unprepare(dev->clock);
 err_vpu_clock:
-	ret = clk_set_min_rate(dev->vpu_clock, 0);
-	if (ret)
+	if (clk_set_min_rate(dev->vpu_clock, 0))
 		unicam_err(dev, "failed to reset the VPU clock\n");
 	clk_disable_unprepare(dev->vpu_clock);
 err_pm_put:


### PR DESCRIPTION
On a failure in start_streaming(), the error code would not propagate to
the calling function on all conditions. This would cause the userland
caller to not know of the failure.

Additionally, clk_disable_unprepare() was called unconditionally in
stop_streaming(). This is incorrect in the cases where start_streaming()
fails, and unprepares all clocks as part of the failure cleanup. Ensure
that clk_disable_unprepare() is only called in stop_streaming() if the
clocks are in a prepared state.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>