### PR TITLE
media: i2c: ov9281: Increase diff between VTS and max exposure

### DIFF
--- a/drivers/media/i2c/ov9281.c
+++ b/drivers/media/i2c/ov9281.c
@@ -52,7 +52,11 @@
 #define OV9281_REG_EXPOSURE		0x3500
 #define	OV9281_EXPOSURE_MIN		4
 #define	OV9281_EXPOSURE_STEP		1
-#define OV9281_VTS_MAX			0x7fff
+/*
+ * Number of lines less than frame length (VTS) that exposure must be.
+ * Datasheet states 25, although empirically 5 appears to work.
+ */
+#define OV9281_EXPOSURE_OFFSET		25
 
 #define OV9281_REG_GAIN_H		0x3508
 #define OV9281_REG_GAIN_L		0x3509
@@ -69,6 +73,7 @@
 #define OV9281_TEST_PATTERN_DISABLE	0x0
 
 #define OV9281_REG_VTS			0x380e
+#define OV9281_VTS_MAX			0x7fff
 
 /*
  * OV9281 native and active pixel array size.
@@ -964,7 +969,7 @@ static int ov9281_set_ctrl(struct v4l2_ctrl *ctrl)
 	switch (ctrl->id) {
 	case V4L2_CID_VBLANK:
 		/* Update max exposure while meeting expected vblanking */
-		max = ov9281->cur_mode->height + ctrl->val - 4;
+		max = ov9281->cur_mode->height + ctrl->val - OV9281_EXPOSURE_OFFSET;
 		__v4l2_ctrl_modify_range(ov9281->exposure,
 					 ov9281->exposure->minimum, max,
 					 ov9281->exposure->step,
@@ -1059,7 +1064,7 @@ static int ov9281_initialize_controls(struct ov9281 *ov9281)
 					   OV9281_VTS_MAX - mode->height, 1,
 					   vblank_def);
 
-	exposure_max = mode->vts_def - 4;
+	exposure_max = mode->vts_def - OV9281_EXPOSURE_OFFSET;
 	ov9281->exposure = v4l2_ctrl_new_std(handler, &ov9281_ctrl_ops,
 					     V4L2_CID_EXPOSURE,
 					     OV9281_EXPOSURE_MIN, exposure_max,


### PR DESCRIPTION
The driver did allow the exposure to go up to VTS - 4 lines,
but this would produce a visible line on 1280x800, and a stall of
the sensor at 640x480.

Whilst it appears to work with a difference of 5, the datasheet states
there should be at least 25 lines difference between VTS and exposure,
so use that value.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>