### PR TITLE
i2c: bcm2835: Make clock-stretch timeout configurable

### DIFF
--- a/drivers/i2c/busses/i2c-bcm2835.c
+++ b/drivers/i2c/busses/i2c-bcm2835.c
@@ -55,6 +55,10 @@ static unsigned int debug;
 module_param(debug, uint, 0644);
 MODULE_PARM_DESC(debug, "1=err, 2=isr, 3=xfer");
 
+static unsigned int clk_tout_ms = 35; /* SMBUs-recommended 35ms */
+module_param(clk_tout_ms, uint, 0644);
+MODULE_PARM_DESC(clk_tout_ms, "clock-stretch timeout (mS)");
+
 #define BCM2835_DEBUG_MAX	512
 struct bcm2835_debug {
 	struct i2c_msg *msg;
@@ -214,12 +218,12 @@ static int clk_bcm2835_i2c_set_rate(struct clk_hw *hw, unsigned long rate,
 			   (redl << BCM2835_I2C_REDL_SHIFT));
 
 	/*
-	 * Set the clock stretch timeout to the SMBUs-recommended 35ms.
+	 * Set the clock stretch timeout.
 	 */
-	if (rate > 0xffff*1000/35)
+	if (rate > 0xffff*1000/clk_tout_ms)
 	    clk_tout = 0xffff;
 	else
-	    clk_tout = 35*rate/1000;
+	    clk_tout = clk_tout_ms*rate/1000;
 
 	bcm2835_i2c_writel(div->i2c_dev, BCM2835_I2C_CLKT, clk_tout);
 


### PR DESCRIPTION
The default clock-stretch timeout is 35 mS, which works well for
SMBus, but there are some I2C devices which can stretch the clock even
longer. Rather than trying to prescribe a safe default for everyone,
allow the timeout to be configured.

Signed-off-by: Alex Crawford <raspberrypi/linux@code.acrawford.com>