### PR TITLE
drm/vc4: Notify firmware when use of simple framebuffer is complete

### DIFF
--- a/Documentation/devicetree/bindings/clock/raspberrypi,firmware-clocks.yaml
+++ b/Documentation/devicetree/bindings/clock/raspberrypi,firmware-clocks.yaml
@@ -16,15 +16,9 @@ properties:
   compatible:
     const: raspberrypi,firmware-clocks
 
-  raspberrypi,firmware:
-    $ref: /schemas/types.yaml#/definitions/phandle
-    description: >
-      Phandle to the mailbox node to communicate with the firmware.
-
 required:
   - "#clock-cells"
   - compatible
-  - raspberrypi,firmware
 
 additionalProperties: false
 
@@ -32,7 +26,6 @@ examples:
   - |
     firmware_clocks: firmware-clocks {
         compatible = "raspberrypi,firmware-clocks";
-        raspberrypi,firmware = <&firmware>;
         #clock-cells = <1>;
     };
 

--- a/Documentation/devicetree/bindings/display/brcm,bcm2835-vc4.yaml
+++ b/Documentation/devicetree/bindings/display/brcm,bcm2835-vc4.yaml
@@ -21,6 +21,11 @@ properties:
       - brcm,bcm2835-vc4
       - brcm,cygnus-vc4
 
+  raspberrypi,firmware:
+    $ref: /schemas/types.yaml#/definitions/phandle
+    description: >
+      Phandle to the mailbox node to communicate with the firmware.
+
 required:
   - compatible
 

--- a/arch/arm/boot/dts/bcm2711-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2711-rpi.dtsi
@@ -35,6 +35,10 @@
 	};
 };
 
+&vc4 {
+	raspberrypi,firmware = <&firmware>;
+};
+
 &cma {
 	/* Limit cma to the lower 768MB to allow room for HIGHMEM on 32-bit */
 	alloc-ranges = <0x0 0x00000000 0x30000000>;

--- a/arch/arm/boot/dts/bcm2835-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2835-rpi.dtsi
@@ -76,6 +76,10 @@
 	power-domains = <&power RPI_POWER_DOMAIN_USB>;
 };
 
+&vc4 {
+	raspberrypi,firmware = <&firmware>;
+};
+
 &vec {
 	power-domains = <&power RPI_POWER_DOMAIN_VEC>;
 	status = "okay";

--- a/drivers/gpu/drm/vc4/vc4_drv.c
+++ b/drivers/gpu/drm/vc4/vc4_drv.c
@@ -305,6 +305,8 @@ static int vc4_drm_bind(struct device *dev)
 	if (ret)
 		return ret;
 
+	drm_fb_helper_remove_conflicting_framebuffers(NULL, "vc4drmfb", false);
+
 	ret = component_bind_all(dev, drm);
 	if (ret)
 		return ret;
@@ -314,8 +316,6 @@ static int vc4_drm_bind(struct device *dev)
 		if (ret)
 			goto unbind_all;
 	}
-
-	drm_fb_helper_remove_conflicting_framebuffers(NULL, "vc4drmfb", false);
 
 	ret = vc4_kms_load(drm);
 	if (ret < 0)

--- a/drivers/gpu/drm/vc4/vc4_drv.c
+++ b/drivers/gpu/drm/vc4/vc4_drv.c
@@ -36,6 +36,8 @@
 #include <drm/drm_fb_helper.h>
 #include <drm/drm_vblank.h>
 
+#include <soc/bcm2835/raspberrypi-firmware.h>
+
 #include "uapi/drm/vc4_drm.h"
 
 #include "vc4_drv.h"
@@ -305,7 +307,24 @@ static int vc4_drm_bind(struct device *dev)
 	if (ret)
 		return ret;
 
+	node = of_parse_phandle(dev->of_node, "raspberrypi,firmware", 0);
+	if (node) {
+		vc4->firmware = rpi_firmware_get(dev->of_node);
+		of_node_put(node);
+
+		if (!vc4->firmware)
+			return -EPROBE_DEFER;
+	}
+
 	drm_fb_helper_remove_conflicting_framebuffers(NULL, "vc4drmfb", false);
+
+	if (vc4->firmware) {
+		ret = rpi_firmware_property(vc4->firmware,
+					    RPI_FIRMWARE_NOTIFY_DISPLAY_DONE,
+					    NULL, 0);
+		if (ret)
+			drm_warn(drm, "Couldn't stop firmware display driver: %d\n", ret);
+	}
 
 	ret = component_bind_all(dev, drm);
 	if (ret)

--- a/include/soc/bcm2835/raspberrypi-firmware.h
+++ b/include/soc/bcm2835/raspberrypi-firmware.h
@@ -99,6 +99,7 @@ enum rpi_firmware_property_tag {
 	RPI_FIRMWARE_NOTIFY_XHCI_RESET =                      0x00030058,
 	RPI_FIRMWARE_GET_REBOOT_FLAGS =                       0x00030064,
 	RPI_FIRMWARE_SET_REBOOT_FLAGS =                       0x00038064,
+	RPI_FIRMWARE_NOTIFY_DISPLAY_DONE =                    0x00030066,
 
 	/* Dispmanx TAGS */
 	RPI_FIRMWARE_FRAMEBUFFER_ALLOCATE =                   0x00040001,


### PR DESCRIPTION
With latest firmware and this call, the firmware is able to free the memory allocation for the simple framebuffer that was used in initial booting. This can be up to 16MB of gpu memory when running with `hdmi_enable_4kp60=1`.

It also allows the firmware to release the boost to the core clock that was necessary when driving that hdmi mode, and may no longer be required if kms choosing a lower resolution hdmi mode.