### PR TITLE
dtoverlays: Add overlay for cap1106 capacitive touch sensor

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -30,6 +30,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	audiosense-pi.dtbo \
 	audremap.dtbo \
 	balena-fin.dtbo \
+	cap1106.dtbo \
 	cma.dtbo \
 	dht11.dtbo \
 	dionaudio-loco.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -621,6 +621,10 @@ Name:   bmp085_i2c-sensor
 Info:   This overlay is now deprecated - see i2c-sensor
 Load:   <Deprecated>
 
+Name:   cap1106
+Info:   Enables the ability to use the cap1106 touch sensor as a keyboard 
+Load:   dtoverlay=cap1106
+Params: <None>
 
 Name:   cma
 Info:   Set custom CMA sizes, only use if you know what you are doing, might

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -621,10 +621,12 @@ Name:   bmp085_i2c-sensor
 Info:   This overlay is now deprecated - see i2c-sensor
 Load:   <Deprecated>
 
+
 Name:   cap1106
 Info:   Enables the ability to use the cap1106 touch sensor as a keyboard 
 Load:   dtoverlay=cap1106
 Params: <None>
+
 
 Name:   chipdip-i2s-master-dac
 Info:   Configures Raspberry PI to work as I2S slave with BCLK=64Fs.

--- a/arch/arm/boot/dts/overlays/cap1106-overlay.dts
+++ b/arch/arm/boot/dts/overlays/cap1106-overlay.dts
@@ -1,0 +1,54 @@
+// Overlay for cap1106 from  Microchip Semiconductor
+// add CONFIG_KEYBOARD_CAP11XX=y
+
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "brcm,bcm2835";
+        fragment@0 {
+                target = <&i2c1>;
+                __overlay__{
+                        status = "okay";
+                        cap1106: cap1106@28 {
+                                compatible = "microchip,cap1106";
+                                pinctrl-0 = <&cap1106_pins>;
+                                pinctrl-names = "default";
+                                interrupt-parent = <&gpio>;
+                                interrupts = <4 2>;
+                                reg = <0x28>;
+                                autorepeat;
+                                microchip,sensor-gain = <2>;
+
+                                linux,keycodes = <2>,           /* KEY_1 */
+                                                <3>,            /* KEY_2 */
+                                                <4>,            /* KEY_3 */
+                                                <5>,            /* KEY_4 */
+                                                <6>,            /* KEY_5 */
+                                                <7>;            /* KEY_6 */
+
+                                #address-cells = <1>;
+                                #size-cells = <0>;
+                                status = "okay";
+
+                        };
+                };
+        };
+        fragment@1 {
+                target = <&gpio>;
+                __overlay__ {
+                        cap1106_pins: cap1106_pins {
+                                brcm,pins = <4>;
+                                brcm,function = <0>; /* in */
+                                brcm,pull = <0>; /* none */
+                        };
+                };
+        };
+
+        __overrides__ {
+                int_pin = <&cap1106>, "interrupts:0",
+                          <&cap1106_pins>, "brcm,pins:0";
+        };
+};
+
+


### PR DESCRIPTION
Tested works on rpi3, alert pin being pin 4 