### PR TITLE
dtoverlays: Add backlight-gpio parameter to vc4-kms-dpi-generic

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3625,6 +3625,8 @@ Params: clock-frequency         Display clock frequency (Hz)
         rgb888                  Change to RGB888 output on GPIOs 0-27
         bus-format              Override the bus format for a MEDIA_BUS_FMT_*
                                 value. NB also overridden by rgbXXX overrides.
+        backlight-gpio          Defines a GPIO to be used for backlight control
+                                (default of none).
 
 
 Name:   vc4-kms-dsi-7inch

--- a/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
@@ -63,6 +63,23 @@
 		};
 	};
 
+	fragment@2 {
+		target = <&panel>;
+		__dormant__  {
+			backlight = <&backlight>;
+		};
+	};
+
+	fragment@3 {
+		target-path = "/";
+		__dormant__  {
+			backlight: backlight {
+				compatible = "gpio-backlight";
+				gpios = <&gpio 255 GPIO_ACTIVE_HIGH>;
+			};
+		};
+	};
+
 	__overrides__ {
 		clock-frequency = <&timing>, "clock-frequency:0";
 		hactive = <&timing>, "hactive:0";
@@ -88,5 +105,7 @@
 		rgb888 = <&panel>, "bus-format:0=0x100a",
 			<&dpi_node>, "pinctrl-0:0=",<&dpi_gpio0>;
 		bus-format = <&panel>, "bus-format:0";
+		backlight-gpio = <0>, "+2+3",
+			<&backlight>, "gpios:4";
 	};
 };


### PR DESCRIPTION
To allow for the cases where a simple panel does have a GPIO
controlled backlight. Defaults to having no backlight defined.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>