### PR TITLE
drivers: staging: bcm2835-isp: Do not cleanup mmal vcsm buffer on sto…

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
@@ -622,7 +622,6 @@ static void bcm2835_isp_node_stop_streaming(struct vb2_queue *q)
 {
 	struct bcm2835_isp_node *node = vb2_get_drv_priv(q);
 	struct bcm2835_isp_dev *dev = node_get_dev(node);
-	unsigned int i;
 	int ret;
 
 	v4l2_dbg(1, debug, &dev->v4l2_dev, "%s: node %s[%d], mmal port %p\n",
@@ -651,14 +650,6 @@ static void bcm2835_isp_node_stop_streaming(struct vb2_queue *q)
 				 atomic_read(&node->port->buffers_with_vpu));
 			break;
 		}
-	}
-
-	/* Release the VCSM handle here to release the associated dmabuf */
-	for (i = 0; i < q->num_buffers; i++) {
-		struct vb2_v4l2_buffer *vb2 = to_vb2_v4l2_buffer(q->bufs[i]);
-		struct bcm2835_isp_buffer *buf =
-			container_of(vb2, struct bcm2835_isp_buffer, vb);
-		bcm2835_isp_mmal_buf_cleanup(&buf->mmal);
 	}
 
 	atomic_dec(&dev->num_streaming);


### PR DESCRIPTION
…p_streaming

On stop_streaming() the vcsm buffer handle gets released by the buffer cleanup
code.  This will subsequently cause and error if userland re-queues the same
buffer on the next start_streaming() call.

Remove this cleanup code and rely on the vb2_ops->buf_cleanup() call to do the
cleanups instead.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>