### PR TITLE
overlays: Add pcie-32bit-dma overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -127,6 +127,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	ov9281.dtbo \
 	papirus.dtbo \
 	pca953x.dtbo \
+	pcie-32bit-dma.dtbo \
 	pibell.dtbo \
 	pifacedigital.dtbo \
 	pifi-40.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2079,6 +2079,13 @@ Params: addr                    I2C address of expander. Default 0x20.
         xra1202                 Select the Exar XRA1202 (8 bit)
 
 
+Name:   pcie-32bit-dma
+Info:   Force PCIe config to support 32bit DMA addresses at the expense of
+        having to bounce buffers.
+Load:   dtoverlay=pcie-32bit-dma
+Params: <None>
+
+
 [ The pcf2127-rtc overlay has been deleted. See i2c-rtc. ]
 
 

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -37,6 +37,10 @@
 		deprecated = "use gpio-ir";
 	};
 
+	pcie-32bit-dma {
+		bcm2711;
+	};
+
 	pi3-act-led {
 		renamed = "act-led";
 	};

--- a/arch/arm/boot/dts/overlays/pcie-32bit-dma-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pcie-32bit-dma-overlay.dts
@@ -1,0 +1,18 @@
+/*
+ * pcie-32bit-dma-overlay.dts
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2711";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			pcie0 = "";
+		};
+	};
+
+};


### PR DESCRIPTION
In order to accommodate full PCI DMA access to memory on newer BCM2711
revisions, we're forced to map PCIe's view of physical memory with an
offset. This offset makes DMA addressing dependent on having 64bit
support on the PCI device's side. Which isn't always the case.

In order to mitigate this, introduce the pcie-32bit-dma overlay which
will forbid firmware from updating the default inbound memory window.
The default setting, albeit limited to accessing the lower 3GB of
memory, will allow for 32bit DMA addresses at the expense of having to
bounce buffers.

Link: https://github.com/raspberrypi/linux/issues/4197
Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>