### PR TITLE
dtoverlays: Update all image sensor overlays for Media Controller option

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -416,6 +416,8 @@ Info:   Analog Devices ADV7282M analogue video to CSI2 bridge.
         variants.
 Load:   dtoverlay=adv7282m,<param>=<val>
 Params: addr                    Overrides the I2C address (default 0x21)
+        media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default off)
 
 
 Name:   adv728x-m
@@ -426,6 +428,8 @@ Params: addr                    Overrides the I2C address (default 0x21)
         adv7280m                Select ADV7280-M.
         adv7281m                Select ADV7281-M.
         adv7281ma               Select ADV7281-MA.
+        media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default off)
 
 
 Name:   akkordion-iqdacplus
@@ -1708,6 +1712,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 180)
         orientation             Sensor orientation (0 = front, 1 = rear,
                                 2 = external, default external)
+        media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default on)
 
 
 Name:   imx290
@@ -1728,6 +1734,8 @@ Params: 4lane                   Enable 4 CSI2 lanes. This requires a Compute
                                 2 = external, default external)
         rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 0)
+        media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default on)
 
 
 Name:   imx378
@@ -1739,6 +1747,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 180)
         orientation             Sensor orientation (0 = front, 1 = rear,
                                 2 = external, default external)
+        media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default on)
 
 
 Name:   imx477
@@ -1750,6 +1760,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 180)
         orientation             Sensor orientation (0 = front, 1 = rear,
                                 2 = external, default external)
+        media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default on)
 
 
 Name:   imx519
@@ -1761,6 +1773,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 0)
         orientation             Sensor orientation (0 = front, 1 = rear,
                                 2 = external, default external)
+        media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default on)
 
 
 Name:   iqaudio-codec
@@ -1824,8 +1838,9 @@ Name:   irs1125
 Info:   Infineon irs1125 TOF camera module.
         Uses Unicam 1, which is the standard camera connector on most Pi
         variants.
-Load:   dtoverlay=irs1125
-Params: <None>
+Load:   dtoverlay=irs1125,<param>=<val>
+Params: media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default off)
 
 
 Name:   jedec-spi-nor
@@ -2237,6 +2252,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 0)
         orientation             Sensor orientation (0 = front, 1 = rear,
                                 2 = external, default external)
+        media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default on)
 
 
 Name:   ov7251
@@ -2248,6 +2265,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 0)
         orientation             Sensor orientation (0 = front, 1 = rear,
                                 2 = external, default external)
+        media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default off)
 
 
 Name:   ov9281
@@ -2259,6 +2278,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 180, default 0)
         orientation             Sensor orientation (0 = front, 1 = rear,
                                 2 = external, default external)
+        media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default on)
 
 
 Name:   papirus
@@ -3239,6 +3260,8 @@ Params: 4lane                   Use 4 lanes (only applicable to Compute Modules
         link-frequency          Set the link frequency. Only values of 297000000
                                 (574Mbit/s) and 486000000 (972Mbit/s - default)
                                 are supported by the driver.
+        media-controller        Configure use of Media Controller API for
+                                configuring the sensor (default off)
 
 
 Name:   tc358743-audio

--- a/arch/arm/boot/dts/overlays/adv7282m-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adv7282m-overlay.dts
@@ -59,7 +59,15 @@
 		};
 	};
 
+	fragment@4 {
+		target = <&csi1>;
+		__dormant__ {
+			brcm,media-controller;
+		};
+	};
+
 	__overrides__ {
 		addr =			<&adv728x>,"reg:0";
+		media-controller = <0>,"=4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx219-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx219-overlay.dts
@@ -108,8 +108,16 @@
 		};
 	};
 
+	fragment@6 {
+		target = <&csi1>;
+		__overlay__ {
+			brcm,media-controller;
+		};
+	};
+
 	__overrides__ {
 		rotation = <&imx219>,"rotation:0";
 		orientation = <&imx219>,"orientation:0";
+		media-controller = <0>,"=6";
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
+++ b/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
@@ -134,11 +134,19 @@
 		};
 	};
 
+	fragment@10 {
+		target = <&csi1>;
+		__overlay__ {
+			brcm,media-controller;
+		};
+	};
+
 	__overrides__ {
 		4lane = <0>, "-6+7-8+9";
 		clock-frequency = <&imx290_clk>,"clock-frequency:0",
 				  <&imx290>,"clock-frequency:0";
 		rotation = <&imx290>,"rotation:0";
 		orientation = <&imx290>,"orientation:0";
+		media-controller = <0>,"=10";
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx477_378-overlay.dtsi
+++ b/arch/arm/boot/dts/overlays/imx477_378-overlay.dtsi
@@ -103,8 +103,16 @@
 		};
 	};
 
+	fragment@6 {
+		target = <&csi1>;
+		__overlay__ {
+			brcm,media-controller;
+		};
+	};
+
 	__overrides__ {
 		rotation = <&imx477>,"rotation:0";
 		orientation = <&imx477>,"orientation:0";
+		media-controller = <0>,"=6";
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx519-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx519-overlay.dts
@@ -108,8 +108,16 @@
 		};
 	};
 
+	fragment@6 {
+		target = <&csi1>;
+		__overlay__ {
+			brcm,media-controller;
+		};
+	};
+
 	__overrides__ {
 		rotation = <&imx519>,"rotation:0";
 		orientation = <&imx519>,"orientation:0";
+		media-controller = <0>,"=6";
 	};
 };

--- a/arch/arm/boot/dts/overlays/irs1125-overlay.dts
+++ b/arch/arm/boot/dts/overlays/irs1125-overlay.dts
@@ -82,4 +82,15 @@
 			};
 		};
 	};
+
+	fragment@6 {
+		target = <&csi1>;
+		__dormant__ {
+			brcm,media-controller;
+		};
+	};
+
+	__overrides__ {
+		media-controller = <0>,"=6";
+	};
 };

--- a/arch/arm/boot/dts/overlays/ov5647-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov5647-overlay.dts
@@ -87,8 +87,16 @@
 		};
 	};
 
+	fragment@6 {
+		target = <&csi1>;
+		__overlay__ {
+			brcm,media-controller;
+		};
+	};
+
 	__overrides__ {
 		rotation = <&ov5647>,"rotation:0";
 		orientation = <&ov5647>,"orientation:0";
+		media-controller = <0>,"=6";
 	};
 };

--- a/arch/arm/boot/dts/overlays/ov7251-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov7251-overlay.dts
@@ -106,8 +106,16 @@
 		};
 	};
 
+	fragment@6 {
+		target = <&csi1>;
+		__dormant__ {
+			brcm,media-controller;
+		};
+	};
+
 	__overrides__ {
 		rotation = <&ov7251>,"rotation:0";
 		orientation = <&ov7251>,"orientation:0";
+		media-controller = <0>,"=6";
 	};
 };

--- a/arch/arm/boot/dts/overlays/ov9281-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov9281-overlay.dts
@@ -106,8 +106,16 @@
 		};
 	};
 
+	fragment@6 {
+		target = <&csi1>;
+		__overlay__ {
+			brcm,media-controller;
+		};
+	};
+
 	__overrides__ {
 		rotation = <&ov9281>,"rotation:0";
 		orientation = <&ov9281>,"orientation:0";
+		media-controller = <0>,"=6";
 	};
 };

--- a/arch/arm/boot/dts/overlays/tc358743-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tc358743-overlay.dts
@@ -100,8 +100,16 @@
 		};
 	};
 
+	fragment@9 {
+		target = <&csi1>;
+		__dormant__ {
+			brcm,media-controller;
+		};
+	};
+
 	__overrides__ {
 		4lane = <0>, "-2+3-7+8";
 		link-frequency = <&tc358743>,"link-frequencies#0";
+		media-controller = <0>,"=9";
 	};
 };


### PR DESCRIPTION
Add an option to enable configuration via the Media Controller API
(rather than the video-node-centric /dev/videoN) as about to
be used by libcamera as it enables more complex pipelines to be
handled.

Any source that has a libcamera tuning merged has MC enabled by
default.
Sources with no libcamera tuning merged have it disabled by
default.
In either case it can be overridden with the overlay parameter
"media-controller".

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>

Follow up to #4641 to switch over to MC usage. Wants the libcamera updates to be merged first/at the same time.