### PR TITLE
Update DSI patches to latest sent to dri-devel

### DIFF
--- a/drivers/gpu/drm/bridge/panel.c
+++ b/drivers/gpu/drm/bridge/panel.c
@@ -225,6 +225,9 @@ struct drm_bridge *drm_panel_bridge_add_typed(struct drm_panel *panel,
 	panel_bridge->bridge.ops = DRM_BRIDGE_OP_MODES;
 	panel_bridge->bridge.type = connector_type;
 
+	panel_bridge->bridge.pre_enable_upstream_first =
+						panel->prepare_upstream_first;
+
 	drm_bridge_add(&panel_bridge->bridge);
 
 	return &panel_bridge->bridge;

--- a/drivers/gpu/drm/bridge/tc358762.c
+++ b/drivers/gpu/drm/bridge/tc358762.c
@@ -237,6 +237,7 @@ static int tc358762_probe(struct mipi_dsi_device *dsi)
 	ctx->bridge.funcs = &tc358762_bridge_funcs;
 	ctx->bridge.type = DRM_MODE_CONNECTOR_DPI;
 	ctx->bridge.of_node = dev->of_node;
+	ctx->bridge.pre_enable_upstream_first = true;
 
 	drm_bridge_add(&ctx->bridge);
 

--- a/drivers/gpu/drm/bridge/tc358762.c
+++ b/drivers/gpu/drm/bridge/tc358762.c
@@ -237,7 +237,6 @@ static int tc358762_probe(struct mipi_dsi_device *dsi)
 	ctx->bridge.funcs = &tc358762_bridge_funcs;
 	ctx->bridge.type = DRM_MODE_CONNECTOR_DPI;
 	ctx->bridge.of_node = dev->of_node;
-	ctx->bridge.ops = DRM_BRIDGE_OP_UPSTREAM_FIRST;
 
 	drm_bridge_add(&ctx->bridge);
 

--- a/drivers/gpu/drm/drm_bridge.c
+++ b/drivers/gpu/drm/drm_bridge.c
@@ -463,20 +463,15 @@ EXPORT_SYMBOL(drm_bridge_chain_disable);
  * encoder chain, starting from the first bridge to the last. These are called
  * after completing the encoder's prepare op.
  *
+ * If a bridge sets @pre_enable_upstream_first, then the @post_disable for that
+ * bridge will be called before the previous one to reverse the @pre_enable
+ * calling direction.
+ *
  * Note: the bridge passed should be the one closest to the encoder
  */
 void drm_bridge_chain_post_disable(struct drm_bridge *bridge)
 {
-	struct drm_encoder *encoder;
-
-	if (!bridge)
-		return;
-
-	encoder = bridge->encoder;
-	list_for_each_entry_from(bridge, &encoder->bridge_chain, chain_node) {
-		if (bridge->funcs->post_disable)
-			bridge->funcs->post_disable(bridge);
-	}
+	drm_atomic_bridge_chain_post_disable(bridge, NULL);
 }
 EXPORT_SYMBOL(drm_bridge_chain_post_disable);
 
@@ -518,24 +513,14 @@ EXPORT_SYMBOL(drm_bridge_chain_mode_set);
  * chain, starting from the last bridge to the first. These are called
  * before calling the encoder's commit op.
  *
+ * If a bridge sets @pre_enable_upstream_first, then the @pre_enable for the
+ * previous bridge will be called before @pre_enable of this bridge.
+ *
  * Note: the bridge passed should be the one closest to the encoder
  */
 void drm_bridge_chain_pre_enable(struct drm_bridge *bridge)
 {
-	struct drm_encoder *encoder;
-	struct drm_bridge *iter;
-
-	if (!bridge)
-		return;
-
-	encoder = bridge->encoder;
-	list_for_each_entry_reverse(iter, &encoder->bridge_chain, chain_node) {
-		if (iter->funcs->pre_enable)
-			iter->funcs->pre_enable(iter);
-
-		if (iter == bridge)
-			break;
-	}
+	drm_atomic_bridge_chain_pre_enable(bridge, NULL);
 }
 EXPORT_SYMBOL(drm_bridge_chain_pre_enable);
 
@@ -607,6 +592,25 @@ void drm_atomic_bridge_chain_disable(struct drm_bridge *bridge,
 }
 EXPORT_SYMBOL(drm_atomic_bridge_chain_disable);
 
+static void drm_atomic_bridge_call_post_disable(struct drm_bridge *bridge,
+						struct drm_atomic_state *old_state)
+{
+	if (old_state && bridge->funcs->atomic_post_disable) {
+		struct drm_bridge_state *old_bridge_state;
+
+		old_bridge_state =
+			drm_atomic_get_old_bridge_state(old_state,
+							bridge);
+		if (WARN_ON(!old_bridge_state))
+			return;
+
+		bridge->funcs->atomic_post_disable(bridge,
+						   old_bridge_state);
+	} else if (bridge->funcs->post_disable) {
+		bridge->funcs->post_disable(bridge);
+	}
+}
+
 /**
  * drm_atomic_bridge_chain_post_disable - cleans up after disabling all bridges
  *					  in the encoder chain
@@ -617,6 +621,9 @@ EXPORT_SYMBOL(drm_atomic_bridge_chain_disable);
  * &drm_bridge_funcs.post_disable) op for all the bridges in the encoder chain,
  * starting from the first bridge to the last. These are called after completing
  * &drm_encoder_helper_funcs.atomic_disable
+ * If a bridge sets @pre_enable_upstream_first, then the @post_disable for that
+ * bridge will be called before the previous one to reverse the @pre_enable
+ * calling direction.
  *
  * Note: the bridge passed should be the one closest to the encoder
  */
@@ -624,29 +631,74 @@ void drm_atomic_bridge_chain_post_disable(struct drm_bridge *bridge,
 					  struct drm_atomic_state *old_state)
 {
 	struct drm_encoder *encoder;
+	struct drm_bridge *next, *limit;
 
 	if (!bridge)
 		return;
 
 	encoder = bridge->encoder;
+
 	list_for_each_entry_from(bridge, &encoder->bridge_chain, chain_node) {
-		if (bridge->funcs->atomic_post_disable) {
-			struct drm_bridge_state *old_bridge_state;
+		limit = NULL;
 
-			old_bridge_state =
-				drm_atomic_get_old_bridge_state(old_state,
-								bridge);
-			if (WARN_ON(!old_bridge_state))
-				return;
+		if (!list_is_last(&bridge->chain_node, &encoder->bridge_chain)) {
+			next = list_next_entry(bridge, chain_node);
 
-			bridge->funcs->atomic_post_disable(bridge,
-							   old_bridge_state);
-		} else if (bridge->funcs->post_disable) {
-			bridge->funcs->post_disable(bridge);
+			if (next->pre_enable_upstream_first) {
+				/* Downstream bridge had requested that upstream
+				 * was enabled first, so disabled last
+				 */
+				limit = next;
+
+				/* Find the next bridge that has NOT requested
+				 * upstream to be enabled first / disabled last
+				 */
+				list_for_each_entry_from(next, &encoder->bridge_chain,
+							 chain_node) {
+					if (next->pre_enable_upstream_first) {
+						next = list_prev_entry(next, chain_node);
+						limit = next;
+						break;
+					}
+				}
+
+				/* Call these bridges in reverse order */
+				list_for_each_entry_from_reverse(next, &encoder->bridge_chain,
+								 chain_node) {
+					if (next == bridge)
+						break;
+
+					drm_atomic_bridge_call_post_disable(next,
+									    old_state);
+				}
+			}
 		}
+
+		drm_atomic_bridge_call_post_disable(bridge, old_state);
+
+		if (limit)
+			bridge = limit;
 	}
 }
 EXPORT_SYMBOL(drm_atomic_bridge_chain_post_disable);
+
+static void drm_atomic_bridge_call_pre_enable(struct drm_bridge *bridge,
+					      struct drm_atomic_state *old_state)
+{
+	if (old_state && bridge->funcs->atomic_pre_enable) {
+		struct drm_bridge_state *old_bridge_state;
+
+		old_bridge_state =
+			drm_atomic_get_old_bridge_state(old_state,
+							bridge);
+		if (WARN_ON(!old_bridge_state))
+			return;
+
+		bridge->funcs->atomic_pre_enable(bridge, old_bridge_state);
+	} else if (bridge->funcs->pre_enable) {
+		bridge->funcs->pre_enable(bridge);
+	}
+}
 
 /**
  * drm_atomic_bridge_chain_pre_enable - prepares for enabling all bridges in
@@ -659,32 +711,61 @@ EXPORT_SYMBOL(drm_atomic_bridge_chain_post_disable);
  * starting from the last bridge to the first. These are called before calling
  * &drm_encoder_helper_funcs.atomic_enable
  *
+ * If a bridge sets @pre_enable_upstream_first, then the pre_enable for the
+ * upstream bridge will be called before pre_enable of this bridge.
+ *
  * Note: the bridge passed should be the one closest to the encoder
  */
 void drm_atomic_bridge_chain_pre_enable(struct drm_bridge *bridge,
 					struct drm_atomic_state *old_state)
 {
 	struct drm_encoder *encoder;
-	struct drm_bridge *iter;
+	struct drm_bridge *iter, *next, *limit;
 
 	if (!bridge)
 		return;
 
 	encoder = bridge->encoder;
+
 	list_for_each_entry_reverse(iter, &encoder->bridge_chain, chain_node) {
-		if (iter->funcs->atomic_pre_enable) {
-			struct drm_bridge_state *old_bridge_state;
+		if (iter->pre_enable_upstream_first) {
+			next = iter;
+			limit = bridge;
+			list_for_each_entry_from_reverse(next,
+							 &encoder->bridge_chain,
+							 chain_node) {
+				if (next == bridge)
+					break;
 
-			old_bridge_state =
-				drm_atomic_get_old_bridge_state(old_state,
-								iter);
-			if (WARN_ON(!old_bridge_state))
-				return;
+				if (!next->pre_enable_upstream_first) {
+					/* Found first bridge that does NOT
+					 * request upstream to be enabled first
+					 */
+					limit = list_prev_entry(next, chain_node);
+					break;
+				}
+			}
 
-			iter->funcs->atomic_pre_enable(iter, old_bridge_state);
-		} else if (iter->funcs->pre_enable) {
-			iter->funcs->pre_enable(iter);
+			list_for_each_entry_from(next, &encoder->bridge_chain, chain_node) {
+				/* Call requested upstream bridge pre_enable
+				 * in order.
+				 */
+				if (next == iter)
+					/* At the first bridgge to request upstream
+					 * bridges called first.
+					 */
+					break;
+
+				drm_atomic_bridge_call_pre_enable(next, old_state);
+			}
 		}
+
+		drm_atomic_bridge_call_pre_enable(iter, old_state);
+
+		if (iter->pre_enable_upstream_first)
+			/* Jump all bridges that we have already pre_enabled
+			 */
+			iter = limit;
 
 		if (iter == bridge)
 			break;

--- a/drivers/gpu/drm/drm_bridge.c
+++ b/drivers/gpu/drm/drm_bridge.c
@@ -462,58 +462,21 @@ EXPORT_SYMBOL(drm_bridge_chain_disable);
  * Calls &drm_bridge_funcs.post_disable op for all the bridges in the
  * encoder chain, starting from the first bridge to the last. These are called
  * after completing the encoder's prepare op.
- * If a bridge sets the DRM_BRIDGE_OP_UPSTREAM_FIRST, then the post_disable for
- * that bridge will be called before the previous one to reverse the pre_enable
- * calling direction.
  *
  * Note: the bridge passed should be the one closest to the encoder
  */
 void drm_bridge_chain_post_disable(struct drm_bridge *bridge)
 {
 	struct drm_encoder *encoder;
-	struct drm_bridge *next, *limit;
 
 	if (!bridge)
 		return;
 
 	encoder = bridge->encoder;
 	list_for_each_entry_from(bridge, &encoder->bridge_chain, chain_node) {
-		limit = NULL;
-
-		if (!list_is_last(&bridge->chain_node, &encoder->bridge_chain)) {
-			next = list_next_entry(bridge, chain_node);
-
-			if (next->ops & DRM_BRIDGE_OP_UPSTREAM_FIRST) {
-				limit = next;
-
-				list_for_each_entry_from(next, &encoder->bridge_chain,
-							 chain_node) {
-					if (!(next->ops &
-						DRM_BRIDGE_OP_UPSTREAM_FIRST)) {
-						next = list_prev_entry(next, chain_node);
-						limit = next;
-						break;
-					}
-				}
-
-				list_for_each_entry_from_reverse(next, &encoder->bridge_chain,
-								 chain_node) {
-					if (next == bridge)
-						break;
-
-					if (next->funcs->post_disable)
-						next->funcs->post_disable(next);
-				}
-			}
-		}
-
 		if (bridge->funcs->post_disable)
 			bridge->funcs->post_disable(bridge);
-
-		if (limit)
-			bridge = limit;
 	}
-
 }
 EXPORT_SYMBOL(drm_bridge_chain_post_disable);
 
@@ -554,52 +517,21 @@ EXPORT_SYMBOL(drm_bridge_chain_mode_set);
  * Calls &drm_bridge_funcs.pre_enable op for all the bridges in the encoder
  * chain, starting from the last bridge to the first. These are called
  * before calling the encoder's commit op.
- * If a bridge sets the DRM_BRIDGE_OP_UPSTREAM_FIRST, then the pre_enable for
- * the previous bridge will be called before pre_enable of this bridge.
  *
  * Note: the bridge passed should be the one closest to the encoder
  */
 void drm_bridge_chain_pre_enable(struct drm_bridge *bridge)
 {
 	struct drm_encoder *encoder;
-	struct drm_bridge *iter, *next, *limit;
+	struct drm_bridge *iter;
 
 	if (!bridge)
 		return;
 
 	encoder = bridge->encoder;
-
 	list_for_each_entry_reverse(iter, &encoder->bridge_chain, chain_node) {
-		if (iter->ops & DRM_BRIDGE_OP_UPSTREAM_FIRST) {
-			next = iter;
-			limit = bridge;
-			list_for_each_entry_from_reverse(next,
-							 &encoder->bridge_chain,
-							 chain_node) {
-				if (next == bridge)
-					break;
-
-				if (!(next->ops &
-					DRM_BRIDGE_OP_UPSTREAM_FIRST)) {
-					limit = list_prev_entry(next, chain_node);
-					break;
-				}
-			}
-
-			list_for_each_entry_from(next, &encoder->bridge_chain, chain_node) {
-				if (next == iter)
-					break;
-
-				if (next->funcs->pre_enable)
-					next->funcs->pre_enable(next);
-			}
-		}
-
 		if (iter->funcs->pre_enable)
 			iter->funcs->pre_enable(iter);
-
-		if (iter->ops & DRM_BRIDGE_OP_UPSTREAM_FIRST)
-			iter = limit;
 
 		if (iter == bridge)
 			break;
@@ -675,25 +607,6 @@ void drm_atomic_bridge_chain_disable(struct drm_bridge *bridge,
 }
 EXPORT_SYMBOL(drm_atomic_bridge_chain_disable);
 
-static void drm_atomic_bridge_call_post_disable(struct drm_bridge *bridge,
-						struct drm_atomic_state *old_state)
-{
-	if (bridge->funcs->atomic_post_disable) {
-		struct drm_bridge_state *old_bridge_state;
-
-		old_bridge_state =
-			drm_atomic_get_old_bridge_state(old_state,
-							bridge);
-		if (WARN_ON(!old_bridge_state))
-			return;
-
-		bridge->funcs->atomic_post_disable(bridge,
-						   old_bridge_state);
-	} else if (bridge->funcs->post_disable) {
-		bridge->funcs->post_disable(bridge);
-	}
-}
-
 /**
  * drm_atomic_bridge_chain_post_disable - cleans up after disabling all bridges
  *					  in the encoder chain
@@ -704,9 +617,6 @@ static void drm_atomic_bridge_call_post_disable(struct drm_bridge *bridge,
  * &drm_bridge_funcs.post_disable) op for all the bridges in the encoder chain,
  * starting from the first bridge to the last. These are called after completing
  * &drm_encoder_helper_funcs.atomic_disable
- * If a bridge sets the DRM_BRIDGE_OP_UPSTREAM_FIRST, then the post_disable for
- * that bridge will be called before the previous one to reverse the pre_enable
- * calling direction.
  *
  * Note: the bridge passed should be the one closest to the encoder
  */
@@ -714,68 +624,29 @@ void drm_atomic_bridge_chain_post_disable(struct drm_bridge *bridge,
 					  struct drm_atomic_state *old_state)
 {
 	struct drm_encoder *encoder;
-	struct drm_bridge *next, *limit;
 
 	if (!bridge)
 		return;
 
 	encoder = bridge->encoder;
-
 	list_for_each_entry_from(bridge, &encoder->bridge_chain, chain_node) {
-		limit = NULL;
+		if (bridge->funcs->atomic_post_disable) {
+			struct drm_bridge_state *old_bridge_state;
 
-		if (!list_is_last(&bridge->chain_node, &encoder->bridge_chain)) {
-			next = list_next_entry(bridge, chain_node);
+			old_bridge_state =
+				drm_atomic_get_old_bridge_state(old_state,
+								bridge);
+			if (WARN_ON(!old_bridge_state))
+				return;
 
-			if (next->ops & DRM_BRIDGE_OP_UPSTREAM_FIRST) {
-				limit = next;
-
-				list_for_each_entry_from(next, &encoder->bridge_chain,
-							 chain_node) {
-					if (!(next->ops &
-						DRM_BRIDGE_OP_UPSTREAM_FIRST)) {
-						next = list_prev_entry(next, chain_node);
-						limit = next;
-						break;
-					}
-				}
-
-				list_for_each_entry_from_reverse(next, &encoder->bridge_chain,
-								 chain_node) {
-					if (next == bridge)
-						break;
-
-					drm_atomic_bridge_call_post_disable(next,
-									    old_state);
-				}
-			}
+			bridge->funcs->atomic_post_disable(bridge,
+							   old_bridge_state);
+		} else if (bridge->funcs->post_disable) {
+			bridge->funcs->post_disable(bridge);
 		}
-
-		drm_atomic_bridge_call_post_disable(bridge, old_state);
-
-		if (limit)
-			bridge = limit;
 	}
 }
 EXPORT_SYMBOL(drm_atomic_bridge_chain_post_disable);
-
-static void drm_atomic_bridge_call_pre_enable(struct drm_bridge *bridge,
-					      struct drm_atomic_state *old_state)
-{
-	if (bridge->funcs->atomic_pre_enable) {
-		struct drm_bridge_state *old_bridge_state;
-
-		old_bridge_state =
-			drm_atomic_get_old_bridge_state(old_state,
-							bridge);
-		if (WARN_ON(!old_bridge_state))
-			return;
-
-		bridge->funcs->atomic_pre_enable(bridge, old_bridge_state);
-	} else if (bridge->funcs->pre_enable) {
-		bridge->funcs->pre_enable(bridge);
-	}
-}
 
 /**
  * drm_atomic_bridge_chain_pre_enable - prepares for enabling all bridges in
@@ -787,8 +658,6 @@ static void drm_atomic_bridge_call_pre_enable(struct drm_bridge *bridge,
  * &drm_bridge_funcs.pre_enable) op for all the bridges in the encoder chain,
  * starting from the last bridge to the first. These are called before calling
  * &drm_encoder_helper_funcs.atomic_enable
- * If a bridge sets the DRM_BRIDGE_OP_UPSTREAM_FIRST, then the pre_enable for
- * the previous bridge will be called before pre_enable of this bridge.
  *
  * Note: the bridge passed should be the one closest to the encoder
  */
@@ -796,42 +665,26 @@ void drm_atomic_bridge_chain_pre_enable(struct drm_bridge *bridge,
 					struct drm_atomic_state *old_state)
 {
 	struct drm_encoder *encoder;
-	struct drm_bridge *iter, *next, *limit;
+	struct drm_bridge *iter;
 
 	if (!bridge)
 		return;
 
 	encoder = bridge->encoder;
-
 	list_for_each_entry_reverse(iter, &encoder->bridge_chain, chain_node) {
-		if (iter->ops & DRM_BRIDGE_OP_UPSTREAM_FIRST) {
-			next = iter;
-			limit = bridge;
-			list_for_each_entry_from_reverse(next,
-							 &encoder->bridge_chain,
-							 chain_node) {
-				if (next == bridge)
-					break;
+		if (iter->funcs->atomic_pre_enable) {
+			struct drm_bridge_state *old_bridge_state;
 
-				if (!(next->ops &
-					DRM_BRIDGE_OP_UPSTREAM_FIRST)) {
-					limit = list_prev_entry(next, chain_node);
-					break;
-				}
-			}
+			old_bridge_state =
+				drm_atomic_get_old_bridge_state(old_state,
+								iter);
+			if (WARN_ON(!old_bridge_state))
+				return;
 
-			list_for_each_entry_from(next, &encoder->bridge_chain, chain_node) {
-				if (next == iter)
-					break;
-
-				drm_atomic_bridge_call_pre_enable(next, old_state);
-			}
+			iter->funcs->atomic_pre_enable(iter, old_bridge_state);
+		} else if (iter->funcs->pre_enable) {
+			iter->funcs->pre_enable(iter);
 		}
-
-		drm_atomic_bridge_call_pre_enable(iter, old_state);
-
-		if (iter->ops & DRM_BRIDGE_OP_UPSTREAM_FIRST)
-			iter = limit;
 
 		if (iter == bridge)
 			break;

--- a/include/drm/drm_bridge.h
+++ b/include/drm/drm_bridge.h
@@ -762,6 +762,14 @@ struct drm_bridge {
 	 */
 	bool interlace_allowed;
 	/**
+	 * @pre_enable_upstream_first: The bridge requires that the upstream
+	 * bridge @pre_enable function is called before its @pre_enable,
+	 * and conversely for post_disable. This is most frequently a
+	 * requirement for DSI devices which need the host to be initialised
+	 * before the peripheral.
+	 */
+	bool pre_enable_upstream_first;
+	/**
 	 * @ddc: Associated I2C adapter for DDC access, if any.
 	 */
 	struct i2c_adapter *ddc;

--- a/include/drm/drm_bridge.h
+++ b/include/drm/drm_bridge.h
@@ -718,14 +718,6 @@ enum drm_bridge_ops {
 	 * this flag shall implement the &drm_bridge_funcs->get_modes callback.
 	 */
 	DRM_BRIDGE_OP_MODES = BIT(3),
-	/**
-	 * @DRM_BRIDGE_OP_UPSTREAM_FIRST: The bridge can requires
-	 * that the upstream node pre_enable is called before its pre_enable,
-	 * and conversely for post_disables. This is most frequently a
-	 * requirement for DSI devices which need the host to be initialised
-	 * before them.
-	 */
-	DRM_BRIDGE_OP_UPSTREAM_FIRST = BIT(4),
 };
 
 /**

--- a/include/drm/drm_panel.h
+++ b/include/drm/drm_panel.h
@@ -179,6 +179,16 @@ struct drm_panel {
 	 * Panel entry in registry.
 	 */
 	struct list_head list;
+
+	/**
+	 * @prepare_upstream_first:
+	 *
+	 * The upstream controller should be prepared first, before the prepare
+	 * for the panel is called. This is largely required for DSI panels
+	 * where the DSI host controller should be initialised to LP-11 before
+	 * the panel is powered up.
+	 */
+	bool prepare_upstream_first;
 };
 
 void drm_panel_init(struct drm_panel *panel, struct device *dev,

--- a/include/drm/drm_panel.h
+++ b/include/drm/drm_panel.h
@@ -24,6 +24,7 @@
 #ifndef __DRM_PANEL_H__
 #define __DRM_PANEL_H__
 
+#include <drm/drm_connector.h>
 #include <linux/err.h>
 #include <linux/errno.h>
 #include <linux/list.h>
@@ -34,8 +35,6 @@ struct drm_connector;
 struct drm_device;
 struct drm_panel;
 struct display_timing;
-
-enum drm_panel_orientation;
 
 /**
  * struct drm_panel_funcs - perform operations on a given panel


### PR DESCRIPTION
Reverts the couple of patches that we had applied and applies the new versions. If we're still rebasing then the originals and reverts can be dropped.

I'm still awaiting further comment from upstream - I've had nothing from v2.