### PR TITLE
drm/vc4: Disable Gamma control on HVS5 due to issues writing the table

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -1209,15 +1209,9 @@ int vc4_crtc_init(struct drm_device *drm, struct vc4_crtc *vc4_crtc,
 
 	if (!vc4->hvs->hvs5) {
 		drm_mode_crtc_set_gamma_size(crtc, ARRAY_SIZE(vc4_crtc->lut_r));
-	} else {
-		/* This is a lie for hvs5 which uses a 16 point PWL, but it
-		 * allows for something smarter than just 16 linearly spaced
-		 * segments. Conversion is done in vc5_hvs_update_gamma_lut.
-		 */
-		drm_mode_crtc_set_gamma_size(crtc, 256);
+		drm_crtc_enable_color_mgmt(crtc, 0, false, crtc->gamma_size);
 	}
 
-	drm_crtc_enable_color_mgmt(crtc, 0, false, crtc->gamma_size);
 
 	if (!vc4->hvs->hvs5) {
 		/* We support CTM, but only for one CRTC at a time. It's therefore


### PR DESCRIPTION
Still under investigation, but the conditions under which the HVS
will accept values written to the gamma PWL are not straightforward.

Disable gamma on HVS5 again until it can be resolved to avoid
gamma being enabled with an incorrect table.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>