### PR TITLE
dwc_otg: fix an undeclared variable

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
@@ -1026,7 +1026,8 @@ static void endpoint_reset(struct usb_hcd *hcd, struct usb_host_endpoint *ep)
 	dwc_irqflags_t flags;
 	dwc_otg_hcd_t *dwc_otg_hcd = hcd_to_dwc_otg_hcd(hcd);
 
-	DWC_DEBUGPL(DBG_HCD, "DWC OTG HCD EP RESET: Endpoint Num=0x%02d\n", epnum);
+	DWC_DEBUGPL(DBG_HCD, "DWC OTG HCD EP RESET: Endpoint Num=0x%02d\n",
+		    ep->desc.bEndpointAddress);
 
 	DWC_SPINLOCK_IRQSAVE(dwc_otg_hcd->lock, &flags);
 	if (ep->hcpriv) {


### PR DESCRIPTION
In `drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c: endpoint_reset() line#1029`, there is an undeclared variable `epnum`. 
It's alright for now because 'DWC_DEBUGPL' dose nothing when `DEBUG` is not defined. But it goes wrong when you uncomment `ccflags-y	+= -DDEBUG`  in `drivers/usb/host/dwc_otg/Makefile: line#15`. Error output (undeclared variable) will occur when compiling the kernel.