### PR TITLE
dtoverlay: Reduce size of PCIE IB window in pcie-32-dma overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/pcie-32bit-dma-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pcie-32bit-dma-overlay.dts
@@ -11,7 +11,25 @@
 	fragment@0 {
 		target-path = "/aliases";
 		__overlay__ {
+			/*
+			 * Removing this alias stops the firmware patching the
+			 * PCIE DT dma-ranges based on the detected chip
+			 * revision.
+			 */
 			pcie0 = "";
+		};
+	};
+
+	fragment@1 {
+		target = <&pcie0>;
+		__overlay__ {
+			/*
+			 * The size of the range is rounded up to a power of 2,
+			 * so the range ends up being 0-4GB, and the MSI vector
+			 * gets pushed beyond 4GB.
+			 */
+			dma-ranges = <0x02000000 0x0 0x00000000 0x0 0x00000000
+				      0x0 0x80000000>;
 		};
 	};
 


### PR DESCRIPTION
The PCIE inbound window is rounded up to a power of 2, so the default
of 3GB rounds up to 4GB starting at 0. This prohibits the MSI vector
sitting at 0x0_fffffffc, and causes warnings from some subsystems
(eg ahci) of a 64bit address on a 32bit configuration.

Reduce the window down to 2GB to avoid this issue.

https://github.com/raspberrypi/linux/issues/4848

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>