### PR TITLE
char: silabs: si446x (SiLabs Si446x Transceiver) driver added. 

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -174,6 +174,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	seeed-can-fd-hat-v1.dtbo \
 	seeed-can-fd-hat-v2.dtbo \
 	sh1106-spi.dtbo \
+	si446x-spi0.dtbo \
 	smi.dtbo \
 	smi-dev.dtbo \
 	smi-nand.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2720,6 +2720,12 @@ Params: speed                   SPI bus speed (default 4000000)
         reset_pin               GPIO pin for RESET (default 25)
         height                  Display height (32 or 64; default 64)
 
+Name:   si446x-spi0
+Info:   Overlay for Si446x UHF Transceiver via SPI using si446x driver (currently out-of-tree at https://github.com/sunipkmukherjee/silabs.git)
+Loat:   dtoverlay=si446x-spi0,<param>=<val>
+Params: speed                   SPI bus speed (default 4000000)
+        int_pin                 GPIO pin for interrupts (default 17)
+        reset_pin               GPIO pin for RESET (default 27)
 
 Name:   smi
 Info:   Enables the Secondary Memory Interface peripheral. Uses GPIOs 2-25!

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2722,7 +2722,7 @@ Params: speed                   SPI bus speed (default 4000000)
 
 Name:   si446x-spi0
 Info:   Overlay for Si446x UHF Transceiver via SPI using si446x driver (currently out-of-tree at https://github.com/sunipkmukherjee/silabs.git)
-Loat:   dtoverlay=si446x-spi0,<param>=<val>
+Load:   dtoverlay=si446x-spi0,<param>=<val>
 Params: speed                   SPI bus speed (default 4000000)
         int_pin                 GPIO pin for interrupts (default 17)
         reset_pin               GPIO pin for RESET (default 27)

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2720,12 +2720,15 @@ Params: speed                   SPI bus speed (default 4000000)
         reset_pin               GPIO pin for RESET (default 25)
         height                  Display height (32 or 64; default 64)
 
+
 Name:   si446x-spi0
-Info:   Overlay for Si446x UHF Transceiver via SPI using si446x driver (currently out-of-tree at https://github.com/sunipkmukherjee/silabs.git)
+Info:   Overlay for Si446x UHF Transceiver via SPI using si446x driver 
+        The driver is currently out-of-tree at https://github.com/sunipkmukherjee/silabs.git
 Load:   dtoverlay=si446x-spi0,<param>=<val>
 Params: speed                   SPI bus speed (default 4000000)
         int_pin                 GPIO pin for interrupts (default 17)
         reset_pin               GPIO pin for RESET (default 27)
+
 
 Name:   smi
 Info:   Enables the Secondary Memory Interface peripheral. Uses GPIOs 2-25!

--- a/arch/arm/boot/dts/overlays/si446x-spi0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/si446x-spi0-overlay.dts
@@ -1,0 +1,53 @@
+// Overlay for the SiLabs Si446X Controller - SPI0
+// Default Interrupt Pin: 17
+// Default SDN Pin: 27
+/dts-v1/;
+/plugin/;
+
+   / {
+    compatible = "brcm,bcm2708";
+
+    fragment@0 {
+        target = <&spi0>;
+        __overlay__ {
+            // needed to avoid dtc warning
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            status = "okay";
+
+            uhf0: si446x@0{
+                compatible = "silabs,si446x";
+                reg = <0>; // CE0
+                pinctrl-names = "default";
+                pinctrl-0 = <&uhf0_pins>;
+                interrupt-parent = <&gpio>;
+                interrupts = <17 0x2>; // falling edge
+                spi-max-frequency = <4000000>;
+                sdn_pin = <27>;
+                irq_pin = <17>;
+                status = "okay";
+            };
+        };
+    };
+
+    fragment@1 {
+        target = <&gpio>;
+        __overlay__ {
+            uhf0_pins: uhf0_pins {
+                brcm,pins = <17 27>;
+                brcm,function = <0 1>; // in, out
+                brcm,pull = <2 0>; // high, none
+            };
+        };
+    };
+
+    __overrides__ {
+        int_pin = <&uhf0>, "interrupts:0",
+                  <&uhf0>, "irq_pin:0",
+                  <&uhf0_pins>, "brcm,pins:0";
+        reset_pin = <&uhf0>, "sdn_pin:0",
+                    <&uhf0_pins>, "brcm,pins:1";
+        speed   = <&uhf0>, "spi-max-frequency:0";
+    };
+};

--- a/arch/arm/boot/dts/overlays/si446x-spi0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/si446x-spi0-overlay.dts
@@ -5,7 +5,7 @@
 /plugin/;
 
    / {
-    compatible = "brcm,bcm2708";
+    compatible = "brcm,bcm2835";
 
     fragment@0 {
         target = <&spi0>;
@@ -47,7 +47,7 @@
                   <&uhf0>, "irq_pin:0",
                   <&uhf0_pins>, "brcm,pins:0";
         reset_pin = <&uhf0>, "sdn_pin:0",
-                    <&uhf0_pins>, "brcm,pins:1";
+                    <&uhf0_pins>, "brcm,pins:4";
         speed   = <&uhf0>, "spi-max-frequency:0";
     };
 };


### PR DESCRIPTION
Implements basic API calls over ioctl, and receive/transmit using read/write. Reads can be non-blocking with polling support. Writes are blocking. Overlay `si446x-spi0` provided.
The device is initialized by an userspace program that requires inclusion of the radio configuration generated by the WDS tool from SiLabs, and patched following Zak Kemble's guide (https://blog.zakkemble.net/si4463-radio-library-avr-arduino/).