### PR TITLE
Use `platform_set_drvdata` to save platform driver data in memory for BCM2711

### DIFF
--- a/drivers/thermal/broadcom/bcm2711_thermal.c
+++ b/drivers/thermal/broadcom/bcm2711_thermal.c
@@ -100,6 +100,8 @@ static int bcm2711_thermal_probe(struct platform_device *pdev)
 	}
 
 	priv->thermal = thermal;
+	
+	platform_set_drvdata(pdev, priv);
 
 	thermal->tzp->no_hwmon = false;
 	ret = thermal_add_hwmon_sysfs(thermal);


### PR DESCRIPTION
Many drivers use the `platform_set_drvdata` function to save platform driver data in memory to use later.