### PR TITLE
uapi/v4l2-controls: Reset V4L2_CID_USER_BCM2835_ISP_BASE to same as 5.10

### DIFF
--- a/include/uapi/linux/v4l2-controls.h
+++ b/include/uapi/linux/v4l2-controls.h
@@ -214,7 +214,7 @@ enum v4l2_colorfx {
 
 /* The base for the bcm2835-isp driver controls.
  * We reserve 16 controls for this driver. */
-#define V4L2_CID_USER_BCM2835_ISP_BASE		(V4L2_CID_USER_BASE + 0x10f0)
+#define V4L2_CID_USER_BCM2835_ISP_BASE		(V4L2_CID_USER_BASE + 0x10e0)
 
 /* MPEG-class control IDs */
 /* The MPEG controls are applicable to all codec controls


### PR DESCRIPTION
https://github.com/raspberrypi/linux/issues/4440

Upstream has added additional device specific controls, so the
V4L2_CID_USER_BASE + 0x10e0 value that had been defined for use with
the ISP has been taken by something else (and +0x10f0 has been used as
well)

Duplicate the use on V4L2_CID_USER_BASE + 0x10e0 so that userspace
(libcamera) doesn't need to change. Once the driver is upstream, then
we'll update libcamera to adopt the new value as it then won't change.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>