### PR TITLE
overlays: add support for the MLX90640 thermal camera

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -121,6 +121,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	midi-uart1.dtbo \
 	minipitft13.dtbo \
 	miniuart-bt.dtbo \
+	mlx90640.dtbo \
 	mmc.dtbo \
 	mpu6050.dtbo \
 	mz61581.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2061,6 +2061,12 @@ Params: krnbt                   Set to "on" to enable autoprobing of Bluetooth
                                 driver without need of hciattach/btattach
 
 
+Name:   mlx90640
+Info:   Overlay for i2c connected mlx90640 thermal camera
+Load:   dtoverlay=mlx90640
+Params: <None>
+
+
 Name:   mmc
 Info:   Selects the bcm2835-mmc SD/MMC driver, optionally with overclock
 Load:   dtoverlay=mmc,<param>=<val>

--- a/arch/arm/boot/dts/overlays/mlx90640-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mlx90640-overlay.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+			clock-frequency = <400000>;
+
+			mlx90640: mlx90640@33 {
+				compatible = "melexis,mlx90640";
+				reg = <0x33>;
+				status = "okay";
+			};
+		};
+	};
+};


### PR DESCRIPTION
This allows using the video-i2c camera driver with MLX90640 thermal infrared sensors, connected to Raspberry Pi.