### PR TITLE
dtoverlays: Enable cam1_clock when using tc358743

### DIFF
--- a/arch/arm/boot/dts/overlays/irs1125-overlay.dts
+++ b/arch/arm/boot/dts/overlays/irs1125-overlay.dts
@@ -75,6 +75,7 @@
 	clk_frag: fragment@5 {
 		target = <&cam1_clk>;
 		__overlay__ {
+			status = "okay";
 			clock-frequency = <26000000>;
 		};
 	};

--- a/arch/arm/boot/dts/overlays/tc358743-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tc358743-overlay.dts
@@ -78,6 +78,7 @@
 	clk_frag: fragment@6 {
 		target = <&cam1_clk>;
 		__overlay__ {
+			status = "okay";
 			clock-frequency = <27000000>;
 		};
 	};


### PR DESCRIPTION
This fixes a regression introduced in 131f1322039284932ccb601a5cffdd9ca5d36d96 (see also https://github.com/raspberrypi/linux/issues/4791). The tc358743 driver refused to bind to the device.

The new unified cam1_clk node that represents the fixed on-board oscillator is marked as disabled by default. The tc358743 overlay didn't expect this and so the clock node was stuck in disabled state.

This commit just adds the required status = "okay" line. Other sensor drivers do this too.

Fixes: #4791