### PR TITLE
overlays: mcp2515 overlay that works like the mcp251xfd overlay.

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -113,6 +113,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	mbed-dac.dtbo \
 	mcp23017.dtbo \
 	mcp23s17.dtbo \
+	mcp2515.dtbo \
 	mcp2515-can0.dtbo \
 	mcp2515-can1.dtbo \
 	mcp251xfd.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1977,6 +1977,21 @@ Params: s08-spi<n>-<m>-present  4-bit integer, bitmap indicating MCP23S08
                                 or INTB output of MCP23S17 is connected.
 
 
+Name:   mcp2515
+Info:   Configures the MCP2515 CAN controller on spi0/1/2
+        For devices on spi1 or spi2, the interfaces should be enabled
+        with one of the spi1-1/2/3cs and/or spi2-1/2/3cs overlays.
+Load:   dtoverlay=mcp2515,<param>=<val>
+Params: spi<n>-<m>              Configure device at spi<n>, cs<m>
+                                (boolean, required)
+
+        oscillator              Clock frequency for the CAN controller (Hz)
+
+        speed                   Maximum SPI frequence (Hz)
+
+        interrupt               GPIO for interrupt signal
+
+
 Name:   mcp2515-can0
 Info:   Configures the MCP2515 CAN controller on spi0.0
 Load:   dtoverlay=mcp2515-can0,<param>=<val>

--- a/arch/arm/boot/dts/overlays/mcp2515-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp2515-overlay.dts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/pinctrl/bcm2835.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev1>;
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target-path = "spi1/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target-path = "spi1/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target-path = "spi1/spidev@2";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@5 {
+		target-path = "spi2/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@6 {
+		target-path = "spi2/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@7 {
+		target-path = "spi2/spidev@2";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@8 {
+		target = <&gpio>;
+		__overlay__ {
+			mcp2515_pins: mcp2515_pins {
+				brcm,pins = <25>;
+				brcm,function = <BCM2835_FSEL_GPIO_IN>;
+			};
+		};
+	};
+
+	fragment@9 {
+		target-path = "/clocks";
+		__overlay__ {
+			clk_mcp2515_osc: mcp2515-osc {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <16000000>;
+			};
+		};
+	};
+
+	mcp2515_frag: fragment@10 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mcp2515: mcp2515@0 {
+				compatible = "microchip,mcp2515";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&mcp2515_pins>;
+				spi-max-frequency = <10000000>;
+				interrupt-parent = <&gpio>;
+				interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
+				clocks = <&clk_mcp2515_osc>;
+			};
+		};
+	};
+
+	__overrides__ {
+		spi0-0 = <0>, "+0",
+			<&mcp2515_frag>, "target:0=", <&spi0>,
+			<&mcp2515>, "reg:0=0",
+			<&mcp2515_pins>, "name=mcp2515_spi0_0_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi0-0-osc";
+		spi0-1 = <0>, "+1",
+			<&mcp2515_frag>, "target:0=", <&spi0>,
+			<&mcp2515>, "reg:0=1",
+			<&mcp2515_pins>, "name=mcp2515_spi0_1_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi0-1-osc";
+		spi1-0 = <0>, "+2",
+			<&mcp2515_frag>, "target:0=", <&spi1>,
+			<&mcp2515>, "reg:0=0",
+			<&mcp2515_pins>, "name=mcp2515_spi1_0_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi1-0-osc";
+		spi1-1 = <0>, "+3",
+			<&mcp2515_frag>, "target:0=", <&spi1>,
+			<&mcp2515>, "reg:0=1",
+			<&mcp2515_pins>, "name=mcp2515_spi1_1_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi1-1-osc";
+		spi1-2 = <0>, "+4",
+			<&mcp2515_frag>, "target:0=", <&spi1>,
+			<&mcp2515>, "reg:0=2",
+			<&mcp2515_pins>, "name=mcp2515_spi1_2_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi1-2-osc";
+		spi2-0 = <0>, "+5",
+			<&mcp2515_frag>, "target:0=", <&spi2>,
+			<&mcp2515>, "reg:0=0",
+			<&mcp2515_pins>, "name=mcp2515_spi2_0_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi2-0-osc";
+		spi2-1 = <0>, "+6",
+			<&mcp2515_frag>, "target:0=", <&spi2>,
+			<&mcp2515>, "reg:0=1",
+			<&mcp2515_pins>, "name=mcp2515_spi2_1_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi2-1-osc";
+		spi2-2 = <0>, "+7",
+			<&mcp2515_frag>, "target:0=", <&spi2>,
+			<&mcp2515>, "reg:0=2",
+			<&mcp2515_pins>, "name=mcp2515_spi2_2_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi2-2-osc";
+		oscillator = <&clk_mcp2515_osc>, "clock-frequency:0";
+		speed = <&mcp2515>, "spi-max-frequency:0";
+		interrupt = <&mcp2515_pins>, "brcm,pins:0",
+			<&mcp2515>, "interrupts:0";
+	};
+};


### PR DESCRIPTION
Can configure mcp2515 on spi0/1/2 without the need for multiple overlays.