### PR TITLE
dtoverlays: Add orientation (and rotation) parameter to sensor overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1678,6 +1678,8 @@ Info:   Sony IMX219 camera module.
 Load:   dtoverlay=imx219,<param>=<val>
 Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 180)
+        orientation             Sensor orientation (0 = front, 1 = rear,
+                                2 = external, default external)
 
 
 Name:   imx290
@@ -1694,6 +1696,10 @@ Params: 4lane                   Enable 4 CSI2 lanes. This requires a Compute
                                 (the default), whilst those from Innomaker use
                                 74.25MHz.
         mono                    Denote that the module is a mono sensor.
+        orientation             Sensor orientation (0 = front, 1 = rear,
+                                2 = external, default external)
+        rotation                Mounting rotation of the camera sensor (0 or
+                                180, default 0)
 
 
 Name:   imx378
@@ -1703,6 +1709,8 @@ Info:   Sony IMX378 camera module.
 Load:   dtoverlay=imx378,<param>=<val>
 Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 180)
+        orientation             Sensor orientation (0 = front, 1 = rear,
+                                2 = external, default external)
 
 
 Name:   imx477
@@ -1712,6 +1720,8 @@ Info:   Sony IMX477 camera module.
 Load:   dtoverlay=imx477,<param>=<val>
 Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 180)
+        orientation             Sensor orientation (0 = front, 1 = rear,
+                                2 = external, default external)
 
 
 Name:   iqaudio-codec
@@ -2137,22 +2147,30 @@ Info:   Omnivision OV5647 camera module.
 Load:   dtoverlay=ov5647,<param>=<val>
 Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 0)
+        orientation             Sensor orientation (0 = front, 1 = rear,
+                                2 = external, default external)
 
 
 Name:   ov7251
 Info:   Omnivision OV7251 camera module.
         Uses Unicam 1, which is the standard camera connector on most Pi
         variants.
-Load:   dtoverlay=ov7251
-Params: <None>
+Load:   dtoverlay=ov7251,<param>=<val>
+Params: rotation                Mounting rotation of the camera sensor (0 or
+                                180, default 0)
+        orientation             Sensor orientation (0 = front, 1 = rear,
+                                2 = external, default external)
 
 
 Name:   ov9281
 Info:   Omnivision OV9281 camera module.
         Uses Unicam 1, which is the standard camera connector on most Pi
         variants.
-Load:   dtoverlay=ov9281
-Params: <None>
+Load:   dtoverlay=ov9281,<param>=<val>
+Params: rotation                Mounting rotation of the camera sensor (0 or
+                                180, default 0)
+        orientation             Sensor orientation (0 = front, 1 = rear,
+                                2 = external, default external)
 
 
 Name:   papirus

--- a/arch/arm/boot/dts/overlays/imx219-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx219-overlay.dts
@@ -28,6 +28,7 @@
 				VDDL-supply = <&imx219_vddl>;	/* 1.2v */
 
 				rotation = <180>;
+				orientation = <2>;
 
 				port {
 					imx219_0: endpoint {
@@ -109,5 +110,6 @@
 
 	__overrides__ {
 		rotation = <&imx219>,"rotation:0";
+		orientation = <&imx219>,"orientation:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
+++ b/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
@@ -24,6 +24,9 @@
 				clock-names = "xclk";
 				clock-frequency = <37125000>;
 
+				rotation = <0>;
+				orientation = <2>;
+
 				vdda-supply = <&cam1_reg>;	/* 2.8v */
 				vdddo-supply = <&imx290_vdddo>;	/* 1.8v */
 				vddd-supply = <&imx290_vddd>;	/* 1.5v */
@@ -135,5 +138,7 @@
 		4lane = <0>, "-6+7-8+9";
 		clock-frequency = <&imx290_clk>,"clock-frequency:0",
 				  <&imx290>,"clock-frequency:0";
+		rotation = <&imx290>,"rotation:0";
+		orientation = <&imx290>,"orientation:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx477_378-overlay.dtsi
+++ b/arch/arm/boot/dts/overlays/imx477_378-overlay.dtsi
@@ -23,6 +23,7 @@
 				VDDL-supply = <&imx477_vddl>;	/* 1.8v */
 
 				rotation = <180>;
+				orientation = <2>;
 
 				port {
 					imx477_0: endpoint {
@@ -104,5 +105,6 @@
 
 	__overrides__ {
 		rotation = <&imx477>,"rotation:0";
+		orientation = <&imx477>,"orientation:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/ov5647-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov5647-overlay.dts
@@ -22,6 +22,7 @@
 				clocks = <&ov5647_clk>;
 
 				rotation = <0>;
+				orientation = <2>;
 
 				port {
 					ov5647_0: endpoint {
@@ -88,5 +89,6 @@
 
 	__overrides__ {
 		rotation = <&ov5647>,"rotation:0";
+		orientation = <&ov5647>,"orientation:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/ov7251-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov7251-overlay.dts
@@ -28,6 +28,9 @@
 				vdda-supply = <&cam1_reg>;
 				vddd-supply = <&ov7251_dvdd>;
 
+				rotation = <0>;
+				orientation = <2>;
+
 				port {
 					ov7251_0: endpoint {
 						remote-endpoint = <&csi1_ep>;
@@ -101,5 +104,10 @@
 			regulator-min-microvolt = <2800000>;
 			regulator-max-microvolt = <2800000>;
 		};
+	};
+
+	__overrides__ {
+		rotation = <&ov7251>,"rotation:0";
+		orientation = <&ov7251>,"orientation:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/ov9281-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov9281-overlay.dts
@@ -27,6 +27,9 @@
 				dovdd-supply = <&ov9281_dovdd>;
 				dvdd-supply = <&ov9281_dvdd>;
 
+				rotation = <0>;
+				orientation = <2>;
+
 				port {
 					ov9281_0: endpoint {
 						remote-endpoint = <&csi1_ep>;
@@ -103,4 +106,8 @@
 		};
 	};
 
+	__overrides__ {
+		rotation = <&ov9281>,"rotation:0";
+		orientation = <&ov9281>,"orientation:0";
+	};
 };

--- a/drivers/media/i2c/imx290.c
+++ b/drivers/media/i2c/imx290.c
@@ -1242,6 +1242,7 @@ static const struct of_device_id imx290_of_match[] = {
 
 static int imx290_probe(struct i2c_client *client)
 {
+	struct v4l2_fwnode_device_properties props;
 	struct device *dev = &client->dev;
 	struct fwnode_handle *endpoint;
 	/* Only CSI2 is supported for now: */
@@ -1363,7 +1364,7 @@ static int imx290_probe(struct i2c_client *client)
 	 */
 	imx290_entity_init_cfg(&imx290->sd, NULL);
 
-	v4l2_ctrl_handler_init(&imx290->ctrls, 9);
+	v4l2_ctrl_handler_init(&imx290->ctrls, 11);
 
 	v4l2_ctrl_new_std(&imx290->ctrls, &imx290_ctrl_ops,
 			  V4L2_CID_ANALOGUE_GAIN, 0, 100, 1, 0);
@@ -1410,6 +1411,15 @@ static int imx290_probe(struct i2c_client *client)
 				     V4L2_CID_TEST_PATTERN,
 				     ARRAY_SIZE(imx290_test_pattern_menu) - 1,
 				     0, 0, imx290_test_pattern_menu);
+
+	ret = v4l2_fwnode_device_parse(&client->dev, &props);
+	if (ret)
+		goto free_ctrl;
+
+	ret = v4l2_ctrl_new_fwnode_properties(&imx290->ctrls, &imx290_ctrl_ops,
+					      &props);
+	if (ret)
+		goto free_ctrl;
 
 	imx290->sd.ctrl_handler = &imx290->ctrls;
 

--- a/drivers/media/i2c/ov7251.c
+++ b/drivers/media/i2c/ov7251.c
@@ -1253,6 +1253,7 @@ static const struct v4l2_subdev_ops ov7251_subdev_ops = {
 
 static int ov7251_probe(struct i2c_client *client)
 {
+	struct v4l2_fwnode_device_properties props;
 	struct device *dev = &client->dev;
 	struct fwnode_handle *endpoint;
 	struct ov7251 *ov7251;
@@ -1338,7 +1339,7 @@ static int ov7251_probe(struct i2c_client *client)
 
 	mutex_init(&ov7251->lock);
 
-	v4l2_ctrl_handler_init(&ov7251->ctrls, 7);
+	v4l2_ctrl_handler_init(&ov7251->ctrls, 9);
 	ov7251->ctrls.lock = &ov7251->lock;
 
 	v4l2_ctrl_new_std(&ov7251->ctrls, &ov7251_ctrl_ops,
@@ -1373,6 +1374,15 @@ static int ov7251_probe(struct i2c_client *client)
 		ret = ov7251->ctrls.error;
 		goto free_ctrl;
 	}
+
+	ret = v4l2_fwnode_device_parse(&client->dev, &props);
+	if (ret)
+		goto free_ctrl;
+
+	ret = v4l2_ctrl_new_fwnode_properties(&ov7251->ctrls, &ov7251_ctrl_ops,
+					      &props);
+	if (ret)
+		goto free_ctrl;
 
 	v4l2_i2c_subdev_init(&ov7251->sd, client, &ov7251_subdev_ops);
 	ov7251->sd.flags |= V4L2_SUBDEV_FL_HAS_DEVNODE;

--- a/drivers/media/i2c/ov9281.c
+++ b/drivers/media/i2c/ov9281.c
@@ -25,6 +25,7 @@
 #include <media/media-entity.h>
 #include <media/v4l2-async.h>
 #include <media/v4l2-ctrls.h>
+#include <media/v4l2-fwnode.h>
 #include <media/v4l2-subdev.h>
 
 #define OV9281_LINK_FREQ_400MHZ		400000000
@@ -1020,6 +1021,7 @@ static const struct v4l2_ctrl_ops ov9281_ctrl_ops = {
 
 static int ov9281_initialize_controls(struct ov9281 *ov9281)
 {
+	struct v4l2_fwnode_device_properties props;
 	const struct ov9281_mode *mode;
 	struct v4l2_ctrl_handler *handler;
 	struct v4l2_ctrl *ctrl;
@@ -1029,7 +1031,7 @@ static int ov9281_initialize_controls(struct ov9281 *ov9281)
 
 	handler = &ov9281->ctrl_handler;
 	mode = ov9281->cur_mode;
-	ret = v4l2_ctrl_handler_init(handler, 9);
+	ret = v4l2_ctrl_handler_init(handler, 11);
 	if (ret)
 		return ret;
 	handler->lock = &ov9281->mutex;
@@ -1090,6 +1092,15 @@ static int ov9281_initialize_controls(struct ov9281 *ov9281)
 			"Failed to init controls(%d)\n", ret);
 		goto err_free_handler;
 	}
+
+	ret = v4l2_fwnode_device_parse(&ov9281->client->dev, &props);
+	if (ret)
+		goto err_free_handler;
+
+	ret = v4l2_ctrl_new_fwnode_properties(handler, &ov9281_ctrl_ops,
+					      &props);
+	if (ret)
+		goto err_free_handler;
 
 	ov9281->subdev.ctrl_handler = handler;
 


### PR DESCRIPTION
Add the orientation parameter to all the camera sensor overlays to
avoid libcamera complaining, and add the rotation parameter where
it hadn't been added before.

Hopefully this resolves #4500 , but I've not tested it myself yet, nor double checked that all the drivers I've amended actually call v4l2_ctrl_new_fwnode_properties to read them (that's my next job).