### PR TITLE
Patching lan78xx for SOF_TIMESTAMPING_TX_SOFTWARE support

### DIFF
--- a/drivers/net/usb/lan78xx.c
+++ b/drivers/net/usb/lan78xx.c
@@ -1685,6 +1685,7 @@ static const struct ethtool_ops lan78xx_ethtool_ops = {
 	.set_link_ksettings = lan78xx_set_link_ksettings,
 	.get_regs_len	= lan78xx_get_regs_len,
 	.get_regs	= lan78xx_get_regs,
+	.get_ts_info    = ethtool_op_get_ts_info,
 };
 
 static void lan78xx_init_mac_address(struct lan78xx_net *dev)


### PR DESCRIPTION
This patch to the Raspberry 3B+ LAN78xx kernel driver enables the support for _SOF_TIMESTAMPING_TX_SOFTWARE_.

Aiming the software-transmit capability for PTP:

```
 ethtool -T eth0
Time stamping parameters for eth0:
Capabilities:
	software-transmit
	software-receive
	software-system-clock
PTP Hardware Clock: none
Hardware Transmit Timestamp Modes: none
Hardware Receive Filter Modes: none
```