### PR TITLE
Update r8152.c

### DIFF
--- a/drivers/net/usb/r8152.c
+++ b/drivers/net/usb/r8152.c
@@ -1761,6 +1761,10 @@ static void read_bulk_callback(struct urb *urb)
 		return;
 	case -ENOENT:
 		return;	/* the urb is in unlink state */
+	case -EPROTO:
+		if (net_ratelimit())
+			netdev_warn(netdev, "Rx status %d\n", status);
+		return;
 	case -ETIME:
 		if (net_ratelimit())
 			netdev_warn(netdev, "maybe reset is needed?\n");


### PR DESCRIPTION
When Hot unplug the USB rtl8152 on raspberry pi (whit open connections and traffic), Need handle the error EPROTO on the read_bulk_callback.