### PR TITLE
Update cx231xx-cards.c

### DIFF
--- a/drivers/media/usb/cx231xx/cx231xx-cards.c
+++ b/drivers/media/usb/cx231xx/cx231xx-cards.c
@@ -996,6 +996,8 @@ const unsigned int cx231xx_bcount = ARRAY_SIZE(cx231xx_boards);
 struct usb_device_id cx231xx_id_table[] = {
 	{USB_DEVICE(0x1D19, 0x6109),
 	.driver_info = CX231XX_BOARD_PV_XCAPTURE_USB},
+	{USB_DEVICE(0x1D19, 0x610A),
+	.driver_info = CX231XX_BOARD_PV_XCAPTURE_USB},
 	{USB_DEVICE(0x0572, 0x5A3C),
 	 .driver_info = CX231XX_BOARD_UNKNOWN},
 	{USB_DEVICE(0x0572, 0x58A2),


### PR DESCRIPTION
Added support for second source devices distributed from MEDION. The original device was also distributed from the discounters Lidl and ALDI. Lidl with the name Silvercrest, ALDI with the name MEDION. MEDION changed the device-ID from 0x6109 to 0x610A.
This patch was released in 2014 on this site https://www.mail-archive.com/linux-media@vger.kernel.org/msg69768.html , but the driver_info was not correct.