### PR TITLE
drm/vc4: Don't try disabling SCDC on Pi0-3.

### DIFF
--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-7inch-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-7inch-overlay.dts
@@ -113,6 +113,6 @@
 	};
 
 	__overrides__ {
-		disable_touch = <0>, "-10-11-12-13";
+		disable_touch = <0>, "-10-11-12";
 	};
 };

--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -2608,7 +2608,8 @@ static int vc4_hdmi_bind(struct device *dev, struct device *master, void *data)
 	 * vc4_hdmi_disable_scrambling() will thus run at boot, make
 	 * sure it's disabled, and avoid any inconsistency.
 	 */
-	vc4_hdmi->scdc_enabled = true;
+	if (variant->max_pixel_clock > HDMI_14_MAX_TMDS_CLK)
+		vc4_hdmi->scdc_enabled = true;
 
 	ret = variant->init_resources(vc4_hdmi);
 	if (ret)


### PR DESCRIPTION
The code that set the scdc_enabled flag to ensure it was
disabled at boot time also ran on Pi0-3 where there is no
SCDC support. This lead to a warning in vc4_hdmi_encoder_post_crtc_disable
due to vc4_hdmi_disable_scrambling being called and trying to
read (and write) register HDMI_SCRAMBLER_CTL which doesn't
exist on those platforms.

Only set the flag should the interface be configured to support
more than HDMI 1.4.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>