### PR TITLE
overlays: Add overlay for QCA7000 via UART0

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -157,6 +157,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	pwm-2chan.dtbo \
 	pwm-ir-tx.dtbo \
 	qca7000.dtbo \
+	qca7000-uart0.dtbo \
 	rotary-encoder.dtbo \
 	rpi-backlight.dtbo \
 	rpi-cirrus-wm5102.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2505,10 +2505,21 @@ Params: gpio_pin                Output GPIO (default 18)
 
 Name:   qca7000
 Info:   in-tech's Evaluation Board for PLC Stamp micro
+        This uses spi0 and a separate GPIO interrupt to connect the QCA7000.
 Load:   dtoverlay=qca7000,<param>=<val>
 Params: int_pin                 GPIO pin for interrupt signal (default 23)
 
         speed                   SPI bus speed (default 12 MHz)
+
+
+Name:   qca7000-uart0
+Info:   in-tech's Evaluation Board for PLC Stamp micro (UART)
+        This uses uart0/ttyAMA0 over GPIOs 14 & 15 to connect the QCA7000.
+        But it requires disabling of onboard Bluetooth on
+        Pi 3B, 3B+, 3A+, 4B and Zero W.
+Load:   dtoverlay=qca7000-uart0,<param>=<val>
+Params: baudrate                Set the baudrate for the UART (default
+                                "115200")
 
 
 Name:   rotary-encoder

--- a/arch/arm/boot/dts/overlays/qca7000-uart0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/qca7000-uart0-overlay.dts
@@ -1,0 +1,46 @@
+// Overlay for the Qualcomm Atheros QCA7000 on PLC Stamp micro EVK
+// Visit: https://in-tech-smartcharging.com/products/evaluation-tools/plc-stamp-micro-2-evaluation-board for details
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&uart0>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&uart0_pins>;
+			status = "okay";
+
+			eth2: qca7000 {
+				compatible = "qca,qca7000";
+				current-speed = <115200>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			uart0_pins: uart0_pins {
+				brcm,pins = <14 15>;
+				brcm,function = <4>; /* alt0 */
+				brcm,pull = <0 2>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path = "/aliases";
+		__overlay__ {
+			serial0 = "/soc/serial@7e201000";
+			serial1 = "/soc/serial@7e215040";
+		};
+	};
+
+	__overrides__ {
+		baudrate = <&eth2>, "current-speed:0";
+	};
+};


### PR DESCRIPTION
This adds an overlay to connect the QCA7000 in UART mode via UART0.
The qcauart driver uses the serial device bus instead of deprecated
line disciplines.

Signed-off-by: Stefan Wahren <stefan.wahren@in-tech.com>