### PR TITLE
clk: requests: Dereference the request pointer after the check

### DIFF
--- a/drivers/clk/clk.c
+++ b/drivers/clk/clk.c
@@ -2496,10 +2496,11 @@ EXPORT_SYMBOL_GPL(clk_request_start);
  */
 void clk_request_done(struct clk_request *req)
 {
-	struct clk_core *core = req->clk->core;
+	struct clk_core *core;
 
 	if (!req)
 		return;
+	core = req->clk->core;
 
 	clk_prepare_lock();
 


### PR DESCRIPTION
The current code will first dereference the req pointer and then test if
it's NULL, resulting in a NULL pointer dereference if req is indeed
NULL. Reorder the test and derefence to avoid the issue

Signed-off-by: Maxime Ripard <maxime@cerno.tech>