### PR TITLE
Fixed dead code

### DIFF
--- a/drivers/char/broadcom/vc_mem.c
+++ b/drivers/char/broadcom/vc_mem.c
@@ -333,9 +333,8 @@ vc_mem_init(void)
 	vc_mem_inited = 1;
 	return 0;
 
-	device_destroy(vc_mem_class, vc_mem_devnum);
-
 out_class_destroy:
+	device_destroy(vc_mem_class, vc_mem_devnum);
 	class_destroy(vc_mem_class);
 	vc_mem_class = NULL;
 


### PR DESCRIPTION
'device_destroy(vc_mem_class, vc_mem_devnum)' is never being executed and
needs to be moved insde the 'goto out_class_destroy' block.