### PR TITLE
Revert "media: videobuf2: Fix length check for single plane dmabuf queueing"

### DIFF
--- a/drivers/media/common/videobuf2/videobuf2-v4l2.c
+++ b/drivers/media/common/videobuf2/videobuf2-v4l2.c
@@ -118,8 +118,7 @@ static int __verify_length(struct vb2_buffer *vb, const struct v4l2_buffer *b)
 				return -EINVAL;
 		}
 	} else {
-		length = (b->memory == VB2_MEMORY_USERPTR ||
-			  b->memory == VB2_MEMORY_DMABUF)
+		length = (b->memory == VB2_MEMORY_USERPTR)
 			? b->length : vb->planes[0].length;
 
 		if (b->bytesused > length)


### PR DESCRIPTION
This reverts commit 961d3b27a2aff52dda0b97d35085a743a27c2f46.

The updated length check for dmabuf types broke existing usage in v4l2
userland clients.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>