### PR TITLE
media: bcm2835-unicam: Clear clock state when stopping streaming

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -1769,6 +1769,7 @@ static void unicam_stop_streaming(struct vb2_queue *vq)
 
 			clk_disable_unprepare(dev->vpu_clock);
 			clk_disable_unprepare(dev->clock);
+			dev->clocks_enabled = false;
 		}
 		unicam_runtime_put(dev);
 


### PR DESCRIPTION
Commit 65e08c465020d4c5b51afb452efc2246d80fd66f failed to clear the
clock state when the device stopped streaming. Fix this, as it might
again cause the same problems when doing an unprepare.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>