### PR TITLE
firmware: raspberrypi: Use g_pdev pointer in rpi_firmware_get()

### DIFF
--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -431,9 +431,10 @@ static int rpi_firmware_remove(struct platform_device *pdev)
  */
 struct rpi_firmware *rpi_firmware_get(struct device_node *firmware_node)
 {
-	struct platform_device *pdev = of_find_device_by_node(firmware_node);
+	struct platform_device *pdev;
 	struct rpi_firmware *fw;
 
+	pdev = g_pdev ? g_pdev : of_find_device_by_node(firmware_node);
 	if (!pdev)
 		return NULL;
 


### PR DESCRIPTION
Since the merge a35653e rpi_firmware_get() can't be called with a NULL pointer anymore. The bcm2835-sdhost driver relies on this. Which then leads to a NULL pointer dereference.