### PR TITLE
Fixes a problem with the DAC PLL when changing sample rates

### DIFF
--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -57,6 +57,10 @@ static bool leds_off;
 static void snd_rpi_hifiberry_dacplus_select_clk(struct snd_soc_component *component,
 	int clk_id)
 {
+	/* reset PLL divider */
+	snd_soc_component_update_bits(component, PCM512x_MASTER_MODE,
+					PCM512x_RLRK | PCM512x_RBCK, 0);
+
 	switch (clk_id) {
 	case HIFIBERRY_DACPRO_NOCLOCK:
 		snd_soc_component_update_bits(component, PCM512x_GPIO_CONTROL_1, 0x24, 0x00);

--- a/sound/soc/bcm/hifiberry_dacplusadcpro.c
+++ b/sound/soc/bcm/hifiberry_dacplusadcpro.c
@@ -176,6 +176,10 @@ static int pcm1863_add_controls(struct snd_soc_component *component)
 static void snd_rpi_hifiberry_dacplusadcpro_select_clk(
 					struct snd_soc_component *component, int clk_id)
 {
+	/* reset PLL divider */
+	snd_soc_component_update_bits(component, PCM512x_MASTER_MODE,
+					PCM512x_RLRK | PCM512x_RBCK, 0);
+
 	switch (clk_id) {
 	case HIFIBERRY_DACPRO_NOCLOCK:
 		snd_soc_component_update_bits(component,


### PR DESCRIPTION
This fix for Hifiberry DAC+ and DAC+ADC PRO adds RESET of
PLL-dividers for LR- and B-CLK before every change of
sample rate to allow the PLL a clean start up.

Signed-off-by: Joerg Schambacher <joerg@hifiberry.com>