### PR TITLE
Add DPI mode 3 (rgb565-padhi) support to vc4-kms-dpi-generic

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3649,6 +3649,8 @@ Params: clock-frequency         Display clock frequency (Hz)
         width-mm                Define the screen width in mm
         height-mm               Define the screen height in mm
         rgb565                  Change to RGB565 output on GPIOs 0-19
+        rgb565-padhi            Change to RGB565 output on GPIOs 0-8, 12-17, and
+                                20-24
         rgb666-padhi            Change to RGB666 output on GPIOs 0-9, 12-17, and
                                 20-25
         rgb888                  Change to RGB888 output on GPIOs 0-27

--- a/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
@@ -65,6 +65,8 @@
 
 		rgb565 = <&panel_generic>, "bus-format:0=0x1017",
 			<&dpi_node_generic>, "pinctrl-0:0=",<&dpi_16bit_gpio0>;
+		rgb565-padhi = <&panel_generic>, "bus-format:0=0x1020",
+			<&dpi_node_generic>, "pinctrl-0:0=",<&dpi_16bit_cpadhi_gpio0>;
 		rgb666-padhi = <&panel_generic>, "bus-format:0=0x1015",
 			<&dpi_node_generic>, "pinctrl-0:0=",<&dpi_18bit_cpadhi_gpio0>;
 		rgb888 = <&panel_generic>, "bus-format:0=0x100a",

--- a/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
@@ -12,7 +12,7 @@
 
 	fragment@0 {
 		target = <&panel>;
-		__overlay__  {
+		panel_generic: __overlay__  {
 			compatible = "panel-dpi";
 
 			width-mm = <154>;
@@ -40,7 +40,7 @@
 
 	fragment@1 {
 		target = <&dpi>;
-		__overlay__  {
+		dpi_node_generic: __overlay__  {
 			pinctrl-0 = <&dpi_18bit_gpio0>;
 		};
 	};
@@ -63,12 +63,12 @@
 		width-mm = <&panel>, "width-mm:0";
 		height-mm = <&panel>, "height-mm:0";
 
-		rgb565 = <&panel>, "bus-format:0=0x1017",
-			<&dpi_node>, "pinctrl-0:0=",<&dpi_16bit_gpio0>;
-		rgb666-padhi = <&panel>, "bus-format:0=0x1015",
-			<&dpi_node>, "pinctrl-0:0=",<&dpi_18bit_cpadhi_gpio0>;
-		rgb888 = <&panel>, "bus-format:0=0x100a",
-			<&dpi_node>, "pinctrl-0:0=",<&dpi_gpio0>;
-		bus-format = <&panel>, "bus-format:0";
+		rgb565 = <&panel_generic>, "bus-format:0=0x1017",
+			<&dpi_node_generic>, "pinctrl-0:0=",<&dpi_16bit_gpio0>;
+		rgb666-padhi = <&panel_generic>, "bus-format:0=0x1015",
+			<&dpi_node_generic>, "pinctrl-0:0=",<&dpi_18bit_cpadhi_gpio0>;
+		rgb888 = <&panel_generic>, "bus-format:0=0x100a",
+			<&dpi_node_generic>, "pinctrl-0:0=",<&dpi_gpio0>;
+		bus-format = <&panel_generic>, "bus-format:0";
 	};
 };


### PR DESCRIPTION
Adds support for DPI mode 3 (a different pin mapping) to the vc4-kms-dpi-generic overlay. This mode is used by some cheap DPI VGA adapters in particular, such as '[VGA565](https://hackaday.io/project/9763-super-low-cost-vga-output-for-the-pi-zero)'. It can be used with these like this:

```
dtoverlay=vc4-kms-dpi-generic
dtparam=hactive=1024,hfp=24,hsync=136,hbp=160
dtparam=vactive=768,vfp=3,vsync=6,vbp=29
dtparam=clock-frequency=65000000
dtparam=rgb565-padhi
```
I noticed that the overrides weren't working, neither for bus format nor for the pin mapping overrides. I believe a recent refactoring broke this. I included a workaround, but I am not sure how correct it is. My Device Tree knowledge is very limited.