### PR TITLE
vc4/drv: Only notify firmware of display done with kms

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_drv.c
+++ b/drivers/gpu/drm/vc4/vc4_drv.c
@@ -258,6 +258,18 @@ const struct of_device_id vc4_dma_range_matches[] = {
 	{}
 };
 
+/*
+ * we need this helper function for determining presence of fkms
+ * before it's been bound
+ */
+static bool firmware_kms(void)
+{
+	return of_device_is_available(of_find_compatible_node(NULL, NULL,
+	       "raspberrypi,rpi-firmware-kms")) ||
+	       of_device_is_available(of_find_compatible_node(NULL, NULL,
+	       "raspberrypi,rpi-firmware-kms-2711"));
+}
+
 static int vc4_drm_bind(struct device *dev)
 {
 	struct platform_device *pdev = to_platform_device(dev);
@@ -318,7 +330,7 @@ static int vc4_drm_bind(struct device *dev)
 
 	drm_fb_helper_remove_conflicting_framebuffers(NULL, "vc4drmfb", false);
 
-	if (vc4->firmware) {
+	if (vc4->firmware && !firmware_kms()) {
 		ret = rpi_firmware_property(vc4->firmware,
 					    RPI_FIRMWARE_NOTIFY_DISPLAY_DONE,
 					    NULL, 0);


### PR DESCRIPTION
fkms driver still wants firmware display to be active

Signed-off-by: Dom Cobley <popcornmix@gmail.com>