### PR TITLE
KMS and FKMS right/bottom margin fixes

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -458,15 +458,15 @@ static int vc4_fkms_margins_adj(struct drm_plane_state *pstate,
 	plane->dst_x = DIV_ROUND_CLOSEST(plane->dst_x * adjhdisplay,
 					 (int)crtc_state->mode.hdisplay);
 	plane->dst_x += left;
-	if (plane->dst_x > (int)(crtc_state->mode.hdisplay - left))
-		plane->dst_x = crtc_state->mode.hdisplay - left;
+	if (plane->dst_x > (int)(crtc_state->mode.hdisplay - right))
+		plane->dst_x = crtc_state->mode.hdisplay - right;
 
 	adjvdisplay = crtc_state->mode.vdisplay - (top + bottom);
 	plane->dst_y = DIV_ROUND_CLOSEST(plane->dst_y * adjvdisplay,
 					 (int)crtc_state->mode.vdisplay);
 	plane->dst_y += top;
-	if (plane->dst_y > (int)(crtc_state->mode.vdisplay - top))
-		plane->dst_y = crtc_state->mode.vdisplay - top;
+	if (plane->dst_y > (int)(crtc_state->mode.vdisplay - bottom))
+		plane->dst_y = crtc_state->mode.vdisplay - bottom;
 
 	plane->dst_w = DIV_ROUND_CLOSEST(plane->dst_w * adjhdisplay,
 					 crtc_state->mode.hdisplay);

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -310,16 +310,16 @@ static int vc4_plane_margins_adj(struct drm_plane_state *pstate)
 					       adjhdisplay,
 					       crtc_state->mode.hdisplay);
 	vc4_pstate->crtc_x += left;
-	if (vc4_pstate->crtc_x > crtc_state->mode.hdisplay - left)
-		vc4_pstate->crtc_x = crtc_state->mode.hdisplay - left;
+	if (vc4_pstate->crtc_x > crtc_state->mode.hdisplay - right)
+		vc4_pstate->crtc_x = crtc_state->mode.hdisplay - right;
 
 	adjvdisplay = crtc_state->mode.vdisplay - (top + bottom);
 	vc4_pstate->crtc_y = DIV_ROUND_CLOSEST(vc4_pstate->crtc_y *
 					       adjvdisplay,
 					       crtc_state->mode.vdisplay);
 	vc4_pstate->crtc_y += top;
-	if (vc4_pstate->crtc_y > crtc_state->mode.vdisplay - top)
-		vc4_pstate->crtc_y = crtc_state->mode.vdisplay - top;
+	if (vc4_pstate->crtc_y > crtc_state->mode.vdisplay - bottom)
+		vc4_pstate->crtc_y = crtc_state->mode.vdisplay - bottom;
 
 	vc4_pstate->crtc_w = DIV_ROUND_CLOSEST(vc4_pstate->crtc_w *
 					       adjhdisplay,


### PR DESCRIPTION
See #4447 

There's still a further issue where you can create a plane that sits in the overscan area, so that'll be a follow on to clip the display objects to the visible area before scaling for overscan.