### PR TITLE
Dev/5.10/fix streamoff 1

### DIFF
--- a/drivers/staging/media/rpivid/rpivid.h
+++ b/drivers/staging/media/rpivid/rpivid.h
@@ -81,12 +81,6 @@ typedef void (*rpivid_irq_callback)(struct rpivid_dev *dev, void *ctx);
 struct rpivid_q_aux;
 #define RPIVID_AUX_ENT_COUNT VB2_MAX_FRAME
 
-
-#define RPIVID_CTX_STATE_STOPPED	0	/* stream_off */
-#define RPIVID_CTX_STATE_STREAM_ON	1	/* decoding */
-#define RPIVID_CTX_STATE_STREAM_STOP	2	/* in stream_off */
-#define RPIVID_CTX_STATE_STREAM_ERR	3	/* stream_on but broken */
-
 struct rpivid_ctx {
 	struct v4l2_fh			fh;
 	struct rpivid_dev		*dev;
@@ -95,7 +89,6 @@ struct rpivid_ctx {
 	struct v4l2_pix_format_mplane	dst_fmt;
 	int dst_fmt_set;
 
-	atomic_t 			stream_state;
 	struct clk_request		*clk_req;
 	int 				src_stream_on;
 	int 				dst_stream_on;

--- a/drivers/staging/media/rpivid/rpivid_h265.c
+++ b/drivers/staging/media/rpivid/rpivid_h265.c
@@ -2365,12 +2365,50 @@ static void dec_state_delete(struct rpivid_ctx *const ctx)
 	kfree(s);
 }
 
-static void rpivid_h265_stop(struct rpivid_ctx *ctx)
-{
-	struct rpivid_dev *const dev = ctx->dev;
-	unsigned int i;
+struct irq_sync {
+	atomic_t done;
+	wait_queue_head_t wq;
+	struct rpivid_hw_irq_ent irq_ent;
+};
 
-	v4l2_info(&dev->v4l2_dev, "%s\n", __func__);
+static void phase2_sync_claimed(struct rpivid_dev *const dev, void *v)
+{
+	struct irq_sync *const sync = v;
+
+	atomic_set(&sync->done, 1);
+	wake_up(&sync->wq);
+}
+
+static void phase1_sync_claimed(struct rpivid_dev *const dev, void *v)
+{
+	struct irq_sync *const sync = v;
+
+	rpivid_hw_irq_active1_enable_claim(dev, 1);
+	rpivid_hw_irq_active2_claim(dev, &sync->irq_ent, phase2_sync_claimed, sync);
+}
+
+/* Sync with IRQ operations
+ *
+ * Claims phase1 and phase2 in turn and waits for the phase2 claim so any
+ * pending IRQ ops will have completed by the time this returns
+ *
+ * phase1 has counted enables so must reenable once claimed
+ * phase2 has unlimited enables
+ */
+static void irq_sync(struct rpivid_dev *const dev)
+{
+	struct irq_sync sync;
+
+	atomic_set(&sync.done, 0);
+	init_waitqueue_head(&sync.wq);
+
+	rpivid_hw_irq_active1_claim(dev, &sync.irq_ent, phase1_sync_claimed, &sync);
+	wait_event(sync.wq, atomic_read(&sync.done));
+}
+
+static void h265_ctx_uninit(struct rpivid_dev *const dev, struct rpivid_ctx *ctx)
+{
+	unsigned int i;
 
 	dec_env_uninit(ctx);
 	dec_state_delete(ctx);
@@ -2385,6 +2423,16 @@ static void rpivid_h265_stop(struct rpivid_ctx *ctx)
 		gptr_free(dev, ctx->pu_bufs + i);
 	for (i = 0; i != ARRAY_SIZE(ctx->coeff_bufs); ++i)
 		gptr_free(dev, ctx->coeff_bufs + i);
+}
+
+static void rpivid_h265_stop(struct rpivid_ctx *ctx)
+{
+	struct rpivid_dev *const dev = ctx->dev;
+
+	v4l2_info(&dev->v4l2_dev, "%s\n", __func__);
+
+	irq_sync(dev);
+	h265_ctx_uninit(dev, ctx);
 }
 
 static int rpivid_h265_start(struct rpivid_ctx *ctx)
@@ -2448,7 +2496,7 @@ static int rpivid_h265_start(struct rpivid_ctx *ctx)
 	return 0;
 
 fail:
-	rpivid_h265_stop(ctx);
+	h265_ctx_uninit(dev, ctx);
 	return -ENOMEM;
 }
 


### PR DESCRIPTION
Fixes a CMA leak, also worked around by reordering streamoffs in FFmpeg