### PR TITLE
Add midi-uart{2345}-overlay.dts

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -123,6 +123,10 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	merus-amp.dtbo \
 	midi-uart0.dtbo \
 	midi-uart1.dtbo \
+	midi-uart2.dtbo \
+	midi-uart3.dtbo \
+	midi-uart4.dtbo \
+	midi-uart5.dtbo \
 	minipitft13.dtbo \
 	miniuart-bt.dtbo \
 	mmc.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2087,6 +2087,29 @@ Info:   Configures UART1 (ttyS0) so that a requested 38.4kbaud actually gets
 Load:   dtoverlay=midi-uart1
 Params: <None>
 
+Name:   midi-uart2
+Info:   Configures UART2 (ttyAMA1) so that a requested 38.4kbaud actually gets
+        31.25kbaud, the frequency required for MIDI
+Load:   dtoverlay=midi-uart2
+Params: <None>
+
+Name:   midi-uart3
+Info:   Configures UART3 (ttyAMA2) so that a requested 38.4kbaud actually gets
+        31.25kbaud, the frequency required for MIDI
+Load:   dtoverlay=midi-uart3
+Params: <None>
+
+Name:   midi-uart4
+Info:   Configures UART4 (ttyAMA3) so that a requested 38.4kbaud actually gets
+        31.25kbaud, the frequency required for MIDI
+Load:   dtoverlay=midi-uart4
+Params: <None>
+
+Name:   midi-uart5
+Info:   Configures UART5 (ttyAMA4) so that a requested 38.4kbaud actually gets
+        31.25kbaud, the frequency required for MIDI
+Load:   dtoverlay=midi-uart5
+Params: <None>
 
 Name:   minipitft13
 Info:   Overlay for AdaFruit Mini Pi 1.3" TFT via SPI using fbtft driver.

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2087,11 +2087,13 @@ Info:   Configures UART1 (ttyS0) so that a requested 38.4kbaud actually gets
 Load:   dtoverlay=midi-uart1
 Params: <None>
 
+
 Name:   midi-uart2
 Info:   Configures UART2 (ttyAMA1) so that a requested 38.4kbaud actually gets
         31.25kbaud, the frequency required for MIDI
 Load:   dtoverlay=midi-uart2
 Params: <None>
+
 
 Name:   midi-uart3
 Info:   Configures UART3 (ttyAMA2) so that a requested 38.4kbaud actually gets
@@ -2099,17 +2101,20 @@ Info:   Configures UART3 (ttyAMA2) so that a requested 38.4kbaud actually gets
 Load:   dtoverlay=midi-uart3
 Params: <None>
 
+
 Name:   midi-uart4
 Info:   Configures UART4 (ttyAMA3) so that a requested 38.4kbaud actually gets
         31.25kbaud, the frequency required for MIDI
 Load:   dtoverlay=midi-uart4
 Params: <None>
 
+
 Name:   midi-uart5
 Info:   Configures UART5 (ttyAMA4) so that a requested 38.4kbaud actually gets
         31.25kbaud, the frequency required for MIDI
 Load:   dtoverlay=midi-uart5
 Params: <None>
+
 
 Name:   minipitft13
 Info:   Overlay for AdaFruit Mini Pi 1.3" TFT via SPI using fbtft driver.

--- a/arch/arm/boot/dts/overlays/midi-uart2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart2-overlay.dts
@@ -1,0 +1,37 @@
+/dts-v1/;
+/plugin/;
+
+//#include <dt-bindings/clock/bcm2835.h>
+
+/*
+ * Fake a higher clock rate to get a larger divisor, and thereby a lower
+ * baudrate. The real clock is 48MHz, which we scale so that requesting
+ * 38.4kHz results in an actual 31.25kHz.
+ *
+ *   48000000*38400/31250 = 58982400
+ */
+
+/{
+        compatible = "brcm,bcm2835";
+
+        fragment@0 {
+                target-path = "/";
+                __overlay__ {
+                        midi_clk: midi_clk2 {
+                                compatible = "fixed-clock";
+                                #clock-cells = <0>;
+                                clock-output-names = "uart2_pclk";
+                                clock-frequency = <58982400>;
+                        };
+                };
+        };
+
+        fragment@1 {
+                target = <&uart2>;
+                __overlay__ {
+                        clocks = <&midi_clk>,
+                                 <&clocks 20>;
+                };
+        };
+};
+

--- a/arch/arm/boot/dts/overlays/midi-uart2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart2-overlay.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 /plugin/;
 
-//#include <dt-bindings/clock/bcm2835.h>
+#include <dt-bindings/clock/bcm2835.h>
 
 /*
  * Fake a higher clock rate to get a larger divisor, and thereby a lower
@@ -30,7 +30,7 @@
                 target = <&uart2>;
                 __overlay__ {
                         clocks = <&midi_clk>,
-                                 <&clocks 20>;
+                                 <&clocks BCM2835_CLOCK_VPU>;
                 };
         };
 };

--- a/arch/arm/boot/dts/overlays/midi-uart3-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart3-overlay.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 /plugin/;
 
-//#include <dt-bindings/clock/bcm2835.h>
+#include <dt-bindings/clock/bcm2835.h>
 
 /*
  * Fake a higher clock rate to get a larger divisor, and thereby a lower
@@ -30,7 +30,7 @@
                 target = <&uart3>;
                 __overlay__ {
                         clocks = <&midi_clk>,
-                                 <&clocks 20>;
+                                 <&clocks BCM2835_CLOCK_VPU>;
                 };
         };
 };

--- a/arch/arm/boot/dts/overlays/midi-uart3-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart3-overlay.dts
@@ -1,0 +1,38 @@
+/dts-v1/;
+/plugin/;
+
+//#include <dt-bindings/clock/bcm2835.h>
+
+/*
+ * Fake a higher clock rate to get a larger divisor, and thereby a lower
+ * baudrate. The real clock is 48MHz, which we scale so that requesting
+ * 38.4kHz results in an actual 31.25kHz.
+ *
+ *   48000000*38400/31250 = 58982400
+ */
+
+/{
+        compatible = "brcm,bcm2835";
+
+        fragment@0 {
+                target-path = "/";
+                __overlay__ {
+                        midi_clk: midi_clk3 {
+                                compatible = "fixed-clock";
+                                #clock-cells = <0>;
+                                clock-output-names = "uart3_pclk";
+                                clock-frequency = <58982400>;
+                        };
+                };
+        };
+
+        fragment@1 {
+                target = <&uart3>;
+                __overlay__ {
+                        clocks = <&midi_clk>,
+                                 <&clocks 20>;
+                };
+        };
+};
+
+

--- a/arch/arm/boot/dts/overlays/midi-uart4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart4-overlay.dts
@@ -1,0 +1,38 @@
+/dts-v1/;
+/plugin/;
+
+//#include <dt-bindings/clock/bcm2835.h>
+
+/*
+ * Fake a higher clock rate to get a larger divisor, and thereby a lower
+ * baudrate. The real clock is 48MHz, which we scale so that requesting
+ * 38.4kHz results in an actual 31.25kHz.
+ *
+ *   48000000*38400/31250 = 58982400
+ */
+
+/{
+        compatible = "brcm,bcm2835";
+
+        fragment@0 {
+                target-path = "/";
+                __overlay__ {
+                        midi_clk: midi_clk4 {
+                                compatible = "fixed-clock";
+                                #clock-cells = <0>;
+                                clock-output-names = "uart4_pclk";
+                                clock-frequency = <58982400>;
+                        };
+                };
+        };
+
+        fragment@1 {
+                target = <&uart4>;
+                __overlay__ {
+                        clocks = <&midi_clk>,
+                                 <&clocks 20>;
+                };
+        };
+};
+
+

--- a/arch/arm/boot/dts/overlays/midi-uart4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart4-overlay.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 /plugin/;
 
-//#include <dt-bindings/clock/bcm2835.h>
+#include <dt-bindings/clock/bcm2835.h>
 
 /*
  * Fake a higher clock rate to get a larger divisor, and thereby a lower
@@ -30,7 +30,7 @@
                 target = <&uart4>;
                 __overlay__ {
                         clocks = <&midi_clk>,
-                                 <&clocks 20>;
+                                 <&clocks BCM2835_CLOCK_VPU>;
                 };
         };
 };

--- a/arch/arm/boot/dts/overlays/midi-uart5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart5-overlay.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 /plugin/;
 
-//#include <dt-bindings/clock/bcm2835.h>
+#include <dt-bindings/clock/bcm2835.h>
 
 /*
  * Fake a higher clock rate to get a larger divisor, and thereby a lower
@@ -30,7 +30,7 @@
                 target = <&uart5>;
                 __overlay__ {
                         clocks = <&midi_clk>,
-                                 <&clocks 20>;
+                                 <&clocks BCM2835_CLOCK_VPU>;
                 };
         };
 };

--- a/arch/arm/boot/dts/overlays/midi-uart5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart5-overlay.dts
@@ -1,0 +1,38 @@
+/dts-v1/;
+/plugin/;
+
+//#include <dt-bindings/clock/bcm2835.h>
+
+/*
+ * Fake a higher clock rate to get a larger divisor, and thereby a lower
+ * baudrate. The real clock is 48MHz, which we scale so that requesting
+ * 38.4kHz results in an actual 31.25kHz.
+ *
+ *   48000000*38400/31250 = 58982400
+ */
+
+/{
+        compatible = "brcm,bcm2835";
+
+        fragment@0 {
+                target-path = "/";
+                __overlay__ {
+                        midi_clk: midi_clk5 {
+                                compatible = "fixed-clock";
+                                #clock-cells = <0>;
+                                clock-output-names = "uart5_pclk";
+                                clock-frequency = <58982400>;
+                        };
+                };
+        };
+
+        fragment@1 {
+                target = <&uart5>;
+                __overlay__ {
+                        clocks = <&midi_clk>,
+                                 <&clocks 20>;
+                };
+        };
+};
+
+


### PR DESCRIPTION
As per this thread: https://www.raspberrypi.org/forums/viewtopic.php?f=107&t=317249
Overlays for enabling MIDI baud rate for UARTs 2-5 (based on midi-uart0-overlay.dts).
