### PR TITLE
WIP: dtoverlays: Update CSI2 sensor overlays to add a cam0 parameter

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1631,6 +1631,8 @@ Info:   Sony IMX219 camera module.
 Load:   dtoverlay=imx219,<param>=<val>
 Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 180)
+        cam0                    Adopt the default configuration for CAM0 on a
+                                Compute Module (CSI0, i2c_vc, and cam0_reg).
 
 
 Name:   imx290
@@ -1647,6 +1649,8 @@ Params: 4lane                   Enable 4 CSI2 lanes. This requires a Compute
                                 (the default), whilst those from Innomaker use
                                 74.25MHz.
         mono                    Denote that the module is a mono sensor.
+        cam0                    Adopt the default configuration for CAM0 on a
+                                Compute Module (CSI0, i2c_vc, and cam0_reg).
 
 
 Name:   imx477
@@ -1656,6 +1660,8 @@ Info:   Sony IMX477 camera module.
 Load:   dtoverlay=imx477,<param>=<val>
 Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 180)
+        cam0                    Adopt the default configuration for CAM0 on a
+                                Compute Module (CSI0, i2c_vc, and cam0_reg).
 
 
 Name:   iqaudio-codec
@@ -1719,8 +1725,10 @@ Name:   irs1125
 Info:   Infineon irs1125 TOF camera module.
         Uses Unicam 1, which is the standard camera connector on most Pi
         variants.
-Load:   dtoverlay=irs1125
-Params: <None>
+Load:   dtoverlay=irs1125,<param>=<val>
+Params: cam0                    Adopt the default configuration for CAM0 on a
+                                Compute Module (CSI0, i2c_vc, and cam0_reg).
+
 
 
 Name:   jedec-spi-nor
@@ -2081,22 +2089,27 @@ Info:   Omnivision OV5647 camera module.
 Load:   dtoverlay=ov5647,<param>=<val>
 Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 0)
+        cam0                    Adopt the default configuration for CAM0 on a
+                                Compute Module (CSI0, i2c_vc, and cam0_reg).
 
 
 Name:   ov7251
 Info:   Omnivision OV7251 camera module.
         Uses Unicam 1, which is the standard camera connector on most Pi
         variants.
-Load:   dtoverlay=ov7251
-Params: <None>
+Load:   dtoverlay=ov7251,<param>=<val>
+Params: cam0                    Adopt the default configuration for CAM0 on a
+                                Compute Module (CSI0, i2c_vc, and cam0_reg).
+
 
 
 Name:   ov9281
 Info:   Omnivision OV9281 camera module.
         Uses Unicam 1, which is the standard camera connector on most Pi
         variants.
-Load:   dtoverlay=ov9281
-Params: <None>
+Load:   dtoverlay=ov9281,<param>=<val>
+Params: cam0                    Adopt the default configuration for CAM0 on a
+                                Compute Module (CSI0, i2c_vc, and cam0_reg).
 
 
 Name:   papirus
@@ -3014,6 +3027,8 @@ Params: 4lane                   Use 4 lanes (only applicable to Compute Modules
         link-frequency          Set the link frequency. Only values of 297000000
                                 (574Mbit/s) and 486000000 (972Mbit/s - default)
                                 are supported by the driver.
+        cam0                    Adopt the default configuration for CAM0 on a
+                                Compute Module (CSI0, i2c_vc, and cam0_reg).
 
 
 Name:   tc358743-audio

--- a/arch/arm/boot/dts/overlays/adv7282m-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adv7282m-overlay.dts
@@ -7,7 +7,7 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c_csi_dsi>;
+		target = <&i2cbus>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -20,7 +20,7 @@
 				clock-frequency = <24000000>;
 				port {
 					adv728x_0: endpoint {
-						remote-endpoint = <&csi1_ep>;
+						remote-endpoint = <&csi_ep>;
 						clock-lanes = <0>;
 						data-lanes = <1>;
 						link-frequencies =
@@ -33,12 +33,12 @@
 		};
 	};
 	fragment@1 {
-		target = <&csi1>;
+		target = <&csi>;
 		__overlay__ {
 			status = "okay";
 
 			port {
-				csi1_ep: endpoint {
+				csi_ep: endpoint {
 					remote-endpoint = <&adv728x_0>;
 					data-lanes = <1>;
 				};
@@ -59,7 +59,24 @@
 		};
 	};
 
+	frag100: fragment@100 {
+		target = <&i2c_csi_dsi>;
+		i2cbus: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	frag101: fragment@101 {
+		target = <&csi1>;
+		csi: __overlay__ {
+			status = "okay";
+		};
+	};
+
 	__overrides__ {
-		addr =			<&adv728x>,"reg:0";
+		addr =	<&adv728x>,"reg:0";
+		cam0 =	<&frag100>, "target:0=",<&i2c_vc>,
+			<&frag101>, "target:0=",<&csi0>
+			;
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx219-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx219-overlay.dts
@@ -9,7 +9,7 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c_csi_dsi>;
+		target = <&i2cbus>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -23,7 +23,7 @@
 				clocks = <&imx219_clk>;
 				clock-names = "xclk";
 
-				VANA-supply = <&cam1_reg>;	/* 2.8v */
+				VANA-supply = <&cam_reg>;	/* 2.8v */
 				VDIG-supply = <&imx219_vdig>;	/* 1.8v */
 				VDDL-supply = <&imx219_vddl>;	/* 1.2v */
 
@@ -31,7 +31,7 @@
 
 				port {
 					imx219_0: endpoint {
-						remote-endpoint = <&csi1_ep>;
+						remote-endpoint = <&csi_ep>;
 						clock-lanes = <0>;
 						data-lanes = <1 2>;
 						clock-noncontinuous;
@@ -44,12 +44,12 @@
 	};
 
 	fragment@1 {
-		target = <&csi1>;
+		target = <&csi>;
 		__overlay__ {
 			status = "okay";
 
 			port {
-				csi1_ep: endpoint {
+				csi_ep: endpoint {
 					remote-endpoint = <&imx219_0>;
 					clock-lanes = <0>;
 					data-lanes = <1 2>;
@@ -82,10 +82,11 @@
 				regulator-max-microvolt = <1200000>;
 			};
 
-			imx219_clk: camera-clk {
+			imx219_clk: imx219_1_clk {
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-frequency = <24000000>;
+				clock-output-names = "imx219_0_clk";
 			};
 		};
 	};
@@ -98,7 +99,7 @@
 	};
 
 	fragment@5 {
-		target = <&cam1_reg>;
+		target = <&cam_reg>;
 		__overlay__ {
 			status = "okay";
 			regulator-name = "imx219_vana";
@@ -107,7 +108,38 @@
 		};
 	};
 
+	frag100: fragment@100 {
+		target = <&i2c_csi_dsi>;
+		i2cbus: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	frag101: fragment@101 {
+		target = <&csi1>;
+		csi: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	frag102: fragment@102 {
+		target = <&cam1_reg>;
+		cam_reg: __overlay__ {
+			status = "okay";
+		};
+	};
+
 	__overrides__ {
 		rotation = <&imx219>,"rotation:0";
+		cam0 =	<&frag100>, "target:0=",<&i2c_vc>,
+			<&frag101>, "target:0=",<&csi0>,
+			<&frag102>, "target:0=",<&cam0_reg>,
+			<&imx219_vdig>, "name=imx219_0_dovdd",
+			<&imx219_vdig>, "regulator-name=imx219_0_dovdd",
+			<&imx219_vddl>, "name=imx219_0_dvdd",
+			<&imx219_vddl>, "regulator-name=imx219_0_dvdd",
+			<&imx219_clk>, "clock-output-names=imx219_0_clk",
+			<&imx219_clk>, "name=imx219_0_clk"
+			;
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
+++ b/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
@@ -10,7 +10,25 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c_csi_dsi>;
+		target = <&imx290_0>;
+		__overlay__ {
+			data-lanes = <1 2>;
+			link-frequencies =
+				/bits/ 64 <445500000 297000000>;
+		};
+	};
+
+	fragment@1 {
+		target = <&imx290_0>;
+		__dormant__ {
+			data-lanes = <1 2 3 4>;
+			link-frequencies =
+				/bits/ 64 <222750000 148500000>;
+		};
+	};
+
+	fragment@2 {
+		target = <&i2cbus>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -24,13 +42,13 @@
 				clock-names = "xclk";
 				clock-frequency = <37125000>;
 
-				vdda-supply = <&cam1_reg>;	/* 2.8v */
+				vdda-supply = <&cam_reg>;	/* 2.8v */
 				vdddo-supply = <&imx290_vdddo>;	/* 1.8v */
 				vddd-supply = <&imx290_vddd>;	/* 1.5v */
 
 				port {
 					imx290_0: endpoint {
-						remote-endpoint = <&csi1_ep>;
+						remote-endpoint = <&csi_ep>;
 						clock-lanes = <0>;
 					};
 				};
@@ -38,102 +56,117 @@
 		};
 	};
 
-	fragment@1 {
-		target = <&csi1>;
+	fragment@3 {
+		target = <&csi_ep>;
+		__overlay__ {
+			data-lanes = <1 2>;
+		};
+	};
+
+	fragment@4 {
+		target = <&csi_ep>;
+		__dormant__ {
+			data-lanes = <1 2 3 4>;
+		};
+	};
+
+	fragment@5 {
+		target = <&csi>;
 		__overlay__ {
 			status = "okay";
 
 			port {
-				csi1_ep: endpoint {
+				csi_ep: endpoint {
 					remote-endpoint = <&imx290_0>;
 				};
 			};
 		};
 	};
 
-	fragment@2 {
+	fragment@6 {
 		target = <&i2c0if>;
 		__overlay__ {
 			status = "okay";
 		};
 	};
 
-	fragment@3 {
+	fragment@7 {
 		target-path="/";
 		__overlay__ {
-			imx290_vdddo: fixedregulator@1 {
+			imx290_vdddo: imx290_1_vddo {
 				compatible = "regulator-fixed";
-				regulator-name = "imx290_vdddo";
+				regulator-name = "imx290_1_vdddo";
 				regulator-min-microvolt = <1800000>;
 				regulator-max-microvolt = <1800000>;
 			};
-			imx290_vddd: fixedregulator@2 {
+			imx290_vddd: imx290_1_vddd {
 				compatible = "regulator-fixed";
-				regulator-name = "imx290_vddd";
+				regulator-name = "imx290_1_vddd";
 				regulator-min-microvolt = <1500000>;
 				regulator-max-microvolt = <1500000>;
 			};
 
-			imx290_clk: camera-clk {
+			imx290_clk: imx290_1_clk {
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-frequency = <37125000>;
+				clock-output-names = "imx290_1_clk";
 			};
 		};
 	};
 
-	fragment@4 {
+	fragment@8 {
 		target = <&i2c0mux>;
 		__overlay__ {
 			status = "okay";
 		};
 	};
 
-	fragment@5 {
-		target = <&cam1_reg>;
+	fragment@9 {
+		target = <&cam_reg>;
 		__overlay__ {
 			status = "okay";
-			regulator-name = "imx290_vdda";
+			regulator-name = "imx290_1_vdda";
 			regulator-min-microvolt = <2800000>;
 			regulator-max-microvolt = <2800000>;
 		};
 	};
 
-	fragment@6 {
-		target = <&imx290_0>;
-		__overlay__ {
-			data-lanes = <1 2>;
-			link-frequencies =
-				/bits/ 64 <445500000 297000000>;
+	frag100: fragment@100 {
+		target = <&i2c_csi_dsi>;
+		i2cbus: __overlay__ {
+			status = "okay";
 		};
 	};
 
-	fragment@7 {
-		target = <&imx290_0>;
-		__dormant__ {
-			data-lanes = <1 2 3 4>;
-			link-frequencies =
-				/bits/ 64 <222750000 148500000>;
+	frag101: fragment@101 {
+		target = <&csi1>;
+		csi: __overlay__ {
+			status = "okay";
 		};
 	};
 
-	fragment@8 {
-		target = <&csi1_ep>;
-		__overlay__ {
-			data-lanes = <1 2>;
+	frag102: fragment@102 {
+		target = <&cam1_reg>;
+		cam_reg: __overlay__ {
+			status = "okay";
 		};
 	};
 
-	fragment@9 {
-		target = <&csi1_ep>;
-		__dormant__ {
-			data-lanes = <1 2 3 4>;
-		};
-	};
 
 	__overrides__ {
-		4lane = <0>, "-6+7-8+9";
+		4lane = <0>, "-0+1-3+4";
 		clock-frequency = <&imx290_clk>,"clock-frequency:0",
 				  <&imx290>,"clock-frequency:0";
+		cam0 =	<&frag100>, "target:0=",<&i2c_vc>,
+			<&frag101>, "target:0=",<&csi0>,
+			<&frag102>, "target:0=",<&cam0_reg>,
+			<&imx290_vdddo>, "name=imx290_0_dovdd",
+			<&imx290_vdddo>, "regulator-name=imx290_0_dovdd",
+			<&imx290_vddd>, "name=imx290_0_dvdd",
+			<&imx290_vddd>, "regulator-name=imx290_0_dvdd",
+			<&imx290_clk>, "clock-output-names=imx290_0_clk",
+			<&imx290_clk>, "name=imx290_0_clk"
+			;
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx477-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx477-overlay.dts
@@ -9,7 +9,7 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c_csi_dsi>;
+		target = <&i2cbus>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -23,7 +23,7 @@
 				clocks = <&imx477_clk>;
 				clock-names = "xclk";
 
-				VANA-supply = <&cam1_reg>;	/* 2.8v */
+				VANA-supply = <&cam_reg>;	/* 2.8v */
 				VDIG-supply = <&imx477_vdig>;	/* 1.05v */
 				VDDL-supply = <&imx477_vddl>;	/* 1.8v */
 
@@ -31,7 +31,7 @@
 
 				port {
 					imx477_0: endpoint {
-						remote-endpoint = <&csi1_ep>;
+						remote-endpoint = <&csi_ep>;
 						clock-lanes = <0>;
 						data-lanes = <1 2>;
 						clock-noncontinuous;
@@ -44,12 +44,12 @@
 	};
 
 	fragment@1 {
-		target = <&csi1>;
+		target = <&csi>;
 		__overlay__ {
 			status = "okay";
 
 			port {
-				csi1_ep: endpoint {
+				csi_ep: endpoint {
 					remote-endpoint = <&imx477_0>;
 					clock-lanes = <0>;
 					data-lanes = <1 2>;
@@ -69,22 +69,23 @@
 	fragment@3 {
 		target-path="/";
 		__overlay__ {
-			imx477_vdig: fixedregulator@0 {
+			imx477_vdig: imx477_1_vdig {
 				compatible = "regulator-fixed";
-				regulator-name = "imx477_vdig";
+				regulator-name = "imx477_1_vdig";
 				regulator-min-microvolt = <1050000>;
 				regulator-max-microvolt = <1050000>;
 			};
-			imx477_vddl: fixedregulator@1 {
+			imx477_vddl: imx477_1_vddl {
 				compatible = "regulator-fixed";
-				regulator-name = "imx477_vddl";
+				regulator-name = "imx477_1_vddl";
 				regulator-min-microvolt = <1800000>;
 				regulator-max-microvolt = <1800000>;
 			};
-			imx477_clk: camera-clk {
+			imx477_clk: imx477_1_clk {
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-frequency = <24000000>;
+				clock-output-names = "imx477_1_clk";
 			};
 		};
 	};
@@ -97,17 +98,48 @@
 	};
 
 	fragment@5 {
-		target = <&cam1_reg>;
+		target = <&cam_reg>;
 		__overlay__ {
 			status = "okay";
-			regulator-name = "imx477_vana";
+			regulator-name = "imx477_1_vana";
 			startup-delay-us = <300000>;
 			regulator-min-microvolt = <2800000>;
 			regulator-max-microvolt = <2800000>;
 		};
 	};
 
+	frag100: fragment@100 {
+		target = <&i2c_csi_dsi>;
+		i2cbus: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	frag101: fragment@101 {
+		target = <&csi1>;
+		csi: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	frag102: fragment@102 {
+		target = <&cam1_reg>;
+		cam_reg: __overlay__ {
+			status = "okay";
+		};
+	};
+
 	__overrides__ {
 		rotation = <&imx477>,"rotation:0";
+		cam0 =	<&frag100>, "target:0=",<&i2c_vc>,
+			<&frag101>, "target:0=",<&csi0>,
+			<&frag102>, "target:0=",<&cam0_reg>,
+			<&imx477_vdig>, "name=imx477_0_dovdd",
+			<&imx477_vdig>, "regulator-name=imx477_0_dovdd",
+			<&imx477_vddl>, "name=imx477_0_dvdd",
+			<&imx477_vddl>, "regulator-name=imx477_0_dvdd",
+			<&imx477_clk>, "clock-output-names=imx477_0_clk",
+			<&imx477_clk>, "name=imx477_0_clk"
+			;
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx477-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx477-overlay.dts
@@ -23,7 +23,7 @@
 				clocks = <&imx477_clk>;
 				clock-names = "xclk";
 
-				VANA-supply = <&cam_reg>;	/* 2.8v */
+				VANA-supply = <&cam1_reg>;	/* 2.8v */
 				VDIG-supply = <&imx477_vdig>;	/* 1.05v */
 				VDDL-supply = <&imx477_vddl>;	/* 1.8v */
 
@@ -98,7 +98,7 @@
 	};
 
 	fragment@5 {
-		target = <&cam_reg>;
+		target = <&cam1_reg>;
 		__overlay__ {
 			status = "okay";
 			regulator-name = "imx477_1_vana";
@@ -108,32 +108,38 @@
 		};
 	};
 
-	frag100: fragment@100 {
+	fragment@6 {
+		target = <&cam0_reg>;
+		__dormant__ {
+			status = "okay";
+			regulator-name = "imx477_0_vana";
+			startup-delay-us = <300000>;
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
+		};
+	};
+
+	frag101: fragment@101 {
 		target = <&i2c_csi_dsi>;
 		i2cbus: __overlay__ {
 			status = "okay";
 		};
 	};
 
-	frag101: fragment@101 {
+	frag102: fragment@102 {
 		target = <&csi1>;
 		csi: __overlay__ {
 			status = "okay";
 		};
 	};
 
-	frag102: fragment@102 {
-		target = <&cam1_reg>;
-		cam_reg: __overlay__ {
-			status = "okay";
-		};
-	};
 
 	__overrides__ {
 		rotation = <&imx477>,"rotation:0";
-		cam0 =	<&frag100>, "target:0=",<&i2c_vc>,
-			<&frag101>, "target:0=",<&csi0>,
-			<&frag102>, "target:0=",<&cam0_reg>,
+		cam0 =	<&frag101>, "target:0=",<&i2c_vc>,
+			<&frag102>, "target:0=",<&csi0>,
+			<0>, "-5+6",
+			<&imx477>, "VANA-supply:0=",<&cam0_reg>,
 			<&imx477_vdig>, "name=imx477_0_dovdd",
 			<&imx477_vdig>, "regulator-name=imx477_0_dovdd",
 			<&imx477_vddl>, "name=imx477_0_dvdd",

--- a/arch/arm/boot/dts/overlays/irs1125-overlay.dts
+++ b/arch/arm/boot/dts/overlays/irs1125-overlay.dts
@@ -7,13 +7,13 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c_csi_dsi>;
+		target = <&i2cbus>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
 
-			irs1125: irs1125@3D {
+			irs1125: irs1125@3d {
 				compatible = "infineon,irs1125";
 				reg = <0x3D>;
 				status = "okay";
@@ -23,7 +23,7 @@
 
 				port {
 					irs1125_0: endpoint {
-						remote-endpoint = <&csi1_ep>;
+						remote-endpoint = <&csi_ep>;
 						clock-lanes = <0>;
 						data-lanes = <1 2>;
 						clock-noncontinuous;
@@ -36,12 +36,12 @@
 	};
 
 	fragment@1 {
-		target = <&csi1>;
+		target = <&csi>;
 		__overlay__ {
 			status = "okay";
 
 			port {
-				csi1_ep: endpoint {
+				csi_ep: endpoint {
 					remote-endpoint = <&irs1125_0>;
 					data-lanes = <1 2>;
 					clock-noncontinuous;
@@ -65,6 +65,18 @@
 	};
 
 	fragment@4 {
+		target-path = "/";
+		__overlay__ {
+			irs1125_clk: irs1125-1-clk {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <26000000>;
+				clock-output-names = "irs1125_1_clk";
+			};
+		};
+	};
+
+	fragment@5 {
 		target-path="/__overrides__";
 		__overlay__ {
 			cam0-pwdn-ctrl = <&irs1125>,"pwdn-gpios:0";
@@ -72,14 +84,34 @@
 		};
 	};
 
-	fragment@5 {
-		target-path = "/";
+	fragment@6 {
+		target-path="/__overrides__";
 		__overlay__ {
-			irs1125_clk: camera-clk {
-				compatible = "fixed-clock";
-				#clock-cells = <0>;
-				clock-frequency = <26000000>;
-			};
+			cam1-pwdn-ctrl = <&irs1125>,"pwdn-gpios:0";
+			cam1-pwdn      = <&irs1125>,"pwdn-gpios:4";
 		};
+	};
+
+	frag100: fragment@100 {
+		target = <&i2c_csi_dsi>;
+		i2cbus: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	frag101: fragment@101 {
+		target = <&csi1>;
+		csi: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	__overrides__ {
+		cam0 =	<&frag100>, "target:0=",<&i2c_vc>,
+			<&frag101>, "target:0=",<&csi0>,
+			<&irs1125_clk>, "clock-output-names=irs1125_0_clk",
+			<&irs1125_clk>, "name=irs1125_0_clk",
+			<0>, "-4+5"
+			;
 	};
 };

--- a/arch/arm/boot/dts/overlays/ov5647-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov5647-overlay.dts
@@ -7,7 +7,7 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c_csi_dsi>;
+		target = <&i2cbus>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -25,7 +25,7 @@
 
 				port {
 					ov5647_0: endpoint {
-						remote-endpoint = <&csi1_ep>;
+						remote-endpoint = <&csi_ep>;
 						clock-lanes = <0>;
 						data-lanes = <1 2>;
 						clock-noncontinuous;
@@ -38,12 +38,12 @@
 	};
 
 	fragment@1 {
-		target = <&csi1>;
+		target = <&csi>;
 		__overlay__ {
 			status = "okay";
 
 			port {
-				csi1_ep: endpoint {
+				csi_ep: endpoint {
 					remote-endpoint = <&ov5647_0>;
 					data-lanes = <1 2>;
 				};
@@ -76,17 +76,49 @@
 	};
 
 	fragment@5 {
+		target-path="/__overrides__";
+		__overlay__ {
+			cam1-pwdn-ctrl = <&ov5647>,"pwdn-gpios:0";
+			cam1-pwdn      = <&ov5647>,"pwdn-gpios:4";
+			cam1-led-ctrl  = <&ov5647>,"pwdn-gpios:12";
+			cam1-led       = <&ov5647>,"pwdn-gpios:16";
+		};
+	};
+
+	fragment@6 {
 		target-path = "/";
 		__overlay__ {
-			ov5647_clk: camera-clk {
+			ov5647_clk: ov5647_1_clk {
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-frequency = <25000000>;
+				clock-output-names = "ov5647_1_clk";
 			};
+		};
+	};
+
+	frag100: fragment@100 {
+		target = <&i2c_csi_dsi>;
+		i2cbus: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	frag101: fragment@101 {
+		target = <&csi1>;
+		csi: __overlay__ {
+			status = "okay";
 		};
 	};
 
 	__overrides__ {
 		rotation = <&ov5647>,"rotation:0";
+		cam0 =	<&frag100>, "target:0=",<&i2c_vc>,
+			<&frag101>, "target:0=",<&csi0>,
+			<&frag102>, "target:0=",<&cam0_reg>,
+			<&ov5647_clk>, "clock-output-names=ov5647_0_clk",
+			<&ov5647_clk>, "name=ov5647_0_clk",
+			<0>, "-4+5"
+			;
 	};
 };

--- a/arch/arm/boot/dts/overlays/ov7251-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov7251-overlay.dts
@@ -9,7 +9,7 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c_csi_dsi>;
+		target = <&i2cbus>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -25,12 +25,12 @@
 				clock-frequency = <24000000>;
 
 				vdddo-supply = <&ov7251_dovdd>;
-				vdda-supply = <&cam1_reg>;
+				vdda-supply = <&cam_reg>;
 				vddd-supply = <&ov7251_dvdd>;
 
 				port {
 					ov7251_0: endpoint {
-						remote-endpoint = <&csi1_ep>;
+						remote-endpoint = <&csi_ep>;
 						clock-lanes = <0>;
 						data-lanes = <1>;
 						clock-noncontinuous;
@@ -43,12 +43,12 @@
 	};
 
 	fragment@1 {
-		target = <&csi1>;
+		target = <&csi>;
 		__overlay__ {
 			status = "okay";
 
 			port {
-				csi1_ep: endpoint {
+				csi_ep: endpoint {
 					remote-endpoint = <&ov7251_0>;
 					data-lanes = <1>;
 				};
@@ -66,22 +66,23 @@
 	fragment@3 {
 		target-path="/";
 		__overlay__ {
-			ov7251_dovdd: fixedregulator@1 {
+			ov7251_dovdd: ov7251_1_dovdd {
 				compatible = "regulator-fixed";
-				regulator-name = "ov7251_dovdd";
+				regulator-name = "ov7251_1_dovdd";
 				regulator-min-microvolt = <1800000>;
 				regulator-max-microvolt = <1800000>;
 			};
-			ov7251_dvdd: fixedregulator@2 {
+			ov7251_dvdd: ov7251_1_dvdd {
 				compatible = "regulator-fixed";
-				regulator-name = "ov7251_dvdd";
+				regulator-name = "ov7251_1_dvdd";
 				regulator-min-microvolt = <1200000>;
 				regulator-max-microvolt = <1200000>;
 			};
-			ov7251_clk: ov7251-clk {
+			ov7251_clk: ov7251_1_clk {
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-frequency = <24000000>;
+				clock-output-names = "ov7251_1_clk";
 			};
 		};
 	};
@@ -94,12 +95,47 @@
 	};
 
 	fragment@5 {
-		target = <&cam1_reg>;
+		target = <&cam_reg>;
 		__overlay__ {
 			status = "okay";
-			regulator-name = "ov7251_avdd";
+			regulator-name = "ov7251_1_avdd";
 			regulator-min-microvolt = <2800000>;
 			regulator-max-microvolt = <2800000>;
 		};
+	};
+
+	frag100: fragment@100 {
+		target = <&i2c_csi_dsi>;
+		i2cbus: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	frag101: fragment@101 {
+		target = <&csi1>;
+		csi: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	frag102: fragment@102 {
+		target = <&cam1_reg>;
+		cam_reg: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	__overrides__ {
+		cam0 =	<&frag100>, "target:0=",<&i2c_vc>,
+			<&frag101>, "target:0=",<&csi0>,
+			<&frag102>, "target:0=",<&cam0_reg>,
+			<&frag102>, "regulator-name=ov7251_0_avdd",
+			<&ov7251_dovdd>, "name=ov7251_0_dovdd",
+			<&ov7251_dovdd>, "regulator-name=ov7251_0_dovdd",
+			<&ov7251_dvdd>, "name=ov7251_0_dvdd",
+			<&ov7251_dvdd>, "regulator-name=ov7251_0_dvdd",
+			<&ov7251_clk>, "clock-output-names=ov7251_0_clk",
+			<&ov7251_clk>, "name=ov7251_0_clk"
+			;
 	};
 };

--- a/arch/arm/boot/dts/overlays/ov9281-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov9281-overlay.dts
@@ -9,7 +9,7 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c_csi_dsi>;
+		target = <&i2cbus>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -23,13 +23,13 @@
 				clocks = <&ov9281_clk>;
 				clock-names = "xvclk";
 
-				avdd-supply = <&cam1_reg>;
+				avdd-supply = <&cam_reg>;
 				dovdd-supply = <&ov9281_dovdd>;
 				dvdd-supply = <&ov9281_dvdd>;
 
 				port {
 					ov9281_0: endpoint {
-						remote-endpoint = <&csi1_ep>;
+						remote-endpoint = <&csi_ep>;
 						clock-lanes = <0>;
 						data-lanes = <1 2>;
 						clock-noncontinuous;
@@ -42,12 +42,12 @@
 	};
 
 	fragment@1 {
-		target = <&csi1>;
+		target = <&csi>;
 		__overlay__ {
 			status = "okay";
 
 			port {
-				csi1_ep: endpoint {
+				csi_ep: endpoint {
 					remote-endpoint = <&ov9281_0>;
 					data-lanes = <1 2>;
 					clock-noncontinuous;
@@ -66,22 +66,23 @@
 	fragment@3 {
 		target-path="/";
 		__overlay__ {
-			ov9281_dovdd: fixedregulator@1 {
+			ov9281_dovdd: ov9281_1_dovdd {
 				compatible = "regulator-fixed";
-				regulator-name = "ov9281_dovdd";
+				regulator-name = "ov9281_1_dovdd";
 				regulator-min-microvolt = <1800000>;
 				regulator-max-microvolt = <1800000>;
 			};
-			ov9281_dvdd: fixedregulator@2 {
+			ov9281_dvdd: ov9281_1_dvdd {
 				compatible = "regulator-fixed";
-				regulator-name = "ov9281_dvdd";
+				regulator-name = "ov9281_1_dvdd";
 				regulator-min-microvolt = <1200000>;
 				regulator-max-microvolt = <1200000>;
 			};
-			ov9281_clk: ov9281-clk {
+			ov9281_clk: ov9281_1_clk {
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-frequency = <24000000>;
+				clock-output-names = "ov9281_1_clk";
 			};
 		};
 	};
@@ -94,13 +95,46 @@
 	};
 
 	fragment@5 {
-		target = <&cam1_reg>;
+		target = <&cam_reg>;
 		__overlay__ {
-			status = "okay";
 			regulator-name = "ov9281_avdd";
 			regulator-min-microvolt = <2800000>;
 			regulator-max-microvolt = <2800000>;
 		};
+	};
+
+	frag100: fragment@100 {
+		target = <&i2c_csi_dsi>;
+		i2cbus: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	frag101: fragment@101 {
+		target = <&csi1>;
+		csi: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	frag102: fragment@102 {
+		target = <&cam1_reg>;
+		cam_reg: __overlay__ {
+			status = "okay";
+		};
+	};
+
+	__overrides__ {
+		cam0 =	<&frag100>, "target:0=",<&i2c_vc>,
+			<&frag101>, "target:0=",<&csi0>,
+			<&frag102>, "target:0=",<&cam0_reg>,
+			<&ov9281_dovdd>, "regulator-name=ov9281_0_dovdd",
+			<&ov9281_dovdd>, "name=ov9281_0_dvdd",
+			<&ov9281_dvdd>, "regulator-name=ov9281_0_dvdd",
+			<&ov9281_dvdd>, "name=ov9281_0_dvdd",
+			<&ov9281_clk>, "clock-output-names=ov9281_0_clk",
+			<&ov9281_clk>, "name=ov9281_0_clk"
+			;
 	};
 
 };

--- a/arch/arm/boot/dts/overlays/tc358743-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tc358743-overlay.dts
@@ -7,7 +7,32 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c_csi_dsi>;
+		target-path = "/";
+		__overlay__ {
+			tc358743_clk: bridge-1-clk {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <27000000>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&tc358743>;
+		__overlay__ {
+			data-lanes = <1 2>;
+		};
+	};
+
+	fragment@2 {
+		target = <&tc358743>;
+		__dormant__ {
+			data-lanes = <1 2 3 4>;
+		};
+	};
+
+	fragment@3 {
+		target = <&i2cbus>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -23,7 +48,7 @@
 
 				port {
 					tc358743: endpoint {
-						remote-endpoint = <&csi1_ep>;
+						remote-endpoint = <&csi_ep>;
 						clock-lanes = <0>;
 						clock-noncontinuous;
 						link-frequencies =
@@ -34,74 +59,69 @@
 		};
 	};
 
-	fragment@1 {
-		target = <&csi1>;
-		__overlay__ {
-			status = "okay";
-
-			port {
-				csi1_ep: endpoint {
-					remote-endpoint = <&tc358743>;
-				};
-			};
-		};
-	};
-
-	fragment@2 {
-		target = <&tc358743>;
+	fragment@4 {
+		target = <&csi_ep>;
 		__overlay__ {
 			data-lanes = <1 2>;
 		};
 	};
 
-	fragment@3 {
-		target = <&tc358743>;
+	fragment@5 {
+		target = <&csi_ep>;
 		__dormant__ {
 			data-lanes = <1 2 3 4>;
 		};
 	};
 
-	fragment@4 {
+	fragment@6 {
+		target = <&csi>;
+		__overlay__ {
+			status = "okay";
+
+			port {
+				csi_ep: endpoint {
+					remote-endpoint = <&tc358743>;
+					data-lanes = <1 2>;
+				};
+			};
+		};
+	};
+
+	fragment@7 {
 		target = <&i2c0if>;
 		__overlay__ {
 			status = "okay";
 		};
 	};
 
-	fragment@5 {
+	fragment@8 {
 		target = <&i2c0mux>;
 		__overlay__ {
 			status = "okay";
 		};
 	};
 
-	fragment@6 {
-		target-path = "/";
-		__overlay__ {
-			tc358743_clk: bridge-clk {
-				compatible = "fixed-clock";
-				#clock-cells = <0>;
-				clock-frequency = <27000000>;
-			};
+	frag100: fragment@100 {
+		target = <&i2c_csi_dsi>;
+		i2cbus: __overlay__ {
+			status = "okay";
 		};
 	};
 
-	fragment@7 {
-		target = <&csi1_ep>;
-		__overlay__ {
-			data-lanes = <1 2>;
-		};
-	};
-
-	fragment@8 {
-		target = <&csi1_ep>;
-		__dormant__ {
-			data-lanes = <1 2 3 4>;
+	frag101: fragment@101 {
+		target = <&csi1>;
+		csi: __overlay__ {
+			status = "okay";
 		};
 	};
 
 	__overrides__ {
-		4lane = <0>, "-2+3-7+8";
+		4lane = <0>, "-1+2-4+5";
 		link-frequency = <&tc358743>,"link-frequencies#0";
+		cam0 =	<&frag100>, "target:0=",<&i2c_vc>,
+			<&frag101>, "target:0=",<&csi0>,
+			<&tc358743_clk>, "clock-output-names=bridge-0-clk",
+			<&tc358743_clk>, "name=bridge-0-clk"
+			;
 	};
 };

--- a/drivers/media/i2c/ov7251.c
+++ b/drivers/media/i2c/ov7251.c
@@ -1330,7 +1330,8 @@ static int ov7251_probe(struct i2c_client *client)
 		return PTR_ERR(ov7251->analog_regulator);
 	}
 
-	ov7251->enable_gpio = devm_gpiod_get(dev, "enable", GPIOD_OUT_HIGH);
+	ov7251->enable_gpio = devm_gpiod_get_optional(dev, "enable",
+						      GPIOD_OUT_HIGH);
 	if (IS_ERR(ov7251->enable_gpio)) {
 		dev_err(dev, "cannot get enable gpio\n");
 		return PTR_ERR(ov7251->enable_gpio);


### PR DESCRIPTION
Add a cam0 parameter to the CSI2 sensor overlays to switch
to the CAM0 connector on Compute Module IO boards.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>