### PR TITLE
V4L2 Codec and camera patches

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-camera/controls.c
+++ b/drivers/staging/vc04_services/bcm2835-camera/controls.c
@@ -709,6 +709,8 @@ static int ctrl_set_video_encode_profile_level(struct bm2835_mmal_dev *dev,
 		case V4L2_MPEG_VIDEO_H264_LEVEL_3_1:
 		case V4L2_MPEG_VIDEO_H264_LEVEL_3_2:
 		case V4L2_MPEG_VIDEO_H264_LEVEL_4_0:
+		case V4L2_MPEG_VIDEO_H264_LEVEL_4_1:
+		case V4L2_MPEG_VIDEO_H264_LEVEL_4_2:
 			dev->capture.enc_level = ctrl->val;
 			break;
 		default:
@@ -773,6 +775,17 @@ static int ctrl_set_video_encode_profile_level(struct bm2835_mmal_dev *dev,
 			break;
 		case V4L2_MPEG_VIDEO_H264_LEVEL_4_0:
 			param.level = MMAL_VIDEO_LEVEL_H264_4;
+			break;
+		/*
+		 * Note that the hardware spec is level 4.0. Achieving levels
+		 * above that depend on exactly the resolution and frame rate
+		 * being requested.
+		 */
+		case V4L2_MPEG_VIDEO_H264_LEVEL_4_1:
+			param.level = MMAL_VIDEO_LEVEL_H264_41;
+			break;
+		case V4L2_MPEG_VIDEO_H264_LEVEL_4_2:
+			param.level = MMAL_VIDEO_LEVEL_H264_42;
 			break;
 		default:
 			/* Should never get here */
@@ -1224,8 +1237,10 @@ static const struct bm2835_mmal_v4l2_ctrl v4l2_ctrls[V4L2_CTRL_COUNT] = {
 			 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_3_0) |
 			 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_3_1) |
 			 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_3_2) |
-			 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_4_0)),
-		.max = V4L2_MPEG_VIDEO_H264_LEVEL_4_0,
+			 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_4_0) |
+			 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_4_1) |
+			 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_4_2)),
+		.max = V4L2_MPEG_VIDEO_H264_LEVEL_4_2,
 		.def = V4L2_MPEG_VIDEO_H264_LEVEL_4_0,
 		.step = 1,
 		.imenu = NULL,

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -930,23 +930,43 @@ static void send_eos_event(struct bcm2835_codec_ctx *ctx)
 	v4l2_event_queue_fh(&ctx->fh, &ev);
 }
 
-static void color_mmal2v4l(struct bcm2835_codec_ctx *ctx, u32 mmal_color_space)
+static void color_mmal2v4l(struct bcm2835_codec_ctx *ctx, u32 encoding,
+			   u32 color_space)
 {
-	switch (mmal_color_space) {
-	case MMAL_COLOR_SPACE_ITUR_BT601:
-		ctx->colorspace = V4L2_COLORSPACE_REC709;
-		ctx->xfer_func = V4L2_XFER_FUNC_709;
-		ctx->ycbcr_enc = V4L2_YCBCR_ENC_601;
-		ctx->quant = V4L2_QUANTIZATION_LIM_RANGE;
-		break;
+	int is_rgb;
 
-	case MMAL_COLOR_SPACE_ITUR_BT709:
-		ctx->colorspace = V4L2_COLORSPACE_REC709;
-		ctx->xfer_func = V4L2_XFER_FUNC_709;
-		ctx->ycbcr_enc = V4L2_YCBCR_ENC_709;
-		ctx->quant = V4L2_QUANTIZATION_LIM_RANGE;
+	switch (encoding) {
+	case MMAL_ENCODING_I420:
+	case MMAL_ENCODING_YV12:
+	case MMAL_ENCODING_NV12:
+	case MMAL_ENCODING_NV21:
+	case V4L2_PIX_FMT_YUYV:
+	case V4L2_PIX_FMT_YVYU:
+	case V4L2_PIX_FMT_UYVY:
+	case V4L2_PIX_FMT_VYUY:
+		/* YUV based colourspaces */
+		switch (color_space) {
+		case MMAL_COLOR_SPACE_ITUR_BT601:
+			ctx->colorspace = V4L2_COLORSPACE_SMPTE170M;
+			break;
+
+		case MMAL_COLOR_SPACE_ITUR_BT709:
+			ctx->colorspace = V4L2_COLORSPACE_REC709;
+			break;
+		default:
+			break;
+		}
+		break;
+	default:
+		/* RGB based colourspaces */
+		ctx->colorspace = V4L2_COLORSPACE_SRGB;
 		break;
 	}
+	ctx->xfer_func = V4L2_MAP_XFER_FUNC_DEFAULT(ctx->colorspace);
+	ctx->ycbcr_enc = V4L2_MAP_YCBCR_ENC_DEFAULT(ctx->colorspace);
+	is_rgb = ctx->colorspace == V4L2_COLORSPACE_SRGB;
+	ctx->quant = V4L2_MAP_QUANTIZATION_DEFAULT(is_rgb, ctx->colorspace,
+						   ctx->ycbcr_enc);
 }
 
 static void handle_fmt_changed(struct bcm2835_codec_ctx *ctx,
@@ -985,7 +1005,8 @@ static void handle_fmt_changed(struct bcm2835_codec_ctx *ctx,
 	q_data->height = format->es.video.height;
 	q_data->sizeimage = format->buffer_size_min;
 	if (format->es.video.color_space)
-		color_mmal2v4l(ctx, format->es.video.color_space);
+		color_mmal2v4l(ctx, format->format.encoding,
+			       format->es.video.color_space);
 
 	q_data->aspect_ratio.numerator = format->es.video.par.num;
 	q_data->aspect_ratio.denominator = format->es.video.par.den;

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1789,6 +1789,17 @@ static int bcm2835_codec_set_level_profile(struct bcm2835_codec_ctx *ctx,
 		case V4L2_MPEG_VIDEO_H264_LEVEL_4_0:
 			param.level = MMAL_VIDEO_LEVEL_H264_4;
 			break;
+		/*
+		 * Note that the hardware spec is level 4.0. Levels above that
+		 * are there for correctly encoding the headers and may not
+		 * be able to keep up with real-time.
+		 */
+		case V4L2_MPEG_VIDEO_H264_LEVEL_4_1:
+			param.level = MMAL_VIDEO_LEVEL_H264_41;
+			break;
+		case V4L2_MPEG_VIDEO_H264_LEVEL_4_2:
+			param.level = MMAL_VIDEO_LEVEL_H264_42;
+			break;
 		default:
 			/* Should never get here */
 			break;


### PR DESCRIPTION
Minor fixes, and enabling H264 levels 4.1 and 4.2 for codecs and camera.