### PR TITLE
staging: vc04_services: isp: Set the YUV420/YVU420 format stride to 64 bytes

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835-isp-fmts.h
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835-isp-fmts.h
@@ -48,7 +48,7 @@ static const struct bcm2835_isp_fmt supported_formats[] = {
 		/* YUV formats */
 		.fourcc		    = V4L2_PIX_FMT_YUV420,
 		.depth		    = 8,
-		.bytesperline_align = 32,
+		.bytesperline_align = 64,
 		.mmal_fmt	    = MMAL_ENCODING_I420,
 		.size_multiplier_x2 = 3,
 		.colorspace_mask    = V4L2_COLORSPACE_MASK_YUV,
@@ -57,7 +57,7 @@ static const struct bcm2835_isp_fmt supported_formats[] = {
 	}, {
 		.fourcc		    = V4L2_PIX_FMT_YVU420,
 		.depth		    = 8,
-		.bytesperline_align = 32,
+		.bytesperline_align = 64,
 		.mmal_fmt	    = MMAL_ENCODING_YV12,
 		.size_multiplier_x2 = 3,
 		.colorspace_mask    = V4L2_COLORSPACE_MASK_YUV,


### PR DESCRIPTION
The bcm2835 ISP requires all input/output planes to have 32 byte alignment.
Using a Y stride of 32 bytes would not guarantee that the V plane would fulfil
this, e.g. a height of 650 lines would mean the V plane buffer is not 32 byte
aligned for YUV420 formats.

Having a Y stride of 64 bytes would ensure both U and V planes have a 32 byte
alignment, provided the height is an even number of lines.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>