### PR TITLE
ARM: dts: Remove usless sdhci/wifi node from bcm2711-rpi-cm4

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
@@ -40,11 +40,6 @@
 		};
 	};
 
-	wifi_pwrseq: wifi-pwrseq {
-		compatible = "mmc-pwrseq-simple";
-		reset-gpios = <&expgpio 1 GPIO_ACTIVE_LOW>;
-	};
-
 	sd_io_1v8_reg: sd_io_1v8_reg {
 		compatible = "regulator-gpio";
 		regulator-name = "vdd-sd-io";
@@ -241,23 +236,6 @@
 		reg = <0x0 0x0 0x0>;
 		no-map;
 		status = "disabled";
-	};
-};
-
-/* SDHCI is used to control the SDIO for wireless */
-&sdhci {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	pinctrl-names = "default";
-	pinctrl-0 = <&emmc_gpio34>;
-	bus-width = <4>;
-	non-removable;
-	mmc-pwrseq = <&wifi_pwrseq>;
-	status = "okay";
-
-	brcmf: wifi@1 {
-		reg = <1>;
-		compatible = "brcm,bcm4329-fmac";
 	};
 };
 


### PR DESCRIPTION
The sdhci node gets deleted in bcm2711.dtsi. The entry in this dts is
usless and makes the false impression it would be used.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>