### PR TITLE
drm/amdgpu: Add missing conversion of is_hdr_metadata_different for amdgpu

### DIFF
--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
@@ -7754,7 +7754,7 @@ static void amdgpu_dm_atomic_commit_tail(struct drm_atomic_state *state)
 			      dm_old_crtc_state->abm_level;
 
 		hdr_changed =
-			is_hdr_metadata_different(old_con_state, new_con_state);
+			!drm_connector_atomic_hdr_metadata_equal(old_con_state, new_con_state);
 
 		if (!scaling_changed && !abm_changed && !hdr_changed)
 			continue;


### PR DESCRIPTION
(For 5.10.y branch, as that's the one I'm currently testing.)

See: #4534

I just did this so I could finish cross-compiling for 5.10.y, let me know if you'd like something changed or want me to submit differently against all the pre-5.14 branches. (I haven't tested on 5.11/5.12/5.13).