### PR TITLE
Add a camera regulator node(s) to allow sharing on CM4 and remove firmware nastiness

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
@@ -5,6 +5,7 @@
 #include "bcm283x-rpi-smsc9514.dtsi"
 #include "bcm283x-rpi-csi1-2lane.dtsi"
 #include "bcm283x-rpi-i2c0mux_0_28.dtsi"
+#include "bcm283x-rpi-cam1-regulator.dtsi"
 
 / {
 	compatible = "raspberrypi,model-b-plus", "brcm,bcm2835";
@@ -109,6 +110,10 @@
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+};
+
+&cam1_reg {
+	gpio = <&gpio 41 GPIO_ACTIVE_HIGH>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2708-rpi-b-rev1.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-rev1.dts
@@ -4,6 +4,7 @@
 #include "bcm2708-rpi.dtsi"
 #include "bcm283x-rpi-smsc9512.dtsi"
 #include "bcm283x-rpi-csi1-2lane.dtsi"
+#include "bcm283x-rpi-cam1-regulator.dtsi"
 
 / {
 	compatible = "raspberrypi,model-b", "brcm,bcm2835";
@@ -116,6 +117,10 @@ i2c_csi_dsi: &i2c1 {
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+};
+
+&cam1_reg {
+	gpio = <&gpio 27 GPIO_ACTIVE_HIGH>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -5,6 +5,7 @@
 #include "bcm283x-rpi-smsc9512.dtsi"
 #include "bcm283x-rpi-csi1-2lane.dtsi"
 #include "bcm283x-rpi-i2c0mux_0_28.dtsi"
+#include "bcm283x-rpi-cam1-regulator.dtsi"
 
 / {
 	compatible = "raspberrypi,model-b", "brcm,bcm2835";
@@ -103,6 +104,10 @@
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+};
+
+&cam1_reg {
+	gpio = <&gpio 21 GPIO_ACTIVE_HIGH>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2708-rpi-cm.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-cm.dts
@@ -8,6 +8,21 @@
 / {
 	compatible = "raspberrypi,compute-module", "brcm,bcm2835";
 	model = "Raspberry Pi Compute Module";
+
+	cam1_reg: cam1_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "cam1-regulator";
+		gpio = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		status = "disabled";
+	};
+	cam0_reg: cam0_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "cam0-regulator";
+		gpio = <&gpio 30 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		status = "disabled";
+	};
 };
 
 &uart0 {

--- a/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
@@ -5,6 +5,7 @@
 #include "bcm283x-rpi-csi1-2lane.dtsi"
 #include "bcm283x-rpi-i2c0mux_0_28.dtsi"
 #include "bcm2708-rpi-bt.dtsi"
+#include "bcm283x-rpi-cam1-regulator.dtsi"
 
 / {
 	compatible = "raspberrypi,model-zero-w", "brcm,bcm2835";
@@ -153,6 +154,10 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
 	brcm,disable-headphones = <1>;
+};
+
+&cam1_reg {
+	gpio = <&gpio 44 GPIO_ACTIVE_HIGH>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2708-rpi-zero.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero.dts
@@ -4,6 +4,7 @@
 #include "bcm2708-rpi.dtsi"
 #include "bcm283x-rpi-csi1-2lane.dtsi"
 #include "bcm283x-rpi-i2c0mux_0_28.dtsi"
+#include "bcm283x-rpi-cam1-regulator.dtsi"
 
 / {
 	compatible = "raspberrypi,model-zero", "brcm,bcm2835";
@@ -107,6 +108,10 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
 	brcm,disable-headphones = <1>;
+};
+
+&cam1_reg {
+	gpio = <&gpio 41 GPIO_ACTIVE_HIGH>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
@@ -5,6 +5,7 @@
 #include "bcm283x-rpi-smsc9514.dtsi"
 #include "bcm283x-rpi-csi1-2lane.dtsi"
 #include "bcm283x-rpi-i2c0mux_0_28.dtsi"
+#include "bcm283x-rpi-cam1-regulator.dtsi"
 
 / {
 	compatible = "raspberrypi,2-model-b", "brcm,bcm2836";
@@ -109,6 +110,10 @@
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+};
+
+&cam1_reg {
+	gpio = <&gpio 41 GPIO_ACTIVE_HIGH>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2710-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-2-b.dts
@@ -5,6 +5,7 @@
 #include "bcm283x-rpi-smsc9514.dtsi"
 #include "bcm283x-rpi-csi1-2lane.dtsi"
 #include "bcm283x-rpi-i2c0mux_0_28.dtsi"
+#include "bcm283x-rpi-cam1-regulator.dtsi"
 
 / {
 	compatible = "raspberrypi,2-model-b-rev2", "brcm,bcm2837";
@@ -109,6 +110,10 @@
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+};
+
+&cam1_reg {
+	gpio = <&gpio 41 GPIO_ACTIVE_HIGH>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
@@ -6,6 +6,7 @@
 #include "bcm283x-rpi-csi1-2lane.dtsi"
 #include "bcm283x-rpi-i2c0mux_0_44.dtsi"
 #include "bcm271x-rpi-bt.dtsi"
+#include "bcm283x-rpi-cam1-regulator.dtsi"
 
 / {
 	compatible = "raspberrypi,3-model-b-plus", "brcm,bcm2837";
@@ -174,6 +175,10 @@
 	microchip,eee-enabled;
 	microchip,tx-lpi-timer = <600>; /* non-aggressive*/
 	microchip,downshift-after = <2>;
+};
+
+&cam1_reg {
+	gpio = <&expgpio 5 GPIO_ACTIVE_HIGH>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
@@ -6,6 +6,7 @@
 #include "bcm283x-rpi-csi1-2lane.dtsi"
 #include "bcm283x-rpi-i2c0mux_0_44.dtsi"
 #include "bcm271x-rpi-bt.dtsi"
+#include "bcm283x-rpi-cam1-regulator.dtsi"
 
 / {
 	compatible = "raspberrypi,3-model-b", "brcm,bcm2837";
@@ -183,6 +184,10 @@
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+};
+
+&cam1_reg {
+	gpio = <&expgpio 5 GPIO_ACTIVE_HIGH>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
@@ -8,6 +8,21 @@
 / {
 	compatible = "raspberrypi,3-compute-module", "brcm,bcm2837";
 	model = "Raspberry Pi Compute Module 3";
+
+	cam1_reg: cam1_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "cam1-regulator";
+		gpio = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		status = "disabled";
+	};
+	cam0_reg: cam0_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "cam0-regulator";
+		gpio = <&gpio 30 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		status = "disabled";
+	};
 };
 
 &uart0 {

--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
@@ -319,6 +319,7 @@
 #include "bcm2711-rpi.dtsi"
 #include "bcm283x-rpi-csi1-2lane.dtsi"
 #include "bcm283x-rpi-i2c0mux_0_44.dtsi"
+#include "bcm283x-rpi-cam1-regulator.dtsi"
 
 / {
 	chosen {
@@ -583,6 +584,10 @@
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+};
+
+&cam1_reg {
+	gpio = <&expgpio 5 GPIO_ACTIVE_HIGH>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
@@ -327,6 +327,14 @@
 	};
 
 	/delete-node/ wifi-pwrseq;
+
+	cam0_reg: cam1_reg: cam1_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "cam1-reg";
+		gpio = <&expgpio 5 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		status = "disabled";
+	};
 };
 
 &mmcnr {

--- a/arch/arm/boot/dts/bcm283x-rpi-cam1-regulator.dtsi
+++ b/arch/arm/boot/dts/bcm283x-rpi-cam1-regulator.dtsi
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/ {
+	cam1_reg: cam1_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "cam1-reg";
+		enable-active-high;
+		status = "disabled";
+	};
+};

--- a/arch/arm/boot/dts/overlays/imx219-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx219-overlay.dts
@@ -23,7 +23,7 @@
 				clocks = <&imx219_clk>;
 				clock-names = "xclk";
 
-				VANA-supply = <&imx219_vana>;	/* 2.8v */
+				VANA-supply = <&cam1_reg>;	/* 2.8v */
 				VDIG-supply = <&imx219_vdig>;	/* 1.8v */
 				VDDL-supply = <&imx219_vddl>;	/* 1.2v */
 
@@ -69,14 +69,6 @@
 	fragment@3 {
 		target-path="/";
 		__overlay__ {
-			imx219_vana: fixedregulator@0 {
-				compatible = "regulator-fixed";
-				regulator-name = "imx219_vana";
-				regulator-min-microvolt = <2800000>;
-				regulator-max-microvolt = <2800000>;
-				gpio = <&gpio 41 GPIO_ACTIVE_HIGH>;
-				enable-active-high;
-			};
 			imx219_vdig: fixedregulator@1 {
 				compatible = "regulator-fixed";
 				regulator-name = "imx219_vdig";
@@ -106,10 +98,12 @@
 	};
 
 	fragment@5 {
-		target-path="/__overrides__";
+		target = <&cam1_reg>;
 		__overlay__ {
-			cam0-pwdn-ctrl = <&imx219_vana>,"gpio:0";
-			cam0-pwdn      = <&imx219_vana>,"gpio:4";
+			status = "okay";
+			regulator-name = "imx219_vana";
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
+++ b/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
@@ -24,7 +24,7 @@
 				clock-names = "xclk";
 				clock-frequency = <37125000>;
 
-				vdda-supply = <&imx290_vdda>;	/* 2.8v */
+				vdda-supply = <&cam1_reg>;	/* 2.8v */
 				vdddo-supply = <&imx290_vdddo>;	/* 1.8v */
 				vddd-supply = <&imx290_vddd>;	/* 1.5v */
 
@@ -61,14 +61,6 @@
 	fragment@3 {
 		target-path="/";
 		__overlay__ {
-			imx290_vdda: fixedregulator@0 {
-				compatible = "regulator-fixed";
-				regulator-name = "imx290_vdda";
-				regulator-min-microvolt = <2800000>;
-				regulator-max-microvolt = <2800000>;
-				gpio = <&gpio 41 GPIO_ACTIVE_HIGH>;
-				enable-active-high;
-			};
 			imx290_vdddo: fixedregulator@1 {
 				compatible = "regulator-fixed";
 				regulator-name = "imx290_vdddo";
@@ -98,10 +90,12 @@
 	};
 
 	fragment@5 {
-		target-path="/__overrides__";
+		target = <&cam1_reg>;
 		__overlay__ {
-			cam0-pwdn-ctrl = <&imx290_vdda>,"gpio:0";
-			cam0-pwdn      = <&imx290_vdda>,"gpio:4";
+			status = "okay";
+			regulator-name = "imx290_vdda";
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/imx477-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx477-overlay.dts
@@ -23,7 +23,7 @@
 				clocks = <&imx477_clk>;
 				clock-names = "xclk";
 
-				VANA-supply = <&imx477_vana>;	/* 2.8v */
+				VANA-supply = <&cam1_reg>;	/* 2.8v */
 				VDIG-supply = <&imx477_vdig>;	/* 1.05v */
 				VDDL-supply = <&imx477_vddl>;	/* 1.8v */
 
@@ -69,22 +69,13 @@
 	fragment@3 {
 		target-path="/";
 		__overlay__ {
-			imx477_vana: fixedregulator@0 {
-				compatible = "regulator-fixed";
-				regulator-name = "imx477_vana";
-				regulator-min-microvolt = <2800000>;
-				regulator-max-microvolt = <2800000>;
-				gpio = <&gpio 41 GPIO_ACTIVE_HIGH>;
-				enable-active-high;
-				startup-delay-us = <300000>;
-			};
-			imx477_vdig: fixedregulator@1 {
+			imx477_vdig: fixedregulator@0 {
 				compatible = "regulator-fixed";
 				regulator-name = "imx477_vdig";
 				regulator-min-microvolt = <1050000>;
 				regulator-max-microvolt = <1050000>;
 			};
-			imx477_vddl: fixedregulator@2 {
+			imx477_vddl: fixedregulator@1 {
 				compatible = "regulator-fixed";
 				regulator-name = "imx477_vddl";
 				regulator-min-microvolt = <1800000>;
@@ -106,10 +97,13 @@
 	};
 
 	fragment@5 {
-		target-path="/__overrides__";
+		target = <&cam1_reg>;
 		__overlay__ {
-			cam0-pwdn-ctrl = <&imx477_vana>,"gpio:0";
-			cam0-pwdn      = <&imx477_vana>,"gpio:4";
+			status = "okay";
+			regulator-name = "imx477_vana";
+			startup-delay-us = <300000>;
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/ov7251-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov7251-overlay.dts
@@ -25,10 +25,8 @@
 				clock-frequency = <24000000>;
 
 				vdddo-supply = <&ov7251_dovdd>;
-				vdda-supply = <&ov7251_avdd>;
+				vdda-supply = <&cam1_reg>;
 				vddd-supply = <&ov7251_dvdd>;
-
-				enable-gpios = <&gpio 41 GPIO_ACTIVE_HIGH>;
 
 				port {
 					ov7251_0: endpoint {
@@ -68,12 +66,6 @@
 	fragment@3 {
 		target-path="/";
 		__overlay__ {
-			ov7251_avdd: fixedregulator@0 {
-				compatible = "regulator-fixed";
-				regulator-name = "ov7251_avdd";
-				regulator-min-microvolt = <2800000>;
-				regulator-max-microvolt = <2800000>;
-			};
 			ov7251_dovdd: fixedregulator@1 {
 				compatible = "regulator-fixed";
 				regulator-name = "ov7251_dovdd";
@@ -102,10 +94,12 @@
 	};
 
 	fragment@5 {
-		target-path="/__overrides__";
+		target = <&cam1_reg>;
 		__overlay__ {
-			cam0-pwdn-ctrl = <&ov7251>,"enable-gpios:0";
-			cam0-pwdn      = <&ov7251>,"enable-gpios:4";
+			status = "okay";
+			regulator-name = "ov7251_avdd";
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
 		};
 	};
 };

--- a/arch/arm/boot/dts/overlays/ov9281-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov9281-overlay.dts
@@ -23,7 +23,7 @@
 				clocks = <&ov9281_clk>;
 				clock-names = "xvclk";
 
-				avdd-supply = <&ov9281_avdd>;
+				avdd-supply = <&cam1_reg>;
 				dovdd-supply = <&ov9281_dovdd>;
 				dvdd-supply = <&ov9281_dvdd>;
 
@@ -66,14 +66,6 @@
 	fragment@3 {
 		target-path="/";
 		__overlay__ {
-			ov9281_avdd: fixedregulator@0 {
-				compatible = "regulator-fixed";
-				regulator-name = "ov9281_avdd";
-				regulator-min-microvolt = <2800000>;
-				regulator-max-microvolt = <2800000>;
-				gpio = <&gpio 41 GPIO_ACTIVE_HIGH>;
-				enable-active-high;
-			};
 			ov9281_dovdd: fixedregulator@1 {
 				compatible = "regulator-fixed";
 				regulator-name = "ov9281_dovdd";
@@ -102,10 +94,13 @@
 	};
 
 	fragment@5 {
-		target-path="/__overrides__";
+		target = <&cam1_reg>;
 		__overlay__ {
-			cam0-pwdn-ctrl = <&ov9281_avdd>,"gpio:0";
-			cam0-pwdn      = <&ov9281_avdd>,"gpio:4";
+			status = "okay";
+			regulator-name = "ov9281_avdd";
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
 		};
 	};
+
 };


### PR DESCRIPTION
At the moment the firmware fixes up where the camera shutdown line goes, which means those overlays can't be dynamically loaded.
Because the overlays are claiming GPIOs it also means there isn't an easy way to load a very similar overlay for both CAM0 and CAM1 on a CM4 where the same GPIO is shared for both camera modules.

Adds a new cam1_reg node (and cam0_reg on CMs), and update those overlays that use regulators to use it.