### PR TITLE
Revert "overlays: Update display GPIO declarations" for Goodix

### DIFF
--- a/arch/arm/boot/dts/overlays/goodix-overlay.dts
+++ b/arch/arm/boot/dts/overlays/goodix-overlay.dts
@@ -31,7 +31,7 @@
 				interrupt-parent = <&gpio>;
 				interrupts = <4 2>; // high-to-low edge triggered
 				irq-gpios = <&gpio 4 0>; // Pin7 on GPIO header
-				reset-gpios = <&gpio 17 1>; // Pin11 on GPIO header
+				reset-gpios = <&gpio 17 0>; // Pin11 on GPIO header
 			};
 		};
 	};


### PR DESCRIPTION
This reverts commit b7d685c0b1bd1b98af0e9c1f5d43769982bdbfb2 for Goodix

Reverting the change for the Goodix overlay, introduced by that commit, makes the Goodix touch work here again.

The Goodix driver supports the decision to use GPIO_ACTIVE_HIGH for both the irq and reset pins:

From `include/linux/gpio/consumer.h`:
```
struct acpi_gpio_params {
        unsigned int crs_entry_index;
        unsigned int line_index;
        bool active_low;
};
```
From `drivers/input/touchscreen/goodix.c`:
```
static const struct acpi_gpio_params first_gpio = { 0, 0, false };
static const struct acpi_gpio_params second_gpio = { 1, 0, false };
```
