### PR TITLE
bcm2835-v4l2-codec: Remove advertised support of VP8

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -598,11 +598,6 @@ static const struct bcm2835_codec_fmt supported_formats[] = {
 		.flags			= V4L2_FMT_FLAG_COMPRESSED,
 		.mmal_fmt		= MMAL_ENCODING_MP2V,
 	}, {
-		.fourcc			= V4L2_PIX_FMT_VP8,
-		.depth			= 0,
-		.flags			= V4L2_FMT_FLAG_COMPRESSED,
-		.mmal_fmt		= MMAL_ENCODING_VP8,
-	}, {
 		.fourcc			= V4L2_PIX_FMT_VC1_ANNEX_G,
 		.depth			= 0,
 		.flags			= V4L2_FMT_FLAG_COMPRESSED,


### PR DESCRIPTION
The support for this format by firmware is very limited
and won't be faster than the arm.

Signed-off-by: Dom Cobley <popcornmix@gmail.com>