### PR TITLE
staging: bcm2835-camera: Add V4L2 control for sensor_mode

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.h
+++ b/drivers/staging/vc04_services/bcm2835-camera/bcm2835-camera.h
@@ -13,7 +13,7 @@
  * core driver device
  */
 
-#define V4L2_CTRL_COUNT 32 /* number of v4l controls */
+#define V4L2_CTRL_COUNT 33 /* number of v4l controls */
 
 enum {
 	COMP_CAMERA = 0,


### PR DESCRIPTION
I wonder if I could request this feature be merged into the Raspberry Pi V4L2 camera driver?  It replicates the functionality of raspivid's `-md` option, which allows for example higher quality videos if a reduced framerate is acceptable.

I am using this to set sensor_mode=2 when capturing at 1296x972 with a Pi V1 camera, as this allows the sensor's full resolution to be used to build the 1296x972 image.  Without this, due to the way the sensor works, the video quality is only effectively 640x480 resolution upscaled to 1296x972.  Since I am using this as a security camera, having finer detail visible in the image is worth the cost of the 15 fps limit introduced by this sensor mode.

The only thing I am unsure about with this patch is that I am borrowing the `V4L2_CID_USER_BCM2835_ISP_BASE` constant even though it is only tangentially related to this code.  You may prefer using a different constant for the custom control ID, so happy to discuss options there.

The new V4L2 control added by this code is used by running `v4l2-ctl --set-ctrl=sensor_mode=2` before starting a V4L2 capture.