### PR TITLE
ARM: dts: BCM2711 AON_INTR2 generates IRQ edges

### DIFF
--- a/arch/arm/boot/dts/bcm2711.dtsi
+++ b/arch/arm/boot/dts/bcm2711.dtsi
@@ -319,7 +319,7 @@
 		aon_intr: interrupt-controller@7ef00100 {
 			compatible = "brcm,bcm2711-l2-intc", "brcm,l2-intc";
 			reg = <0x7ef00100 0x30>;
-			interrupts = <GIC_SPI 96 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 96 IRQ_TYPE_EDGE_RISING>;
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			status = "disabled";
@@ -402,7 +402,7 @@
 				 <&clk_27MHz>;
 			resets = <&dvp 1>;
 			interrupt-parent = <&aon_intr>;
-			interrupts = <8>, <7>, <6>,
+			interrupts = <8>, <7>, <6>,	// This is correct
 				     <9>, <10>, <11>;
 			interrupt-names = "cec-tx", "cec-rx", "cec-low",
 					  "wakeup", "hpd-connected", "hpd-removed";


### PR DESCRIPTION
THe AON_INTR2 controller manages the HDMI interrupts, combining them
into a single interrupt passed to the GIC. bcm2711.dtsi declares the
interrupt as being IRQ_TYPE_LEVEL_HIGH, but it should be
IRQ_TYPE_EDGE_RISING. Most of the time the distinction shouldn't
matter, but there is a small possibility of losing interrupts unless
it is corrected.

See: http://lists.infradead.org/pipermail/linux-arm-kernel/2022-January/710292.html

Signed-off-by: Phil Elwell <phil@raspberrypi.com>