### PR TITLE
overlays: spi-rtc: Add ds3232 and ds3234

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2689,7 +2689,17 @@ Params: <None>
 Name:   spi-rtc
 Info:   Adds support for a number of SPI Real Time Clock devices
 Load:   dtoverlay=spi-rtc,<param>=<val>
-Params: pcf2123                 Select the PCF2123 device
+Params: ds3232                  Select the DS3232 device
+        ds3234                  Select the DS3234 device
+        pcf2123                 Select the PCF2123 device
+
+        spi0_0                  Use spi0.0 (default)
+        spi0_1                  Use spi0.1
+        spi1_0                  Use spi1.0
+        spi1_1                  Use spi1.1
+        spi2_0                  Use spi2.0
+        spi2_1                  Use spi2.1
+        cs_high                 This device requires an active-high CS
 
 
 Name:   spi0-1cs

--- a/arch/arm/boot/dts/overlays/spi-rtc-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi-rtc-overlay.dts
@@ -1,3 +1,4 @@
+// Definitions for several SPI-based Real Time Clocks
 /dts-v1/;
 /plugin/;
 
@@ -5,29 +6,70 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&spidev0>;
+		target = <&rtc>;
 		__dormant__ {
-			status = "disabled";
+			compatible = "maxim,ds3232";
 		};
 	};
 
 	fragment@1 {
-		target = <&spi0>;
+		target = <&rtc>;
 		__dormant__ {
+			compatible = "maxim,ds3234";
+		};
+	};
+
+	fragment@2 {
+		target = <&rtc>;
+		__dormant__ {
+			compatible = "nxp,rtc-pcf2123";
+		};
+	};
+
+	spidev: fragment@100 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	frag101: fragment@101 {
+		target = <&spi0>;
+		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
 
-			rtc-pcf2123@0 {
-				compatible = "nxp,rtc-pcf2123";
-				spi-max-frequency = <5000000>;
-				spi-cs-high = <1>;
+			rtc: rtc@0 {
 				reg = <0>;
+				spi-max-frequency = <5000000>;
 			};
 		};
 	};
 
 	__overrides__ {
-		pcf2123 = <0>, "=0=1";
+		spi0_0 = <&spidev>, "target:0=",<&spidev0>,
+		         <&frag101>, "target:0=",<&spi0>,
+		         <&rtc>, "reg:0=0";
+		spi0_1 = <&spidev>, "target:0=",<&spidev1>,
+		         <&frag101>, "target:0=",<&spi0>,
+		         <&rtc>, "reg:0=1";
+		spi1_0 = <0>,"-100",
+		         <&frag101>, "target:0=",<&spi1>,
+		         <&rtc>, "reg:0=0";
+		spi1_1 = <0>,"-100",
+		         <&frag101>, "target:0=",<&spi1>,
+		         <&rtc>, "reg:0=1";
+		spi2_0 = <0>,"-100",
+		         <&frag101>, "target:0=",<&spi2>,
+		         <&rtc>, "reg:0=0";
+		spi2_1 = <0>,"-100",
+		         <&frag101>, "target:0=",<&spi2>,
+		         <&rtc>, "reg:0=1";
+		cs_high = <&rtc>, "spi-cs-high?";
+
+		ds3232 = <0>,"+0";
+		ds3234 = <0>,"+1";
+		pcf2123 = <0>,"+2";
 	};
 };


### PR DESCRIPTION
Extend the spi-rtc overlay to support the ds3232 and ds3234 RTCs, as
well as adding parameters to select difference SPI controllers and
chip selects.

N.B. The default CS is now active-low - use the "cs_high" parameter to
override this.

Signed-off-by: Phil Elwell <phil@raspberrypi.com>