### PR TITLE
Fixes an onboard clock detection problem of the PRO versions

### DIFF
--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -111,7 +111,7 @@ static void snd_rpi_hifiberry_dacplus_select_clk(struct snd_soc_component *compo
 		snd_soc_component_update_bits(component, PCM512x_GPIO_CONTROL_1, 0x24, 0x04);
 		break;
 	}
-	usleep_range(2000, 2100);
+	usleep_range(3000, 4000);
 }
 
 static void snd_rpi_hifiberry_dacplus_clk_gpio(struct snd_soc_component *component)

--- a/sound/soc/bcm/hifiberry_dacplusadcpro.c
+++ b/sound/soc/bcm/hifiberry_dacplusadcpro.c
@@ -190,7 +190,7 @@ static void snd_rpi_hifiberry_dacplusadcpro_select_clk(
 				PCM512x_GPIO_CONTROL_1, 0x24, 0x04);
 		break;
 	}
-	usleep_range(2000, 2100);
+	usleep_range(3000, 4000);
 }
 
 static void snd_rpi_hifiberry_dacplusadcpro_clk_gpio(struct snd_soc_component *component)


### PR DESCRIPTION
Increasing the sleep time after clock selection to 3-4ms
allows the correct detection of all combinations of DAC+ Pro
and DAC+ADC Pro sound cards and the various PI revisions.

Signed-off-by: Joerg Schambacher <joerg@hifiberry.com>