### PR TITLE
V4L2 codec updates for interlaced decode

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1071,7 +1071,7 @@ static void op_buffer_cb(struct vchiq_mmal_instance *instance,
 	struct vb2_v4l2_buffer *vb2;
 
 	v4l2_dbg(2, debug, &ctx->dev->v4l2_dev,
-		 "%s: status:%d, buf:%p, length:%lu, flags %u, pts %lld\n",
+		 "%s: status:%d, buf:%p, length:%lu, flags %04x, pts %lld\n",
 		 __func__, status, mmal_buf, mmal_buf->length,
 		 mmal_buf->mmal_flags, mmal_buf->pts);
 

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1347,7 +1347,7 @@ static int vidioc_g_fmt_vid_cap(struct file *file, void *priv,
 static int vidioc_try_fmt(struct bcm2835_codec_ctx *ctx, struct v4l2_format *f,
 			  struct bcm2835_codec_fmt *fmt)
 {
-	unsigned int sizeimage;
+	unsigned int sizeimage, min_bytesperline;
 
 	/*
 	 * The V4L2 specification requires the driver to correct the format
@@ -1375,8 +1375,12 @@ static int vidioc_try_fmt(struct bcm2835_codec_ctx *ctx, struct v4l2_format *f,
 			f->fmt.pix_mp.height = ALIGN(f->fmt.pix_mp.height, 16);
 	}
 	f->fmt.pix_mp.num_planes = 1;
+	min_bytesperline = get_bytesperline(f->fmt.pix_mp.width, fmt);
+	if (f->fmt.pix_mp.plane_fmt[0].bytesperline < min_bytesperline)
+		f->fmt.pix_mp.plane_fmt[0].bytesperline = min_bytesperline;
 	f->fmt.pix_mp.plane_fmt[0].bytesperline =
-		get_bytesperline(f->fmt.pix_mp.width, fmt);
+		ALIGN(f->fmt.pix_mp.plane_fmt[0].bytesperline, fmt->bytesperline_align);
+
 	sizeimage = get_sizeimage(f->fmt.pix_mp.plane_fmt[0].bytesperline,
 				  f->fmt.pix_mp.width, f->fmt.pix_mp.height,
 				  fmt);

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -619,6 +619,7 @@ struct bcm2835_codec_q_data {
 	unsigned int		crop_height;
 	bool			selection_set;
 	struct v4l2_fract	aspect_ratio;
+	enum v4l2_field		field;
 
 	unsigned int		sizeimage;
 	unsigned int		sequence;
@@ -986,6 +987,10 @@ static void handle_fmt_changed(struct bcm2835_codec_ctx *ctx,
 	struct bcm2835_codec_q_data *q_data;
 	struct mmal_msg_event_format_changed *format =
 		(struct mmal_msg_event_format_changed *)mmal_buf->buffer;
+	struct mmal_parameter_video_interlace_type interlace;
+	int interlace_size = sizeof(interlace);
+	int ret;
+
 	v4l2_dbg(1, debug, &ctx->dev->v4l2_dev, "%s: Format changed: buff size min %u, rec %u, buff num min %u, rec %u\n",
 		 __func__,
 		 format->buffer_size_min,
@@ -1028,6 +1033,30 @@ static void handle_fmt_changed(struct bcm2835_codec_ctx *ctx,
 
 	q_data->aspect_ratio.numerator = format->es.video.par.num;
 	q_data->aspect_ratio.denominator = format->es.video.par.den;
+
+	ret = vchiq_mmal_port_parameter_get(ctx->dev->instance,
+					    &ctx->component->output[0],
+					    MMAL_PARAMETER_VIDEO_INTERLACE_TYPE,
+					    &interlace,
+					    &interlace_size);
+	if (!ret) {
+		switch (interlace.mode) {
+		case MMAL_INTERLACE_PROGRESSIVE:
+		default:
+			q_data->field = V4L2_FIELD_NONE;
+			break;
+		case MMAL_INTERLACE_FIELDS_INTERLEAVED_UPPER_FIRST:
+			q_data->field = V4L2_FIELD_INTERLACED_TB;
+			break;
+		case MMAL_INTERLACE_FIELDS_INTERLEAVED_LOWER_FIRST:
+			q_data->field = V4L2_FIELD_INTERLACED_BT;
+			break;
+		}
+		v4l2_dbg(1, debug, &ctx->dev->v4l2_dev, "%s: interlace mode %u, v4l2 field %u\n",
+			 __func__, interlace.mode, q_data->field);
+	} else {
+		q_data->field = V4L2_FIELD_NONE;
+	}
 
 	queue_res_chg_event(ctx);
 }
@@ -1101,6 +1130,22 @@ static void op_buffer_cb(struct vchiq_mmal_instance *instance,
 	vb2->vb2_buf.timestamp = mmal_buf->pts * 1000;
 
 	vb2_set_plane_payload(&vb2->vb2_buf, 0, mmal_buf->length);
+	switch (mmal_buf->mmal_flags &
+				(MMAL_BUFFER_HEADER_VIDEO_FLAG_INTERLACED |
+				 MMAL_BUFFER_HEADER_VIDEO_FLAG_TOP_FIELD_FIRST)) {
+	case 0:
+	case MMAL_BUFFER_HEADER_VIDEO_FLAG_TOP_FIELD_FIRST: /* Bogus */
+		vb2->field = V4L2_FIELD_NONE;
+		break;
+	case MMAL_BUFFER_HEADER_VIDEO_FLAG_INTERLACED:
+		vb2->field = V4L2_FIELD_INTERLACED_BT;
+		break;
+	case (MMAL_BUFFER_HEADER_VIDEO_FLAG_INTERLACED |
+	      MMAL_BUFFER_HEADER_VIDEO_FLAG_TOP_FIELD_FIRST):
+		vb2->field = V4L2_FIELD_INTERLACED_TB;
+		break;
+	}
+
 	if (mmal_buf->mmal_flags & MMAL_BUFFER_HEADER_FLAG_KEYFRAME)
 		vb2->flags |= V4L2_BUF_FLAG_KEYFRAME;
 
@@ -1272,7 +1317,7 @@ static int vidioc_g_fmt(struct bcm2835_codec_ctx *ctx, struct v4l2_format *f)
 	f->fmt.pix_mp.width			= q_data->crop_width;
 	f->fmt.pix_mp.height			= q_data->height;
 	f->fmt.pix_mp.pixelformat		= q_data->fmt->fourcc;
-	f->fmt.pix_mp.field			= V4L2_FIELD_NONE;
+	f->fmt.pix_mp.field			= q_data->field;
 	f->fmt.pix_mp.colorspace		= ctx->colorspace;
 	f->fmt.pix_mp.plane_fmt[0].sizeimage	= q_data->sizeimage;
 	f->fmt.pix_mp.plane_fmt[0].bytesperline	= q_data->bytesperline;
@@ -1347,7 +1392,33 @@ static int vidioc_try_fmt(struct bcm2835_codec_ctx *ctx, struct v4l2_format *f,
 	memset(f->fmt.pix_mp.plane_fmt[0].reserved, 0,
 	       sizeof(f->fmt.pix_mp.plane_fmt[0].reserved));
 
-	f->fmt.pix_mp.field = V4L2_FIELD_NONE;
+	if (ctx->dev->role == DECODE) {
+		switch (f->fmt.pix_mp.field) {
+		/*
+		 * All of this is pretty much guesswork as we'll set the
+		 * interlace format correctly come format changed, and signal
+		 * it appropriately on each buffer.
+		 */
+		default:
+		case V4L2_FIELD_NONE:
+		case V4L2_FIELD_ANY:
+			f->fmt.pix_mp.field = V4L2_FIELD_NONE;
+			break;
+		case V4L2_FIELD_INTERLACED:
+			f->fmt.pix_mp.field = V4L2_FIELD_INTERLACED;
+			break;
+		case V4L2_FIELD_TOP:
+		case V4L2_FIELD_BOTTOM:
+		case V4L2_FIELD_INTERLACED_TB:
+			f->fmt.pix_mp.field = V4L2_FIELD_INTERLACED_TB;
+			break;
+		case V4L2_FIELD_INTERLACED_BT:
+			f->fmt.pix_mp.field = V4L2_FIELD_INTERLACED_BT;
+			break;
+		}
+	} else {
+		f->fmt.pix_mp.field = V4L2_FIELD_NONE;
+	}
 
 	return 0;
 }
@@ -1429,6 +1500,8 @@ static int vidioc_s_fmt(struct bcm2835_codec_ctx *ctx, struct v4l2_format *f,
 	ctx->xfer_func = f->fmt.pix_mp.xfer_func;
 	ctx->ycbcr_enc = f->fmt.pix_mp.ycbcr_enc;
 	ctx->quant = f->fmt.pix_mp.quantization;
+
+	q_data->field = f->fmt.pix_mp.field;
 
 	/* All parameters should have been set correctly by try_fmt */
 	q_data->bytesperline = f->fmt.pix_mp.plane_fmt[0].bytesperline;
@@ -2429,11 +2502,6 @@ static int bcm2835_codec_buf_prepare(struct vb2_buffer *vb)
 	if (V4L2_TYPE_IS_OUTPUT(vb->vb2_queue->type)) {
 		if (vbuf->field == V4L2_FIELD_ANY)
 			vbuf->field = V4L2_FIELD_NONE;
-		if (vbuf->field != V4L2_FIELD_NONE) {
-			v4l2_err(&ctx->dev->v4l2_dev, "%s field isn't supported\n",
-				 __func__);
-			return -EINVAL;
-		}
 	}
 
 	if (vb2_plane_size(vb, 0) < q_data->sizeimage) {
@@ -2735,6 +2803,7 @@ static int bcm2835_codec_open(struct file *file)
 			      ctx->q_data[V4L2_M2M_SRC].crop_width,
 			      ctx->q_data[V4L2_M2M_SRC].height,
 			      ctx->q_data[V4L2_M2M_SRC].fmt);
+	ctx->q_data[V4L2_M2M_SRC].field = V4L2_FIELD_NONE;
 
 	ctx->q_data[V4L2_M2M_DST].crop_width = DEFAULT_WIDTH;
 	ctx->q_data[V4L2_M2M_DST].crop_height = DEFAULT_HEIGHT;
@@ -2749,6 +2818,7 @@ static int bcm2835_codec_open(struct file *file)
 			      ctx->q_data[V4L2_M2M_DST].fmt);
 	ctx->q_data[V4L2_M2M_DST].aspect_ratio.numerator = 1;
 	ctx->q_data[V4L2_M2M_DST].aspect_ratio.denominator = 1;
+	ctx->q_data[V4L2_M2M_DST].field = V4L2_FIELD_NONE;
 
 	ctx->colorspace = V4L2_COLORSPACE_REC709;
 	ctx->bitrate = 10 * 1000 * 1000;

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -97,8 +97,19 @@ static const char * const components[] = {
 #define MAX_W		1920
 #define MAX_H		1920
 #define BPL_ALIGN	32
-#define DEFAULT_WIDTH	640
-#define DEFAULT_HEIGHT	480
+/*
+ * The decoder spec supports the V4L2_EVENT_SOURCE_CHANGE event, but the docs
+ * seem to want it to always be generated on startup, which prevents the client
+ * from configuring the CAPTURE queue based on any parsing it has already done
+ * which may save time and allow allocation of CAPTURE buffers early. Surely
+ * SOURCE_CHANGE means something has changed, not just "always notify".
+ *
+ * For those clients that don't set the CAPTURE resolution, adopt a default
+ * resolution that is seriously unlikely to be correct, therefore almost
+ * guaranteed to get the SOURCE_CHANGE event.
+ */
+#define DEFAULT_WIDTH	32
+#define DEFAULT_HEIGHT	32
 /*
  * The unanswered question - what is the maximum size of a compressed frame?
  * V4L2 mandates that the encoded frame must fit in a single buffer. Sizing

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1111,7 +1111,7 @@ static void op_buffer_cb(struct vchiq_mmal_instance *instance,
 		v4l2_dbg(2, debug, &ctx->dev->v4l2_dev, "%s: Empty buffer - flags %04x",
 			 __func__, mmal_buf->mmal_flags);
 		if (!(mmal_buf->mmal_flags & MMAL_BUFFER_HEADER_FLAG_EOS)) {
-			vb2_buffer_done(&vb2->vb2_buf, VB2_BUF_STATE_ERROR);
+			vb2_buffer_done(&vb2->vb2_buf, VB2_BUF_STATE_QUEUED);
 			if (!port->enabled)
 				complete(&ctx->frame_cmplt);
 			return;
@@ -2683,7 +2683,7 @@ static void bcm2835_codec_stop_streaming(struct vb2_queue *q)
 		v4l2_dbg(1, debug, &ctx->dev->v4l2_dev, "%s: return buffer %p\n",
 			 __func__, vbuf);
 
-		v4l2_m2m_buf_done(vbuf, VB2_BUF_STATE_ERROR);
+		v4l2_m2m_buf_done(vbuf, VB2_BUF_STATE_QUEUED);
 	}
 
 	/* Disable MMAL port - this will flush buffers back */

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -2222,10 +2222,10 @@ static int vidioc_enum_framesizes(struct file *file, void *fh,
 
 	fsize->stepwise.min_width = MIN_W;
 	fsize->stepwise.max_width = MAX_W;
-	fsize->stepwise.step_width = 1;
+	fsize->stepwise.step_width = 2;
 	fsize->stepwise.min_height = MIN_H;
 	fsize->stepwise.max_height = MAX_H;
-	fsize->stepwise.step_height = 1;
+	fsize->stepwise.step_height = 2;
 
 	return 0;
 }

--- a/drivers/staging/vc04_services/vchiq-mmal/mmal-msg.h
+++ b/drivers/staging/vc04_services/vchiq-mmal/mmal-msg.h
@@ -253,6 +253,25 @@ struct mmal_msg_port_action_reply {
 /* Signals that a buffer failed to be transmitted */
 #define MMAL_BUFFER_HEADER_FLAG_TRANSMISSION_FAILED    BIT(10)
 
+/* Video buffer header flags
+ * videobufferheaderflags
+ * The following flags describe properties of a video buffer header.
+ * As there is no collision with the MMAL_BUFFER_HEADER_FLAGS_ defines, these
+ * flags will also be present in the MMAL_BUFFER_HEADER_T flags field.
+ */
+#define MMAL_BUFFER_HEADER_FLAG_FORMAT_SPECIFIC_START_BIT 16
+#define MMAL_BUFFER_HEADER_FLAG_FORMAT_SPECIFIC_START \
+			(1 << MMAL_BUFFER_HEADER_FLAG_FORMAT_SPECIFIC_START_BIT)
+/* Signals an interlaced video frame */
+#define MMAL_BUFFER_HEADER_VIDEO_FLAG_INTERLACED \
+			(MMAL_BUFFER_HEADER_FLAG_FORMAT_SPECIFIC_START << 0)
+/*
+ * Signals that the top field of the current interlaced frame should be
+ * displayed first
+ */
+#define MMAL_BUFFER_HEADER_VIDEO_FLAG_TOP_FIELD_FIRST \
+			(MMAL_BUFFER_HEADER_FLAG_FORMAT_SPECIFIC_START << 1)
+
 struct mmal_driver_buffer {
 	u32 magic;
 	u32 component_handle;

--- a/drivers/staging/vc04_services/vchiq-mmal/mmal-parameters.h
+++ b/drivers/staging/vc04_services/vchiq-mmal/mmal-parameters.h
@@ -809,6 +809,43 @@ struct mmal_parameter_displayregion {
 	u32 alpha;
 };
 
+enum mmal_interlace_type {
+	/* The data is not interlaced, it is progressive scan */
+	MMAL_INTERLACE_PROGRESSIVE,
+	/*
+	 * The data is interlaced, fields sent separately in temporal order, with
+	 * upper field first
+	 */
+	MMAL_INTERLACE_FIELD_SINGLE_UPPER_FIRST,
+	/*
+	 * The data is interlaced, fields sent separately in temporal order, with
+	 * lower field first
+	 */
+	MMAL_INTERLACE_FIELD_SINGLE_LOWER_FIRST,
+	/*
+	 * The data is interlaced, two fields sent together line interleaved,
+	 * with the upper field temporally earlier
+	 */
+	MMAL_INTERLACE_FIELDS_INTERLEAVED_UPPER_FIRST,
+	/*
+	 * The data is interlaced, two fields sent together line interleaved,
+	 * with the lower field temporally earlier
+	 */
+	MMAL_INTERLACE_FIELDS_INTERLEAVED_LOWER_FIRST,
+	/*
+	 * The stream may contain a mixture of progressive and interlaced
+	 * frames
+	 */
+	MMAL_INTERLACE_MIXED,
+
+	MMAL_INTERLACE_DUMMY = 0x7FFFFFFF
+};
+
+struct mmal_parameter_video_interlace_type {
+	enum mmal_interlace_type mode;	/* The interlace type of the content */
+	u32 bRepeatFirstField;		/* Whether to repeat the first field */
+};
+
 #define MMAL_MAX_IMAGEFX_PARAMETERS 5
 
 struct mmal_parameter_imagefx_parameters {


### PR DESCRIPTION
This puts all the correct signalling in place for interlaced content.

There is still a tweak needed so that the decoder stops on any change of colourspace or interlacing as required by the V4L2 spec, but FFmpeg doesn't appear to follow the spec in ALWAYS stopping and restarting the output (V4L2 CAPTURE) queue on a source change event, so it would most likely stall.

GStreamer 1.14.4 likewise seems to have an issue if you tell it that the output stream should be interlaced in that it tries to propagate it further up the pipeline, and h264parse seems to object. Telling it that it's progressive works fine. I'll try to sort a 1.19 build at some point, or Bullseye using 1.18, and see how that fairs.

@popcornmix It'd be interesting to know what Kodi makes of this change.

Chromium 88 seems to be happy with it (using BBC-News2017 clip from TestMedia), although it's a touch glitchy (1080i50). Nothing is actually deinterlacing the content of course.