### PR TITLE
bcm2711_thermal: Don't clamp temperature at zero

### DIFF
--- a/drivers/thermal/broadcom/bcm2711_thermal.c
+++ b/drivers/thermal/broadcom/bcm2711_thermal.c
@@ -52,7 +52,7 @@ static int bcm2711_get_temp(void *data, int *temp)
 	/* Convert a HW code to a temperature reading (millidegree celsius) */
 	t = slope * val + offset;
 
-	*temp = t < 0 ? 0 : t;
+	*temp = t;
 
 	return 0;
 }


### PR DESCRIPTION
The temperature sensor is valid below zero and the linux framework is happy with it.

See: https://www.raspberrypi.org/forums/viewtopic.php?f=98&t=315382
Signed-off-by: Dom Cobley <popcornmix@gmail.com>