### PR TITLE
net: phy: lan87xx: Allow more time for link detect

### DIFF
--- a/drivers/net/phy/smsc.c
+++ b/drivers/net/phy/smsc.c
@@ -195,12 +195,12 @@ static int lan87xx_read_status(struct phy_device *phydev)
 		if (rc < 0)
 			return rc;
 
-		/* Wait max 640 ms to detect energy and the timeout is not
+		/* Wait max 1500 ms to detect energy and the timeout is not
 		 * an actual error.
 		 */
 		read_poll_timeout(phy_read, rc,
 				  rc & MII_LAN83C185_ENERGYON || rc < 0,
-				  10000, 640000, true, phydev,
+				  10000, 1500000, true, phydev,
 				  MII_LAN83C185_CTRL_STATUS);
 		if (rc < 0)
 			return rc;


### PR DESCRIPTION
With EDPWRDOWN set in idle, it must be cleared before checking for
ENERGYON going high, indicating that a link is being established.
The existing code allows 640ms for ENERGYON to go high, but on
Raspberry Pis that appears not to be enough, causing link detection
to fail.

Increase the polling timeout to 1500ms - with a polling interval of
10ms it shouldn't cause unnecessary delays.

See: https://github.com/raspberrypi/linux/issues/4393

Signed-off-by: Phil Elwell <phil@raspberrypi.com>