### PR TITLE
Prevent A4tech FHD 1080p webcams from being suspended automatically

### DIFF
--- a/sound/usb/quirks-table.h
+++ b/sound/usb/quirks-table.h
@@ -47,6 +47,15 @@
 },
 
 {
+	/* A4Tech FHD 1080p webcam */
+	USB_DEVICE(0x09da, 0x2695),
+	.driver_info = (unsigned long) &(const struct snd_usb_audio_quirk) {
+		.ifnum = QUIRK_ANY_INTERFACE,
+		.type = QUIRK_SETUP_DISABLE_AUTOSUSPEND
+	}
+},
+
+{
 	/* Creative BT-D1 */
 	USB_DEVICE(0x041e, 0x0005),
 	.driver_info = (unsigned long) &(const struct snd_usb_audio_quirk) {

--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -1521,6 +1521,7 @@ bool snd_usb_get_sample_rate_quirk(struct snd_usb_audio *chip)
 	case USB_ID(0x21b4, 0x0081): /* AudioQuest DragonFly */
 	case USB_ID(0x2912, 0x30c8): /* Audioengine D1 */
 	case USB_ID(0x413c, 0xa506): /* Dell AE515 sound bar */
+	case USB_ID(0x09da, 0x2695): /* A4Tech FHD 1080p webcam */
 		return true;
 	}
 

--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -523,6 +523,11 @@ static int setup_disable_autosuspend(struct snd_usb_audio *chip,
 				       struct usb_driver *driver,
 				       const struct snd_usb_audio_quirk *quirk)
 {
+	/*
+	 * Grab the interface, because on a webcam uvcvideo may race
+	 * with snd-usb-audio during probe and re-enable autosuspend.
+	 */
+	usb_autopm_get_interface(iface);
 	usb_disable_autosuspend(interface_to_usbdev(iface));
 	return 1;	/* Continue with creating streams and mixer */
 }


### PR DESCRIPTION
A variant of this camera has an annoying bug surrounding suspend/resume. These two commits fix it.