### PR TITLE
Fix for cursor corruption with overscan

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -341,6 +341,14 @@ struct vc4_hvs {
 
 	/* HVS version 5 flag, therefore requires updated dlist structures */
 	bool hvs5;
+
+	spinlock_t hw_dlist_lock;
+	struct {
+		unsigned int start;
+		unsigned int size;
+		u32 shadow[2048];
+		bool pending;
+	} fifo[3];
 };
 
 struct vc4_plane {
@@ -380,6 +388,11 @@ struct vc4_plane_state {
 	 * hardware at vc4_crtc_atomic_flush() time.
 	 */
 	u32 __iomem *hw_dlist;
+
+	/* Offset where the plane's dlist was last stored in the
+	 * shadow dlist bucket at vc4_crtc_atomic_flush() time.
+	 */
+	unsigned int dlist_offset;
 
 	/* Clipped coordinates of the plane on the display. */
 	int crtc_x, crtc_y, crtc_w, crtc_h;

--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -983,7 +983,10 @@ int vc4_kms_load(struct drm_device *dev);
 struct drm_plane *vc4_plane_init(struct drm_device *dev,
 				 enum drm_plane_type type);
 int vc4_plane_create_additional_planes(struct drm_device *dev);
-u32 vc4_plane_write_dlist(struct drm_plane *plane, u32 __iomem *dlist);
+u32 vc4_plane_write_dlist(struct vc4_hvs *hvs,
+			  struct vc4_crtc_state *vc4_crtc_state,
+			  struct vc4_plane_state *vc4_plane_state,
+			  unsigned dlist_offset);
 u32 vc4_plane_dlist_size(const struct drm_plane_state *state);
 void vc4_plane_async_set_fb(struct drm_plane *plane,
 			    struct drm_framebuffer *fb);

--- a/drivers/gpu/drm/vc4/vc4_hvs.c
+++ b/drivers/gpu/drm/vc4/vc4_hvs.c
@@ -674,6 +674,7 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 	struct drm_device *dev = crtc->dev;
 	struct vc4_dev *vc4 = to_vc4_dev(dev);
 	struct vc4_crtc_state *vc4_state = to_vc4_crtc_state(crtc->state);
+	unsigned int channel = vc4_state->assigned_channel;
 	struct drm_plane *plane;
 	struct vc4_plane_state *vc4_plane_state;
 	bool debug_dump_regs = false;
@@ -714,8 +715,8 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 		/* This sets a black background color fill, as is the case
 		 * with other DRM drivers.
 		 */
-		HVS_WRITE(SCALER_DISPBKGNDX(vc4_state->assigned_channel),
-			  HVS_READ(SCALER_DISPBKGNDX(vc4_state->assigned_channel)) |
+		HVS_WRITE(SCALER_DISPBKGNDX(channel),
+			  HVS_READ(SCALER_DISPBKGNDX(channel)) |
 			  SCALER_DISPBKGND_FILL);
 
 	/* Only update DISPLIST if the CRTC was already running and is not
@@ -729,7 +730,7 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 		vc4_hvs_update_dlist(crtc);
 
 	if (crtc->state->color_mgmt_changed) {
-		u32 dispbkgndx = HVS_READ(SCALER_DISPBKGNDX(vc4_state->assigned_channel));
+		u32 dispbkgndx = HVS_READ(SCALER_DISPBKGNDX(channel));
 
 		if (crtc->state->gamma_lut) {
 			if (!vc4->hvs->hvs5) {
@@ -752,7 +753,7 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 			if (!vc4->hvs->hvs5)
 				dispbkgndx &= ~SCALER_DISPBKGND_GAMMA;
 		}
-		HVS_WRITE(SCALER_DISPBKGNDX(vc4_state->assigned_channel), dispbkgndx);
+		HVS_WRITE(SCALER_DISPBKGNDX(channel), dispbkgndx);
 	}
 
 	if (debug_dump_regs) {

--- a/drivers/gpu/drm/vc4/vc4_hvs.c
+++ b/drivers/gpu/drm/vc4/vc4_hvs.c
@@ -616,14 +616,11 @@ static void vc4_hvs_update_dlist(struct drm_crtc *crtc)
 			crtc->state->event = NULL;
 		}
 
-		HVS_WRITE(SCALER_DISPLISTX(vc4_state->assigned_channel),
-			  vc4_state->mm.start);
-
 		spin_unlock_irqrestore(&dev->event_lock, flags);
-	} else {
-		HVS_WRITE(SCALER_DISPLISTX(vc4_state->assigned_channel),
-			  vc4_state->mm.start);
 	}
+
+	HVS_WRITE(SCALER_DISPLISTX(vc4_state->assigned_channel),
+		  vc4_state->mm.start);
 
 	spin_lock_irqsave(&vc4_crtc->irq_lock, flags);
 	vc4_crtc->current_dlist = vc4_state->mm.start;

--- a/drivers/gpu/drm/vc4/vc4_hvs.c
+++ b/drivers/gpu/drm/vc4/vc4_hvs.c
@@ -686,6 +686,9 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 	u32 __iomem *dlist_start = vc4->hvs->dlist + vc4_state->mm.start;
 	u32 __iomem *dlist_next = dlist_start;
 
+	if (vc4_state->assigned_channel == VC4_HVS_CHANNEL_DISABLED)
+		return;
+
 	if (debug_dump_regs) {
 		DRM_INFO("CRTC %d HVS before:\n", drm_crtc_index(crtc));
 		vc4_hvs_dump_state(dev);

--- a/drivers/gpu/drm/vc4/vc4_hvs.c
+++ b/drivers/gpu/drm/vc4/vc4_hvs.c
@@ -596,14 +596,56 @@ int vc4_hvs_atomic_check(struct drm_crtc *crtc, struct drm_atomic_state *state)
 	return vc4_hvs_gamma_check(crtc, state);
 }
 
-static void vc4_hvs_install_dlist(struct drm_crtc *crtc)
+static void vc4_hvs_install_dlist(struct vc4_dev *vc4, unsigned int channel)
 {
-	struct drm_device *dev = crtc->dev;
-	struct vc4_dev *vc4 = to_vc4_dev(dev);
-	struct vc4_crtc_state *vc4_state = to_vc4_crtc_state(crtc->state);
+	struct vc4_hvs *hvs = vc4->hvs;
+	u32 __iomem *dlist_start;
+	unsigned long flags;
+	unsigned i;
+	u32 reg;
 
-	HVS_WRITE(SCALER_DISPLISTX(vc4_state->assigned_channel),
-		  vc4_state->mm.start);
+	spin_lock_irqsave(&hvs->hw_dlist_lock, flags);
+
+	if (!hvs->fifo[channel].pending) {
+		spin_unlock_irqrestore(&hvs->hw_dlist_lock, flags);
+		return;
+	}
+
+	dlist_start = hvs->dlist + hvs->fifo[channel].start;
+	/* Can't memcpy_toio() because it needs to be 32-bit writes. */
+	for (i = 0; i < hvs->fifo[channel].size; i++)
+		writel(hvs->fifo[channel].shadow[i], dlist_start + i);
+
+	HVS_WRITE(SCALER_DISPLISTX(channel), hvs->fifo[channel].start);
+
+	hvs->fifo[channel].pending = false;
+
+	reg = HVS_READ(SCALER_DISPCTRL);
+	reg &= ~BIT(7 + (channel * 4));
+	HVS_WRITE(SCALER_DISPCTRL, reg);
+
+	spin_unlock_irqrestore(&hvs->hw_dlist_lock, flags);
+}
+
+static void vc4_hvs_schedule_dlist_update(struct vc4_dev *vc4,
+					  unsigned int channel)
+{
+	struct vc4_hvs *hvs = vc4->hvs;
+	unsigned long flags;
+
+	spin_lock_irqsave(&hvs->hw_dlist_lock, flags);
+
+	if (hvs->fifo[channel].pending) {
+		spin_unlock_irqrestore(&hvs->hw_dlist_lock, flags);
+		return;
+	}
+
+	HVS_WRITE(SCALER_DISPCTRL,
+		  HVS_READ(SCALER_DISPCTRL) | BIT(7 + (channel * 4)));
+
+	hvs->fifo[channel].pending = true;
+
+	spin_unlock_irqrestore(&hvs->hw_dlist_lock, flags);
 }
 
 static void vc4_hvs_update_dlist(struct drm_crtc *crtc)
@@ -650,11 +692,14 @@ void vc4_hvs_atomic_enable(struct drm_crtc *crtc,
 {
 	struct drm_device *dev = crtc->dev;
 	struct vc4_dev *vc4 = to_vc4_dev(dev);
+	struct vc4_hvs *hvs = vc4->hvs;
 	struct drm_display_mode *mode = &crtc->state->adjusted_mode;
 	struct vc4_crtc *vc4_crtc = to_vc4_crtc(crtc);
+	struct vc4_crtc_state *vc4_state = to_vc4_crtc_state(crtc->state);
 	bool oneshot = vc4_crtc->feeds_txp;
 
-	vc4_hvs_install_dlist(crtc);
+	hvs->fifo[vc4_state->assigned_channel].pending = true;
+	vc4_hvs_install_dlist(vc4, vc4_state->assigned_channel);
 	vc4_hvs_update_dlist(crtc);
 	vc4_hvs_init_channel(vc4, crtc, mode, oneshot);
 }
@@ -683,7 +728,7 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 	struct drm_plane *plane;
 	bool debug_dump_regs = false;
 	bool enable_bg_fill = false;
-	unsigned int dlist_start = vc4_state->mm.start;
+	unsigned int dlist_start = 0;
 	unsigned int dlist_next = dlist_start;
 
 	if (vc4_state->assigned_channel == VC4_HVS_CHANNEL_DISABLED)
@@ -693,6 +738,8 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 		DRM_INFO("CRTC %d HVS before:\n", drm_crtc_index(crtc));
 		vc4_hvs_dump_state(dev);
 	}
+
+	memset(&hvs->fifo[channel], 0, sizeof(hvs->fifo[channel]));
 
 	/* Copy all the active planes' dlist contents to the hardware dlist. */
 	drm_atomic_crtc_for_each_plane(plane, crtc) {
@@ -716,10 +763,11 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 						    vc4_plane_state, dlist_next);
 	}
 
-	writel(SCALER_CTL0_END, vc4->hvs->dlist + dlist_next);
-	dlist_next++;
+	hvs->fifo[channel].shadow[dlist_next++] = SCALER_CTL0_END;
+	hvs->fifo[channel].start = vc4_state->mm.start;
+	hvs->fifo[channel].size = vc4_state->mm.size;
 
-	WARN_ON_ONCE(dlist_next - dlist_start != vc4_state->mm.size);
+	WARN_ON_ONCE(dlist_next != vc4_state->mm.size);
 
 	if (enable_bg_fill)
 		/* This sets a black background color fill, as is the case
@@ -737,7 +785,7 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 	 * information.
 	 */
 	if (crtc->state->active && old_state->active) {
-		vc4_hvs_install_dlist(crtc);
+		vc4_hvs_schedule_dlist_update(vc4, channel);
 		vc4_hvs_update_dlist(crtc);
 	}
 
@@ -825,6 +873,11 @@ static irqreturn_t vc4_hvs_irq_handler(int irq, void *data)
 
 			irqret = IRQ_HANDLED;
 		}
+
+		if (status & SCALER_DISPSTAT_EOF(channel)) {
+			vc4_hvs_install_dlist(vc4, channel);
+			irqret = IRQ_HANDLED;
+		}
 	}
 
 	/* Clear every per-channel interrupt flag. */
@@ -881,6 +934,7 @@ static int vc4_hvs_bind(struct device *dev, struct device *master, void *data)
 		hvs->dlist = hvs->regs + SCALER5_DLIST_START;
 
 	spin_lock_init(&hvs->mm_lock);
+	spin_lock_init(&hvs->hw_dlist_lock);
 
 	/* Set up the HVS display list memory manager.  We never
 	 * overwrite the setup from the bootloader (just 128b out of

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -390,9 +390,10 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 	}
 
 	if (vc4->hvs && vc4->hvs->hvs5) {
+		unsigned long state_rate = max(old_hvs_state->core_clock_rate,
+					       new_hvs_state->core_clock_rate);
 		unsigned long core_rate = max_t(unsigned long,
-						500000000,
-						new_hvs_state->core_clock_rate);
+						500000000, state_rate);
 
 		core_req = clk_request_start(hvs->core_clk, core_rate);
 		/*

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -1162,18 +1162,21 @@ static void vc4_plane_atomic_update(struct drm_plane *plane,
 	 */
 }
 
-u32 vc4_plane_write_dlist(struct drm_plane *plane, u32 __iomem *dlist)
+u32 vc4_plane_write_dlist(struct vc4_hvs *hvs,
+			  struct vc4_crtc_state *vc4_crtc_state,
+			  struct vc4_plane_state *vc4_plane_state,
+			  unsigned dlist_offset)
 {
-	struct vc4_plane_state *vc4_state = to_vc4_plane_state(plane->state);
+	u32 __iomem *dlist = hvs->dlist + dlist_offset;
 	int i;
 
-	vc4_state->hw_dlist = dlist;
+	vc4_plane_state->hw_dlist = dlist;
 
 	/* Can't memcpy_toio() because it needs to be 32-bit writes. */
-	for (i = 0; i < vc4_state->dlist_count; i++)
-		writel(vc4_state->dlist[i], &dlist[i]);
+	for (i = 0; i < vc4_plane_state->dlist_count; i++)
+		writel(vc4_plane_state->dlist[i], &dlist[i]);
 
-	return vc4_state->dlist_count;
+	return vc4_plane_state->dlist_count;
 }
 
 u32 vc4_plane_dlist_size(const struct drm_plane_state *state)

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -1167,14 +1167,15 @@ u32 vc4_plane_write_dlist(struct vc4_hvs *hvs,
 			  struct vc4_plane_state *vc4_plane_state,
 			  unsigned dlist_offset)
 {
-	u32 __iomem *dlist = hvs->dlist + dlist_offset;
+	u32 __iomem *dlist = hvs->dlist + vc4_crtc_state->mm.start + dlist_offset;
+	unsigned int channel = vc4_crtc_state->assigned_channel;
 	int i;
 
 	vc4_plane_state->hw_dlist = dlist;
+	vc4_plane_state->dlist_offset = dlist_offset;
 
-	/* Can't memcpy_toio() because it needs to be 32-bit writes. */
 	for (i = 0; i < vc4_plane_state->dlist_count; i++)
-		writel(vc4_plane_state->dlist[i], &dlist[i]);
+		hvs->fifo[channel].shadow[dlist_offset + i] = vc4_plane_state->dlist[i];
 
 	return vc4_plane_state->dlist_count;
 }
@@ -1192,6 +1193,9 @@ u32 vc4_plane_dlist_size(const struct drm_plane_state *state)
  */
 void vc4_plane_async_set_fb(struct drm_plane *plane, struct drm_framebuffer *fb)
 {
+	struct vc4_dev *vc4 = to_vc4_dev(plane->dev);
+	struct drm_crtc_state *crtc_state = plane->state->crtc->state;
+	struct vc4_crtc_state *vc4_crtc_state = to_vc4_crtc_state(crtc_state);
 	struct vc4_plane_state *vc4_state = to_vc4_plane_state(plane->state);
 	struct drm_gem_cma_object *bo = drm_fb_cma_get_gem_obj(fb, 0);
 	uint32_t addr;
@@ -1213,13 +1217,20 @@ void vc4_plane_async_set_fb(struct drm_plane *plane, struct drm_framebuffer *fb)
 	 * also use our updated address.
 	 */
 	vc4_state->dlist[vc4_state->ptr0_offset] = addr;
+
+	/* Update the channel shadow dlist */
+	vc4_plane_write_dlist(vc4->hvs, vc4_crtc_state,
+			      vc4_state, vc4_state->dlist_offset);
 }
 
 static void vc4_plane_atomic_async_update(struct drm_plane *plane,
 					  struct drm_atomic_state *state)
 {
+	struct vc4_dev *vc4 = to_vc4_dev(plane->dev);
 	struct drm_plane_state *new_plane_state = drm_atomic_get_new_plane_state(state,
 										 plane);
+	struct drm_crtc_state *crtc_state = new_plane_state->crtc->state;
+	struct vc4_crtc_state *vc4_crtc_state = to_vc4_crtc_state(crtc_state);
 	struct vc4_plane_state *vc4_state, *new_vc4_state;
 
 	swap(plane->state->fb, new_plane_state->fb);
@@ -1273,16 +1284,17 @@ static void vc4_plane_atomic_async_update(struct drm_plane *plane,
 	vc4_state->dlist[vc4_state->ptr0_offset] =
 		new_vc4_state->dlist[vc4_state->ptr0_offset];
 
-	/* Note that we can't just call vc4_plane_write_dlist()
-	 * because that would smash the context data that the HVS is
-	 * currently using.
-	 */
+	/* Update the hardware dlist entries. */
 	writel(vc4_state->dlist[vc4_state->pos0_offset],
 	       &vc4_state->hw_dlist[vc4_state->pos0_offset]);
 	writel(vc4_state->dlist[vc4_state->pos2_offset],
 	       &vc4_state->hw_dlist[vc4_state->pos2_offset]);
 	writel(vc4_state->dlist[vc4_state->ptr0_offset],
 	       &vc4_state->hw_dlist[vc4_state->ptr0_offset]);
+
+	/* Update the channel shadow dlist */
+	vc4_plane_write_dlist(vc4->hvs, vc4_crtc_state,
+			      new_vc4_state, new_vc4_state->dlist_offset);
 }
 
 static int vc4_plane_atomic_async_check(struct drm_plane *plane,


### PR DESCRIPTION
Hi,

Here's a PR that fixes #4475.

The last commit has most of the details, but the basic idea is that when we move the cursor along the edges, we end up reusing and corrupting the active dlist.

Let me know what you think,
Maxime