### PR TITLE
overlays: vc4-kms-v3d: Change composite handling

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3620,8 +3620,8 @@ Params: cma-512                 CMA is 512MB (needs 1GB)
         cma-default             Use upstream's default value
         audio                   Enable or disable audio over HDMI (default "on")
         noaudio                 Disable all HDMI audio (default "off")
-        nocomposite             Disable the composite video output (default
-                                "off")
+        composite               Enable the composite output (default "off")
+                                N.B. Disables all other outputs on a Pi 4.
 
 
 Name:   vc4-kms-v3d-pi4

--- a/arch/arm/boot/dts/overlays/upstream-overlay.dts
+++ b/arch/arm/boot/dts/overlays/upstream-overlay.dts
@@ -1,4 +1,4 @@
-// redo: ovmerge -c vc4-kms-v3d-overlay.dts,cma-default dwc2-overlay.dts,dr_mode=otg
+// redo: ovmerge -c vc4-kms-v3d-overlay.dts,cma-default,composite dwc2-overlay.dts,dr_mode=otg
 
 /dts-v1/;
 /plugin/;

--- a/arch/arm/boot/dts/overlays/vc4-kms-v3d-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-v3d-overlay.dts
@@ -89,7 +89,7 @@
 
 	fragment@11 {
 		target = <&vec>;
-		__overlay__  {
+		__dormant__  {
 			status = "okay";
 		};
 	};
@@ -118,6 +118,6 @@
 	__overrides__ {
 		audio   = <0>,"!13";
 		noaudio = <0>,"=13";
-		nocomposite = <0>, "!11";
+		composite = <0>, "=11";
 	};
 };


### PR DESCRIPTION
On a Pi 4, enabling composite video disables the HDMI output. As a
consequence, the composite output is disabled by default. Change the
vc4-kms-v3d overlay used on older Pis to also disable composite by
default, replacing the "nocomposite" parameter with a "composite"
parameter.

Signed-off-by: Phil Elwell <phil@raspberrypi.com>