### PR TITLE
drivers: bcm2835_unicam: Disable trigger mode operation

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -983,11 +983,6 @@ static irqreturn_t unicam_isr(int irq, void *dev)
 		}
 	}
 
-	if (reg_read(unicam, UNICAM_ICTL) & UNICAM_FCM) {
-		/* Switch out of trigger mode if selected */
-		reg_write_field(unicam, UNICAM_ICTL, 1, UNICAM_TFC);
-		reg_write_field(unicam, UNICAM_ICTL, 0, UNICAM_FCM);
-	}
 	return IRQ_HANDLED;
 }
 
@@ -2297,8 +2292,7 @@ static void unicam_start_rx(struct unicam_device *dev, dma_addr_t *addr)
 
 	reg_write_field(dev, UNICAM_ANA, 0, UNICAM_DDL);
 
-	/* Always start in trigger frame capture mode (UNICAM_FCM set) */
-	val = UNICAM_FSIE | UNICAM_FEIE | UNICAM_FCM | UNICAM_IBOB;
+	val = UNICAM_FSIE | UNICAM_FEIE | UNICAM_IBOB;
 	set_field(&val, line_int_freq, UNICAM_LCIE_MASK);
 	reg_write(dev, UNICAM_ICTL, val);
 	reg_write(dev, UNICAM_STA, UNICAM_STA_MASK_ALL);
@@ -2411,12 +2405,6 @@ static void unicam_start_rx(struct unicam_device *dev, dma_addr_t *addr)
 	/* Load embedded data buffer pointers if needed */
 	if (dev->node[METADATA_PAD].streaming && dev->sensor_embedded_data)
 		reg_write_field(dev, UNICAM_DCS, 1, UNICAM_LDP);
-
-	/*
-	 * Enable trigger only for the first frame to
-	 * sync correctly to the FS from the source.
-	 */
-	reg_write_field(dev, UNICAM_ICTL, 1, UNICAM_TFC);
 }
 
 static void unicam_disable(struct unicam_device *dev)


### PR DESCRIPTION
On a Pi3 B/B+ platform the imx219 sensor frequently generates a single corrupt
frame when the sensor first starts. This can either be a missing line, or
invalid samples within the line. This only occurrs using the Unicam kernel
driver.

Disabling trigger mode elimiates this corruption. Since trigger mode is a
legacy feature copied from the firmeare driver and not expected to be needed,
remove it. Tested on the Raspberry Pi cameras and shows no ill effects.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>