### PR TITLE
firmware: raspberrypi: Fix botched upstream stable merge

### DIFF
--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -431,7 +431,7 @@ static int rpi_firmware_remove(struct platform_device *pdev)
  */
 struct rpi_firmware *rpi_firmware_get(struct device_node *firmware_node)
 {
-	struct platform_device *pdev = of_find_device_by_node(firmware_node);
+	struct platform_device *pdev = g_pdev;
 	struct rpi_firmware *fw;
 
 	if (!pdev)


### PR DESCRIPTION
The merge of upstream stable commit 60831f5ae6c7 ("firmware: raspberrypi:
Keep count of all consumers") accidentially replaced a statement from
downstream commit e4a6adeb157e ("firmware: bcm2835: Support ARCH_BCM270x").
Fix that.

Signed-off-by: Juerg Haefliger <juergh@canonical.com>