### PR TITLE
Backport VL805 initialization code for RPi4 from 5.4.y (fix #3713, #3976)

### DIFF
--- a/include/soc/bcm2835/raspberrypi-firmware.h
+++ b/include/soc/bcm2835/raspberrypi-firmware.h
@@ -98,7 +98,7 @@ enum rpi_firmware_property_tag {
 	RPI_FIRMWARE_SET_PERIPH_REG =                         0x00038045,
 	RPI_FIRMWARE_GET_POE_HAT_VAL =                        0x00030049,
 	RPI_FIRMWARE_SET_POE_HAT_VAL =                        0x00030050,
-
+	RPI_FIRMWARE_NOTIFY_XHCI_RESET =                      0x00030058,
 
 	/* Dispmanx TAGS */
 	RPI_FIRMWARE_FRAMEBUFFER_ALLOCATE =                   0x00040001,


### PR DESCRIPTION
Without this patch RPi4 with 4.19.y-rt has no USB at all.
It should fix #3713 and #3976.

------------------------------------------------------------------------------------------------------

The VL805 FW may either be loaded from an SPI EEPROM or alternatively
loaded directly by the VideoCore firmware. A PCI reset will reset
the VL805 XHCI controller on the Raspberry Pi4 requiring the firmware
to be reloaded if an SPI EEPROM is not present.

Use a VideoCore mailbox to trigger the loading of the VL805
firmware (if necessary) after a PCI reset.