### PR TITLE
staging:bcm2835-camera: Fix the cherry-pick of AWB Greyworld

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-camera/controls.c
+++ b/drivers/staging/vc04_services/bcm2835-camera/controls.c
@@ -1056,8 +1056,8 @@ static const struct bm2835_mmal_v4l2_ctrl v4l2_ctrls[V4L2_CTRL_COUNT] = {
 	{
 		.id = V4L2_CID_AUTO_N_PRESET_WHITE_BALANCE,
 		.type = MMAL_CONTROL_TYPE_STD_MENU,
-		.min = ~0x3ff,
-		.max = V4L2_WHITE_BALANCE_SHADE,
+		.min = ~0x7ff,
+		.max = V4L2_WHITE_BALANCE_GREYWORLD,
 		.def = V4L2_WHITE_BALANCE_AUTO,
 		.step = 0,
 		.imenu = NULL,


### PR DESCRIPTION
The cherry-pick of the patch that added the greyworld AWB mode
was incomplete. Fix it up.

Fixes: b3ef481fe243 "staging: bcm2835-camera: Add greyworld AWB mode"
Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>