### PR TITLE
vc4/drm: hdmi: Fix missing declaration

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -2178,6 +2178,7 @@ static int vc4_hdmi_hotplug_init(struct vc4_hdmi *vc4_hdmi)
 {
 	struct platform_device *pdev = vc4_hdmi->pdev;
 	struct device *dev = &pdev->dev;
+	struct drm_connector *connector = &vc4_hdmi->connector;
 	int ret;
 
 	if (vc4_hdmi->variant->external_irq_controller) {


### PR DESCRIPTION
Fixes: 671a8068ee5feae1d92e6d48027fa8de062e2af2
Signed-off-by: Dom Cobley <popcornmix@gmail.com>