### PR TITLE
CM4s: keep disabled node hdmi1 in devicetree

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
@@ -206,8 +206,6 @@
 #include "bcm283x-rpi-csi1-4lane.dtsi"
 #include "bcm283x-rpi-i2c0mux_0_28.dtsi"
 
-/delete-node/ &hdmi1;
-
 / {
 	chosen {
 		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_compat_alsa=0 snd_bcm2835.enable_hdmi=1";


### PR DESCRIPTION
The second hdmi port on cm4s is disabled by default (default from bcm2711-rpi.dtsi) and therefore it is not necessary to remove it in the specific cm4s overlay (as done in 64328ab674dc3e3f0356d066916546f6b2876257)

refs #4863