### PR TITLE
Single overlay file to configure the Si4682 I2S

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -28,7 +28,6 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	audioinjector-ultra.dtbo \
 	audioinjector-wm8731-audio.dtbo \
 	audiosense-pi.dtbo \
-	ugreen-dabboard.dtbo \
 	audremap.dtbo \
 	balena-fin.dtbo \
 	cma.dtbo \
@@ -210,6 +209,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	uart4.dtbo \
 	uart5.dtbo \
 	udrc.dtbo \
+	ugreen-dabboard.dtbo \
 	upstream.dtbo \
 	upstream-pi4.dtbo \
 	vc4-fkms-v3d.dtbo \

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -28,6 +28,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	audioinjector-ultra.dtbo \
 	audioinjector-wm8731-audio.dtbo \
 	audiosense-pi.dtbo \
+	ugreen-dabboard.dtbo \
 	audremap.dtbo \
 	balena-fin.dtbo \
 	cma.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -599,16 +599,6 @@ Load:   dtoverlay=audiosense-pi
 Params: <None>
 
 
-Name:   ugreen-dabboard
-Info:   Configures the ugreen-dabboard I2S overlay
-        This is a simple overlay based on the simple-audio-card and the dmic 
-        codec. It has the speciality that it is configured to use the codec 
-        as a master I2S device. It works for example with the Si468x DAB 
-        receiver on the uGreen DABBoard.
-Load:   dtoverlay=ugreen-dabboard
-Params: <None>
-
-
 Name:   audremap
 Info:   Switches PWM sound output to GPIOs on the 40-pin header
 Load:   dtoverlay=audremap,<param>=<val>
@@ -3138,6 +3128,16 @@ Name:   udrc
 Info:   Configures the NW Digital Radio UDRC Hat
 Load:   dtoverlay=udrc,<param>=<val>
 Params: alsaname                Name of the ALSA audio device (default "udrc")
+
+
+Name:   ugreen-dabboard
+Info:   Configures the ugreen-dabboard I2S overlay
+        This is a simple overlay based on the simple-audio-card and the dmic
+        codec. It has the speciality that it is configured to use the codec
+        as a master I2S device. It works for example with the Si468x DAB
+        receiver on the uGreen DABBoard.
+Load:   dtoverlay=ugreen-dabboard,<param>=<val>
+Params: card-name               Override the default, "dabboard", card name.
 
 
 Name:   upstream

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -599,6 +599,16 @@ Load:   dtoverlay=audiosense-pi
 Params: <None>
 
 
+Name:   ugreen-dabboard
+Info:   Configures the ugreen-dabboard I2S overlay
+        This is a simple overlay based on the simple-audio-card and the dmic 
+        codec. It has the speciality that it is configured to use the codec 
+        as a master I2S device. It works for example with the Si468x DAB 
+        receiver on the uGreen DABBoard.
+Load:   dtoverlay=ugreen-dabboard
+Params: <None>
+
+
 Name:   audremap
 Info:   Switches PWM sound output to GPIOs on the 40-pin header
 Load:   dtoverlay=audremap,<param>=<val>

--- a/arch/arm/boot/dts/overlays/ugreen-dabboard-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ugreen-dabboard-overlay.dts
@@ -3,47 +3,47 @@
 /plugin/;
 
 / {
-    compatible = "brcm,bcm2835";
+	compatible = "brcm,bcm2835";
 
-    fragment@0 {
-        target = <&i2s>;
-        __overlay__ {
-            status = "okay";
-        };
-    };
+	fragment@0 {
+		target = <&i2s>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
 
-    fragment@1 {
-        target-path = "/";
-        __overlay__ {
-                dmic_codec: dmic-codec {
-                compatible = "dmic-codec";
-                status = "okay";
-            };
-        };
-    };
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			dmic_codec: dmic-codec {
+				#sound-dai-cells = <0>;
+				compatible = "dmic-codec";
+				status = "okay";
+			};
+		};
+	};
 
-    fragment@2 {
-        target = <&sound>;
-            sound_overlay: __overlay__ {
-            compatible = "simple-audio-card";
-            simple-audio-card,format = "i2s";
-            simple-audio-card,name = "dabboard";
-            simple-audio-card,bitclock-master = <&dailink0_slave>;
-            simple-audio-card,frame-master = <&dailink0_slave>;
-            simple-audio-card,widgets =
-                    "Microphone", "Microphone Jack";
-            status = "okay";
-            simple-audio-card,cpu {
-                sound-dai = <&i2s>;
-            };
-            dailink0_slave: simple-audio-card,codec {
-                sound-dai = <&dmic_codec>;
-            };
-        };
-    };
+	fragment@2 {
+		target = <&sound>;
+		sound_overlay: __overlay__ {
+			compatible = "simple-audio-card";
+			simple-audio-card,format = "i2s";
+			simple-audio-card,name = "dabboard";
+			simple-audio-card,bitclock-master = <&dailink0_slave>;
+			simple-audio-card,frame-master = <&dailink0_slave>;
+			simple-audio-card,widgets = "Microphone", "Microphone Jack";
+			status = "okay";
+			simple-audio-card,cpu {
+				sound-dai = <&i2s>;
+			};
+			dailink0_slave: simple-audio-card,codec {
+				#sound-dai-cells = <0>;
+				sound-dai = <&dmic_codec>;
+			};
+		};
+	};
 
-
-    __overrides__ {
-        card-name = <&sound_overlay>,"simple-audio-card,name";
-    };
+	__overrides__ {
+		card-name = <&sound_overlay>,"simple-audio-card,name";
+	};
 };

--- a/arch/arm/boot/dts/overlays/ugreen-dabboard-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ugreen-dabboard-overlay.dts
@@ -1,0 +1,49 @@
+// Definitions for the ugreen dabboard I2S
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "brcm,bcm2835";
+
+    fragment@0 {
+        target = <&i2s>;
+        __overlay__ {
+            status = "okay";
+        };
+    };
+
+    fragment@1 {
+        target-path = "/";
+        __overlay__ {
+                dmic_codec: dmic-codec {
+                compatible = "dmic-codec";
+                status = "okay";
+            };
+        };
+    };
+
+    fragment@2 {
+        target = <&sound>;
+            sound_overlay: __overlay__ {
+            compatible = "simple-audio-card";
+            simple-audio-card,format = "i2s";
+            simple-audio-card,name = "dabboard";
+            simple-audio-card,bitclock-master = <&dailink0_slave>;
+            simple-audio-card,frame-master = <&dailink0_slave>;
+            simple-audio-card,widgets =
+                    "Microphone", "Microphone Jack";
+            status = "okay";
+            simple-audio-card,cpu {
+                sound-dai = <&i2s>;
+            };
+            dailink0_slave: simple-audio-card,codec {
+                sound-dai = <&dmic_codec>;
+            };
+        };
+    };
+
+
+    __overrides__ {
+        card-name = <&sound_overlay>,"simple-audio-card,name";
+    };
+};


### PR DESCRIPTION
This is a simple overlay based on the simple-audio-card and the dmic 
codec. It has the speciality that it is configured to use the codec 
as a master I2S device. It works for example with the Si468x DAB 
receiver on the uGreen DABBoard.