### PR TITLE
ASoC:ma120x0p: Increase maximum sample rate to 192KHz

### DIFF
--- a/sound/soc/codecs/ma120x0p.c
+++ b/sound/soc/codecs/ma120x0p.c
@@ -1002,7 +1002,7 @@ static struct snd_soc_dai_driver ma120x0p_dai = {
 		.channels_max	= 2,
 		.rates = SNDRV_PCM_RATE_CONTINUOUS,
 		.rate_min = 44100,
-		.rate_max = 96000,
+		.rate_max = 192000,
 		.formats = SNDRV_PCM_FMTBIT_S24_LE | SNDRV_PCM_FMTBIT_S32_LE
 	},
 	.ops        = &ma120x0p_dai_ops,


### PR DESCRIPTION
Change the maximum sample rate for the amplifier to
192KHz as given in the Infineon specification.

Signed-off-by: Joerg Schambacher <joerg@hifiberry.com>