### PR TITLE
media: i2c: imx477: Selection compliance fixes

### DIFF
--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -900,8 +900,8 @@ static const struct imx477_mode supported_modes_12bit[] = {
 		.height = 3040,
 		.line_length_pix = 0x5dc0,
 		.crop = {
-			.left = 0,
-			.top = 0,
+			.left = IMX477_PIXEL_ARRAY_LEFT,
+			.top = IMX477_PIXEL_ARRAY_TOP,
 			.width = 4056,
 			.height = 3040,
 		},
@@ -924,8 +924,8 @@ static const struct imx477_mode supported_modes_12bit[] = {
 		.height = 1520,
 		.line_length_pix = 0x31c4,
 		.crop = {
-			.left = 0,
-			.top = 0,
+			.left = IMX477_PIXEL_ARRAY_LEFT,
+			.top = IMX477_PIXEL_ARRAY_TOP,
 			.width = 4056,
 			.height = 3040,
 		},
@@ -948,8 +948,8 @@ static const struct imx477_mode supported_modes_12bit[] = {
 		.height = 1080,
 		.line_length_pix = 0x31c4,
 		.crop = {
-			.left = 0,
-			.top = 440,
+			.left = IMX477_PIXEL_ARRAY_LEFT,
+			.top = IMX477_PIXEL_ARRAY_TOP + 440,
 			.width = 4056,
 			.height = 2600,
 		},
@@ -983,8 +983,8 @@ static const struct imx477_mode supported_modes_10bit[] = {
 			 * rectangle once the driver is expanded to represent
 			 * its processing blocks with multiple subdevs.
 			 */
-			.left = 4,
-			.top = 0,
+			.left = IMX477_PIXEL_ARRAY_LEFT + 4,
+			.top = IMX477_PIXEL_ARRAY_TOP,
 			.width = 4052,
 			.height = 3040,
 		},
@@ -1696,6 +1696,7 @@ static int imx477_get_selection(struct v4l2_subdev *sd,
 		return 0;
 
 	case V4L2_SEL_TGT_CROP_DEFAULT:
+	case V4L2_SEL_TGT_CROP_BOUNDS:
 		sel->r.left = IMX477_PIXEL_ARRAY_LEFT;
 		sel->r.top = IMX477_PIXEL_ARRAY_TOP;
 		sel->r.width = IMX477_PIXEL_ARRAY_WIDTH;


### PR DESCRIPTION
To comply with the intended usage of the V4L2 selection target when
used to retrieve a sensor image properties, adjust the rectangles
returned by the imx477 driver.

The top/left crop coordinates of the TGT_CROP rectangle were set to
(0, 0) instead of (8, 16) which is the offset from the larger physical
pixel array rectangle. This was also a mismatch with the default values
crop rectangle value, so this is corrected. Found with v4l2-compliance.

While at it, add V4L2_SEL_TGT_CROP_BOUNDS support: CROP_DEFAULT and
CROP_BOUNDS have the same size as the non-active pixels are not readable
using the selection API. Found with v4l2-compliance.

This commit mirrors 543790f777ba1b3264c168c653db6d415e7c983f done for
the imx219 sensor.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>