### PR TITLE
[rpi-5.15.y] Fix clang warnings

### DIFF
--- a/drivers/media/i2c/ov9281.c
+++ b/drivers/media/i2c/ov9281.c
@@ -1124,7 +1124,7 @@ static int ov9281_check_sensor_id(struct ov9281 *ov9281,
 				  struct i2c_client *client)
 {
 	struct device *dev = &ov9281->client->dev;
-	u32 id = 0, id_msb;
+	u32 id = 0, id_msb = 0;
 	int ret;
 
 	ret = ov9281_read_reg(client, OV9281_REG_CHIP_ID + 1,

--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -3108,6 +3108,7 @@ static int unicam_async_complete(struct v4l2_async_notifier *notifier)
 	}
 	if (!source_pads) {
 		unicam_err(unicam, "No source pads on sensor.\n");
+		ret = -ENODEV;
 		goto unregister;
 	}
 

--- a/drivers/misc/bcm2835_smi.c
+++ b/drivers/misc/bcm2835_smi.c
@@ -689,7 +689,7 @@ void bcm2835_smi_write_buf(
 			inst->dev,
 			(void *)buf,
 			n_bytes,
-			DMA_MEM_TO_DEV);
+			DMA_TO_DEVICE);
 		struct scatterlist *sgl =
 			smi_scatterlist_from_buffer(inst, phy_addr, n_bytes,
 				&inst->buffer_sgl);
@@ -702,7 +702,7 @@ void bcm2835_smi_write_buf(
 		smi_dma_write_sgl(inst, sgl, 1, n_bytes);
 
 		dma_unmap_single
-			(inst->dev, phy_addr, n_bytes, DMA_MEM_TO_DEV);
+			(inst->dev, phy_addr, n_bytes, DMA_TO_DEVICE);
 	} else if (n_bytes) {
 		smi_write_fifo(inst, (uint32_t *) buf, n_bytes);
 	}
@@ -748,7 +748,7 @@ void bcm2835_smi_read_buf(struct bcm2835_smi_instance *inst,
 	if (n_bytes > DMA_THRESHOLD_BYTES) {
 		dma_addr_t phy_addr = dma_map_single(inst->dev,
 						     buf, n_bytes,
-						     DMA_DEV_TO_MEM);
+						     DMA_FROM_DEVICE);
 		struct scatterlist *sgl = smi_scatterlist_from_buffer(
 			inst, phy_addr, n_bytes,
 			&inst->buffer_sgl);
@@ -758,7 +758,7 @@ void bcm2835_smi_read_buf(struct bcm2835_smi_instance *inst,
 			goto out;
 		}
 		smi_dma_read_sgl(inst, sgl, 1, n_bytes);
-		dma_unmap_single(inst->dev, phy_addr, n_bytes, DMA_DEV_TO_MEM);
+		dma_unmap_single(inst->dev, phy_addr, n_bytes, DMA_FROM_DEVICE);
 	} else if (n_bytes) {
 		smi_read_fifo(inst, (uint32_t *)buf, n_bytes);
 	}

--- a/sound/soc/bcm/allo-piano-dac-plus.c
+++ b/sound/soc/bcm/allo-piano-dac-plus.c
@@ -63,7 +63,7 @@ static const char * const allo_piano_mode_texts[] = {
 	"2.2",
 };
 
-static const SOC_ENUM_SINGLE_DECL(allo_piano_mode_enum,
+static SOC_ENUM_SINGLE_DECL(allo_piano_mode_enum,
 		0, 0, allo_piano_mode_texts);
 
 static const char * const allo_piano_dual_mode_texts[] = {
@@ -72,7 +72,7 @@ static const char * const allo_piano_dual_mode_texts[] = {
 	"Dual-Stereo",
 };
 
-static const SOC_ENUM_SINGLE_DECL(allo_piano_dual_mode_enum,
+static SOC_ENUM_SINGLE_DECL(allo_piano_dual_mode_enum,
 		0, 0, allo_piano_dual_mode_texts);
 
 static const char * const allo_piano_dsp_low_pass_texts[] = {
@@ -93,7 +93,7 @@ static const char * const allo_piano_dsp_low_pass_texts[] = {
 	"200",
 };
 
-static const SOC_ENUM_SINGLE_DECL(allo_piano_enum,
+static SOC_ENUM_SINGLE_DECL(allo_piano_enum,
 		0, 0, allo_piano_dsp_low_pass_texts);
 
 static int __snd_allo_piano_dsp_program(struct snd_soc_pcm_runtime *rtd,

--- a/sound/soc/codecs/ma120x0p.c
+++ b/sound/soc/codecs/ma120x0p.c
@@ -888,7 +888,7 @@ static const int pwr_mode_values[] = {
 		0x70,
 	};
 
-static const SOC_VALUE_ENUM_SINGLE_DECL(pwr_mode_ctrl,
+static SOC_VALUE_ENUM_SINGLE_DECL(pwr_mode_ctrl,
 	ma_pm_man__a, 0, 0x70,
 	pwr_mode_texts,
 	pwr_mode_values);


### PR DESCRIPTION
This series cleans up the clang warnings that I see with `ARCH=arm bcm2709_defconfig`, `ARCH=arm bcm2711_defconfig`, and `ARCH=arm64 bcm2711_defconfig`. The warnings are in the commit messages for references.

Most of these fixes line up with the ones suggested in https://github.com/raspberrypi/linux/issues/4818 but I only looked at the full issue after resolving them so that I was only influenced by the warning text and current code.

Closes https://github.com/raspberrypi/linux/issues/4818.
