### PR TITLE
uapi: bcm2835-isp: Add colour denoise mode config

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835-isp-ctrls.h
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835-isp-ctrls.h
@@ -57,6 +57,11 @@ static const struct bcm2835_isp_custom_ctrl custom_ctrls[] = {
 		.size	= sizeof(struct bcm2835_isp_denoise),
 		.flags  = 0
 	}, {
+		.name	= "Colour Denoise",
+		.id	= V4L2_CID_USER_BCM2835_ISP_CDN,
+		.size	= sizeof(struct bcm2835_isp_cdn),
+		.flags  = 0
+	}, {
 		.name	= "Defective Pixel Correction",
 		.id	= V4L2_CID_USER_BCM2835_ISP_DPC,
 		.size	= sizeof(struct bcm2835_isp_dpc),

--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
@@ -764,6 +764,11 @@ static int bcm2835_isp_s_ctrl(struct v4l2_ctrl *ctrl)
 				    ctrl->p_new.p_u8,
 				    sizeof(struct bcm2835_isp_denoise));
 		break;
+	case V4L2_CID_USER_BCM2835_ISP_CDN:
+		ret = set_isp_param(node, MMAL_PARAMETER_CDN,
+				    ctrl->p_new.p_u8,
+				    sizeof(struct bcm2835_isp_cdn));
+		break;
 	case V4L2_CID_USER_BCM2835_ISP_SHARPEN:
 		ret = set_isp_param(node, MMAL_PARAMETER_SHARPEN,
 				    ctrl->p_new.p_u8,

--- a/drivers/staging/vc04_services/vchiq-mmal/mmal-parameters.h
+++ b/drivers/staging/vc04_services/vchiq-mmal/mmal-parameters.h
@@ -277,6 +277,8 @@ enum mmal_parameter_camera_type {
 	MMAL_PARAMETER_DPC,
 		/**< Tales a @ref MMAP_PARAMETER_GAMMA_T */
 	MMAL_PARAMETER_GAMMA,
+		/**< Takes a @ref MMAL_PARAMETER_CDN_T */
+	MMAL_PARAMETER_CDN,
 };
 
 struct mmal_parameter_rational {
@@ -911,6 +913,17 @@ struct mmal_parameter_gamma {
 	u32 enabled;
 	u16 x[MMAL_NUM_GAMMA_PTS];
 	u16 y[MMAL_NUM_GAMMA_PTS];
+};
+
+enum mmal_parameter_cdn_mode {
+	MMAL_PARAM_CDN_FAST = 0,
+	MMAL_PARAM_CDN_HIGH_QUALITY = 1,
+	MMAL_PARAM_CDN_DUMMY  = 0x7FFFFFFF
+};
+
+struct mmal_parameter_colour_denoise {
+	u32 enabled;
+	enum mmal_parameter_cdn_mode mode;
 };
 
 struct mmal_parameter_denoise {

--- a/include/uapi/linux/bcm2835-isp.h
+++ b/include/uapi/linux/bcm2835-isp.h
@@ -31,6 +31,8 @@
 				(V4L2_CID_USER_BCM2835_ISP_BASE + 0x0007)
 #define V4L2_CID_USER_BCM2835_ISP_DPC		\
 				(V4L2_CID_USER_BCM2835_ISP_BASE + 0x0008)
+#define V4L2_CID_USER_BCM2835_ISP_CDN \
+				(V4L2_CID_USER_BCM2835_ISP_BASE + 0x0009)
 
 /*
  * All structs below are directly mapped onto the equivalent structs in
@@ -173,6 +175,31 @@ struct bcm2835_isp_gamma {
 	__u32 enabled;
 	__u16 x[BCM2835_NUM_GAMMA_PTS];
 	__u16 y[BCM2835_NUM_GAMMA_PTS];
+};
+
+/**
+ * enum bcm2835_isp_cdn_mode - Mode of operation for colour denoise.
+ *
+ * @CDN_MODE_FAST:		Fast (but lower quality) colour denoise
+ *				algorithm, typically used for video recording.
+ * @CDN_HIGH_QUALITY:		High quality (but slower) colour denoise
+ *				algorithm, typically used for stills capture.
+ */
+enum bcm2835_isp_cdn_mode {
+	CDN_MODE_FAST = 0,
+	CDN_MODE_HIGH_QUALITY = 1,
+};
+
+/**
+ * struct bcm2835_isp_cdn - Colour denoise parameters set with the
+ *			    V4L2_CID_USER_BCM2835_ISP_CDN ctrl.
+ *
+ * @enabled:	Enable colour denoise.
+ * @mode:	Colour denoise operating mode (see enum &bcm2835_isp_cdn_mode)
+ */
+struct bcm2835_isp_cdn {
+	__u32 enabled;
+	__u32 mode;
 };
 
 /**


### PR DESCRIPTION
Add a field to the bcm2835_isp_denoise config structure to control
colour denoise operating modes.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>