### PR TITLE
draft: drivers/char/broadcom: Fix some kconfig related bugs

### DIFF
--- a/arch/arm/mach-bcm/Kconfig
+++ b/arch/arm/mach-bcm/Kconfig
@@ -167,6 +167,7 @@ config ARCH_BCM2835
 	select PINCTRL_BCM2835
 	select MFD_CORE
 	select MFD_SYSCON if ARCH_MULTI_V7
+	select ARM_DMA_MEM_BUFFERABLE
 	help
 	  This enables support for the Broadcom BCM2711 and BCM283x SoCs.
 	  This SoC is used in the Raspberry Pi and Roku 2 devices.

--- a/drivers/char/broadcom/Kconfig
+++ b/drivers/char/broadcom/Kconfig
@@ -25,6 +25,7 @@ endif
 
 config BCM2835_DEVGPIOMEM
 	tristate "/dev/gpiomem rootless GPIO access via mmap() on the BCM2835"
+	depends on ARM_DMA_MEM_BUFFERABLE
 	default m
 	help
 		Provides users with root-free access to the GPIO registers

--- a/drivers/char/broadcom/vc_mem.c
+++ b/drivers/char/broadcom/vc_mem.c
@@ -355,7 +355,7 @@ vc_mem_exit(void)
 	pr_debug("%s: called\n", __func__);
 
 	if (vc_mem_inited) {
-#if CONFIG_DEBUG_FS
+#ifdef CONFIG_DEBUG_FS
 		vc_mem_debugfs_deinit();
 #endif
 		device_destroy(vc_mem_class, vc_mem_devnum);


### PR DESCRIPTION
Fix a warning when `CONFIG_DEBUG_FS` is not enabled.

Fix an error when `CONFIG_ARM_DMA_MEM_BUFFERABLE` is not enabled. The bcm2835-gpiomem driver depends on this option to compile but isn't marked as such in Kconfig. I wasn't able to figure out what config option usually enables this, I've selected it in `ARCH_BCM2835` although I'm not sure if this is the correct approach.