### PR TITLE
staging/bcm2835-camera: Add support for DMABUFs

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.c
+++ b/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.c
@@ -1453,6 +1453,7 @@ static const struct v4l2_ioctl_ops camera0_ioctl_ops = {
 	.vidioc_querybuf = vb2_ioctl_querybuf,
 	.vidioc_qbuf = vb2_ioctl_qbuf,
 	.vidioc_dqbuf = vb2_ioctl_dqbuf,
+	.vidioc_expbuf = vb2_ioctl_expbuf,
 	.vidioc_enum_framesizes = vidioc_enum_framesizes,
 	.vidioc_enum_frameintervals = vidioc_enum_frameintervals,
 	.vidioc_g_parm        = vidioc_g_parm,
@@ -1934,7 +1935,7 @@ static int bcm2835_mmal_probe(struct platform_device *pdev)
 		q = &dev->capture.vb_vidq;
 		memset(q, 0, sizeof(*q));
 		q->type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-		q->io_modes = VB2_MMAP | VB2_USERPTR | VB2_READ;
+		q->io_modes = VB2_MMAP | VB2_USERPTR | VB2_READ | VB2_DMABUF;
 		q->drv_priv = dev;
 		q->buf_struct_size = sizeof(struct vb2_mmal_buffer);
 		q->ops = &bm2835_mmal_video_qops;


### PR DESCRIPTION
DMABUFs are all handled by videobuf2, so there is no reason not
to enable support for them.

Note that this driver is still using the vmalloc allocator, so
the buffers it allocates will not be compatible with the codec
or ISP driver that require contiguous buffers. However this
driver should be able to import the buffers allocated by them.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>