### PR TITLE
dtoverlays: Connect the backlight to the pitft35 display

### DIFF
--- a/arch/arm/boot/dts/overlays/pitft35-resistive-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pitft35-resistive-overlay.dts
@@ -102,7 +102,7 @@
 	fragment@5 {
 		target-path = "/soc";
 		__overlay__ {
-			backlight {
+			backlight: backlight {
 				compatible = "gpio-backlight";
 				gpios = <&stmpe_gpio 2 0>;
 				default-on;
@@ -115,6 +115,7 @@
 		rotate =  <&pitft>,"rotate:0";
 		fps =     <&pitft>,"fps:0";
 		debug =   <&pitft>,"debug:0";
-		drm =     <&pitft>,"compatible=adafruit,yx350hv15";
+		drm =     <&pitft>,"compatible=adafruit,yx350hv15",
+			  <&pitft>,"backlight:0=",<&backlight>;
 	};
 };


### PR DESCRIPTION
DRM will automatically handle the backlight with the display if
told about the linking, so link the two together.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>