### PR TITLE
Make more use of shared clock improvements

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -313,6 +313,7 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 	struct vc4_hvs *hvs = vc4->hvs;
 	struct drm_crtc_state *new_crtc_state;
 	struct drm_crtc *crtc;
+	struct clk_request *core_req;
 	int i;
 
 	for_each_new_crtc_in_state(state, crtc, new_crtc_state, i) {
@@ -326,7 +327,7 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 	}
 
 	if (vc4->hvs && vc4->hvs->hvs5)
-		clk_set_min_rate(hvs->core_clk, 500000000);
+		core_req = clk_request_start(hvs->core_clk, 500000000);
 
 	drm_atomic_helper_wait_for_fences(dev, state, false);
 
@@ -358,7 +359,7 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 	drm_atomic_helper_commit_cleanup_done(state);
 
 	if (vc4->hvs && vc4->hvs->hvs5)
-		clk_set_min_rate(hvs->core_clk, 0);
+		clk_request_done(core_req);
 
 	drm_atomic_state_put(state);
 

--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -426,6 +426,8 @@ struct unicam_device {
 	struct clk *clock;
 	/* vpu clock handle */
 	struct clk *vpu_clock;
+	/* vpu clock request */
+	struct clk_request *vpu_req;
 	/* clock status for error handling */
 	bool clocks_enabled;
 	/* V4l2 device */
@@ -1691,8 +1693,8 @@ static int unicam_start_streaming(struct vb2_queue *vq, unsigned int count)
 	unicam_dbg(1, dev, "Running with %u data lanes\n",
 		   dev->active_data_lanes);
 
-	ret = clk_set_min_rate(dev->vpu_clock, MIN_VPU_CLOCK_RATE);
-	if (ret) {
+	dev->vpu_req = clk_request_start(dev->vpu_clock, MIN_VPU_CLOCK_RATE);
+	if (!dev->vpu_req) {
 		unicam_err(dev, "failed to set up VPU clock\n");
 		goto err_pm_put;
 	}
@@ -1748,8 +1750,7 @@ err_disable_unicam:
 	unicam_disable(dev);
 	clk_disable_unprepare(dev->clock);
 err_vpu_clock:
-	if (clk_set_min_rate(dev->vpu_clock, 0))
-		unicam_err(dev, "failed to reset the VPU clock\n");
+	clk_request_done(dev->vpu_req);
 	clk_disable_unprepare(dev->vpu_clock);
 err_pm_put:
 	unicam_runtime_put(dev);
@@ -1779,9 +1780,7 @@ static void unicam_stop_streaming(struct vb2_queue *vq)
 		unicam_disable(dev);
 
 		if (dev->clocks_enabled) {
-			if (clk_set_min_rate(dev->vpu_clock, 0))
-				unicam_err(dev, "failed to reset the min VPU clock\n");
-
+			clk_request_done(dev->vpu_req);
 			clk_disable_unprepare(dev->vpu_clock);
 			clk_disable_unprepare(dev->clock);
 			dev->clocks_enabled = false;

--- a/drivers/staging/media/rpivid/rpivid.h
+++ b/drivers/staging/media/rpivid/rpivid.h
@@ -172,6 +172,7 @@ struct rpivid_dev {
 	void __iomem		*base_h265;
 
 	struct clk		*clock;
+	struct clk_request      *hevc_req;
 
 	struct rpivid_hw_irq_ctrl ic_active1;
 	struct rpivid_hw_irq_ctrl ic_active2;


### PR DESCRIPTION
This should be merged after https://github.com/raspberrypi/linux/pull/4278

Currently we behave badly either by using `clk_set_min_rate` which never lowers the clock again,
or by using clk_set_rate which doesn't respect multiple clients' wishes.