### PR TITLE
clk: Move vec clock to clk-raspberrypi

### DIFF
--- a/arch/arm/boot/dts/bcm2711.dtsi
+++ b/arch/arm/boot/dts/bcm2711.dtsi
@@ -303,7 +303,7 @@
 		vec: vec@7ec13000 {
 			compatible = "brcm,bcm2711-vec";
 			reg = <0x7ec13000 0x1000>;
-			clocks = <&clocks BCM2835_CLOCK_VEC>;
+			clocks = <&firmware_clocks 15>;
 			interrupts = <GIC_SPI 123 IRQ_TYPE_LEVEL_HIGH>;
 			status = "disabled";
 		};

--- a/arch/arm/boot/dts/bcm2835-common.dtsi
+++ b/arch/arm/boot/dts/bcm2835-common.dtsi
@@ -109,7 +109,7 @@
 		vec: vec@7e806000 {
 			compatible = "brcm,bcm2835-vec";
 			reg = <0x7e806000 0x1000>;
-			clocks = <&clocks BCM2835_CLOCK_VEC>;
+			clocks = <&firmware_clocks 15>;
 			interrupts = <2 27>;
 			status = "disabled";
 		};

--- a/drivers/clk/bcm/clk-bcm2835.c
+++ b/drivers/clk/bcm/clk-bcm2835.c
@@ -2214,21 +2214,6 @@ static const struct bcm2835_clk_desc clk_desc_array[] = {
 		.frac_bits = 12,
 		.tcnt_mux = 28),
 
-	/* TV encoder clock.  Only operating frequency is 108Mhz.  */
-	[BCM2835_CLOCK_VEC]	= REGISTER_PER_CLK(
-		SOC_ALL,
-		.name = "vec",
-		.ctl_reg = CM_VECCTL,
-		.div_reg = CM_VECDIV,
-		.int_bits = 4,
-		.frac_bits = 0,
-		/*
-		 * Allow rate change propagation only on PLLH_AUX which is
-		 * assigned index 7 in the parent array.
-		 */
-		.set_rate_parent = BIT(7),
-		.tcnt_mux = 29),
-
 	/* dsi clocks */
 	[BCM2835_CLOCK_DSI0E]	= REGISTER_PER_CLK(
 		SOC_ALL,

--- a/drivers/clk/bcm/clk-raspberrypi.c
+++ b/drivers/clk/bcm/clk-raspberrypi.c
@@ -33,6 +33,7 @@ enum rpi_firmware_clk_id {
 	RPI_FIRMWARE_EMMC2_CLK_ID,
 	RPI_FIRMWARE_M2MC_CLK_ID,
 	RPI_FIRMWARE_PIXEL_BVB_CLK_ID,
+	RPI_FIRMWARE_VEC_CLK_ID,
 	RPI_FIRMWARE_NUM_CLK_ID,
 };
 
@@ -51,6 +52,7 @@ static char *rpi_firmware_clk_names[] = {
 	[RPI_FIRMWARE_EMMC2_CLK_ID]	= "emmc2",
 	[RPI_FIRMWARE_M2MC_CLK_ID]	= "m2mc",
 	[RPI_FIRMWARE_PIXEL_BVB_CLK_ID]	= "pixel-bvb",
+	[RPI_FIRMWARE_VEC_CLK_ID]	= "vec",
 };
 
 #define RPI_FIRMWARE_STATE_ENABLE_BIT	BIT(0)
@@ -273,6 +275,7 @@ static int raspberrypi_discover_clocks(struct raspberrypi_clk *rpi,
 		case RPI_FIRMWARE_V3D_CLK_ID:
 		case RPI_FIRMWARE_HEVC_CLK_ID:
 		case RPI_FIRMWARE_PIXEL_BVB_CLK_ID:
+		case RPI_FIRMWARE_VEC_CLK_ID:
 			hw = raspberrypi_clk_register(rpi, clks->parent,
 						      clks->id);
 			if (IS_ERR(hw))


### PR DESCRIPTION
clk-2835 is deprecated and gets an innacurate clock for vec (107.143MHz).
Switch to clk-raspberrypi which uses the right PLL to get an accurate 108MHz

Signed-off-by: Dom Cobley <popcornmix@gmail.com>