### PR TITLE
overlays: qca7000: Fix URL & README

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2504,7 +2504,7 @@ Params: gpio_pin                Output GPIO (default 18)
 
 
 Name:   qca7000
-Info:   I2SE's Evaluation Board for PLC Stamp micro
+Info:   in-tech's Evaluation Board for PLC Stamp micro
 Load:   dtoverlay=qca7000,<param>=<val>
 Params: int_pin                 GPIO pin for interrupt signal (default 23)
 

--- a/arch/arm/boot/dts/overlays/qca7000-overlay.dts
+++ b/arch/arm/boot/dts/overlays/qca7000-overlay.dts
@@ -1,5 +1,5 @@
-// Overlay for the Qualcomm Atheros QCA7000 on I2SE's PLC Stamp micro EVK
-// Visit: https://www.i2se.com/product/plc-stamp-micro-evk for details
+// Overlay for the Qualcomm Atheros QCA7000 on PLC Stamp micro EVK
+// Visit: https://in-tech-smartcharging.com/products/evaluation-tools/plc-stamp-micro-2-evaluation-board for details
 
 /dts-v1/;
 /plugin/;


### PR DESCRIPTION
I2SE has been acquired by in-tech smart charging. Now the product URL in the overlay is broken. So fix the URL & README accordingly.


