### PR TITLE
drm/vc4: Add support for non-standard modes in VEC

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -408,6 +408,7 @@ static void vc4_crtc_config_pv(struct drm_crtc *crtc, struct drm_encoder *encode
 		CRTC_WRITE(PV_V_CONTROL,
 			   PV_VCONTROL_CONTINUOUS |
 			   (is_dsi ? PV_VCONTROL_DSI : 0));
+		CRTC_WRITE(PV_VSYNCD_EVEN, 0);
 	}
 
 	CRTC_WRITE(PV_VERTA,

--- a/drivers/gpu/drm/vc4/vc4_vec.c
+++ b/drivers/gpu/drm/vc4/vc4_vec.c
@@ -251,7 +251,8 @@ enum vc4_vec_tv_mode_id {
 };
 
 struct vc4_vec_tv_mode {
-	const struct drm_display_mode *mode;
+	const struct drm_display_mode *interlaced_mode;
+	const struct drm_display_mode *progressive_mode;
 	u32 config0;
 	u32 config1;
 	u32 custom_freq;
@@ -285,61 +286,81 @@ static const struct debugfs_reg32 vec_regs[] = {
 };
 
 static const struct drm_display_mode drm_mode_480i = {
-	DRM_MODE("720x480", DRM_MODE_TYPE_DRIVER, 13500,
+	DRM_MODE("720x480i", DRM_MODE_TYPE_DRIVER, 13500,
 		 720, 720 + 14, 720 + 14 + 64, 720 + 14 + 64 + 60, 0,
 		 480, 480 + 7, 480 + 7 + 6, 525, 0,
 		 DRM_MODE_FLAG_INTERLACE)
 };
 
+static const struct drm_display_mode drm_mode_240p = {
+	DRM_MODE("720x240", DRM_MODE_TYPE_DRIVER, 13500,
+		 720, 720 + 14, 720 + 14 + 64, 720 + 14 + 64 + 60, 0,
+		 240, 240 + 3, 240 + 3 + 3, 262, 0, 0)
+};
+
 static const struct drm_display_mode drm_mode_576i = {
-	DRM_MODE("720x576", DRM_MODE_TYPE_DRIVER, 13500,
+	DRM_MODE("720x576i", DRM_MODE_TYPE_DRIVER, 13500,
 		 720, 720 + 20, 720 + 20 + 64, 720 + 20 + 64 + 60, 0,
 		 576, 576 + 4, 576 + 4 + 6, 625, 0,
 		 DRM_MODE_FLAG_INTERLACE)
 };
 
+static const struct drm_display_mode drm_mode_288p = {
+	DRM_MODE("720x288", DRM_MODE_TYPE_DRIVER, 13500,
+		 720, 720 + 20, 720 + 20 + 64, 720 + 20 + 64 + 60, 0,
+		 288, 288 + 2, 288 + 2 + 3, 312, 0, 0)
+};
+
 static const struct vc4_vec_tv_mode vc4_vec_tv_modes[] = {
 	[VC4_VEC_TV_MODE_NTSC] = {
-		.mode = &drm_mode_480i,
+		.interlaced_mode = &drm_mode_480i,
+		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_NTSC_STD | VEC_CONFIG0_PDEN,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 	},
 	[VC4_VEC_TV_MODE_NTSC_J] = {
-		.mode = &drm_mode_480i,
+		.interlaced_mode = &drm_mode_480i,
+		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_NTSC_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 	},
 	[VC4_VEC_TV_MODE_NTSC_443] = {
 		/* NTSC with PAL chroma frequency */
-		.mode = &drm_mode_480i,
+		.interlaced_mode = &drm_mode_480i,
+		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_NTSC_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS | VEC_CONFIG1_CUSTOM_FREQ,
 		.custom_freq = 0x2a098acb,
 	},
 	[VC4_VEC_TV_MODE_PAL] = {
-		.mode = &drm_mode_576i,
+		.interlaced_mode = &drm_mode_576i,
+		.progressive_mode = &drm_mode_288p,
 		.config0 = VEC_CONFIG0_PAL_BDGHI_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 	},
 	[VC4_VEC_TV_MODE_PAL_M] = {
-		.mode = &drm_mode_480i,
+		.interlaced_mode = &drm_mode_480i,
+		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_PAL_M_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 	},
 	[VC4_VEC_TV_MODE_PAL_N] = {
-		.mode = &drm_mode_576i,
+		.interlaced_mode = &drm_mode_576i,
+		.progressive_mode = &drm_mode_288p,
 		.config0 = VEC_CONFIG0_PAL_N_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 	},
 	[VC4_VEC_TV_MODE_PAL60] = {
 		/* PAL-M with chroma frequency of regular PAL */
-		.mode = &drm_mode_480i,
+		.interlaced_mode = &drm_mode_480i,
+		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_PAL_M_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS | VEC_CONFIG1_CUSTOM_FREQ,
 		.custom_freq = 0x2a098acb,
 	},
 	[VC4_VEC_TV_MODE_SECAM] = {
-		.mode = &drm_mode_576i,
+		.interlaced_mode = &drm_mode_576i,
+		.progressive_mode = &drm_mode_288p,
 		.config0 = VEC_CONFIG0_SECAM_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 		.custom_freq = 0x29c71c72,
@@ -399,16 +420,32 @@ static void vc4_vec_connector_destroy(struct drm_connector *connector)
 static int vc4_vec_connector_get_modes(struct drm_connector *connector)
 {
 	struct drm_connector_state *state = connector->state;
-	struct drm_display_mode *mode;
+	struct drm_display_mode *interlaced_mode, *progressive_mode;
 
-	mode = drm_mode_duplicate(connector->dev,
-				  vc4_vec_tv_modes[state->tv.mode].mode);
-	if (!mode) {
+	interlaced_mode =
+		drm_mode_duplicate(connector->dev,
+				   vc4_vec_tv_modes[state->tv.mode].interlaced_mode);
+	progressive_mode =
+		drm_mode_duplicate(connector->dev,
+				   vc4_vec_tv_modes[state->tv.mode].progressive_mode);
+	if (!interlaced_mode || !progressive_mode) {
 		DRM_ERROR("Failed to create a new display mode\n");
+		drm_mode_destroy(connector->dev, interlaced_mode);
+		drm_mode_destroy(connector->dev, progressive_mode);
 		return -ENOMEM;
 	}
 
-	drm_mode_probed_add(connector, mode);
+	if (connector->cmdline_mode.specified &&
+	    connector->cmdline_mode.refresh_specified &&
+	    !connector->cmdline_mode.interlace)
+		/* progressive mode set at boot, let's make it preferred */
+		progressive_mode->type |= DRM_MODE_TYPE_PREFERRED;
+	else
+		/* otherwise, interlaced mode is preferred */
+		interlaced_mode->type |= DRM_MODE_TYPE_PREFERRED;
+
+	drm_mode_probed_add(connector, interlaced_mode);
+	drm_mode_probed_add(connector, progressive_mode);
 
 	return 1;
 }
@@ -589,7 +626,7 @@ static int vc4_vec_encoder_atomic_check(struct drm_encoder *encoder,
 					struct drm_connector_state *conn_state)
 {
 	const struct drm_display_mode *reference_mode =
-		vc4_vec_tv_modes[conn_state->tv.mode].mode;
+		vc4_vec_tv_modes[conn_state->tv.mode].interlaced_mode;
 
 	if (crtc_state->adjusted_mode.crtc_clock != reference_mode->clock ||
 	    crtc_state->adjusted_mode.crtc_htotal != reference_mode->htotal ||

--- a/drivers/gpu/drm/vc4/vc4_vec.c
+++ b/drivers/gpu/drm/vc4/vc4_vec.c
@@ -429,18 +429,11 @@ static int vc4_vec_connector_atomic_check(struct drm_connector *conn,
 	struct drm_connector_state *new_state =
 		drm_atomic_get_new_connector_state(state, conn);
 
-	const struct vc4_vec_tv_mode *vec_mode =
-		&vc4_vec_tv_modes[new_state->tv.mode];
-
-	if (new_state->crtc) {
+	if (new_state->crtc && old_state->tv.mode != new_state->tv.mode) {
 		struct drm_crtc_state *crtc_state =
 			drm_atomic_get_new_crtc_state(state, new_state->crtc);
 
-		if (!drm_mode_equal(vec_mode->mode, &crtc_state->mode))
-			return -EINVAL;
-
-		if (old_state->tv.mode != new_state->tv.mode)
-			crtc_state->mode_changed = true;
+		crtc_state->mode_changed = true;
 	}
 
 	return 0;
@@ -565,7 +558,10 @@ static void vc4_vec_encoder_enable(struct drm_encoder *encoder)
 	VEC_WRITE(VEC_CLMP0_START, 0xac);
 	VEC_WRITE(VEC_CLMP0_END, 0xec);
 	VEC_WRITE(VEC_CONFIG2,
-		  VEC_CONFIG2_UV_DIG_DIS | VEC_CONFIG2_RGB_DIG_DIS);
+		  VEC_CONFIG2_UV_DIG_DIS |
+		  VEC_CONFIG2_RGB_DIG_DIS |
+		  ((encoder->crtc->state->adjusted_mode.flags &
+		    DRM_MODE_FLAG_INTERLACE) ? 0 : VEC_CONFIG2_PROG_SCAN));
 	VEC_WRITE(VEC_CONFIG3, VEC_CONFIG3_HORIZ_LEN_STD);
 	VEC_WRITE(VEC_DAC_CONFIG, vec->variant->dac_config);
 
@@ -588,17 +584,88 @@ static void vc4_vec_encoder_enable(struct drm_encoder *encoder)
 }
 
 
-static bool vc4_vec_encoder_mode_fixup(struct drm_encoder *encoder,
-				       const struct drm_display_mode *mode,
-				       struct drm_display_mode *adjusted_mode)
+static int vc4_vec_encoder_atomic_check(struct drm_encoder *encoder,
+					struct drm_crtc_state *crtc_state,
+					struct drm_connector_state *conn_state)
 {
-	return true;
+	const struct drm_display_mode *reference_mode =
+		vc4_vec_tv_modes[conn_state->tv.mode].mode;
+
+	if (crtc_state->adjusted_mode.crtc_clock != reference_mode->clock ||
+	    crtc_state->adjusted_mode.crtc_htotal != reference_mode->htotal ||
+	    crtc_state->adjusted_mode.crtc_hdisplay % 4 != 0 ||
+	    crtc_state->adjusted_mode.crtc_hsync_end -
+		    crtc_state->adjusted_mode.crtc_hsync_start < 1)
+		return -EINVAL;
+
+	switch (reference_mode->vtotal) {
+	case 525:
+		if (crtc_state->adjusted_mode.crtc_vdisplay < 1 ||
+		    crtc_state->adjusted_mode.crtc_vdisplay > 253 ||
+		    crtc_state->adjusted_mode.crtc_vsync_start -
+			    crtc_state->adjusted_mode.crtc_vdisplay < 1 ||
+		    crtc_state->adjusted_mode.crtc_vsync_end -
+			    crtc_state->adjusted_mode.crtc_vsync_start != 3 ||
+		    crtc_state->adjusted_mode.crtc_vtotal -
+			    crtc_state->adjusted_mode.crtc_vsync_end < 4 ||
+		    crtc_state->adjusted_mode.crtc_vtotal > 262)
+			return -EINVAL;
+
+		if ((crtc_state->adjusted_mode.flags &
+		     DRM_MODE_FLAG_INTERLACE) &&
+		    (crtc_state->adjusted_mode.vdisplay % 2 != 0 ||
+		     crtc_state->adjusted_mode.vsync_start % 2 != 1 ||
+		     crtc_state->adjusted_mode.vsync_end % 2 != 1 ||
+		     crtc_state->adjusted_mode.vtotal % 2 != 1))
+			return -EINVAL;
+
+		/* progressive mode is hard-wired to 262 total lines */
+		if (!(crtc_state->adjusted_mode.flags &
+		      DRM_MODE_FLAG_INTERLACE) &&
+		    crtc_state->adjusted_mode.crtc_vtotal != 262)
+			return -EINVAL;
+
+		break;
+
+	case 625:
+		if (crtc_state->adjusted_mode.crtc_vdisplay < 1 ||
+		    crtc_state->adjusted_mode.crtc_vdisplay > 305 ||
+		    crtc_state->adjusted_mode.crtc_vsync_start -
+			    crtc_state->adjusted_mode.crtc_vdisplay < 1 ||
+		    crtc_state->adjusted_mode.crtc_vsync_end -
+			    crtc_state->adjusted_mode.crtc_vsync_start != 3 ||
+		    crtc_state->adjusted_mode.crtc_vtotal -
+			    crtc_state->adjusted_mode.crtc_vsync_end < 2 ||
+		    crtc_state->adjusted_mode.crtc_vtotal > 312)
+			return -EINVAL;
+
+		if ((crtc_state->adjusted_mode.flags &
+		     DRM_MODE_FLAG_INTERLACE) &&
+		    (crtc_state->adjusted_mode.vdisplay % 2 != 0 ||
+		     crtc_state->adjusted_mode.vsync_start % 2 != 0 ||
+		     crtc_state->adjusted_mode.vsync_end % 2 != 0 ||
+		     crtc_state->adjusted_mode.vtotal % 2 != 1))
+			return -EINVAL;
+
+		/* progressive mode is hard-wired to 312 total lines */
+		if (!(crtc_state->adjusted_mode.flags &
+		      DRM_MODE_FLAG_INTERLACE) &&
+		    crtc_state->adjusted_mode.crtc_vtotal != 312)
+			return -EINVAL;
+
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 static const struct drm_encoder_helper_funcs vc4_vec_encoder_helper_funcs = {
 	.disable = vc4_vec_encoder_disable,
 	.enable = vc4_vec_encoder_enable,
-	.mode_fixup = vc4_vec_encoder_mode_fixup,
+	.atomic_check = vc4_vec_encoder_atomic_check,
 };
 
 static const struct vc4_vec_variant bcm2835_vec_variant = {


### PR DESCRIPTION
This PR adds support for non-standard composite output modelines, specifically:
* **Progressive modes**. These are equivalent to firmware's `sdtv_mode=16`/`sdtv_mode=18` in terms of the resulting signal's timing, although the firmware modes employ implicit scaling (480/576 active lines from software scaled down to 240/288 lines on actual output). I added the `720x240` and `720x288` modes that are reported via `vc4_vec_connector_get_modes()`.
* **Custom interlaced modelines**. Some examples of what can be done with it:
  * `"720x486i" 13.5 720 734 798 858 486 491 497 525 Interlace` - NTSC with all the active lines from the original spec, before the convention of cropping the outermost 6
  * `"720x506i" 13.5 720 734 798 858 506 509 515 525 Interlace` - NTSC mode with basically the entire VBI accessible
  * `"720x610i" 13.5 720 740 804 864 610 612 618 625 Interlace` - the same but for PAL; you can e.g. emit teletext by drawing in the uppermost lines
  * `"720x480i" 13.5 720 740 804 864 480 486 492 525 Interlace` - an approximation of the "NTSC" mode while VEC is put in the 625-line mode; allows e.g. putting SECAM color on top of that, which is a really dumb idea but it works ;)
  * Basically any interlaced mode that has horizontal timings compatible with either the 525-line or 625-line mode, and no more lines than the standard, will work and generate a sane-looking signal. I don't know how could that be useful, but if it works, then why not. Unfortunately the progressive modes are much stricter, the VEC is locked to either 262 or 312 total lines, so the only thing you can do is change the proportions between active picture and VBI.
    * `"640x200" 13.5 640 694 758 858 200 223 226 262` is an example CGA-like mode with black borders.
* ~**Support for clocking the VEC at different frequencies than 108 MHz**. This also includes recalculating the color subcarrier frequencies, so that they stay within spec even in that case. I guess that this point will be the most controversial of it all, but it has some uses:~
  * ~For fun, you can try modes such as `"720x378i 8.68725 720 734 798 858 378 381 387 405 Interlace` - that in theory closely approximates the early British 405-line TV system and _may_ be able to drive such a set. Obviously I don't have hardware to check that ;)~
  * ~More importantly though, this makes the composite output somewhat usable even without `enable_tvout=1` on Pi4. Due to the clock being 0.8% slower than the spec, the ratio relationship between the line frequeny and subcarrier frequency is broken, which makes this mode cause a lot more cross-color artifacts, but the picture is still usable.~ Custom clock rate support has been removed, as it is nearly useless now that #4639 is merged.
  * As a side note, by using a [customized DT overlay](https://gist.github.com/kFYatek/7df69a03fd76fcccee41e78ddd9e6497) that enables both VEC and HDMI at the same time, I was able to get a working dual-screen HDMI+Composite setup on Pi4. Curiously, it works both with and without `enable_tvout=1` (although I don't know, maybe the HDMI timings aren't quite standard then?). So maybe having an option for this type of setup in `vc4-kms-v3d-pi4.dtbo` would make sense.
    * Actually, I was kind of hoping that triple screen (2xHDMI + Composite) setup would be possible, but unfortunately I get CRTC activation error if I try enabling composite while both HDMIs are enabled already ;) 