### PR TITLE
KMS fixes and ISP pitch fix

### DIFF
--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-7inch-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-7inch-overlay.dts
@@ -95,6 +95,7 @@
 		target = <&i2c0if>;
 		__overlay__ {
 			status = "okay";
+			clock-frequency = <50000>;
 		};
 	};
 

--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -1848,7 +1848,7 @@ static int vc4_hdmi_audio_init(struct vc4_hdmi *vc4_hdmi)
 	snd_soc_card_set_drvdata(card, vc4_hdmi);
 	ret = devm_snd_soc_register_card(dev, card);
 	if (ret)
-		dev_err(dev, "Could not register sound card: %d\n", ret);
+		dev_err_probe(dev, ret, "Could not register sound card: %d\n");
 
 	return ret;
 

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -157,14 +157,14 @@ static const struct bcm2835_codec_fmt supported_formats[] = {
 		/* YUV formats */
 		.fourcc			= V4L2_PIX_FMT_YUV420,
 		.depth			= 8,
-		.bytesperline_align	= 32,
+		.bytesperline_align	= 64,
 		.flags			= 0,
 		.mmal_fmt		= MMAL_ENCODING_I420,
 		.size_multiplier_x2	= 3,
 	}, {
 		.fourcc			= V4L2_PIX_FMT_YVU420,
 		.depth			= 8,
-		.bytesperline_align	= 32,
+		.bytesperline_align	= 64,
 		.flags			= 0,
 		.mmal_fmt		= MMAL_ENCODING_YV12,
 		.size_multiplier_x2	= 3,


### PR DESCRIPTION
- Drop I2C baud rate whilst still investigating 7" display issues
- Avoid an erroneous error log line from a EPROBE_DEFER in HDMI audio
- Fix ISP pitch requirements for 3 plane YUV formats.