### PR TITLE
dwc-otg: fix clang warnings

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_cil_intr.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_cil_intr.c
@@ -805,7 +805,7 @@ static int32_t dwc_otg_handle_pwrdn_session_change(dwc_otg_core_if_t * core_if)
  */
 static uint32_t dwc_otg_handle_pwrdn_stschng_intr(dwc_otg_device_t *otg_dev)
 {
-	int retval;
+	uint32_t retval = 0;
 	gpwrdn_data_t gpwrdn = {.d32 = 0 };
 	gpwrdn_data_t gpwrdn_temp = {.d32 = 0 };
 	dwc_otg_core_if_t *core_if = otg_dev->core_if;

--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h
+++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.h
@@ -255,17 +255,17 @@ struct fiq_dma_info {
 	u8 slot_len[6];
 };
 
-struct __attribute__((packed)) fiq_split_dma_slot {
+struct fiq_split_dma_slot {
 	u8 buf[188];
-};
+} __attribute__((packed));
 
 struct fiq_dma_channel {
-	struct __attribute__((packed)) fiq_split_dma_slot index[6];
-};
+	struct fiq_split_dma_slot index[6];
+} __attribute__((packed));
 
 struct fiq_dma_blob {
-	struct __attribute__((packed)) fiq_dma_channel channel[0];
-};
+	struct fiq_dma_channel channel[0];
+} __attribute__((packed));
 
 /**
  * struct fiq_hs_isoc_info - USB2.0 isochronous data

--- a/drivers/usb/host/dwc_otg/dwc_otg_pcd.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_pcd.c
@@ -1487,7 +1487,7 @@ int dwc_otg_pcd_ep_enable(dwc_otg_pcd_t * pcd,
 	num = UE_GET_ADDR(desc->bEndpointAddress);
 	dir = UE_GET_DIR(desc->bEndpointAddress);
 
-	if (!desc->wMaxPacketSize) {
+	if (!UGETW(desc->wMaxPacketSize)) {
 		DWC_WARN("bad maxpacketsize\n");
 		retval = -DWC_E_INVALID;
 		goto out;


### PR DESCRIPTION
The one in dwc_otg_pcd.c actually fixes a minor bug.