### PR TITLE
remove ddc1 from cm4s overlay

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
@@ -207,6 +207,7 @@
 #include "bcm283x-rpi-i2c0mux_0_28.dtsi"
 
 /delete-node/ &hdmi1;
+/delete-node/ &ddc1;
 
 / {
 	chosen {


### PR DESCRIPTION
On CM4s the second hdmi port is not connected. Therefore the i2c ddc
pins for this (ddc1) should be removed from the device tree. This is
already implemented for the hdmi1 node.

This is also mentioned in #4857.

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>