### PR TITLE
media: i2c: imx477: Add support for imx378 as a compatible sensor

### DIFF
--- a/Documentation/devicetree/bindings/media/i2c/imx378.yaml
+++ b/Documentation/devicetree/bindings/media/i2c/imx378.yaml
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/media/i2c/imx378.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Sony 1/2.3-Inch 12Mpixel CMOS Digital Image Sensor
+
+maintainers:
+  - Naushir Patuck <naush@raspberypi.com>
+
+description: |-
+  The Sony IMX378 is a 1/2.3-inch CMOS active pixel digital image sensor
+  with an active array size of 4056H x 3040V. It is programmable through
+  I2C interface. The I2C address is fixed to 0x1A as per sensor data sheet.
+  Image data is sent through MIPI CSI-2, which is configured as either 2 or
+  4 data lanes.
+
+properties:
+  compatible:
+    const: sony,imx378
+
+  reg:
+    description: I2C device address
+    maxItems: 1
+
+  clocks:
+    maxItems: 1
+
+  VDIG-supply:
+    description:
+      Digital I/O voltage supply, 1.05 volts
+
+  VANA-supply:
+    description:
+      Analog voltage supply, 2.8 volts
+
+  VDDL-supply:
+    description:
+      Digital core voltage supply, 1.8 volts
+
+  reset-gpios:
+    description: |-
+      Reference to the GPIO connected to the xclr pin, if any.
+      Must be released (set high) after all supplies and INCK are applied.
+
+  # See ../video-interfaces.txt for more details
+  port:
+    type: object
+    properties:
+      endpoint:
+        type: object
+        properties:
+          data-lanes:
+            description: |-
+              The sensor supports either two-lane, or four-lane operation.
+              For two-lane operation the property must be set to <1 2>.
+            items:
+              - const: 1
+              - const: 2
+
+          clock-noncontinuous:
+            type: boolean
+            description: |-
+              MIPI CSI-2 clock is non-continuous if this property is present,
+              otherwise it's continuous.
+
+          link-frequencies:
+            allOf:
+              - $ref: /schemas/types.yaml#/definitions/uint64-array
+            description:
+              Allowed data bus frequencies.
+
+        required:
+          - link-frequencies
+
+required:
+  - compatible
+  - reg
+  - clocks
+  - VANA-supply
+  - VDIG-supply
+  - VDDL-supply
+  - port
+
+additionalProperties: false
+
+examples:
+  - |
+    i2c0 {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        imx378: sensor@10 {
+            compatible = "sony,imx378";
+            reg = <0x1a>;
+            clocks = <&imx378_clk>;
+            VANA-supply = <&imx378_vana>;   /* 2.8v */
+            VDIG-supply = <&imx378_vdig>;   /* 1.05v */
+            VDDL-supply = <&imx378_vddl>;   /* 1.8v */
+
+            port {
+                imx378_0: endpoint {
+                    remote-endpoint = <&csi1_ep>;
+                    data-lanes = <1 2>;
+                    clock-noncontinuous;
+                    link-frequencies = /bits/ 64 <450000000>;
+                };
+            };
+        };
+    };
+
+...

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -16360,6 +16360,7 @@ M:	Raspberry Pi Kernel Maintenance <kernel-list@raspberrypi.com>
 L:	linux-media@vger.kernel.org
 S:	Maintained
 T:	git git://linuxtv.org/media_tree.git
+F:	Documentation/devicetree/bindings/media/i2c/imx378.yaml
 F:	Documentation/devicetree/bindings/media/i2c/imx477.yaml
 F:	drivers/media/i2c/imx477.c
 

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -94,6 +94,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	ilitek251x.dtbo \
 	imx219.dtbo \
 	imx290.dtbo \
+	imx378.dtbo \
 	imx477.dtbo \
 	iqaudio-codec.dtbo \
 	iqaudio-dac.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1674,6 +1674,15 @@ Params: 4lane                   Enable 4 CSI2 lanes. This requires a Compute
         mono                    Denote that the module is a mono sensor.
 
 
+Name:   imx378
+Info:   Sony IMX378 camera module.
+        Uses Unicam 1, which is the standard camera connector on most Pi
+        variants.
+Load:   dtoverlay=imx378,<param>=<val>
+Params: rotation                Mounting rotation of the camera sensor (0 or
+                                180, default 180)
+
+
 Name:   imx477
 Info:   Sony IMX477 camera module.
         Uses Unicam 1, which is the standard camera connector on most Pi

--- a/arch/arm/boot/dts/overlays/imx378-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx378-overlay.dts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Definitions for IMX477 camera module on VC I2C bus
+// Definitions for IMX378 camera module on VC I2C bus
 /dts-v1/;
 /plugin/;
 
 #include "imx477_378-overlay.dtsi"
 
 &imx477 {
-	compatible = "sony,imx477";
+	compatible = "sony,imx378";
 };

--- a/arch/arm/boot/dts/overlays/imx477_378-overlay.dtsi
+++ b/arch/arm/boot/dts/overlays/imx477_378-overlay.dtsi
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Definitions for IMX477 camera module on VC I2C bus
+
+/{
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c_csi_dsi>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			imx477: imx477@1a {
+				reg = <0x1a>;
+				status = "okay";
+
+				clocks = <&imx477_clk>;
+				clock-names = "xclk";
+
+				VANA-supply = <&cam1_reg>;	/* 2.8v */
+				VDIG-supply = <&imx477_vdig>;	/* 1.05v */
+				VDDL-supply = <&imx477_vddl>;	/* 1.8v */
+
+				rotation = <180>;
+
+				port {
+					imx477_0: endpoint {
+						remote-endpoint = <&csi1_ep>;
+						clock-lanes = <0>;
+						data-lanes = <1 2>;
+						clock-noncontinuous;
+						link-frequencies =
+							/bits/ 64 <450000000>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&csi1>;
+		__overlay__ {
+			status = "okay";
+
+			port {
+				csi1_ep: endpoint {
+					remote-endpoint = <&imx477_0>;
+					clock-lanes = <0>;
+					data-lanes = <1 2>;
+					clock-noncontinuous;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c0if>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target-path="/";
+		__overlay__ {
+			imx477_vdig: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "imx477_vdig";
+				regulator-min-microvolt = <1050000>;
+				regulator-max-microvolt = <1050000>;
+			};
+			imx477_vddl: fixedregulator@1 {
+				compatible = "regulator-fixed";
+				regulator-name = "imx477_vddl";
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+			};
+			imx477_clk: camera-clk {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <24000000>;
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&i2c0mux>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@5 {
+		target = <&cam1_reg>;
+		__overlay__ {
+			status = "okay";
+			regulator-name = "imx477_vana";
+			startup-delay-us = <300000>;
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
+		};
+	};
+
+	__overrides__ {
+		rotation = <&imx477>,"rotation:0";
+	};
+};

--- a/drivers/media/i2c/Kconfig
+++ b/drivers/media/i2c/Kconfig
@@ -807,7 +807,7 @@ config VIDEO_IMX477
 	depends on MEDIA_CAMERA_SUPPORT
 	help
 	  This is a Video4Linux2 sensor driver for the Sony
-	  IMX477 camera.
+	  IMX477 camera. Also supports the Sony IMX378.
 
 	  To compile this driver as a module, choose M here: the
 	  module will be called imx477.

--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -12,6 +12,7 @@
 #include <linux/gpio/consumer.h>
 #include <linux/i2c.h>
 #include <linux/module.h>
+#include <linux/of_device.h>
 #include <linux/pm_runtime.h>
 #include <linux/regulator/consumer.h>
 #include <media/v4l2-ctrls.h>
@@ -26,6 +27,7 @@
 /* Chip ID */
 #define IMX477_REG_CHIP_ID		0x0016
 #define IMX477_CHIP_ID			0x0477
+#define IMX378_CHIP_ID			0x0378
 
 #define IMX477_REG_MODE_SELECT		0x0100
 #define IMX477_MODE_STANDBY		0x00
@@ -1069,6 +1071,11 @@ static const char * const imx477_supply_name[] = {
 #define IMX477_XCLR_MIN_DELAY_US	8000
 #define IMX477_XCLR_DELAY_RANGE_US	1000
 
+struct imx477_compatible_data {
+	unsigned int chip_id;
+	struct imx477_reg_list extra_regs;
+};
+
 struct imx477 {
 	struct v4l2_subdev sd;
 	struct media_pad pad[NUM_PADS];
@@ -1107,6 +1114,9 @@ struct imx477 {
 
 	/* Current long exposure factor in use. Set through V4L2_CID_VBLANK */
 	unsigned int long_exp_shift;
+
+	/* Any extra information related to different compatible sensors */
+	const struct imx477_compatible_data *compatible_data;
 };
 
 static inline struct imx477 *to_imx477(struct v4l2_subdev *_sd)
@@ -1673,11 +1683,18 @@ static int imx477_start_streaming(struct imx477 *imx477)
 {
 	struct i2c_client *client = v4l2_get_subdevdata(&imx477->sd);
 	const struct imx477_reg_list *reg_list;
+	const struct imx477_reg_list *extra_regs;
 	int ret;
 
 	if (!imx477->common_regs_written) {
 		ret = imx477_write_regs(imx477, mode_common_regs,
 					ARRAY_SIZE(mode_common_regs));
+		if (!ret) {
+			extra_regs = &imx477->compatible_data->extra_regs;
+			ret = imx477_write_regs(imx477,	extra_regs->regs,
+						extra_regs->num_of_regs);
+		}
+
 		if (ret) {
 			dev_err(&client->dev, "%s failed to set common settings\n",
 				__func__);
@@ -1863,7 +1880,7 @@ static int imx477_get_regulators(struct imx477 *imx477)
 }
 
 /* Verify chip ID */
-static int imx477_identify_module(struct imx477 *imx477)
+static int imx477_identify_module(struct imx477 *imx477, u32 expected_id)
 {
 	struct i2c_client *client = v4l2_get_subdevdata(&imx477->sd);
 	int ret;
@@ -1873,15 +1890,17 @@ static int imx477_identify_module(struct imx477 *imx477)
 			      IMX477_REG_VALUE_16BIT, &val);
 	if (ret) {
 		dev_err(&client->dev, "failed to read chip id %x, with error %d\n",
-			IMX477_CHIP_ID, ret);
+			expected_id, ret);
 		return ret;
 	}
 
-	if (val != IMX477_CHIP_ID) {
+	if (val != expected_id) {
 		dev_err(&client->dev, "chip id mismatch: %x!=%x\n",
-			IMX477_CHIP_ID, val);
+			expected_id, val);
 		return -EIO;
 	}
+
+	dev_info(&client->dev, "Device found is imx%x\n", val);
 
 	return 0;
 }
@@ -2078,10 +2097,39 @@ error_out:
 	return ret;
 }
 
+static const struct imx477_compatible_data imx477_compatible = {
+	.chip_id = IMX477_CHIP_ID,
+	.extra_regs = {
+		.num_of_regs = 0,
+		.regs = NULL
+	}
+};
+
+static const struct imx477_reg imx378_regs[] = {
+	{0x3e35, 0x01},
+	{0x4421, 0x08},
+	{0x3ff9, 0x00},
+};
+
+static const struct imx477_compatible_data imx378_compatible = {
+	.chip_id = IMX378_CHIP_ID,
+	.extra_regs = {
+		.num_of_regs = ARRAY_SIZE(imx378_regs),
+		.regs = imx378_regs
+	}
+};
+
+static const struct of_device_id imx477_dt_ids[] = {
+	{ .compatible = "sony,imx477", .data = &imx477_compatible },
+	{ .compatible = "sony,imx378", .data = &imx378_compatible },
+	{ /* sentinel */ }
+};
+
 static int imx477_probe(struct i2c_client *client)
 {
 	struct device *dev = &client->dev;
 	struct imx477 *imx477;
+	const struct of_device_id *match;
 	int ret;
 
 	imx477 = devm_kzalloc(&client->dev, sizeof(*imx477), GFP_KERNEL);
@@ -2089,6 +2137,12 @@ static int imx477_probe(struct i2c_client *client)
 		return -ENOMEM;
 
 	v4l2_i2c_subdev_init(&imx477->sd, client, &imx477_subdev_ops);
+
+	match = of_match_device(imx477_dt_ids, dev);
+	if (!match)
+		return -ENODEV;
+	imx477->compatible_data =
+		(const struct imx477_compatible_data *)match->data;
 
 	/* Check the hardware configuration in device tree */
 	if (imx477_check_hwcfg(dev))
@@ -2126,7 +2180,7 @@ static int imx477_probe(struct i2c_client *client)
 	if (ret)
 		return ret;
 
-	ret = imx477_identify_module(imx477);
+	ret = imx477_identify_module(imx477, imx477->compatible_data->chip_id);
 	if (ret)
 		goto error_power_off;
 
@@ -2198,10 +2252,6 @@ static int imx477_remove(struct i2c_client *client)
 	return 0;
 }
 
-static const struct of_device_id imx477_dt_ids[] = {
-	{ .compatible = "sony,imx477" },
-	{ /* sentinel */ }
-};
 MODULE_DEVICE_TABLE(of, imx477_dt_ids);
 
 static const struct dev_pm_ops imx477_pm_ops = {


### PR DESCRIPTION
The imx378 is almost identical to the imx477 and can be supported by
the same driver with just a few extra register writes.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>