### PR TITLE
Colorspace fixes

### DIFF
--- a/drivers/media/i2c/imx219.c
+++ b/drivers/media/i2c/imx219.c
@@ -681,7 +681,7 @@ static void imx219_set_default_format(struct imx219 *imx219)
 
 	fmt = &imx219->fmt;
 	fmt->code = MEDIA_BUS_FMT_SRGGB10_1X10;
-	fmt->colorspace = V4L2_COLORSPACE_SRGB;
+	fmt->colorspace = V4L2_COLORSPACE_RAW;
 	fmt->ycbcr_enc = V4L2_MAP_YCBCR_ENC_DEFAULT(fmt->colorspace);
 	fmt->quantization = V4L2_MAP_QUANTIZATION_DEFAULT(true,
 							  fmt->colorspace,
@@ -877,7 +877,7 @@ static int imx219_enum_frame_size(struct v4l2_subdev *sd,
 
 static void imx219_reset_colorspace(struct v4l2_mbus_framefmt *fmt)
 {
-	fmt->colorspace = V4L2_COLORSPACE_SRGB;
+	fmt->colorspace = V4L2_COLORSPACE_RAW;
 	fmt->ycbcr_enc = V4L2_MAP_YCBCR_ENC_DEFAULT(fmt->colorspace);
 	fmt->quantization = V4L2_MAP_QUANTIZATION_DEFAULT(true,
 							  fmt->colorspace,

--- a/drivers/media/i2c/imx290.c
+++ b/drivers/media/i2c/imx290.c
@@ -885,7 +885,7 @@ static int imx290_set_fmt(struct v4l2_subdev *sd,
 
 	fmt->format.code = imx290->formats[i].code;
 	fmt->format.field = V4L2_FIELD_NONE;
-	fmt->format.colorspace = V4L2_COLORSPACE_SRGB;
+	fmt->format.colorspace = V4L2_COLORSPACE_RAW;
 	fmt->format.ycbcr_enc =
 			V4L2_MAP_YCBCR_ENC_DEFAULT(fmt->format.colorspace);
 	fmt->format.quantization =

--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -1471,7 +1471,7 @@ static int imx477_enum_frame_size(struct v4l2_subdev *sd,
 
 static void imx477_reset_colorspace(struct v4l2_mbus_framefmt *fmt)
 {
-	fmt->colorspace = V4L2_COLORSPACE_SRGB;
+	fmt->colorspace = V4L2_COLORSPACE_RAW;
 	fmt->ycbcr_enc = V4L2_MAP_YCBCR_ENC_DEFAULT(fmt->colorspace);
 	fmt->quantization = V4L2_MAP_QUANTIZATION_DEFAULT(true,
 							  fmt->colorspace,

--- a/drivers/media/i2c/imx519.c
+++ b/drivers/media/i2c/imx519.c
@@ -1317,7 +1317,7 @@ static int imx519_enum_frame_size(struct v4l2_subdev *sd,
 
 static void imx519_reset_colorspace(struct v4l2_mbus_framefmt *fmt)
 {
-	fmt->colorspace = V4L2_COLORSPACE_SRGB;
+	fmt->colorspace = V4L2_COLORSPACE_RAW;
 	fmt->ycbcr_enc = V4L2_MAP_YCBCR_ENC_DEFAULT(fmt->colorspace);
 	fmt->quantization = V4L2_MAP_QUANTIZATION_DEFAULT(true,
 							  fmt->colorspace,

--- a/drivers/media/i2c/ov5647.c
+++ b/drivers/media/i2c/ov5647.c
@@ -601,7 +601,7 @@ static struct ov5647_mode supported_modes_8bit[] = {
 	{
 		.format = {
 			.code = MEDIA_BUS_FMT_SBGGR8_1X8,
-			.colorspace = V4L2_COLORSPACE_SRGB,
+			.colorspace = V4L2_COLORSPACE_RAW,
 			.field = V4L2_FIELD_NONE,
 			.width = 640,
 			.height = 480
@@ -627,7 +627,7 @@ static struct ov5647_mode supported_modes_10bit[] = {
 	{
 		.format = {
 			.code = MEDIA_BUS_FMT_SBGGR10_1X10,
-			.colorspace = V4L2_COLORSPACE_SRGB,
+			.colorspace = V4L2_COLORSPACE_RAW,
 			.field = V4L2_FIELD_NONE,
 			.width = 2592,
 			.height = 1944
@@ -651,7 +651,7 @@ static struct ov5647_mode supported_modes_10bit[] = {
 	{
 		.format = {
 			.code = MEDIA_BUS_FMT_SBGGR10_1X10,
-			.colorspace = V4L2_COLORSPACE_SRGB,
+			.colorspace = V4L2_COLORSPACE_RAW,
 			.field = V4L2_FIELD_NONE,
 			.width = 1920,
 			.height = 1080
@@ -674,7 +674,7 @@ static struct ov5647_mode supported_modes_10bit[] = {
 	{
 		.format = {
 			.code = MEDIA_BUS_FMT_SBGGR10_1X10,
-			.colorspace = V4L2_COLORSPACE_SRGB,
+			.colorspace = V4L2_COLORSPACE_RAW,
 			.field = V4L2_FIELD_NONE,
 			.width = 1296,
 			.height = 972
@@ -698,7 +698,7 @@ static struct ov5647_mode supported_modes_10bit[] = {
 	{
 		.format = {
 			.code = MEDIA_BUS_FMT_SBGGR10_1X10,
-			.colorspace = V4L2_COLORSPACE_SRGB,
+			.colorspace = V4L2_COLORSPACE_RAW,
 			.field = V4L2_FIELD_NONE,
 			.width = 640,
 			.height = 480

--- a/drivers/media/i2c/ov9281.c
+++ b/drivers/media/i2c/ov9281.c
@@ -507,7 +507,7 @@ static int ov9281_set_fmt(struct v4l2_subdev *sd,
 	fmt->format.width = mode->width;
 	fmt->format.height = mode->height;
 	fmt->format.field = V4L2_FIELD_NONE;
-	fmt->format.colorspace = V4L2_COLORSPACE_SRGB;
+	fmt->format.colorspace = V4L2_COLORSPACE_RAW;
 	fmt->format.ycbcr_enc =
 			V4L2_MAP_YCBCR_ENC_DEFAULT(fmt->format.colorspace);
 	fmt->format.quantization =
@@ -557,7 +557,7 @@ static int ov9281_get_fmt(struct v4l2_subdev *sd,
 		fmt->format.height = mode->height;
 		fmt->format.code = ov9281->code;
 		fmt->format.field = V4L2_FIELD_NONE;
-		fmt->format.colorspace = V4L2_COLORSPACE_SRGB;
+		fmt->format.colorspace = V4L2_COLORSPACE_RAW;
 		fmt->format.ycbcr_enc =
 			V4L2_MAP_YCBCR_ENC_DEFAULT(fmt->format.colorspace);
 		fmt->format.quantization =
@@ -908,7 +908,7 @@ static int ov9281_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 	try_fmt->height = def_mode->height;
 	try_fmt->code = MEDIA_BUS_FMT_Y10_1X10;
 	try_fmt->field = V4L2_FIELD_NONE;
-	try_fmt->colorspace = V4L2_COLORSPACE_SRGB;
+	try_fmt->colorspace = V4L2_COLORSPACE_RAW;
 	try_fmt->ycbcr_enc = V4L2_MAP_YCBCR_ENC_DEFAULT(try_fmt->colorspace);
 	try_fmt->quantization =
 		V4L2_MAP_QUANTIZATION_DEFAULT(true, try_fmt->colorspace,

--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
@@ -1032,7 +1032,9 @@ static int bcm2835_isp_node_try_fmt(struct file *file, void *priv,
 		/* In all cases, we only support the defaults for these: */
 		f->fmt.pix.ycbcr_enc = V4L2_MAP_YCBCR_ENC_DEFAULT(f->fmt.pix.colorspace);
 		f->fmt.pix.xfer_func = V4L2_MAP_XFER_FUNC_DEFAULT(f->fmt.pix.colorspace);
-		is_rgb = f->fmt.pix.colorspace == V4L2_COLORSPACE_SRGB;
+		/* RAW counts as sRGB here so that we get full range. */
+		is_rgb = f->fmt.pix.colorspace == V4L2_COLORSPACE_SRGB ||
+			f->fmt.pix.colorspace == V4L2_COLORSPACE_RAW;
 		f->fmt.pix.quantization = V4L2_MAP_QUANTIZATION_DEFAULT(is_rgb, f->fmt.pix.colorspace,
 									f->fmt.pix.ycbcr_enc);
 


### PR DESCRIPTION
@6by9 @naushir
This is a set of small changes to fix colour space issues noticed during libcamera development. Most of them involve sensors that were incorrectly reporting sRGB rather than RAW colour spaces. Additionally I've also made our ISP advertise that it wants full, rather than limited, range RAW input.

Nothing was actually failing before, it was a case of the debug warnings showing that colour spaces were wrong, even though they were being over-written later. I've worked through each of the affected camera modules double-checking that the changes don't break anything!