### PR TITLE
media: bcm2835-codec: Increase video callbacks limit

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -2511,7 +2511,7 @@ static int bcm2835_codec_create_component(struct bcm2835_codec_ctx *ctx)
 					      &enable,
 					      sizeof(enable));
 
-		enable = (unsigned int)-5;
+		enable = (unsigned int)-6;
 		vchiq_mmal_port_parameter_set(dev->instance,
 					      &ctx->component->control,
 					      MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS,


### PR DESCRIPTION
The previous commit limited callbacks to DPB+5.
This has been found insufficient for kodi and ffmpeg
decoding h.264. Increase to DPB+6

Fixes: f814bfc5f4d3005eb266a1556be8b7b8770629bd

Signed-off-by: Dom Cobley <popcornmix@gmail.com>