### PR TITLE
drm/vc4: hdmi: Fix clock value used for validating hdmi modes

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -1496,7 +1496,7 @@ vc4_hdmi_encoder_compute_mode_clock(const struct drm_display_mode *mode,
 				    unsigned int bpc,
 				    enum vc4_hdmi_output_format fmt)
 {
-	unsigned long long clock = mode->crtc_clock * 1000;
+	unsigned long long clock = mode->clock * 1000;
 
 	if (mode->flags & DRM_MODE_FLAG_DBLCLK)
 		clock = clock * 2;


### PR DESCRIPTION
We are using mode->crt_clock here which is filled by drm_mode_set_crtcinfo()
which is called right after .mode_valid.

Use mode->clock which is valid here.

Fixes: 624d93a4f0 ("drm/vc4: hdmi: Move clock calculation into its own function")

Signed-off-by: Dom Cobley <popcornmix@gmail.com>