### PR TITLE
media: i2c: ov9281: Remove override of subdev name

### DIFF
--- a/drivers/media/i2c/ov9281.c
+++ b/drivers/media/i2c/ov9281.c
@@ -1197,8 +1197,6 @@ static int ov9281_probe(struct i2c_client *client,
 	if (ret < 0)
 		goto err_power_off;
 
-	snprintf(sd->name, sizeof(sd->name), "m%s %s",
-		 OV9281_NAME, dev_name(sd->dev));
 	ret = v4l2_async_register_subdev_sensor_common(sd);
 	if (ret) {
 		dev_err(dev, "v4l2 async register subdev failed\n");


### PR DESCRIPTION
From the original Rockchip driver, the subdev was renamed
from the default to being "mov9281 <dev_name>" whereas the
default would have been "ov9281 <dev_name>".

Remove the override to drop back to the default rather than
a vendor custom string.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>