### PR TITLE
audioinjector.net : stereo and zero, use dev_err_probe, report success

### DIFF
--- a/sound/soc/bcm/audioinjector-pi-soundcard.c
+++ b/sound/soc/bcm/audioinjector-pi-soundcard.c
@@ -158,9 +158,11 @@ static int audioinjector_pi_soundcard_probe(struct platform_device *pdev)
 			}
 	}
 
-	if ((ret = devm_snd_soc_register_card(&pdev->dev, card))) {
-		dev_err(&pdev->dev, "snd_soc_register_card failed (%d)\n", ret);
-	}
+	if ((ret = devm_snd_soc_register_card(&pdev->dev, card)))
+		return dev_err_probe(&pdev->dev, ret, "audioinjector_pi_soundcard_probe \n");
+
+	dev_err(&pdev->dev, "audioinjector_pi_soundcard_probe : successfully loaded\n");
+
 	return ret;
 }
 


### PR DESCRIPTION
As per guidance from @[HiassofT](https://github.com/HiassofT) and @[6by9](https://github.com/6by9) I've added dev_err_probe to handle probe defferals cleanly.
It was also necessary to report to the user that probe was successful, in case users look at the logs and don't see any information - which is confusing for them and we get a lot of un-necessary duscussions on the [email list](https://lists.audioinjector.net/mailman/listinfo/people) when nothing is reported.
