### PR TITLE
dtoverlays: Correct field sizes in pcie-32bit-dma

### DIFF
--- a/arch/arm/boot/dts/overlays/pcie-32bit-dma-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pcie-32bit-dma-overlay.dts
@@ -28,6 +28,8 @@
 			 * so the range ends up being 0-4GB, and the MSI vector
 			 * gets pushed beyond 4GB.
 			 */
+			#address-cells = <3>;
+			#size-cells = <2>;
 			dma-ranges = <0x02000000 0x0 0x00000000 0x0 0x00000000
 				      0x0 0x80000000>;
 		};


### PR DESCRIPTION
Adding the dma-ranges to the overlay missed setting the field sizes,
so the compiler rightly flagged a warning.

https://github.com/raspberrypi/linux/issues/4848

Fixes: ee6a81c85402 "dtoverlay: Reduce size of PCIE IB window in pcie-32-dma overlay"

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>