### PR TITLE
VLI vs FAT round 2

### DIFF
--- a/drivers/usb/host/xhci-ring.c
+++ b/drivers/usb/host/xhci-ring.c
@@ -3607,7 +3607,7 @@ int xhci_queue_bulk_tx(struct xhci_hcd *xhci, gfp_t mem_flags,
 	unsigned int num_trbs;
 	unsigned int start_cycle, num_sgs = 0;
 	unsigned int enqd_len, block_len, trb_buff_len, full_len;
-	int sent_len, ret, vli_quirk = 0;
+	int sent_len, ret, vli_bulk_quirk = 0;
 	u32 field, length_field, remainder, maxpacket;
 	u64 addr, send_addr;
 
@@ -3653,14 +3653,9 @@ int xhci_queue_bulk_tx(struct xhci_hcd *xhci, gfp_t mem_flags,
 	send_addr = addr;
 
 	if (xhci->quirks & XHCI_VLI_SS_BULK_OUT_BUG &&
-	    !usb_urb_dir_in(urb) && urb->dev->speed >= USB_SPEED_SUPER) {
-		/*
-		 * VL805 - superspeed bulk OUT traffic can cause
-		 * an internal fifo overflow if the TRB buffer is larger
-		 * than wMaxPacket and the length is not an integer
-		 * multiple of wMaxPacket.
-		 */
-		vli_quirk = 1;
+	    usb_endpoint_is_bulk_out(&urb->ep->desc)
+	    && urb->dev->speed >= USB_SPEED_SUPER) {
+		vli_bulk_quirk = 1;
 	}
 
 	/* Queue the TRBs, even if they are zero-length */
@@ -3675,7 +3670,7 @@ int xhci_queue_bulk_tx(struct xhci_hcd *xhci, gfp_t mem_flags,
 		if (enqd_len + trb_buff_len > full_len)
 			trb_buff_len = full_len - enqd_len;
 
-		if (vli_quirk && trb_buff_len > maxpacket) {
+		if (vli_bulk_quirk && trb_buff_len > maxpacket) {
 			/* SS bulk wMaxPacket is 1024B */
 			remainder = trb_buff_len & (maxpacket - 1);
 			trb_buff_len -= remainder;

--- a/drivers/usb/host/xhci.c
+++ b/drivers/usb/host/xhci.c
@@ -1388,9 +1388,12 @@ static void xhci_unmap_temp_buf(struct usb_hcd *hcd, struct urb *urb)
 static int xhci_map_urb_for_dma(struct usb_hcd *hcd, struct urb *urb,
 				gfp_t mem_flags)
 {
+	unsigned int i, maxpacket;
+	struct scatterlist *sg;
 	struct xhci_hcd *xhci;
 
 	xhci = hcd_to_xhci(hcd);
+	maxpacket = usb_endpoint_maxp(&urb->ep->desc);
 
 	if (xhci_urb_suitable_for_idt(urb))
 		return 0;
@@ -1398,6 +1401,16 @@ static int xhci_map_urb_for_dma(struct usb_hcd *hcd, struct urb *urb,
 	if (xhci->quirks & XHCI_SG_TRB_CACHE_SIZE_QUIRK) {
 		if (xhci_urb_temp_buffer_required(hcd, urb))
 			return xhci_map_temp_buffer(hcd, urb);
+	}
+
+	if (xhci->quirks & XHCI_VLI_SS_BULK_OUT_BUG &&
+	    usb_endpoint_is_bulk_out(&urb->ep->desc) &&
+	    urb->dev->speed >= USB_SPEED_SUPER &&
+	    urb->transfer_buffer_length != 0) {
+		for_each_sg(urb->sg, sg, urb->num_sgs, i) {
+			if (sg->length % maxpacket)
+				return xhci_map_temp_buffer(hcd, urb);
+		}
 	}
 	return usb_hcd_map_urb_for_dma(hcd, urb, mem_flags);
 }
@@ -1412,7 +1425,8 @@ static void xhci_unmap_urb_for_dma(struct usb_hcd *hcd, struct urb *urb)
 	if (urb->num_sgs && (urb->transfer_flags & URB_DMA_MAP_SINGLE))
 		unmap_temp_buf = true;
 
-	if ((xhci->quirks & XHCI_SG_TRB_CACHE_SIZE_QUIRK) && unmap_temp_buf)
+	if ((xhci->quirks & (XHCI_SG_TRB_CACHE_SIZE_QUIRK | XHCI_VLI_SS_BULK_OUT_BUG))
+	     && unmap_temp_buf)
 		xhci_unmap_temp_buf(hcd, urb);
 	else
 		usb_hcd_unmap_urb_for_dma(hcd, urb);


### PR DESCRIPTION
See #4844

All three of my test cases now pass an extended period of time performing copy operations on the boot partition. Bad pendrive, fast usb-storage and fast UAS all perform without complaint.