### PR TITLE
vc4/drm: Fix source offsets with DRM_FORMAT_P030

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -824,9 +824,20 @@ static int vc4_plane_mode_set(struct drm_plane *plane,
 		u32 tile_w, tile, x_off, pix_per_tile;
 
 		if (fb->format->format == DRM_FORMAT_P030) {
+			/*
+			 * Spec says: bits [31:4] of the given address should point to
+			 * the 128-bit word containing the desired starting pixel,
+			 * and bits[3:0] should be between 0 and 11, indicating which
+			 * of the 12-pixels in that 128-bit word is the first pixel to be used
+			 */
+			u32 aligned = vc4_state->src_x / 12;
+			u32 last_bits = vc4_state->src_x % 12;
+
+			x_off = aligned * 16 + last_bits;
 			hvs_format = HVS_PIXEL_FORMAT_YCBCR_10BIT;
 			tiling = SCALER_CTL0_TILING_128B;
-			tile_w = 96;
+			tile_w = 128;
+			pix_per_tile = 96;
 		} else {
 			hvs_format = HVS_PIXEL_FORMAT_H264;
 
@@ -846,17 +857,16 @@ static int vc4_plane_mode_set(struct drm_plane *plane,
 			default:
 				break;
 			}
+			pix_per_tile = tile_w / fb->format->cpp[0];
+			x_off = (vc4_state->src_x % pix_per_tile) /
+				(i ? h_subsample : 1) * fb->format->cpp[i];
 		}
 		if (param > SCALER_TILE_HEIGHT_MASK) {
 			DRM_DEBUG_KMS("SAND height too large (%d)\n",
 				      param);
 			return -EINVAL;
 		}
-
-		pix_per_tile = tile_w / fb->format->cpp[0];
 		tile = vc4_state->src_x / pix_per_tile;
-		x_off = vc4_state->src_x % pix_per_tile;
-
 		/* Adjust the base pointer to the first pixel to be scanned
 		 * out.
 		 *
@@ -872,9 +882,7 @@ static int vc4_plane_mode_set(struct drm_plane *plane,
 			vc4_state->offsets[i] += src_y /
 						 (i ? v_subsample : 1) *
 						 tile_w;
-			vc4_state->offsets[i] += x_off /
-						 (i ? h_subsample : 1) *
-						 fb->format->cpp[i];
+			vc4_state->offsets[i] += x_off & ~(i ? 1 : 0);
 		}
 
 		pitch0 = VC4_SET_FIELD(param, SCALER_TILE_HEIGHT);


### PR DESCRIPTION
Spec says: bits [31:4] of the given address should point to
the 128-bit word containing the desired starting pixel,
and bits[3:0] should be between 0 and 11, indicating which
of the 12-pixels in that 128-bit word is the first pixel to be used

Signed-off-by: Dom Cobley <popcornmix@gmail.com>