### PR TITLE
Fixes for modetest helpers for 5.15

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -325,7 +325,6 @@ struct vc4_hvs {
 	u32 __iomem *dlist;
 
 	struct clk *core_clk;
-	struct clk_request *core_req;
 
 	/* Memory manager for CRTCs to allocate space in the display
 	 * list.  Units are dwords.

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -343,12 +343,12 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 	struct drm_device *dev = state->dev;
 	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct vc4_hvs *hvs = vc4->hvs;
-	struct drm_crtc_state *old_crtc_state;
 	struct drm_crtc_state *new_crtc_state;
 	struct vc4_hvs_state *new_hvs_state;
 	struct drm_crtc *crtc;
 	struct vc4_hvs_state *old_hvs_state;
 	struct clk_request *core_req;
+	unsigned int channel;
 	int i;
 
 	old_hvs_state = vc4_hvs_get_old_global_state(state);
@@ -369,15 +369,9 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 		vc4_hvs_mask_underrun(dev, vc4_crtc_state->assigned_channel);
 	}
 
-	for_each_old_crtc_in_state(state, crtc, old_crtc_state, i) {
-		struct vc4_crtc_state *vc4_crtc_state =
-			to_vc4_crtc_state(old_crtc_state);
+	for (channel = 0; channel < HVS_NUM_CHANNELS; channel++) {
 		struct drm_crtc_commit *commit;
-		unsigned int channel = vc4_crtc_state->assigned_channel;
 		int ret;
-
-		if (channel == VC4_HVS_CHANNEL_DISABLED)
-			continue;
 
 		if (!old_hvs_state->fifo_state[channel].in_use)
 			continue;

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -391,6 +391,7 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 			drm_err(dev, "Timed out waiting for commit\n");
 
 		drm_crtc_commit_put(commit);
+		old_hvs_state->fifo_state[channel].pending_commit = NULL;
 	}
 
 	if (vc4->hvs && vc4->hvs->hvs5) {

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -389,6 +389,8 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 		ret = drm_crtc_commit_wait(commit);
 		if (ret)
 			drm_err(dev, "Timed out waiting for commit\n");
+
+		drm_crtc_commit_put(commit);
 	}
 
 	if (vc4->hvs && vc4->hvs->hvs5) {

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -352,11 +352,11 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 	int i;
 
 	old_hvs_state = vc4_hvs_get_old_global_state(state);
-	if (WARN_ON(!old_hvs_state))
+	if (WARN_ON(IS_ERR(old_hvs_state)))
 		return;
 
 	new_hvs_state = vc4_hvs_get_new_global_state(state);
-	if (WARN_ON(!new_hvs_state))
+	if (WARN_ON(IS_ERR(new_hvs_state)))
 		return;
 
 	for_each_new_crtc_in_state(state, crtc, new_crtc_state, i) {
@@ -470,8 +470,8 @@ static int vc4_atomic_commit_setup(struct drm_atomic_state *state)
 		state->legacy_cursor_update = false;
 
 	hvs_state = vc4_hvs_get_new_global_state(state);
-	if (!hvs_state)
-		return -EINVAL;
+	if (WARN_ON(IS_ERR(hvs_state)))
+		return PTR_ERR(hvs_state);
 
 	for_each_new_crtc_in_state(state, crtc, crtc_state, i) {
 		struct vc4_crtc_state *vc4_crtc_state =
@@ -816,8 +816,8 @@ static int vc4_pv_muxing_atomic_check(struct drm_device *dev,
 	unsigned int i;
 
 	hvs_new_state = vc4_hvs_get_global_state(state);
-	if (!hvs_new_state)
-		return -EINVAL;
+	if (IS_ERR(hvs_new_state))
+		return PTR_ERR(hvs_new_state);
 
 	for (i = 0; i < ARRAY_SIZE(hvs_new_state->fifo_state); i++)
 		if (!hvs_new_state->fifo_state[i].in_use)
@@ -909,8 +909,8 @@ vc4_core_clock_atomic_check(struct drm_atomic_state *state)
 	load_state = to_vc4_load_tracker_state(priv_state);
 
 	hvs_new_state = vc4_hvs_get_global_state(state);
-	if (!hvs_new_state)
-		return -EINVAL;
+	if (IS_ERR(hvs_new_state))
+		return PTR_ERR(hvs_new_state);
 
 	for_each_oldnew_crtc_in_state(state, crtc,
 				      old_crtc_state,

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -40,6 +40,7 @@ static struct vc4_ctm_state *to_vc4_ctm_state(struct drm_private_state *priv)
 struct vc4_hvs_state {
 	struct drm_private_state base;
 	unsigned long core_clock_rate;
+	struct clk_request *core_req;
 
 	struct {
 		unsigned in_use: 1;
@@ -405,7 +406,8 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 		 * And remove the previous one based on the HVS
 		 * requirements if any.
 		 */
-		clk_request_done(hvs->core_req);
+		clk_request_done(old_hvs_state->core_req);
+		old_hvs_state->core_req = NULL;
 	}
 
 	drm_atomic_helper_commit_modeset_disables(dev, state);
@@ -439,8 +441,8 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 		 * Request a clock rate based on the current HVS
 		 * requirements.
 		 */
-		hvs->core_req = clk_request_start(hvs->core_clk,
-						  new_hvs_state->core_clock_rate);
+		new_hvs_state->core_req = clk_request_start(hvs->core_clk,
+							    new_hvs_state->core_clock_rate);
 
 		/* And drop the temporary request */
 		clk_request_done(core_req);

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -720,12 +720,6 @@ vc4_hvs_channels_duplicate_state(struct drm_private_obj *obj)
 	for (i = 0; i < HVS_NUM_CHANNELS; i++) {
 		state->fifo_state[i].in_use = old_state->fifo_state[i].in_use;
 		state->fifo_state[i].fifo_load = old_state->fifo_state[i].fifo_load;
-
-		if (!old_state->fifo_state[i].pending_commit)
-			continue;
-
-		state->fifo_state[i].pending_commit =
-			drm_crtc_commit_get(old_state->fifo_state[i].pending_commit);
 	}
 
 	state->core_clock_rate = old_state->core_clock_rate;


### PR DESCRIPTION
Hi,

Here's a series of a few issues in the KMS commit code that were introduced by moving to generic helpers in (mainline) 5.12.

I'll submit a similar PR for 5.13 at least, since it's what Canonical is using, and can submit it to any other branch if relevant. 5.10 doesn't suffer from those issues since the commits were applied, and then reverted.

Maxime