### PR TITLE
Revert "media: bcm2835-codec: Limit video callbacks"

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -2536,14 +2536,6 @@ static int bcm2835_codec_create_component(struct bcm2835_codec_ctx *ctx)
 					      MMAL_PARAMETER_VIDEO_STOP_ON_PAR_COLOUR_CHANGE,
 					      &enable,
 					      sizeof(enable));
-
-		enable = (unsigned int)-5;
-		vchiq_mmal_port_parameter_set(dev->instance,
-					      &ctx->component->control,
-					      MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS,
-					      &enable,
-					      sizeof(enable));
-
 	} else if (dev->role == DEINTERLACE) {
 		/* Select the default deinterlace algorithm. */
 		int half_framerate = 0;


### PR DESCRIPTION
This reverts commit f814bfc5f4d3005eb266a1556be8b7b8770629bd.

The commit caused media stalls with kodi and stateful
v4l2 video decode.

John is now using a different way of limiting latency
through stateful v4l2 so this is not required.