### PR TITLE
media: i2c: imx477: Fix framerates for 1332x990 mode

### DIFF
--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -982,7 +982,7 @@ static const struct imx477_mode supported_modes_10bit[] = {
 		/* 120fps. 2x2 binned and cropped */
 		.width = 1332,
 		.height = 990,
-		.line_length_pix = 0x1460,
+		.line_length_pix = 6664,
 		.crop = {
 			/*
 			 * FIXME: the analog crop rectangle is actually


### PR DESCRIPTION
The imx477 driver's line length for this mode had not been updated to
the value supplied to us by the sensor manufacturer. With this
correction the sensor delivers the framerates that are expected.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>