### PR TITLE
gpio-poweroff: Remember the old poweroff handler

### DIFF
--- a/drivers/power/reset/gpio-poweroff.c
+++ b/drivers/power/reset/gpio-poweroff.c
@@ -24,6 +24,7 @@ static struct gpio_desc *reset_gpio;
 static u32 timeout = DEFAULT_TIMEOUT_MS;
 static u32 active_delay = 100;
 static u32 inactive_delay = 100;
+static void (*old_power_off)(void);
 
 static void gpio_poweroff_do_poweroff(void)
 {
@@ -42,6 +43,9 @@ static void gpio_poweroff_do_poweroff(void)
 
 	/* give it some time */
 	mdelay(timeout);
+
+	if (old_power_off)
+		old_power_off();
 
 	WARN_ON(1);
 }
@@ -83,6 +87,7 @@ static int gpio_poweroff_probe(struct platform_device *pdev)
 		gpiod_export_link(&pdev->dev, "poweroff-gpio", reset_gpio);
 	}
 
+	old_power_off = pm_power_off;
 	pm_power_off = &gpio_poweroff_do_poweroff;
 	return 0;
 }
@@ -90,7 +95,7 @@ static int gpio_poweroff_probe(struct platform_device *pdev)
 static int gpio_poweroff_remove(struct platform_device *pdev)
 {
 	if (pm_power_off == &gpio_poweroff_do_poweroff)
-		pm_power_off = NULL;
+		pm_power_off = old_power_off;
 
 	gpiod_unexport(reset_gpio);
 


### PR DESCRIPTION
Keeping a copy of the old poweroff handler allows it to be restored
should this module be unloaded, but also provides a fallback if the
power hasn't been removed when the timeout elapses.

See: https://github.com/raspberrypi/rpi-eeprom/issues/330

Signed-off-by: Phil Elwell <phil@raspberrypi.com>