### PR TITLE
BCM2711/BCM2837 cache information

### DIFF
--- a/arch/arm/boot/dts/bcm2711.dtsi
+++ b/arch/arm/boot/dts/bcm2711.dtsi
@@ -471,12 +471,26 @@
 		#size-cells = <0>;
 		enable-method = "brcm,bcm2836-smp"; // for ARM 32-bit
 
+		/* Source for d/i-cache-line-size and d/i-cache-sets
+		 *  https://developer.arm.com/documentation/100095/0003
+		 *  /Level-1-Memory-System/About-the-L1-memory-system?lang=en
+		 * Source for d/i-cache-size
+		 *  https://www.raspberrypi.com/documentation/computers
+		 *  /processors.html#bcm2711
+		 */
 		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a72";
 			reg = <0>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000d8>;
+			d-cache-size = <0x8000>; // 32KB 2-way set-associative data cache
+			d-cache-line-size = <64>;// Fixed line length of 64 bytes
+			d-cache-sets = <256>; // 32KiB(size)/64(line-size)=512ways/2-way set
+			i-cache-size = <0xc000>; // 48kB 3-way set-associative data cache
+			i-cache-line-size = <64>;// Fixed line length of 64 bytes
+			i-cache-sets = <256>; // 48KiB(size)/64(line-size)=768ways/3-way set
+			next-level-cache = <&l2>;
 		};
 
 		cpu1: cpu@1 {
@@ -485,6 +499,13 @@
 			reg = <1>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000e0>;
+			d-cache-size = <0x8000>; // 32KB 2-way set-associative data cache
+			d-cache-line-size = <64>;// Fixed line length of 64 bytes
+			d-cache-sets = <256>; // 32KiB(size)/64(line-size)=512ways/2-way set
+			i-cache-size = <0xc000>; // 48kB 3-way set-associative data cache
+			i-cache-line-size = <64>;// Fixed line length of 64 bytes
+			i-cache-sets = <256>; // 48KiB(size)/64(line-size)=768ways/3-way set
+			next-level-cache = <&l2>;
 		};
 
 		cpu2: cpu@2 {
@@ -493,6 +514,13 @@
 			reg = <2>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000e8>;
+			d-cache-size = <0x8000>; // 32KB 2-way set-associative data cache
+			d-cache-line-size = <64>;// Fixed line length of 64 bytes
+			d-cache-sets = <256>; // 32KiB(size)/64(line-size)=512ways/2-way set
+			i-cache-size = <0xc000>; // 48kB 3-way set-associative data cache
+			i-cache-line-size = <64>;// Fixed line length of 64 bytes
+			i-cache-sets = <256>; // 48KiB(size)/64(line-size)=768ways/3-way set
+			next-level-cache = <&l2>;
 		};
 
 		cpu3: cpu@3 {
@@ -501,6 +529,28 @@
 			reg = <3>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000f0>;
+			d-cache-size = <0x8000>; // 32KB 2-way set-associative data cache
+			d-cache-line-size = <64>;// Fixed line length of 64 bytes
+			d-cache-sets = <256>; // 32KiB(size)/64(line-size)=512ways/2-way set
+			i-cache-size = <0xc000>; // 48kB 3-way set-associative data cache
+			i-cache-line-size = <64>;// Fixed line length of 64 bytes
+			i-cache-sets = <256>; // 48KiB(size)/64(line-size)=768ways/3-way set
+			next-level-cache = <&l2>;
+		};
+
+		l2: l2-cache0 {
+			/* Source for d/i-cache-line-size and d/i-cache-sets
+			*  https://developer.arm.com/documentation/100095/0003
+			*  /Level-2-Memory-System/About-the-L2-memory-system?lang=en
+			*  Source for d/i-cache-size
+			*  https://www.raspberrypi.com/documentation/computers
+			*  /processors.html#bcm2711
+			*/
+			compatible = "cache";
+			cache-size = <0x100000>; // 1MB
+			cache-line-size = <64>; // Fixed line length of 64 bytes
+			cache-sets = <1024>; // 1MiB(size)/64(line-size)=16000ways/16-way set
+			cache-level = <2>;
 		};
 	};
 

--- a/arch/arm/boot/dts/bcm2837.dtsi
+++ b/arch/arm/boot/dts/bcm2837.dtsi
@@ -40,12 +40,26 @@
 		#size-cells = <0>;
 		enable-method = "brcm,bcm2836-smp"; // for ARM 32-bit
 
+		/* Source for d/i-cache-line-size and d/i-cache-sets
+		 *  https://developer.arm.com/documentation/ddi0500/e/level-1-memory-system
+		 *  /about-the-l1-memory-system?lang=en
+		 *
+		 *  Source for d/i-cache-size
+		 *  https://magpi.raspberrypi.com/articles/raspberry-pi-3-specs-benchmarks
+		 */
 		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a53";
 			reg = <0>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000d8>;
+			d-cache-size = <0x8000>; // 32KiB
+			d-cache-line-size = <64>;// Data side cache line length of 64 bytes
+			d-cache-sets = <128>; // 32KiB(size)/64(line-size)=512ways/4-way set
+			i-cache-size = <0x8000>; // 32KiB
+			i-cache-line-size = <64>;// Instruction side cache line length of 64 bytes
+			i-cache-sets = <256>; // 32KiB(size)/64(line-size)=512ways/2-way set
+			next-level-cache = <&l2>;
 		};
 
 		cpu1: cpu@1 {
@@ -54,6 +68,13 @@
 			reg = <1>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000e0>;
+			d-cache-size = <0x8000>; // 32KiB
+			d-cache-line-size = <64>;// Data side cache line length of 64 bytes
+			d-cache-sets = <128>; // 32KiB(size)/64(line-size)=512ways/4-way set
+			i-cache-size = <0x8000>; // 32KiB
+			i-cache-line-size = <64>;// Instruction side cache line length of 64 bytes
+			i-cache-sets = <256>; // 32KiB(size)/64(line-size)=512ways/2-way set
+			next-level-cache = <&l2>;
 		};
 
 		cpu2: cpu@2 {
@@ -62,6 +83,13 @@
 			reg = <2>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000e8>;
+			d-cache-size = <0x8000>; // 32KiB
+			d-cache-line-size = <64>;// Data side cache line length of 64 bytes
+			d-cache-sets = <128>; // 32KiB(size)/64(line-size)=512ways/4-way set
+			i-cache-size = <0x8000>; // 32KiB
+			i-cache-line-size = <64>;// Instruction side cache line length of 64 bytes
+			i-cache-sets = <256>; // 32KiB(size)/64(line-size)=512ways/2-way set
+			next-level-cache = <&l2>;
 		};
 
 		cpu3: cpu@3 {
@@ -70,6 +98,27 @@
 			reg = <3>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x000000f0>;
+			d-cache-size = <0x8000>; // 32KiB
+			d-cache-line-size = <64>;// Data side cache line length of 64 bytes
+			d-cache-sets = <128>; // 32KiB(size)/64(line-size)=512ways/4-way set
+			i-cache-size = <0x8000>; // 32KiB
+			i-cache-line-size = <64>;// Instruction side cache line length of 64 bytes
+			i-cache-sets = <256>; // 32KiB(size)/64(line-size)=512ways/2-way set
+			next-level-cache = <&l2>;
+		};
+
+		l2: l2-cache0 {
+		 /*  Source for cache-line-size + cache-sets
+		  *  https://developer.arm.com/documentation/ddi0500
+		  *  /e/level-2-memory-system/about-the-l2-memory-system?lang=en
+		  *  Source for cache-size
+		  *  https://datasheets.raspberrypi.com/cm/cm1-and-cm3-datasheet.pdf
+		  */
+			compatible = "cache";
+			cache-size = <0x80000>; // 512KiB
+			cache-line-size = <64>; // Fixed line length of 64 bytes
+			cache-sets = <512>; // 512KiB(size)/64(line-size)=8192ways/16-way set
+			cache-level = <2>;
 		};
 	};
 };


### PR DESCRIPTION
This patch adds the L1/L2 cache information for the BCM2711/BCM2837.
The source for this information can be found in the code references.

This fix refers to https://github.com/raspberrypi/Raspberry-Pi-OS-64bit/issues/195

The cache info is available under /sys/devices/system/cpu/cpu0/cache/ .

'lscpu -C' output (bullseye) (BCM2837):
```
NAME ONE-SIZE ALL-SIZE WAYS TYPE        LEVEL SETS PHY-LINE COHERENCY-SIZE
L1d       32K     128K    4 Data            1  128                      64
L1i       32K     128K    2 Instruction     1  256                      64
L2       512K     512K   16 Unified         2  512                      64
```
'lscpu' output (buster, does not support -C) (BCM2711):
```
...
L1d cache:           32K
L1i cache:           48K
L2 cache:            1024K
...
```