### PR TITLE
Make rpi poe fan less noisy in cool environments

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
@@ -16,7 +16,7 @@
 				cooling-min-state = <0>;
 				cooling-max-state = <4>;
 				#cooling-cells = <2>;
-				cooling-levels = <0 31 63 150 255>;
+				cooling-levels = <0 1 10 100 255>;
 				status = "okay";
 			};
 		};


### PR DESCRIPTION
Run the PoE hat fan with reduced noise when possible. The PoE hat fan will spin even at PWM=1 and spins almost silent. Tested at 17ºC, the fan PWM alternates between 1 and 10, which is a lot less noisy then alternating between PWM levels 0 and 31.