### PR TITLE
dtoverlays: Add overlay for ST7735R (160x128) TinyDRM driver

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -4,6 +4,7 @@ dtb-$(CONFIG_ARCH_BCM2835) += overlay_map.dtb
 
 dtbo-$(CONFIG_ARCH_BCM2835) += \
 	act-led.dtbo \
+	adafruit-st7735r.dtbo \
 	adafruit18.dtbo \
 	adau1977-adc.dtbo \
 	adau7002-simple.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -299,9 +299,23 @@ Params: activelow               Set to "on" to invert the sense of the LED
                                 REQUIRED
 
 
+Name:   adafruit-st7735r
+Info:   Overlay for the SPI-connected Adafruit 1.8" 160x128 or 128x128 displays,
+        based on the ST7735R chip.
+        This overlay uses the newer DRM/KMS "Tiny" driver.
+Load:   dtoverlay=adafruit-st7735r,<param>=<val>
+Params: 128x128                 Select the 128x128 driver (default 160x128)
+        rotate                  Display rotation {0,90,180,270} (default 90)
+        speed                   SPI bus speed in Hz (default 4000000)
+        dc_pin                  GPIO pin for D/C (default 24)
+        reset_pin               GPIO pin for RESET (default 25)
+        led_pin                 GPIO used to control backlight (default 18)
+
+
 Name:   adafruit18
 Info:   Overlay for the SPI-connected Adafruit 1.8" display (based on the
         ST7735R chip). It includes support for the "green tab" version.
+        This overlay uses the older fbtft driver.
 Load:   dtoverlay=adafruit18,<param>=<val>
 Params: green                   Use the adafruit18_green variant.
         rotate                  Display rotation {0,90,180,270}

--- a/arch/arm/boot/dts/overlays/adafruit-st7735r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adafruit-st7735r-overlay.dts
@@ -1,0 +1,83 @@
+/*
+ * adafruit-st7735r-overlay.dts
+ *
+ * ST7735R based SPI LCD displays. Either
+ * Adafruit 1.8" 160x128
+ *   or
+ * Okaya 1.44" 128x128
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			adafruit_pins: adafruit_pins {
+				brcm,pins = <25 24>;
+				brcm,function = <1>; /* out */
+			};
+			backlight_pins: backlight_pins {
+				brcm,pins = <18>;
+				brcm,function = <1>; /* out */
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			af18_backlight: backlight {
+				compatible = "gpio-backlight";
+				gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&backlight_pins>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			af18: adafruit18@0 {
+				compatible = "jianda,jd-t18003-t01";
+				reg = <0>;
+				spi-max-frequency = <32000000>;
+				dc-gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
+				reset-gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
+				rotate = <90>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&adafruit_pins>;
+				backlight = <&af18_backlight>;
+			};
+		};
+	};
+
+	__overrides__ {
+		128x128 = <&af18>, "compatible=okaya,rh128128t";
+		speed = <&af18>,"spi-max-frequency:0";
+		rotate = <&af18>,"rotate:0";
+		dc_pin = <&af18>,"dc-gpios:4", <&adafruit_pins>,"brcm,pins:4";
+		reset_pin = <&af18>,"reset-gpios:4",
+			    <&adafruit_pins>,"brcm,pins:0";
+		led_pin = <&af18_backlight>,"gpios:4",
+			  <&backlight_pins>,"brcm,pins:0";
+	};
+};


### PR DESCRIPTION
Adds an overlay to configure the TinyDRM driver for ST7735R
based 160x128 and 128x128 (untested) displays such as the
Adafruit 1.8" display.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>

See forum thread https://www.raspberrypi.org/forums/viewtopic.php?f=44&t=320280