### PR TITLE
drivers: bcm2835_isp: Fix div by 0 bug.

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835-isp-fmts.h
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835-isp-fmts.h
@@ -544,6 +544,7 @@ static const struct bcm2835_isp_fmt supported_formats[] = {
 		.step_size	    = 2,
 	}, {
 		.fourcc		    = V4L2_META_FMT_BCM2835_ISP_STATS,
+		.depth		    = 8,
 		.mmal_fmt	    = MMAL_ENCODING_BRCM_STATS,
 		/* The rest are not valid fields for stats. */
 	}


### PR DESCRIPTION
Fix a possible division by 0 bug when setting up the mmal port for the stats
port.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>