### PR TITLE
media: bcm2835-unicam: Forward input status from subdevice

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -1806,6 +1806,7 @@ static int unicam_enum_input(struct file *file, void *priv,
 {
 	struct unicam_node *node = video_drvdata(file);
 	struct unicam_device *dev = node->dev;
+	int ret;
 
 	if (inp->index != 0)
 		return -EINVAL;
@@ -1822,6 +1823,14 @@ static int unicam_enum_input(struct file *file, void *priv,
 		inp->capabilities = 0;
 		inp->std = 0;
 	}
+
+	if (v4l2_subdev_has_op(dev->sensor, video, g_input_status)) {
+		ret = v4l2_subdev_call(dev->sensor, video, g_input_status,
+				       &inp->status);
+		if (ret < 0)
+			return ret;
+	}
+
 	snprintf(inp->name, sizeof(inp->name), "Camera 0");
 	return 0;
 }


### PR DESCRIPTION
The vidioc_enum_input() v4l2 ioctl is capable of returning
sensor/input status as well. This is used in current
GStreamer HEAD for signal detection [1].

bcm2835-unicam does handle this syscall, but it didn't ask
the subdevice driver about the input status. The input then
appeared as always present.

This commit adds the necessary query. There is a precedent for
this - the R-Car VIN V4L2 driver does a similar call [2].

[1]: https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/blob/ce0be27caf69aa9d96b73bc2b50737451b6f6936/sys/v4l2/gstv4l2src.c#L553
[2]: https://github.com/raspberrypi/linux/blob/7fb9d006d3ff3baf2e205e0c85c4e4fd0a64fcd0/drivers/media/platform/rcar-vin/rcar-v4l2.c#L548

Signed-off-by: Jakub Vaněk <linuxtardis@gmail.com>