### PR TITLE
vc-sm-cma: fixed kbuild problem

### DIFF
--- a/drivers/staging/vc04_services/vchiq-mmal/Kconfig
+++ b/drivers/staging/vc04_services/vchiq-mmal/Kconfig
@@ -1,6 +1,6 @@
 config BCM2835_VCHIQ_MMAL
 	tristate "BCM2835 MMAL VCHIQ service"
-	depends on BCM2835_VCHIQ
+	select BCM2835_VCHIQ
 	select BCM_VC_SM_CMA
 	help
 	  Enables the MMAL API over VCHIQ interface as used for the


### PR DESCRIPTION
error logs:
  drivers/staging/vc04_services/vc-sm-cma/Kconfig:1:error: recursive dependency detected!
  drivers/staging/vc04_services/vc-sm-cma/Kconfig:1:      symbol BCM_VC_SM_CMA is selected by BCM2835_VCHIQ_MMAL
  drivers/staging/vc04_services/vchiq-mmal/Kconfig:1:     symbol BCM2835_VCHIQ_MMAL depends on BCM2835_VCHIQ
  drivers/staging/vc04_services/Kconfig:14:       symbol BCM2835_VCHIQ is selected by BCM_VC_SM_CMA
  For a resolution refer to Documentation/kbuild/kconfig-language.rst
  subsection "Kconfig recursive dependency limitations"

Tested-by: make ARCH=arm64 bcm2711_defconfig
Test platform: fedora 33
Branch: rpi-5.10.y