### PR TITLE
drm/vc4: hdmi: Add missing clk_disable_unprepare on error path

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -940,6 +940,7 @@ static void vc4_hdmi_encoder_pre_crtc_configure(struct drm_encoder *encoder,
 	vc4_hdmi->hsm_req = clk_request_start(vc4_hdmi->hsm_clock, hsm_rate);
 	if (IS_ERR(vc4_hdmi->hsm_req)) {
 		DRM_ERROR("Failed to set HSM clock rate: %ld\n", PTR_ERR(vc4_hdmi->hsm_req));
+		clk_disable_unprepare(vc4_hdmi->pixel_clock);
 		pm_runtime_put(&vc4_hdmi->pdev->dev);
 		return;
 	}


### PR DESCRIPTION
In vc4_hdmi_encoder_pre_crtc_configure, if clk_request_start for the HSM
clock fails, we don't call clk_disable_unprepare on the pixel clock even
though it's enabled by now.

Make sure it's there to avoid leaking that reference.

Fixes: cd4cb49dc5bb ("drm/vc4: hdmi: Adjust HSM clock rate depending on pixel rate")
Signed-off-by: Maxime Ripard <maxime@cerno.tech>