### PR TITLE
Add configuration override for MSEL0 on merus-amp overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1854,8 +1854,8 @@ Params: speed                   Display SPI bus speed
 
 Name:   merus-amp
 Info:   Configures the merus-amp audio card
-Load:   dtoverlay=merus-amp
-Params: <None>
+Load:   dtoverlay=merus-amp,<param>=<val>
+Params: spioff                  Turn SPI bus off
 
 
 Name:   midi-uart0

--- a/arch/arm/boot/dts/overlays/merus-amp-overlay.dts
+++ b/arch/arm/boot/dts/overlays/merus-amp-overlay.dts
@@ -57,4 +57,14 @@
 			status = "okay";
 		};
 	};
+
+	fragment@4 {
+		target = <&spi0>;
+		frag4: __overlay__ {
+		};
+	};
+
+	__overrides__ {
+		spioff = <&frag4>, "status=disabled";
+	};
 };


### PR DESCRIPTION
Currently, on the [merus amp board](https://www.infineon.com/cms/en/product/evaluation-boards/kit_40w_amp_hat_zw/), the MSEL0 pin on the MA12070P is wired in to GPIO8 / SPI CE0 ... this means that if you have the SPI interface enabled on your Pi it stops the card from working.

I am working on a board using the same chip, but will move the MSEL0 pin to a different GPIO. Whilst I could make an entirely different overlay, this seems pointless when we can just provide overrides.

If you look at page 27 of the chip datasheet linked below, you will see the MSEL0 / MSEL1 config table:

![image](https://user-images.githubusercontent.com/3359418/103144873-ad7f5800-4728-11eb-86ac-ad6367b20c69.png)

My main question (probably for @pelwell) is the best way to deal with the MSEL1 pin (which by default on the merus amp board is tied to ground). I guess we provide an empty initial value and then allow it to be overriden?

I will update the [README](https://github.com/raspberrypi/linux/blob/rpi-5.4.y/arch/arm/boot/dts/overlays/README) for the dts updates once we have some consensus on the best thing to do for this overlay.

* Chip datasheet - [Infineon-MA12070P-DS-v01_00-EN.pdf](https://github.com/raspberrypi/linux/files/5742637/Infineon-MA12070P-DS-v01_00-EN.pdf)
* HAT datasheet - [Infineon-KIT_40W_AMP_HAT_ZW-UserManual-v01_00-EN.pdf](https://github.com/raspberrypi/linux/files/5742638/Infineon-KIT_40W_AMP_HAT_ZW-UserManual-v01_00-EN.pdf)
* HAT application notes - [Infineon-KIT_40W_AMP_HAT_ZW-ApplicationNotes-v01_00-EN.pdf](https://github.com/raspberrypi/linux/files/5742639/Infineon-KIT_40W_AMP_HAT_ZW-ApplicationNotes-v01_00-EN.pdf)