### PR TITLE
media: i2c: ov5647: Selection compliance fixes

### DIFF
--- a/drivers/media/i2c/ov5647.c
+++ b/drivers/media/i2c/ov5647.c
@@ -606,8 +606,8 @@ static struct ov5647_mode supported_modes_8bit[] = {
 			.height = 480
 		},
 		.crop = {
-			.left = 0,
-			.top = 0,
+			.left = OV5647_PIXEL_ARRAY_LEFT,
+			.top = OV5647_PIXEL_ARRAY_TOP,
 			.width = 1280,
 			.height = 960,
 		},
@@ -632,8 +632,8 @@ static struct ov5647_mode supported_modes_10bit[] = {
 			.height = 1944
 		},
 		.crop = {
-			.left = 0,
-			.top = 0,
+			.left = OV5647_PIXEL_ARRAY_LEFT,
+			.top = OV5647_PIXEL_ARRAY_TOP,
 			.width = 2592,
 			.height = 1944
 		},
@@ -656,8 +656,8 @@ static struct ov5647_mode supported_modes_10bit[] = {
 			.height = 1080
 		},
 		.crop = {
-			.left = 348,
-			.top = 434,
+			.left = 364,
+			.top = 450,
 			.width = 1928,
 			.height = 1080,
 		},
@@ -679,8 +679,8 @@ static struct ov5647_mode supported_modes_10bit[] = {
 			.height = 972
 		},
 		.crop = {
-			.left = 0,
-			.top = 0,
+			.left = OV5647_PIXEL_ARRAY_LEFT,
+			.top = OV5647_PIXEL_ARRAY_TOP,
 			.width = 2592,
 			.height = 1944,
 		},
@@ -703,8 +703,8 @@ static struct ov5647_mode supported_modes_10bit[] = {
 			.height = 480
 		},
 		.crop = {
-			.left = 16,
-			.top = 0,
+			.left = OV5647_PIXEL_ARRAY_LEFT,
+			.top = OV5647_PIXEL_ARRAY_TOP,
 			.width = 2560,
 			.height = 1920,
 		},
@@ -1080,6 +1080,7 @@ static int ov5647_get_selection(struct v4l2_subdev *sd,
 		return 0;
 
 	case V4L2_SEL_TGT_CROP_DEFAULT:
+	case V4L2_SEL_TGT_CROP_BOUNDS:
 		sel->r.top = OV5647_PIXEL_ARRAY_TOP;
 		sel->r.left = OV5647_PIXEL_ARRAY_LEFT;
 		sel->r.width = OV5647_PIXEL_ARRAY_WIDTH;


### PR DESCRIPTION
To comply with the intended usage of the V4L2 selection target when
used to retrieve a sensor image properties, adjust the rectangles
returned by the ov5647 driver.

The top/left crop coordinates of the TGT_CROP rectangle were set to
(0, 0) instead of (16, 16) which is the offset from the larger physical
pixel array rectangle. This was also a mismatch with the default values
crop rectangle value, so this is corrected. Found with v4l2-compliance.

While at it, add V4L2_SEL_TGT_CROP_BOUNDS support: CROP_DEFAULT and
CROP_BOUNDS have the same size as the non-active pixels are not readable
using the selection API. Found with v4l2-compliance.

Signed-off-by: Paul Elder <paul.elder@ideasonboard.com>