### PR TITLE
drm/vc4: Partial revert of 4441

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -660,26 +660,11 @@ static int vc4_crtc_atomic_check(struct drm_crtc *crtc,
 	struct vc4_crtc_state *vc4_state = to_vc4_crtc_state(crtc_state);
 	struct drm_connector *conn;
 	struct drm_connector_state *conn_state;
-	struct drm_encoder *encoder;
 	int ret, i;
 
 	ret = vc4_hvs_atomic_check(crtc, state);
 	if (ret)
 		return ret;
-
-	encoder = vc4_get_crtc_encoder(crtc, crtc_state);
-	if (encoder) {
-		const struct drm_display_mode *mode = &crtc_state->adjusted_mode;
-		struct vc4_encoder *vc4_encoder = to_vc4_encoder(encoder);
-
-		mode = &crtc_state->adjusted_mode;
-		if (vc4_encoder->type == VC4_ENCODER_TYPE_HDMI0) {
-			vc4_state->hvs_load = max(mode->clock * mode->hdisplay / mode->htotal + 1000,
-						  mode->clock * 9 / 10) * 1000;
-		} else {
-			vc4_state->hvs_load = mode->clock * 1000;
-		}
-	}
 
 	for_each_new_connector_in_state(state, conn, conn_state,
 					i) {

--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -766,6 +766,7 @@ vc4_async_page_flip_complete(struct vc4_seqno_cb *cb)
 		container_of(cb, struct vc4_async_flip_state, cb);
 	struct drm_crtc *crtc = flip_state->crtc;
 	struct drm_device *dev = crtc->dev;
+	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct drm_plane *plane = crtc->primary;
 
 	vc4_plane_async_set_fb(plane, flip_state->fb);
@@ -797,6 +798,8 @@ vc4_async_page_flip_complete(struct vc4_seqno_cb *cb)
 	}
 
 	kfree(flip_state);
+
+	up(&vc4->async_modeset);
 }
 
 /* Implements async (non-vblank-synced) page flips.
@@ -811,6 +814,7 @@ static int vc4_async_page_flip(struct drm_crtc *crtc,
 			       uint32_t flags)
 {
 	struct drm_device *dev = crtc->dev;
+	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct drm_plane *plane = crtc->primary;
 	int ret = 0;
 	struct vc4_async_flip_state *flip_state;
@@ -838,6 +842,15 @@ static int vc4_async_page_flip(struct drm_crtc *crtc,
 	flip_state->fb = fb;
 	flip_state->crtc = crtc;
 	flip_state->event = event;
+
+	/* Make sure all other async modesetes have landed. */
+	ret = down_interruptible(&vc4->async_modeset);
+	if (ret) {
+		drm_framebuffer_put(fb);
+		vc4_bo_dec_usecnt(bo);
+		kfree(flip_state);
+		return ret;
+	}
 
 	/* Save the current FB before it's replaced by the new one in
 	 * drm_atomic_set_fb_for_plane(). We'll need the old FB in

--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -660,11 +660,26 @@ static int vc4_crtc_atomic_check(struct drm_crtc *crtc,
 	struct vc4_crtc_state *vc4_state = to_vc4_crtc_state(crtc_state);
 	struct drm_connector *conn;
 	struct drm_connector_state *conn_state;
+	struct drm_encoder *encoder;
 	int ret, i;
 
 	ret = vc4_hvs_atomic_check(crtc, state);
 	if (ret)
 		return ret;
+
+	encoder = vc4_get_crtc_encoder(crtc, crtc_state);
+	if (encoder) {
+		const struct drm_display_mode *mode = &crtc_state->adjusted_mode;
+		struct vc4_encoder *vc4_encoder = to_vc4_encoder(encoder);
+
+		mode = &crtc_state->adjusted_mode;
+		if (vc4_encoder->type == VC4_ENCODER_TYPE_HDMI0) {
+			vc4_state->hvs_load = max(mode->clock * mode->hdisplay / mode->htotal + 1000,
+						  mode->clock * 9 / 10) * 1000;
+		} else {
+			vc4_state->hvs_load = mode->clock * 1000;
+		}
+	}
 
 	for_each_new_connector_in_state(state, conn, conn_state,
 					i) {

--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -324,7 +324,6 @@ struct vc4_hvs {
 	u32 __iomem *dlist;
 
 	struct clk *core_clk;
-	struct clk_request *core_req;
 
 	/* Memory manager for CRTCs to allocate space in the display
 	 * list.  Units are dwords.
@@ -535,8 +534,6 @@ struct vc4_crtc_state {
 		unsigned int top;
 		unsigned int bottom;
 	} margins;
-
-	unsigned long hvs_load;
 
 	/* Transitional state below, only valid during atomic commits */
 	bool update_muxing;

--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -216,6 +216,8 @@ struct vc4_dev {
 		struct work_struct reset_work;
 	} hangcheck;
 
+	struct semaphore async_modeset;
+
 	struct drm_modeset_lock ctm_state_lock;
 	struct drm_private_obj ctm_manager;
 	struct drm_private_obj hvs_channels;

--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -326,6 +326,7 @@ struct vc4_hvs {
 	u32 __iomem *dlist;
 
 	struct clk *core_clk;
+	struct clk_request *core_req;
 
 	/* Memory manager for CRTCs to allocate space in the display
 	 * list.  Units are dwords.
@@ -536,6 +537,8 @@ struct vc4_crtc_state {
 		unsigned int top;
 		unsigned int bottom;
 	} margins;
+
+	unsigned long hvs_load;
 
 	/* Transitional state below, only valid during atomic commits */
 	bool update_muxing;

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -424,6 +424,8 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 		clk_request_done(core_req);
 
 	drm_atomic_state_put(state);
+
+	up(&vc4->async_modeset);
 }
 
 static void commit_work(struct work_struct *work)
@@ -481,16 +483,25 @@ static int vc4_atomic_commit(struct drm_device *dev,
 			     struct drm_atomic_state *state,
 			     bool nonblock)
 {
+	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	int ret;
 
 	if (state->async_update) {
-		ret = drm_atomic_helper_prepare_planes(dev, state);
+		ret = down_interruptible(&vc4->async_modeset);
 		if (ret)
 			return ret;
+
+		ret = drm_atomic_helper_prepare_planes(dev, state);
+		if (ret) {
+			up(&vc4->async_modeset);
+			return ret;
+		}
 
 		drm_atomic_helper_async_commit(dev, state);
 
 		drm_atomic_helper_cleanup_planes(dev, state);
+
+		up(&vc4->async_modeset);
 
 		return 0;
 	}
@@ -508,14 +519,21 @@ static int vc4_atomic_commit(struct drm_device *dev,
 
 	INIT_WORK(&state->commit_work, commit_work);
 
-	ret = drm_atomic_helper_prepare_planes(dev, state);
+	ret = down_interruptible(&vc4->async_modeset);
 	if (ret)
 		return ret;
+
+	ret = drm_atomic_helper_prepare_planes(dev, state);
+	if (ret) {
+		up(&vc4->async_modeset);
+		return ret;
+	}
 
 	if (!nonblock) {
 		ret = drm_atomic_helper_wait_for_fences(dev, state, true);
 		if (ret) {
 			drm_atomic_helper_cleanup_planes(dev, state);
+			up(&vc4->async_modeset);
 			return ret;
 		}
 	}
@@ -994,6 +1012,8 @@ int vc4_kms_load(struct drm_device *dev)
 		 */
 		vc4->load_tracker_enabled = true;
 	}
+
+	sema_init(&vc4->async_modeset, 1);
 
 	/* Set support for vblank irq fast disable, before drm_vblank_init() */
 	dev->vblank_disable_immediate = true;

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -369,17 +369,11 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 	}
 
 	if (vc4->hvs && vc4->hvs->hvs5) {
-		unsigned long core_rate = max_t(unsigned long,
-						500000000,
-						new_hvs_state->core_clock_rate);
-
-		drm_dbg(dev, "Raising the core clock at %lu Hz\n", core_rate);
-
 		/*
 		 * Do a temporary request on the core clock during the
 		 * modeset.
 		 */
-		core_req = clk_request_start(hvs->core_clk, core_rate);
+		core_req = clk_request_start(hvs->core_clk, 500000000);
 
 		/*
 		 * And remove the previous one based on the HVS

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -39,6 +39,7 @@ static struct vc4_ctm_state *to_vc4_ctm_state(struct drm_private_state *priv)
 
 struct vc4_hvs_state {
 	struct drm_private_state base;
+	unsigned int unassigned_channels;
 
 	struct {
 		unsigned in_use: 1;
@@ -795,6 +796,7 @@ vc4_hvs_channels_duplicate_state(struct drm_private_obj *obj)
 
 	__drm_atomic_helper_private_obj_duplicate_state(obj, &state->base);
 
+	state->unassigned_channels = old_state->unassigned_channels;
 
 	for (i = 0; i < HVS_NUM_CHANNELS; i++) {
 		state->fifo_state[i].in_use = old_state->fifo_state[i].in_use;
@@ -845,6 +847,7 @@ static int vc4_hvs_channels_obj_init(struct vc4_dev *vc4)
 	if (!state)
 		return -ENOMEM;
 
+	state->unassigned_channels = GENMASK(HVS_NUM_CHANNELS - 1, 0);
 	drm_atomic_private_obj_init(&vc4->base, &vc4->hvs_channels,
 				    &state->base,
 				    &vc4_hvs_state_funcs);
@@ -889,16 +892,11 @@ static int vc4_pv_muxing_atomic_check(struct drm_device *dev,
 	struct vc4_hvs_state *hvs_new_state;
 	struct drm_crtc_state *old_crtc_state, *new_crtc_state;
 	struct drm_crtc *crtc;
-	unsigned int unassigned_channels = 0;
 	unsigned int i;
 
 	hvs_new_state = vc4_hvs_get_global_state(state);
 	if (!hvs_new_state)
 		return -EINVAL;
-
-	for (i = 0; i < ARRAY_SIZE(hvs_new_state->fifo_state); i++)
-		if (!hvs_new_state->fifo_state[i].in_use)
-			unassigned_channels |= BIT(i);
 
 	for_each_oldnew_crtc_in_state(state, crtc, old_crtc_state, new_crtc_state, i) {
 		struct vc4_crtc_state *old_vc4_crtc_state =
@@ -922,6 +920,8 @@ static int vc4_pv_muxing_atomic_check(struct drm_device *dev,
 		/* If we're disabling our CRTC, we put back our channel */
 		if (!new_crtc_state->enable) {
 			channel = old_vc4_crtc_state->assigned_channel;
+
+			hvs_new_state->unassigned_channels |= BIT(channel);
 			hvs_new_state->fifo_state[channel].in_use = false;
 			new_vc4_crtc_state->assigned_channel = VC4_HVS_CHANNEL_DISABLED;
 			continue;
@@ -951,13 +951,13 @@ static int vc4_pv_muxing_atomic_check(struct drm_device *dev,
 		 * the future, we will need to have something smarter,
 		 * but it works so far.
 		 */
-		matching_channels = unassigned_channels & vc4_crtc->data->hvs_available_channels;
+		matching_channels = hvs_new_state->unassigned_channels & vc4_crtc->data->hvs_available_channels;
 		if (!matching_channels)
 			return -EINVAL;
 
 		channel = ffs(matching_channels) - 1;
 		new_vc4_crtc_state->assigned_channel = channel;
-		unassigned_channels &= ~BIT(channel);
+		hvs_new_state->unassigned_channels &= ~BIT(channel);
 		hvs_new_state->fifo_state[channel].in_use = true;
 	}
 

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -348,11 +348,17 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 	}
 
 	if (vc4->hvs && vc4->hvs->hvs5) {
+		unsigned long core_rate = max_t(unsigned long,
+						500000000,
+						hvs_state->core_clock_rate);
+
+		drm_dbg(dev, "Raising the core clock at %lu Hz\n", core_rate);
+
 		/*
 		 * Do a temporary request on the core clock during the
 		 * modeset.
 		 */
-		core_req = clk_request_start(hvs->core_clk, 500000000);
+		core_req = clk_request_start(hvs->core_clk, core_rate);
 
 		/*
 		 * And remove the previous one based on the HVS

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -39,11 +39,9 @@ static struct vc4_ctm_state *to_vc4_ctm_state(struct drm_private_state *priv)
 
 struct vc4_hvs_state {
 	struct drm_private_state base;
-	unsigned long core_clock_rate;
 
 	struct {
 		unsigned in_use: 1;
-		unsigned long fifo_load;
 		struct drm_crtc_commit *pending_commit;
 	} fifo_state[HVS_NUM_CHANNELS];
 };
@@ -344,19 +342,10 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 	struct vc4_hvs *hvs = vc4->hvs;
 	struct drm_crtc_state *old_crtc_state;
 	struct drm_crtc_state *new_crtc_state;
-	struct vc4_hvs_state *new_hvs_state;
 	struct drm_crtc *crtc;
 	struct vc4_hvs_state *old_hvs_state;
 	struct clk_request *core_req;
 	int i;
-
-	old_hvs_state = vc4_hvs_get_old_global_state(state);
-	if (WARN_ON(!old_hvs_state))
-		return;
-
-	new_hvs_state = vc4_hvs_get_new_global_state(state);
-	if (WARN_ON(!new_hvs_state))
-		return;
 
 	for_each_new_crtc_in_state(state, crtc, new_crtc_state, i) {
 		struct vc4_crtc_state *vc4_crtc_state;
@@ -368,19 +357,12 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 		vc4_hvs_mask_underrun(dev, vc4_crtc_state->assigned_channel);
 	}
 
-	if (vc4->hvs && vc4->hvs->hvs5) {
-		/*
-		 * Do a temporary request on the core clock during the
-		 * modeset.
-		 */
+	if (vc4->hvs && vc4->hvs->hvs5)
 		core_req = clk_request_start(hvs->core_clk, 500000000);
 
-		/*
-		 * And remove the previous one based on the HVS
-		 * requirements if any.
-		 */
-		clk_request_done(hvs->core_req);
-	}
+	old_hvs_state = vc4_hvs_get_old_global_state(state);
+	if (!old_hvs_state)
+		return;
 
 	for_each_old_crtc_in_state(state, crtc, old_crtc_state, i) {
 		struct vc4_crtc_state *vc4_crtc_state =
@@ -431,20 +413,8 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 
 	drm_atomic_helper_cleanup_planes(dev, state);
 
-	if (vc4->hvs && vc4->hvs->hvs5) {
-		drm_dbg(dev, "Running the core clock at %lu Hz\n",
-			new_hvs_state->core_clock_rate);
-
-		/*
-		 * Request a clock rate based on the current HVS
-		 * requirements.
-		 */
-		hvs->core_req = clk_request_start(hvs->core_clk,
-						  new_hvs_state->core_clock_rate);
-
-		/* And drop the temporary request */
+	if (vc4->hvs && vc4->hvs->hvs5)
 		clk_request_done(core_req);
-	}
 }
 
 static int vc4_atomic_commit_setup(struct drm_atomic_state *state)
@@ -713,7 +683,6 @@ vc4_hvs_channels_duplicate_state(struct drm_private_obj *obj)
 
 	for (i = 0; i < HVS_NUM_CHANNELS; i++) {
 		state->fifo_state[i].in_use = old_state->fifo_state[i].in_use;
-		state->fifo_state[i].fifo_load = old_state->fifo_state[i].fifo_load;
 
 		if (!old_state->fifo_state[i].pending_commit)
 			continue;
@@ -721,9 +690,6 @@ vc4_hvs_channels_duplicate_state(struct drm_private_obj *obj)
 		state->fifo_state[i].pending_commit =
 			drm_crtc_commit_get(old_state->fifo_state[i].pending_commit);
 	}
-
-	state->core_clock_rate = old_state->core_clock_rate;
-
 
 	return &state->base;
 }
@@ -884,76 +850,6 @@ static int vc4_pv_muxing_atomic_check(struct drm_device *dev,
 }
 
 static int
-vc4_core_clock_atomic_check(struct drm_atomic_state *state)
-{
-	struct vc4_dev *vc4 = to_vc4_dev(state->dev);
-	struct drm_private_state *priv_state;
-	struct vc4_hvs_state *hvs_new_state;
-	struct vc4_load_tracker_state *load_state;
-	struct drm_crtc_state *old_crtc_state, *new_crtc_state;
-	struct drm_crtc *crtc;
-	unsigned int num_outputs;
-	unsigned long pixel_rate;
-	unsigned long cob_rate;
-	unsigned int i;
-
-	priv_state = drm_atomic_get_private_obj_state(state,
-						      &vc4->load_tracker);
-	if (IS_ERR(priv_state))
-		return PTR_ERR(priv_state);
-
-	load_state = to_vc4_load_tracker_state(priv_state);
-
-	hvs_new_state = vc4_hvs_get_global_state(state);
-	if (!hvs_new_state)
-		return -EINVAL;
-
-	for_each_oldnew_crtc_in_state(state, crtc,
-				      old_crtc_state,
-				      new_crtc_state,
-				      i) {
-		if (old_crtc_state->active) {
-			struct vc4_crtc_state *old_vc4_state =
-				to_vc4_crtc_state(old_crtc_state);
-			unsigned int channel = old_vc4_state->assigned_channel;
-
-			hvs_new_state->fifo_state[channel].fifo_load = 0;
-		}
-
-		if (new_crtc_state->active) {
-			struct vc4_crtc_state *new_vc4_state =
-				to_vc4_crtc_state(new_crtc_state);
-			unsigned int channel = new_vc4_state->assigned_channel;
-
-			hvs_new_state->fifo_state[channel].fifo_load =
-				new_vc4_state->hvs_load;
-		}
-	}
-
-	cob_rate = 0;
-	num_outputs = 0;
-	for (i = 0; i < HVS_NUM_CHANNELS; i++) {
-		if (!hvs_new_state->fifo_state[i].in_use)
-			continue;
-
-		num_outputs++;
-		cob_rate += hvs_new_state->fifo_state[i].fifo_load;
-	}
-
-	pixel_rate = load_state->hvs_load;
-	if (num_outputs > 1) {
-		pixel_rate = (pixel_rate * 40) / 100;
-	} else {
-		pixel_rate = (pixel_rate * 60) / 100;
-	}
-
-	hvs_new_state->core_clock_rate = max(cob_rate, pixel_rate);
-
-	return 0;
-}
-
-
-static int
 vc4_atomic_check(struct drm_device *dev, struct drm_atomic_state *state)
 {
 	int ret;
@@ -970,11 +866,7 @@ vc4_atomic_check(struct drm_device *dev, struct drm_atomic_state *state)
 	if (ret)
 		return ret;
 
-	ret = vc4_load_tracker_atomic_check(state);
-	if (ret)
-		return ret;
-
-	return vc4_core_clock_atomic_check(state);
+	return vc4_load_tracker_atomic_check(state);
 }
 
 static struct drm_mode_config_helper_funcs vc4_mode_config_helpers = {

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -40,11 +40,6 @@ static struct vc4_ctm_state *to_vc4_ctm_state(struct drm_private_state *priv)
 struct vc4_hvs_state {
 	struct drm_private_state base;
 	unsigned int unassigned_channels;
-
-	struct {
-		unsigned in_use: 1;
-		struct drm_crtc_commit *pending_commit;
-	} fifo_state[HVS_NUM_CHANNELS];
 };
 
 static struct vc4_hvs_state *
@@ -191,32 +186,6 @@ vc4_ctm_commit(struct vc4_dev *vc4, struct drm_atomic_state *state)
 }
 
 static struct vc4_hvs_state *
-vc4_hvs_get_new_global_state(struct drm_atomic_state *state)
-{
-	struct vc4_dev *vc4 = to_vc4_dev(state->dev);
-	struct drm_private_state *priv_state;
-
-	priv_state = drm_atomic_get_new_private_obj_state(state, &vc4->hvs_channels);
-	if (IS_ERR(priv_state))
-		return ERR_CAST(priv_state);
-
-	return to_vc4_hvs_state(priv_state);
-}
-
-static struct vc4_hvs_state *
-vc4_hvs_get_old_global_state(struct drm_atomic_state *state)
-{
-	struct vc4_dev *vc4 = to_vc4_dev(state->dev);
-	struct drm_private_state *priv_state;
-
-	priv_state = drm_atomic_get_old_private_obj_state(state, &vc4->hvs_channels);
-	if (IS_ERR(priv_state))
-		return ERR_CAST(priv_state);
-
-	return to_vc4_hvs_state(priv_state);
-}
-
-static struct vc4_hvs_state *
 vc4_hvs_get_global_state(struct drm_atomic_state *state)
 {
 	struct vc4_dev *vc4 = to_vc4_dev(state->dev);
@@ -342,10 +311,8 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 	struct drm_device *dev = state->dev;
 	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct vc4_hvs *hvs = vc4->hvs;
-	struct drm_crtc_state *old_crtc_state;
 	struct drm_crtc_state *new_crtc_state;
 	struct drm_crtc *crtc;
-	struct vc4_hvs_state *old_hvs_state;
 	struct clk_request *core_req;
 	int i;
 
@@ -365,36 +332,6 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 	drm_atomic_helper_wait_for_fences(dev, state, false);
 
 	drm_atomic_helper_wait_for_dependencies(state);
-
-	old_hvs_state = vc4_hvs_get_old_global_state(state);
-	if (!old_hvs_state)
-		return;
-
-	for_each_old_crtc_in_state(state, crtc, old_crtc_state, i) {
-		struct vc4_crtc_state *vc4_crtc_state =
-			to_vc4_crtc_state(old_crtc_state);
-		struct drm_crtc_commit *commit;
-		unsigned int channel = vc4_crtc_state->assigned_channel;
-		unsigned long done;
-
-		if (channel == VC4_HVS_CHANNEL_DISABLED)
-			continue;
-
-		if (!old_hvs_state->fifo_state[channel].in_use)
-			continue;
-
-		commit = old_hvs_state->fifo_state[i].pending_commit;
-		if (!commit)
-			continue;
-
-		done = wait_for_completion_timeout(&commit->hw_done, 10 * HZ);
-		if (!done)
-			drm_err(dev, "Timed out waiting for hw_done\n");
-
-		done = wait_for_completion_timeout(&commit->flip_done, 10 * HZ);
-		if (!done)
-			drm_err(dev, "Timed out waiting for flip_done\n");
-	}
 
 	drm_atomic_helper_commit_modeset_disables(dev, state);
 
@@ -435,36 +372,6 @@ static void commit_work(struct work_struct *work)
 						      struct drm_atomic_state,
 						      commit_work);
 	vc4_atomic_complete_commit(state);
-}
-
-static int vc4_atomic_commit_setup(struct drm_atomic_state *state)
-{
-	struct drm_crtc_state *crtc_state;
-	struct vc4_hvs_state *hvs_state;
-	struct drm_crtc *crtc;
-	unsigned int i;
-
-	hvs_state = vc4_hvs_get_new_global_state(state);
-	if (!hvs_state)
-		return -EINVAL;
-
-	for_each_new_crtc_in_state(state, crtc, crtc_state, i) {
-		struct vc4_crtc_state *vc4_crtc_state =
-			to_vc4_crtc_state(crtc_state);
-		unsigned int channel =
-			vc4_crtc_state->assigned_channel;
-
-		if (channel == VC4_HVS_CHANNEL_DISABLED)
-			continue;
-
-		if (!hvs_state->fifo_state[channel].in_use)
-			continue;
-
-		hvs_state->fifo_state[channel].pending_commit =
-			drm_crtc_commit_get(crtc_state->commit);
-	}
-
-	return 0;
 }
 
 /**
@@ -788,7 +695,6 @@ vc4_hvs_channels_duplicate_state(struct drm_private_obj *obj)
 {
 	struct vc4_hvs_state *old_state = to_vc4_hvs_state(obj->state);
 	struct vc4_hvs_state *state;
-	unsigned int i;
 
 	state = kzalloc(sizeof(*state), GFP_KERNEL);
 	if (!state)
@@ -798,16 +704,6 @@ vc4_hvs_channels_duplicate_state(struct drm_private_obj *obj)
 
 	state->unassigned_channels = old_state->unassigned_channels;
 
-	for (i = 0; i < HVS_NUM_CHANNELS; i++) {
-		state->fifo_state[i].in_use = old_state->fifo_state[i].in_use;
-
-		if (!old_state->fifo_state[i].pending_commit)
-			continue;
-
-		state->fifo_state[i].pending_commit =
-			drm_crtc_commit_get(old_state->fifo_state[i].pending_commit);
-	}
-
 	return &state->base;
 }
 
@@ -815,14 +711,6 @@ static void vc4_hvs_channels_destroy_state(struct drm_private_obj *obj,
 					   struct drm_private_state *state)
 {
 	struct vc4_hvs_state *hvs_state = to_vc4_hvs_state(state);
-	unsigned int i;
-
-	for (i = 0; i < HVS_NUM_CHANNELS; i++) {
-		if (!hvs_state->fifo_state[i].pending_commit)
-			continue;
-
-		drm_crtc_commit_put(hvs_state->fifo_state[i].pending_commit);
-	}
 
 	kfree(hvs_state);
 }
@@ -919,10 +807,7 @@ static int vc4_pv_muxing_atomic_check(struct drm_device *dev,
 
 		/* If we're disabling our CRTC, we put back our channel */
 		if (!new_crtc_state->enable) {
-			channel = old_vc4_crtc_state->assigned_channel;
-
-			hvs_new_state->unassigned_channels |= BIT(channel);
-			hvs_new_state->fifo_state[channel].in_use = false;
+			hvs_new_state->unassigned_channels |= BIT(old_vc4_crtc_state->assigned_channel);
 			new_vc4_crtc_state->assigned_channel = VC4_HVS_CHANNEL_DISABLED;
 			continue;
 		}
@@ -958,7 +843,6 @@ static int vc4_pv_muxing_atomic_check(struct drm_device *dev,
 		channel = ffs(matching_channels) - 1;
 		new_vc4_crtc_state->assigned_channel = channel;
 		hvs_new_state->unassigned_channels &= ~BIT(channel);
-		hvs_new_state->fifo_state[channel].in_use = true;
 	}
 
 	return 0;
@@ -983,10 +867,6 @@ vc4_atomic_check(struct drm_device *dev, struct drm_atomic_state *state)
 
 	return vc4_load_tracker_atomic_check(state);
 }
-
-static struct drm_mode_config_helper_funcs vc4_mode_config_helpers = {
-	.atomic_commit_setup	= vc4_atomic_commit_setup,
-};
 
 static const struct drm_mode_config_funcs vc4_mode_funcs = {
 	.atomic_check = vc4_atomic_check,
@@ -1034,7 +914,6 @@ int vc4_kms_load(struct drm_device *dev)
 	}
 
 	dev->mode_config.funcs = &vc4_mode_funcs;
-	dev->mode_config.helper_private = &vc4_mode_config_helpers;
 	dev->mode_config.preferred_depth = 24;
 	dev->mode_config.async_page_flip = true;
 	dev->mode_config.allow_fb_modifiers = true;

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -335,7 +335,8 @@ static void vc5_hvs_pv_muxing_commit(struct vc4_dev *vc4,
 	}
 }
 
-static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
+static void
+vc4_atomic_complete_commit(struct drm_atomic_state *state)
 {
 	struct drm_device *dev = state->dev;
 	struct vc4_dev *vc4 = to_vc4_dev(dev);
@@ -359,6 +360,10 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 
 	if (vc4->hvs && vc4->hvs->hvs5)
 		core_req = clk_request_start(hvs->core_clk, 500000000);
+
+	drm_atomic_helper_wait_for_fences(dev, state, false);
+
+	drm_atomic_helper_wait_for_dependencies(state);
 
 	old_hvs_state = vc4_hvs_get_old_global_state(state);
 	if (!old_hvs_state)
@@ -413,26 +418,28 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 
 	drm_atomic_helper_cleanup_planes(dev, state);
 
+	drm_atomic_helper_commit_cleanup_done(state);
+
 	if (vc4->hvs && vc4->hvs->hvs5)
 		clk_request_done(core_req);
+
+	drm_atomic_state_put(state);
+}
+
+static void commit_work(struct work_struct *work)
+{
+	struct drm_atomic_state *state = container_of(work,
+						      struct drm_atomic_state,
+						      commit_work);
+	vc4_atomic_complete_commit(state);
 }
 
 static int vc4_atomic_commit_setup(struct drm_atomic_state *state)
 {
-	struct drm_device *dev = state->dev;
-	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct drm_crtc_state *crtc_state;
 	struct vc4_hvs_state *hvs_state;
 	struct drm_crtc *crtc;
 	unsigned int i;
-
-	/* We know for sure we don't want an async update here. Set
-	 * state->legacy_cursor_update to false to prevent
-	 * drm_atomic_helper_setup_commit() from auto-completing
-	 * commit->flip_done.
-	 */
-	if (!vc4->firmware_kms)
-		state->legacy_cursor_update = false;
 
 	hvs_state = vc4_hvs_get_new_global_state(state);
 	if (!hvs_state)
@@ -453,6 +460,95 @@ static int vc4_atomic_commit_setup(struct drm_atomic_state *state)
 		hvs_state->fifo_state[channel].pending_commit =
 			drm_crtc_commit_get(crtc_state->commit);
 	}
+
+	return 0;
+}
+
+/**
+ * vc4_atomic_commit - commit validated state object
+ * @dev: DRM device
+ * @state: the driver state object
+ * @nonblock: nonblocking commit
+ *
+ * This function commits a with drm_atomic_helper_check() pre-validated state
+ * object. This can still fail when e.g. the framebuffer reservation fails. For
+ * now this doesn't implement asynchronous commits.
+ *
+ * RETURNS
+ * Zero for success or -errno.
+ */
+static int vc4_atomic_commit(struct drm_device *dev,
+			     struct drm_atomic_state *state,
+			     bool nonblock)
+{
+	int ret;
+
+	if (state->async_update) {
+		ret = drm_atomic_helper_prepare_planes(dev, state);
+		if (ret)
+			return ret;
+
+		drm_atomic_helper_async_commit(dev, state);
+
+		drm_atomic_helper_cleanup_planes(dev, state);
+
+		return 0;
+	}
+
+	/* We know for sure we don't want an async update here. Set
+	 * state->legacy_cursor_update to false to prevent
+	 * drm_atomic_helper_setup_commit() from auto-completing
+	 * commit->flip_done.
+	 */
+	if (!vc4->firmware_kms)
+		state->legacy_cursor_update = false;
+	ret = drm_atomic_helper_setup_commit(state, nonblock);
+	if (ret)
+		return ret;
+
+	INIT_WORK(&state->commit_work, commit_work);
+
+	ret = drm_atomic_helper_prepare_planes(dev, state);
+	if (ret)
+		return ret;
+
+	if (!nonblock) {
+		ret = drm_atomic_helper_wait_for_fences(dev, state, true);
+		if (ret) {
+			drm_atomic_helper_cleanup_planes(dev, state);
+			return ret;
+		}
+	}
+
+	/*
+	 * This is the point of no return - everything below never fails except
+	 * when the hw goes bonghits. Which means we can commit the new state on
+	 * the software side now.
+	 */
+
+	BUG_ON(drm_atomic_helper_swap_state(state, false) < 0);
+
+	/*
+	 * Everything below can be run asynchronously without the need to grab
+	 * any modeset locks at all under one condition: It must be guaranteed
+	 * that the asynchronous work has either been cancelled (if the driver
+	 * supports it, which at least requires that the framebuffers get
+	 * cleaned up with drm_atomic_helper_cleanup_planes()) or completed
+	 * before the new state gets committed on the software side with
+	 * drm_atomic_helper_swap_state().
+	 *
+	 * This scheme allows new atomic state updates to be prepared and
+	 * checked in parallel to the asynchronous completion of the previous
+	 * update. Which is important since compositors need to figure out the
+	 * composition of the next frame right after having submitted the
+	 * current layout.
+	 */
+
+	drm_atomic_state_get(state);
+	if (nonblock)
+		queue_work(system_unbound_wq, &state->commit_work);
+	else
+		vc4_atomic_complete_commit(state);
 
 	return 0;
 }
@@ -681,6 +777,7 @@ vc4_hvs_channels_duplicate_state(struct drm_private_obj *obj)
 
 	__drm_atomic_helper_private_obj_duplicate_state(obj, &state->base);
 
+
 	for (i = 0; i < HVS_NUM_CHANNELS; i++) {
 		state->fifo_state[i].in_use = old_state->fifo_state[i].in_use;
 
@@ -871,12 +968,11 @@ vc4_atomic_check(struct drm_device *dev, struct drm_atomic_state *state)
 
 static struct drm_mode_config_helper_funcs vc4_mode_config_helpers = {
 	.atomic_commit_setup	= vc4_atomic_commit_setup,
-	.atomic_commit_tail	= vc4_atomic_commit_tail,
 };
 
 static const struct drm_mode_config_funcs vc4_mode_funcs = {
 	.atomic_check = vc4_atomic_check,
-	.atomic_commit = drm_atomic_helper_commit,
+	.atomic_commit = vc4_atomic_commit,
 	.fb_create = vc4_fb_create,
 };
 

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -40,6 +40,9 @@ static struct vc4_ctm_state *to_vc4_ctm_state(struct drm_private_state *priv)
 struct vc4_hvs_state {
 	struct drm_private_state base;
 	unsigned int unassigned_channels;
+	unsigned int num_outputs;
+	unsigned long fifo_load;
+	unsigned long core_clock_rate;
 };
 
 static struct vc4_hvs_state *
@@ -186,6 +189,19 @@ vc4_ctm_commit(struct vc4_dev *vc4, struct drm_atomic_state *state)
 }
 
 static struct vc4_hvs_state *
+vc4_hvs_get_new_global_state(struct drm_atomic_state *state)
+{
+	struct vc4_dev *vc4 = to_vc4_dev(state->dev);
+	struct drm_private_state *priv_state;
+
+	priv_state = drm_atomic_get_new_private_obj_state(state, &vc4->hvs_channels);
+	if (IS_ERR(priv_state))
+		return ERR_CAST(priv_state);
+
+	return to_vc4_hvs_state(priv_state);
+}
+
+static struct vc4_hvs_state *
 vc4_hvs_get_global_state(struct drm_atomic_state *state)
 {
 	struct vc4_dev *vc4 = to_vc4_dev(state->dev);
@@ -312,9 +328,14 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct vc4_hvs *hvs = vc4->hvs;
 	struct drm_crtc_state *new_crtc_state;
+	struct vc4_hvs_state *hvs_state;
 	struct drm_crtc *crtc;
 	struct clk_request *core_req;
 	int i;
+
+	hvs_state = vc4_hvs_get_new_global_state(state);
+	if (WARN_ON(!hvs_state))
+		return;
 
 	for_each_new_crtc_in_state(state, crtc, new_crtc_state, i) {
 		struct vc4_crtc_state *vc4_crtc_state;
@@ -326,8 +347,19 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 		vc4_hvs_mask_underrun(dev, vc4_crtc_state->assigned_channel);
 	}
 
-	if (vc4->hvs && vc4->hvs->hvs5)
+	if (vc4->hvs && vc4->hvs->hvs5) {
+		/*
+		 * Do a temporary request on the core clock during the
+		 * modeset.
+		 */
 		core_req = clk_request_start(hvs->core_clk, 500000000);
+
+		/*
+		 * And remove the previous one based on the HVS
+		 * requirements if any.
+		 */
+		clk_request_done(hvs->core_req);
+	}
 
 	drm_atomic_helper_wait_for_fences(dev, state, false);
 
@@ -358,8 +390,20 @@ vc4_atomic_complete_commit(struct drm_atomic_state *state)
 
 	drm_atomic_helper_commit_cleanup_done(state);
 
-	if (vc4->hvs && vc4->hvs->hvs5)
+	if (vc4->hvs && vc4->hvs->hvs5) {
+		drm_dbg(dev, "Running the core clock at %lu Hz\n",
+			hvs_state->core_clock_rate);
+
+		/*
+		 * Request a clock rate based on the current HVS
+		 * requirements.
+		 */
+		hvs->core_req = clk_request_start(hvs->core_clk,
+						  hvs_state->core_clock_rate);
+
+		/* And drop the temporary request */
 		clk_request_done(core_req);
+	}
 
 	drm_atomic_state_put(state);
 
@@ -703,6 +747,9 @@ vc4_hvs_channels_duplicate_state(struct drm_private_obj *obj)
 	__drm_atomic_helper_private_obj_duplicate_state(obj, &state->base);
 
 	state->unassigned_channels = old_state->unassigned_channels;
+	state->fifo_load = old_state->fifo_load;
+	state->num_outputs = old_state->num_outputs;
+	state->core_clock_rate = old_state->core_clock_rate;
 
 	return &state->base;
 }
@@ -849,6 +896,65 @@ static int vc4_pv_muxing_atomic_check(struct drm_device *dev,
 }
 
 static int
+vc4_core_clock_atomic_check(struct drm_atomic_state *state)
+{
+	struct vc4_dev *vc4 = to_vc4_dev(state->dev);
+	struct drm_private_state *priv_state;
+	struct vc4_hvs_state *hvs_new_state;
+	struct vc4_load_tracker_state *load_state;
+	struct drm_crtc_state *old_crtc_state, *new_crtc_state;
+	struct drm_crtc *crtc;
+	unsigned long pixel_rate;
+	unsigned long cob_rate;
+	unsigned int i;
+
+	priv_state = drm_atomic_get_private_obj_state(state,
+						      &vc4->load_tracker);
+	if (IS_ERR(priv_state))
+		return PTR_ERR(priv_state);
+
+	load_state = to_vc4_load_tracker_state(priv_state);
+
+	hvs_new_state = vc4_hvs_get_global_state(state);
+	if (!hvs_new_state)
+		return -EINVAL;
+
+	for_each_oldnew_crtc_in_state(state, crtc,
+				      old_crtc_state,
+				      new_crtc_state,
+				      i) {
+		if (old_crtc_state->active) {
+			struct vc4_crtc_state *old_vc4_state =
+				to_vc4_crtc_state(old_crtc_state);
+
+			hvs_new_state->num_outputs -= 1;
+			hvs_new_state->fifo_load -= old_vc4_state->hvs_load;
+		}
+
+		if (new_crtc_state->active) {
+			struct vc4_crtc_state *new_vc4_state =
+				to_vc4_crtc_state(new_crtc_state);
+
+			hvs_new_state->num_outputs += 1;
+			hvs_new_state->fifo_load += new_vc4_state->hvs_load;
+		}
+	}
+
+	cob_rate = hvs_new_state->fifo_load;
+	pixel_rate = load_state->hvs_load;
+	if (hvs_new_state->num_outputs > 1) {
+		pixel_rate = (pixel_rate * 40) / 100;
+	} else {
+		pixel_rate = (pixel_rate * 60) / 100;
+	}
+
+	hvs_new_state->core_clock_rate = max(cob_rate, pixel_rate);
+
+	return 0;
+}
+
+
+static int
 vc4_atomic_check(struct drm_device *dev, struct drm_atomic_state *state)
 {
 	int ret;
@@ -865,7 +971,11 @@ vc4_atomic_check(struct drm_device *dev, struct drm_atomic_state *state)
 	if (ret)
 		return ret;
 
-	return vc4_load_tracker_atomic_check(state);
+	ret = vc4_load_tracker_atomic_check(state);
+	if (ret)
+		return ret;
+
+	return vc4_core_clock_atomic_check(state);
 }
 
 static const struct drm_mode_config_funcs vc4_mode_funcs = {


### PR DESCRIPTION
#4441 has caused a number of issues, specifically switching to the upstream version of "Increase the core clock based on HVS load".

I believe this partial revert should fix the following issues:
https://github.com/raspberrypi/linux/issues/4465
https://github.com/raspberrypi/linux/issues/4474
https://github.com/raspberrypi/linux/issues/4475

It would be useful to get this out quickly for the next stable image.
When the upstream patches are fixed we can add them back in.