### PR TITLE
WIP: VC4 DSI fixes

### DIFF
--- a/drivers/gpu/drm/vc4/Kconfig
+++ b/drivers/gpu/drm/vc4/Kconfig
@@ -14,6 +14,7 @@ config DRM_VC4
 	select SND_SOC_GENERIC_DMAENGINE_PCM
 	select SND_SOC_HDMI_CODEC
 	select DRM_MIPI_DSI
+	select PM
 	help
 	  Choose this option if you have a system that has a Broadcom
 	  VC4 GPU, such as the Raspberry Pi or other BCM2708/BCM2835.

--- a/drivers/gpu/drm/vc4/vc4_dsi.c
+++ b/drivers/gpu/drm/vc4/vc4_dsi.c
@@ -839,11 +839,9 @@ static bool vc4_dsi_encoder_mode_fixup(struct drm_encoder *encoder,
 	/* Find what divider gets us a faster clock than the requested
 	 * pixel clock.
 	 */
-	for (divider = 1; divider < 8; divider++) {
-		if (parent_rate / divider < pll_clock) {
-			divider--;
+	for (divider = 1; divider < 7; divider++) {
+		if (parent_rate / (divider + 1) < pll_clock)
 			break;
-		}
 	}
 
 	/* Now that we've picked a PLL divider, calculate back to its


### PR DESCRIPTION
Creating PR for reference.
A couple of fixups, and moving PHY initialisation to pm_runtime.

WIP as apparently drm_encoder.crtc is deprecated and only for non-atomic drivers, so the current implementation of the pm_runtime resume functions are "incorrect".