### PR TITLE
bcm2835-isp: Default to JFIF colour space for YUV420

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835_isp_fmts.h
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835_isp_fmts.h
@@ -39,7 +39,7 @@ static const struct bcm2835_isp_fmt supported_formats[] = {
 		.flags		    = 0,
 		.mmal_fmt	    = MMAL_ENCODING_I420,
 		.size_multiplier_x2 = 3,
-		.colorspace	    = V4L2_COLORSPACE_SMPTE170M,
+		.colorspace	    = V4L2_COLORSPACE_JPEG,
 		.step_size	    = 2,
 	}, {
 		.fourcc		    = V4L2_PIX_FMT_YVU420,


### PR DESCRIPTION
This is a temporary measure until libcamera can signal colour spaces
correctly.