### PR TITLE
staging/bcm2835-camera: Add support for V4L2_MPEG_VIDEO_BITRATE_MODE_CQ

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.h
+++ b/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.h
@@ -13,7 +13,7 @@
  * core driver device
  */
 
-#define V4L2_CTRL_COUNT 32 /* number of v4l controls */
+#define V4L2_CTRL_COUNT 33 /* number of v4l controls */
 
 enum {
 	COMP_CAMERA = 0,
@@ -41,6 +41,8 @@ struct bm2835_mmal_dev {
 	/* controls */
 	struct v4l2_ctrl_handler ctrl_handler;
 	struct v4l2_ctrl *ctrls[V4L2_CTRL_COUNT];
+	struct v4l2_ctrl *bitrate_ctrl;
+
 	enum v4l2_scene_mode scene_mode;
 	struct mmal_colourfx colourfx;
 	int hflip;


### PR DESCRIPTION
Add support for constant quality mode. In this mode the quality can be set via V4L2_CID_MPEG_VIDEO_CONSTANT_QUALITY.