### PR TITLE
overlays: seeed-can-fd-hat: clarify how to identify HAT version

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2483,16 +2483,18 @@ Load:   <Deprecated>
 
 
 Name:   seeed-can-fd-hat-v1
-Info:   Overlay for Seeed Studio CAN BUS FD HAT with two CAN FD channels
-        (based on the mcp2517fd).
+Info:   Overlay for Seeed Studio CAN BUS FD HAT with two CAN FD
+        channels without RTC. Use this overlay if your HAT has no
+        battery holder.
         https://www.seeedstudio.com/2-Channel-CAN-BUS-FD-Shield-for-Raspberry-Pi-p-4072.html
 Load:   dtoverlay=seeed-can-fd-hat-v1
 Params: <None>
 
 
 Name:   seeed-can-fd-hat-v2
-Info:   Overlay for Seeed Studio CAN BUS FD HAT with two CAN FD channels
-        (based on the mcp2518fd) and an RTC.
+Info:   Overlay for Seeed Studio CAN BUS FD HAT with two CAN FD
+        channels and an RTC. Use this overlay if your HAT has a
+        battery holder.
         https://www.seeedstudio.com/CAN-BUS-FD-HAT-for-Raspberry-Pi-p-4742.html
 Load:   dtoverlay=seeed-can-fd-hat-v2
 Params: <None>


### PR DESCRIPTION
It turns out the used CAN SPI chip is not a good way to identify the version of
the CAN HAT.

There are two different board layouts of the Seeed Studio CAN BUS FD HAT. The
v1 board doesn't have a battery holder, while the v2 board has. Update the
overlay README accordingly.

Link: https://github.com/Seeed-Studio/seeed-linux-dtoverlays/issues/13
Cc: Patrick Menschel <menschel.p@posteo.de>
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>