### PR TITLE
Add Support for Geekworm MZP280 in vc4-dpi-panel-overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3656,6 +3656,7 @@ Params: clock-frequency         Display clock frequency (Hz)
         backlight-def-brightness
                                 Set the default brightness. Normal range 1-16.
                                 (default 16).
+        rotate                  Display rotation {0,90,180,270} (default 0)
 
 
 Name:   vc4-kms-dpi-panel
@@ -3683,6 +3684,7 @@ Params: at056tn53v1             Enable an Innolux 5.6in VGA TFT
         backlight-def-brightness
                                 Set the default brightness. Normal range 1-16.
                                 (default 16).
+        rotate                  Display rotation {0,90,180,270} (default 0)
 
 
 Name:   vc4-kms-dsi-7inch

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3665,6 +3665,7 @@ Info:   Enable a preconfigured KMS DPI panel.
 Load:   dtoverlay=vc4-kms-dpi-panel,<param>=<val>
 Params: at056tn53v1             Enable an Innolux 5.6in VGA TFT
         kippah-7inch            Enable an Adafruit Kippah with 7inch panel.
+        mzp280                  Enable a Geekworm MZP280 panel.
         backlight-gpio          Defines a GPIO to be used for backlight control
                                 (default of none).
         backlight-pwm           Defines a PWM channel to be used for backlight

--- a/arch/arm/boot/dts/overlays/vc4-kms-dpi-panel-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dpi-panel-overlay.dts
@@ -23,6 +23,12 @@
 			compatible = "ontat,yx700wv03", "simple-panel";
 		};
 	};
+	fragment@2 {
+		target = <&panel>;
+		__dormant__  {
+			compatible = "geekworm,mzp280", "simple-panel";
+		};
+	};
 
 	fragment@90 {
 		target = <&dpi>;
@@ -58,5 +64,6 @@
 	__overrides__ {
 		at056tn53v1 = <0>, "+0+90";
 		kippah-7inch = <0>, "+1+91";
+		mzp280 = <0>, "+2+93";
 	};
 };

--- a/arch/arm/boot/dts/overlays/vc4-kms-dpi.dtsi
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dpi.dtsi
@@ -10,6 +10,7 @@
 		target-path = "/";
 		__overlay__ {
 			panel: panel {
+				rotation = <0>;
 				port {
 					panel_in: endpoint {
 						remote-endpoint = <&dpi_out>;
@@ -105,5 +106,6 @@
 		backlight-pwm-gpio = <&pwm_pins>, "brcm,pins:0";
 		backlight-pwm-func = <&pwm_pins>, "brcm,function:0";
 		backlight-def-brightness = <&backlight_pwm>, "default-brightness-level:0";
+		rotate = <&panel>, "rotation:0";
 	};
 };


### PR DESCRIPTION
This pull request is to add support for the mzp280 panel in the generic vc4-dpi-panel-overlay that was merged yesterday. Note that since this panel is rotated 270 (depending upon your application anyway) rotation support is also added to the vc4-dpi-panel overlay.