### PR TITLE
imx219: implement v4l2 set selection api

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -1520,6 +1520,7 @@ static int unicam_g_edid(struct file *file, void *priv, struct v4l2_edid *edid)
 static int unicam_s_selection(struct file *file, void *priv,
 			      struct v4l2_selection *sel)
 {
+	int ret;
 	struct unicam_node *node = video_drvdata(file);
 	struct unicam_device *dev = node->dev;
 	struct v4l2_subdev_selection sdsel = {
@@ -1532,7 +1533,12 @@ static int unicam_s_selection(struct file *file, void *priv,
 	if (sel->type != V4L2_BUF_TYPE_VIDEO_CAPTURE)
 		return -EINVAL;
 
-	return v4l2_subdev_call(dev->sensor, pad, set_selection, NULL, &sdsel);
+	ret = v4l2_subdev_call(dev->sensor, pad, set_selection, NULL, &sdsel);
+	if (!ret) {
+		node->v_fmt.fmt.pix.bytesperline = 0;
+		return unicam_reset_format(node);
+	}
+	return ret;
 }
 
 static int unicam_g_selection(struct file *file, void *priv,


### PR DESCRIPTION
Adding cropping functionality to the imx219 driver using the v4l2 selection api. 
The sequence of operations is:
- imx219_probe - sets the crop based on current mode's default_crop
- VIDIOC_S_FMT - this changes the crop to the selected mode's default_crop
- VIDIOC_S_SELECTION - this changes the crop to the user defined crop after validation and resets the range of exposure and other controls
- imx219_start_streaming - applies the selection into camera registers