### PR TITLE
DPI panel configuration

### DIFF
--- a/arch/arm/boot/dts/bcm270x.dtsi
+++ b/arch/arm/boot/dts/bcm270x.dtsi
@@ -189,6 +189,28 @@
 			     20 21>;
 		brcm,function = <BCM2835_FSEL_ALT2>;
 	};
+	dpi_16bit_gpio0: dpi_16bit_gpio0 {
+		brcm,pins = <0 1 2 3 4 5 6 7 8 9 10 11
+			     12 13 14 15 16 17 18 19>;
+		brcm,function = <BCM2835_FSEL_ALT2>;
+	};
+	dpi_16bit_gpio2: dpi_16bit_gpio2 {
+		brcm,pins = <2 3 4 5 6 7 8 9 10 11
+			     12 13 14 15 16 17 18 19>;
+		brcm,function = <BCM2835_FSEL_ALT2>;
+	};
+	dpi_16bit_cpadhi_gpio0: dpi_16bit_cpadhi_gpio0 {
+		brcm,pins = <0 1 2 3 4 5 6 7 8
+			     12 13 14 15 16 17
+			     20 21 22 23 24>;
+		brcm,function = <BCM2835_FSEL_ALT2>;
+	};
+	dpi_16bit_cpadhi_gpio2: dpi_16bit_cpadhi_gpio2 {
+		brcm,pins = <2 3 4 5 6 7 8
+			     12 13 14 15 16 17
+			     20 21 22 23 24>;
+		brcm,function = <BCM2835_FSEL_ALT2>;
+	};
 };
 
 &uart0 {

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -232,6 +232,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	vc4-fkms-v3d.dtbo \
 	vc4-fkms-v3d-pi4.dtbo \
 	vc4-kms-dpi-at056tn53v1.dtbo \
+	vc4-kms-dpi-generic.dtbo \
 	vc4-kms-dsi-7inch.dtbo \
 	vc4-kms-dsi-lt070me05000.dtbo \
 	vc4-kms-dsi-lt070me05000-v2.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3563,6 +3563,34 @@ Load:   dtoverlay=vc4-kms-dpi-at056tn53v1
 Params: <None>
 
 
+Name:   vc4-kms-dpi-generic
+Info:   Enable a generic DPI display under KMS. Default timings are for the
+        Adafruit Kippah with 800x480 panel and RGB666 (GPIOs 0-21)
+        Requires vc4-kms-v3d to be loaded.
+Load:   dtoverlay=vc4-kms-dpi-generic,<param>=<val>
+Params: clock-frequency         Display clock frequency (Hz)
+        hactive                 Horizontal active pixels
+        hfp                     Horizontal front porch
+        hsync                   Horizontal sync pulse width
+        hbp                     Horizontal back porch
+        vactive                 Vertical active lines
+        vfp                     Vertical front porch
+        vsync                   Vertical sync pulse width
+        vbp                     Vertical back porch
+        hsync-invert            Horizontal sync active low
+        vsync-invert            Vertical sync active low
+        de-invert               Data Enable active low
+        pixclk-invert           Negative edge pixel clock
+        width-mm                Define the screen width in mm
+        height-mm               Define the screen height in mm
+        rgb565                  Change to RGB565 output on GPIOs 0-19
+        rgb666-padhi            Change to RGB666 output on GPIOs 0-9, 12-17, and
+                                20-25
+        rgb888                  Change to RGB888 output on GPIOs 0-27
+        bus-format              Override the bus format for a MEDIA_BUS_FMT_*
+                                value. NB also overridden by rgbXXX overrides.
+
+
 Name:   vc4-kms-dsi-7inch
 Info:   Enable the Raspberry Pi DSI 7" screen.
         Includes the edt-ft5406 for the touchscreen element.

--- a/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
@@ -1,0 +1,92 @@
+/*
+ * vc4-kms-dpi-at056tn53v1-overlay.dts
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/bcm2835.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			panel: panel {
+				compatible = "panel-dpi";
+
+				width-mm = <154>;
+				height-mm = <83>;
+				bus-format = <0x1009>;
+
+				timing: panel-timing {
+					clock-frequency = <29500000>;
+					hactive = <800>;
+					hfront-porch = <24>;
+					hsync-len = <72>;
+					hback-porch = <96>;
+					hsync-active = <0>;
+					vactive = <480>;
+					vfront-porch = <3>;
+					vsync-len = <10>;
+					vback-porch = <7>;
+					vsync-active = <0>;
+
+					de-active = <1>;
+					pixelclk-active = <1>;
+				};
+
+				port {
+					panel_in: endpoint {
+						remote-endpoint = <&dpi_out>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&dpi>;
+		dpi_node: __overlay__  {
+			status = "okay";
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&dpi_18bit_gpio0>;
+
+			port {
+				dpi_out: endpoint {
+					remote-endpoint = <&panel_in>;
+				};
+			};
+		};
+	};
+
+	__overrides__ {
+		clock-frequency = <&timing>, "clock-frequency:0";
+		hactive = <&timing>, "hactive:0";
+		hfp = <&timing>, "hfront-porch:0";
+		hsync = <&timing>, "hsync-len:0";
+		hbp = <&timing>, "hback-porch:0";
+		vactive = <&timing>, "vactive:0";
+		vfp = <&timing>, "vfront-porch:0";
+		vsync = <&timing>, "vsync-len:0";
+		vbp = <&timing>, "vback-porch:0";
+		hsync-invert = <&timing>, "hsync-active:0=0";
+		vsync-invert = <&timing>, "vsync-active:0=0";
+		de-invert = <&timing>, "de-active:0=0";
+		pixclk-invert = <&timing>, "pixelclk-active:0=0";
+
+		width-mm = <&panel>, "width-mm:0";
+		height-mm = <&panel>, "height-mm:0";
+
+		rgb565 = <&panel>, "bus-format:0=0x1017",
+			<&dpi_node>, "pinctrl-0:0=",<&dpi_16bit_gpio0>;
+		rgb666-padhi = <&panel>, "bus-format:0=0x1015",
+			<&dpi_node>, "pinctrl-0:0=",<&dpi_18bit_cpadhi_gpio0>;
+		rgb888 = <&panel>, "bus-format:0=0x100a",
+			<&dpi_node>, "pinctrl-0:0=",<&dpi_gpio0>;
+		bus-format = <&panel>, "bus-format:0";
+	};
+};

--- a/drivers/gpu/drm/panel/panel-simple.c
+++ b/drivers/gpu/drm/panel/panel-simple.c
@@ -559,6 +559,7 @@ static int panel_simple_probe(struct device *dev, const struct panel_desc *desc)
 		err = panel_dpi_probe(dev, panel);
 		if (err)
 			goto free_ddc;
+		desc = panel->desc;
 	} else {
 		if (!of_get_display_timing(dev->of_node, "panel-timing", &dt))
 			panel_simple_parse_panel_timing_node(dev, panel, &dt);

--- a/drivers/gpu/drm/panel/panel-simple.c
+++ b/drivers/gpu/drm/panel/panel-simple.c
@@ -438,6 +438,7 @@ static int panel_dpi_probe(struct device *dev,
 
 	of_property_read_u32(np, "width-mm", &desc->size.width);
 	of_property_read_u32(np, "height-mm", &desc->size.height);
+	of_property_read_u32(np, "bus-format", &desc->bus_format);
 
 	/* Extract bus_flags from display_timing */
 	bus_flags = 0;

--- a/drivers/gpu/drm/panel/panel-simple.c
+++ b/drivers/gpu/drm/panel/panel-simple.c
@@ -447,6 +447,8 @@ static int panel_dpi_probe(struct device *dev,
 
 	/* We do not know the connector for the DT node, so guess it */
 	desc->connector_type = DRM_MODE_CONNECTOR_DPI;
+	/* Likewise for the bit depth. */
+	desc->bpc = 8;
 
 	panel->desc = desc;
 

--- a/drivers/gpu/drm/vc4/vc4_dpi.c
+++ b/drivers/gpu/drm/vc4/vc4_dpi.c
@@ -148,45 +148,58 @@ static void vc4_dpi_encoder_enable(struct drm_encoder *encoder)
 	}
 	drm_connector_list_iter_end(&conn_iter);
 
-	if (connector && connector->display_info.num_bus_formats) {
-		u32 bus_format = connector->display_info.bus_formats[0];
+	if (connector) {
+		if (connector->display_info.num_bus_formats) {
+			u32 bus_format = connector->display_info.bus_formats[0];
 
-		switch (bus_format) {
-		case MEDIA_BUS_FMT_RGB888_1X24:
-			dpi_c |= VC4_SET_FIELD(DPI_FORMAT_24BIT_888_RGB,
-					       DPI_FORMAT);
-			break;
-		case MEDIA_BUS_FMT_BGR888_1X24:
-			dpi_c |= VC4_SET_FIELD(DPI_FORMAT_24BIT_888_RGB,
-					       DPI_FORMAT);
-			dpi_c |= VC4_SET_FIELD(DPI_ORDER_BGR, DPI_ORDER);
-			break;
-		case MEDIA_BUS_FMT_RGB666_1X24_CPADHI:
-			dpi_c |= VC4_SET_FIELD(DPI_FORMAT_18BIT_666_RGB_2,
-					       DPI_FORMAT);
-			break;
-		case MEDIA_BUS_FMT_BGR666_1X24_CPADHI:
-			dpi_c |= VC4_SET_FIELD(DPI_FORMAT_18BIT_666_RGB_2,
-					       DPI_FORMAT);
-			dpi_c |= VC4_SET_FIELD(DPI_ORDER_BGR, DPI_ORDER);
-			break;
-		case MEDIA_BUS_FMT_RGB666_1X18:
-			dpi_c |= VC4_SET_FIELD(DPI_FORMAT_18BIT_666_RGB_1,
-					       DPI_FORMAT);
-			break;
-		case MEDIA_BUS_FMT_BGR666_1X18:
-			dpi_c |= VC4_SET_FIELD(DPI_FORMAT_18BIT_666_RGB_1,
-					       DPI_FORMAT);
-			dpi_c |= VC4_SET_FIELD(DPI_ORDER_BGR, DPI_ORDER);
-			break;
-		case MEDIA_BUS_FMT_RGB565_1X16:
-			dpi_c |= VC4_SET_FIELD(DPI_FORMAT_16BIT_565_RGB_3,
-					       DPI_FORMAT);
-			break;
-		default:
-			DRM_ERROR("Unknown media bus format %d\n", bus_format);
-			break;
+			switch (bus_format) {
+			case MEDIA_BUS_FMT_RGB888_1X24:
+				dpi_c |= VC4_SET_FIELD(DPI_FORMAT_24BIT_888_RGB,
+						       DPI_FORMAT);
+				break;
+			case MEDIA_BUS_FMT_BGR888_1X24:
+				dpi_c |= VC4_SET_FIELD(DPI_FORMAT_24BIT_888_RGB,
+						       DPI_FORMAT);
+				dpi_c |= VC4_SET_FIELD(DPI_ORDER_BGR,
+						       DPI_ORDER);
+				break;
+			case MEDIA_BUS_FMT_RGB666_1X24_CPADHI:
+				dpi_c |= VC4_SET_FIELD(DPI_FORMAT_18BIT_666_RGB_2,
+						       DPI_FORMAT);
+				break;
+			case MEDIA_BUS_FMT_BGR666_1X24_CPADHI:
+				dpi_c |= VC4_SET_FIELD(DPI_FORMAT_18BIT_666_RGB_2,
+						       DPI_FORMAT);
+				dpi_c |= VC4_SET_FIELD(DPI_ORDER_BGR,
+						       DPI_ORDER);
+				break;
+			case MEDIA_BUS_FMT_RGB666_1X18:
+				dpi_c |= VC4_SET_FIELD(DPI_FORMAT_18BIT_666_RGB_1,
+						       DPI_FORMAT);
+				break;
+			case MEDIA_BUS_FMT_BGR666_1X18:
+				dpi_c |= VC4_SET_FIELD(DPI_FORMAT_18BIT_666_RGB_1,
+						       DPI_FORMAT);
+				dpi_c |= VC4_SET_FIELD(DPI_ORDER_BGR,
+						       DPI_ORDER);
+				break;
+			case MEDIA_BUS_FMT_RGB565_1X16:
+				dpi_c |= VC4_SET_FIELD(DPI_FORMAT_16BIT_565_RGB_3,
+						       DPI_FORMAT);
+				break;
+			default:
+				DRM_ERROR("Unknown media bus format %d\n",
+					  bus_format);
+				break;
+			}
 		}
+
+		if (connector->display_info.bus_flags &
+					DRM_BUS_FLAG_PIXDATA_DRIVE_NEGEDGE)
+			dpi_c |= DPI_PIXEL_CLK_INVERT;
+
+		if (connector->display_info.bus_flags & DRM_BUS_FLAG_DE_LOW)
+			dpi_c |= DPI_OUTPUT_ENABLE_INVERT;
 	} else {
 		/* Default to 18bit if no connector found. */
 		dpi_c |= VC4_SET_FIELD(DPI_FORMAT_18BIT_666_RGB_1, DPI_FORMAT);

--- a/drivers/gpu/drm/vc4/vc4_dpi.c
+++ b/drivers/gpu/drm/vc4/vc4_dpi.c
@@ -173,6 +173,10 @@ static void vc4_dpi_encoder_enable(struct drm_encoder *encoder)
 				dpi_c |= VC4_SET_FIELD(DPI_ORDER_BGR,
 						       DPI_ORDER);
 				break;
+			default:
+				DRM_ERROR("Unknown media bus format %d\n",
+					  bus_format);
+				fallthrough;
 			case MEDIA_BUS_FMT_RGB666_1X18:
 				dpi_c |= VC4_SET_FIELD(DPI_FORMAT_18BIT_666_RGB_1,
 						       DPI_FORMAT);
@@ -187,11 +191,12 @@ static void vc4_dpi_encoder_enable(struct drm_encoder *encoder)
 				dpi_c |= VC4_SET_FIELD(DPI_FORMAT_16BIT_565_RGB_3,
 						       DPI_FORMAT);
 				break;
-			default:
-				DRM_ERROR("Unknown media bus format %d\n",
-					  bus_format);
-				break;
 			}
+		} else {
+			/* Default to 18bit if no connector found. */
+			dpi_c |= VC4_SET_FIELD(DPI_FORMAT_18BIT_666_RGB_1,
+					       DPI_FORMAT);
+
 		}
 
 		if (connector->display_info.bus_flags &


### PR DESCRIPTION
Adds a generic DPI panel configuration overlay

@JamesH65 Could do with some testing, and possibly even a magic script to convert a ```dpi_output_format=``` and ```dpi_timings=``` line into the relevant overlay parameters.

Not all output modes are configured as the relevant MEDIA_BUS_FMT_xxx defines don't exist.