### PR TITLE
vc4/drm: Fix source offsets with DRM_FORMAT_P030

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -825,8 +825,9 @@ static int vc4_plane_mode_set(struct drm_plane *plane,
 			 * and bits[3:0] should be between 0 and 11, indicating which
 			 * of the 12-pixels in that 128-bit word is the first pixel to be used
 			 */
-			u32 aligned = vc4_state->src_x / 12;
-			u32 last_bits = vc4_state->src_x % 12;
+	                u32 remaining_pixels = vc4_state->src_x % 96;
+			u32 aligned = remaining_pixels / 12;
+			u32 last_bits = remaining_pixels % 12;
 
 			x_off = aligned * 16 + last_bits;
 			hvs_format = HVS_PIXEL_FORMAT_YCBCR_10BIT;


### PR DESCRIPTION
x_off should only be within current stripe
The stripe number is accounted for elsewhere

Fixes: 9b1b1beb1c7e58b ("vc4/drm: Fix source offsets with DRM_FORMAT_P030")

Signed-off-by: Dom Cobley <popcornmix@gmail.com>