### PR TITLE
Add device tree overlay for ssd1331-spi screen

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -196,6 +196,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	spi6-2cs.dtbo \
 	ssd1306.dtbo \
 	ssd1306-spi.dtbo \
+	ssd1331-spi.dtbo \
 	ssd1351-spi.dtbo \
 	superaudioboard.dtbo \
 	sx150x.dtbo \

--- a/arch/arm/boot/dts/overlays/ssd1331-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ssd1331-spi-overlay.dts
@@ -1,0 +1,83 @@
+/*
+ * Device Tree overlay for SSD1331 based SPI OLED display
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "brcm,bcm2835";
+
+        fragment@0 {
+                target = <&spi0>;
+                __overlay__ {
+                        status = "okay";
+                };
+        };
+
+        fragment@1 {
+                target = <&spidev0>;
+                __overlay__ {
+                        status = "disabled";
+                };
+        };
+
+        fragment@2 {
+                target = <&spidev1>;
+                __overlay__ {
+                        status = "disabled";
+                };
+        };
+
+        fragment@3 {
+                target = <&gpio>;
+                __overlay__ {
+                        ssd1331_pins: ssd1331_pins {
+                                brcm,pins = <25 24>;
+                                brcm,function = <1 1>; /* out out */
+                        };
+                };
+        };
+
+        fragment@4 {
+                target = <&spi0>;
+                __overlay__ {
+                        /* needed to avoid dtc warning */
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        ssd1331: ssd1331@0{
+                                compatible = "solomon,ssd1331";
+                                reg = <0>;
+                                pinctrl-names = "default";
+                                pinctrl-0 = <&ssd1331_pins>;
+
+                                spi-max-frequency = <4500000>;
+                                bgr = <0>;
+                                bpp = <16>;
+                                rotate = <0>;
+                                fps = <25>;
+                                buswidth = <8>;
+                                reset-gpios = <&gpio 25 1>;
+                                dc-gpios = <&gpio 24 0>;
+                                debug = <0>;
+
+                                solomon,height = <64>;
+                                solomon,width = <96>;
+                                solomon,page-offset = <0>;
+                        };
+                };
+        };
+
+        __overrides__ {
+                speed     = <&ssd1331>,"spi-max-frequency:0";
+                rotate    = <&ssd1331>,"rotate:0";
+                fps       = <&ssd1331>,"fps:0";
+                debug     = <&ssd1331>,"debug:0";
+                dc_pin    = <&ssd1331>,"dc-gpios:4",
+                            <&ssd1331_pins>,"brcm,pins:4";
+                reset_pin = <&ssd1331>,"reset-gpios:4",
+                            <&ssd1331_pins>,"brcm,pins:0";
+        };
+};


### PR DESCRIPTION
Connected waveshare 0.95inch RGB OLED with ssd1331 controller

<img src="https://user-images.githubusercontent.com/74985537/120248229-d66ec080-c265-11eb-9852-ecf8bffaa1b9.jpg" width="500" >
<img src="https://user-images.githubusercontent.com/74985537/120248228-d2db3980-c265-11eb-9f27-873fa58858ea.jpg" width="500" >
