### PR TITLE
media: i2c: imx477: Fixes for long exposure modes

### DIFF
--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -1282,7 +1282,7 @@ static void imx477_adjust_exposure_range(struct imx477 *imx477)
 
 	/* Honour the VBLANK limits when setting exposure. */
 	exposure_max = imx477->mode->height + imx477->vblank->val -
-		       (IMX477_EXPOSURE_OFFSET << imx477->long_exp_shift);
+		       IMX477_EXPOSURE_OFFSET;
 	exposure_def = min(exposure_max, imx477->exposure->val);
 	__v4l2_ctrl_modify_range(imx477->exposure, imx477->exposure->minimum,
 				 exposure_max, imx477->exposure->step,


### PR DESCRIPTION
Do not scale IMX477_EXPOSURE_OFFSET with the long exposure factor during
the limit calculations. This allows larger exposure times, and does seem to be
what the sensor is doing internally.

When clipping the frame length calculations during long exposure, use the
maximum possible frame length and exposure factor.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>