### PR TITLE
Adding Ablic S35390A to i2c-rtc-common.dtsi

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1424,6 +1424,8 @@ Params: abx80x                  Select one of the ABx80x family:
 
         sd3078                  Select the ZXW Shenzhen whwave SD3078 device
 
+        s35390a                 Select the ABLIC S35390A device
+
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
 
         i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
@@ -1486,6 +1488,8 @@ Params: abx80x                  Select one of the ABx80x family:
         rv3028                  Select the Micro Crystal RV3028 device
 
         sd3078                  Select the ZXW Shenzhen whwave SD3078 device
+
+        s35390a                 Select the ABLIC S35390A device
 
         addr                    Sets the address for the RTC. Note that the
                                 device must be configured to use the specified

--- a/arch/arm/boot/dts/overlays/i2c-rtc-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-rtc-common.dtsi
@@ -243,6 +243,19 @@
 		};
 	};
 
+	fragment@18 {
+		target = <&i2cbus>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			s35390a: s35390a@30 {
+				compatible = "ablic,s35390a";
+				reg = <0x30>;
+			};
+		};
+	};
+
 	__overrides__ {
 		abx80x = <0>,"+0";
 		ds1307 = <0>,"+1";
@@ -262,6 +275,7 @@
 		sd3078 = <0>,"+14";
 		pcf85063 = <0>,"+15";
 		pcf85063a = <0>,"+16";
+		s35390a = <0>,"+18";
 
 		addr = <&abx80x>, "reg:0",
 		       <&ds1307>, "reg:0",
@@ -272,7 +286,8 @@
 		       <&pcf8523>, "reg:0",
 		       <&pcf8563>, "reg:0",
 		       <&m41t62>, "reg:0",
-		       <&rv1805>, "reg:0";
+		       <&rv1805>, "reg:0",
+		       <&s35390a>, "reg:0";
 		trickle-diode-type = <&abx80x>,"abracon,tc-diode",
 				     <&rv1805>,"abracon,tc-diode";
 		trickle-resistor-ohms = <&ds1339>,"trickle-resistor-ohms:0",


### PR DESCRIPTION
RTC S35390A from ABLIC Inc. added to the i2c-rtc-common.dtsi file. Thre README is modifed accordingly.

If I made something wrong, please be kind as it is my first time contributing to a public repository.