### PR TITLE
ARM: dts: Permanently disable hdmi1 and ddc1 on CM4S

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
@@ -416,6 +416,16 @@
 	};
 };
 
+/* Permanently disable HDMI1 */
+&hdmi1 {
+	compatible = "disabled";
+};
+
+/* Permanently disable DDC1 */
+&ddc1 {
+	compatible = "disabled";
+};
+
 &leds {
 	act_led: led-act {
 		label = "led0";


### PR DESCRIPTION
CM4S has no HDMI1 output, so it is advisable to disable the controller
and its I2C interface in software. This is ordinarily done by setting
their status properties to "disabled", but the vc4-kms-v3d(-pi4)
overlay enables both HDMIs and DDCs as part of the transfer of control
from the VPU.

Knobble the CM4S dts in such a way that the overlay applies
successfully but the hdmi1 and ddc1 nodes remain disabled by changing
the compatible string to something unrecognised.

See: https://github.com/raspberrypi/linux/issues/4857

Signed-off-by: Phil Elwell <phil@raspberrypi.com>