### PR TITLE
drm/vc4: Increase the core clock to a minimum of 500MHz

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -348,11 +348,17 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 	}
 
 	if (vc4->hvs && vc4->hvs->hvs5) {
+		unsigned long core_rate = max_t(unsigned long,
+						500000000,
+						hvs_state->core_clock_rate);
+
+		drm_dbg(dev, "Raising the core clock at %lu Hz\n", core_rate);
+
 		/*
 		 * Do a temporary request on the core clock during the
 		 * modeset.
 		 */
-		core_req = clk_request_start(hvs->core_clk, 500000000);
+		core_req = clk_request_start(hvs->core_clk, core_rate);
 
 		/*
 		 * And remove the previous one based on the HVS


### PR DESCRIPTION
The core clock needs to be raised temporarily during a modeset to
500MHz. However, the HVS core clock requirement might be higher than
500MHz. This rate will be enforced at the end of the mode setting,
meaning that might might end up with a core clock rate lower than
planned on the first mode set.

Use the maximum value of 500MHz and the HVS core clock rate for our
temporary boost to fix this issue.

Signed-off-by: Maxime Ripard <maxime@cerno.tech>