### PR TITLE
raspberrypi-firmware: Remove vestigal commits

### DIFF
--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -45,7 +45,7 @@ static void response_callback(struct mbox_client *cl, void *msg)
  * Sends a request to the firmware through the BCM2835 mailbox driver,
  * and synchronously waits for the reply.
  */
-int
+static int
 rpi_firmware_transaction(struct rpi_firmware *fw, u32 chan, u32 data)
 {
 	u32 message = MBOX_MSG(chan, data);
@@ -70,7 +70,6 @@ rpi_firmware_transaction(struct rpi_firmware *fw, u32 chan, u32 data)
 
 	return ret;
 }
-EXPORT_SYMBOL_GPL(rpi_firmware_transaction);
 
 /**
  * rpi_firmware_property_list - Submit firmware property list

--- a/include/soc/bcm2835/raspberrypi-firmware.h
+++ b/include/soc/bcm2835/raspberrypi-firmware.h
@@ -9,8 +9,6 @@
 #include <linux/types.h>
 #include <linux/of_device.h>
 
-#define RPI_FIRMWARE_CHAN_FB		1
-
 struct rpi_firmware;
 
 enum rpi_firmware_property_status {
@@ -188,6 +186,5 @@ static inline struct rpi_firmware *rpi_firmware_get(struct device_node *firmware
 	return NULL;
 }
 #endif
-int rpi_firmware_transaction(struct rpi_firmware *fw, u32 chan, u32 data);
 
 #endif /* __SOC_RASPBERRY_FIRMWARE_H__ */


### PR DESCRIPTION
I believe both of these are unnecessary and a remnants of older commits after rebasing.
They have been removed from 5.15 without issue.