### PR TITLE
overlays/rpi-display: Add support for DRM driver

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2913,14 +2913,36 @@ Params: <None>
 
 Name:   rpi-display
 Info:   RPi-Display - 2.8" Touch Display by Watterott
+        Linux has 2 drivers that support this display and this overlay supports
+        both.
+
+        Examples:
+          fbtft/fb_ili9341: dtoverlay=rpi-display
+          drm/mi0283qt: dtoverlay=rpi-display,drm,backlight-pwm,rotate=180
+
+        Some notable differences with the DRM driver compared to fbtft:
+        - The display is turned on when it's first used and not on driver load
+          as with fbtft. So if nothing uses the display it stays off.
+        - Can run with a higher SPI clock increasing framerate. This is possible
+          since the driver avoids messing up the controller configuration due to
+          transmission errors by running config commands at 10MHz and only pixel
+          data at full speed (occasional pixel glitch might occur).
+        - PWM backlight is supported.
+
 Load:   dtoverlay=rpi-display,<param>=<val>
 Params: speed                   Display SPI bus speed
         rotate                  Display rotation {0,90,180,270}
-        fps                     Delay between frame updates
-        debug                   Debug output level {0-7}
+        fps                     Delay between frame updates (fbtft only)
+        debug                   Debug output level {0-7} (fbtft only)
         xohms                   Touchpanel sensitivity (X-plate resistance)
         swapxy                  Swap x and y axis
         backlight               Change backlight GPIO pin {e.g. 12, 18}
+                                (fbtft only)
+        drm                     Use DRM/KMS driver mi0283qt instead of fbtft.
+                                Set the SPI clock to 70MHz.
+                                This has to be the first parameter.
+        backlight-pwm           Use pwm for backlight (drm only). NB: Disables
+                                audio headphone output as that also uses PWM.
 
 
 Name:   rpi-ft5406

--- a/arch/arm/boot/dts/overlays/rpi-display-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-display-overlay.dts
@@ -61,7 +61,7 @@
 				buswidth = <8>;
 				reset-gpios = <&gpio 23 1>;
 				dc-gpios = <&gpio 24 0>;
-				led-gpios = <&gpio 18 1>;
+				led-gpios = <&gpio 18 0>;
 				debug = <0>;
 			};
 

--- a/arch/arm/boot/dts/overlays/rpi-display-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-display-overlay.dts
@@ -78,14 +78,73 @@
 			};
 		};
 	};
+
+	fragment@10 {
+		target = <&rpidisplay>;
+		__dormant__  {
+			backlight = <&backlight_gpio>;
+		};
+	};
+
+	fragment@11 {
+		target-path = "/";
+		__dormant__  {
+			backlight_gpio: backlight_gpio {
+				compatible = "gpio-backlight";
+				gpios = <&gpio 18 0>; /* GPIO_ACTIVE_HIGH */
+			};
+		};
+	};
+
+	fragment@20 {
+		target = <&rpidisplay>;
+		__dormant__  {
+			backlight = <&backlight_pwm>;
+		};
+	};
+
+	fragment@21 {
+		target-path = "/";
+		__dormant__  {
+			backlight_pwm: backlight_pwm {
+				compatible = "pwm-backlight";
+				brightness-levels = <0 6 8 12 16 24 32 40 48 64 96 128 160 192 224 255>;
+				default-brightness-level = <16>;
+				pwms = <&pwm 0 200000>;
+			};
+		};
+	};
+
+	fragment@22 {
+		target = <&pwm>;
+		__dormant__ {
+			assigned-clock-rates = <1000000>;
+			status = "okay";
+		};
+	};
+
+	fragment@23 {
+		target = <&audio>;
+		__dormant__  {
+		    brcm,disable-headphones;
+		};
+	};
+
 	__overrides__ {
 		speed =     <&rpidisplay>,"spi-max-frequency:0";
-		rotate =    <&rpidisplay>,"rotate:0";
+		rotate =    <&rpidisplay>,"rotate:0", /* fbtft */
+			    <&rpidisplay>,"rotation:0"; /* drm */
 		fps =       <&rpidisplay>,"fps:0";
 		debug =     <&rpidisplay>,"debug:0";
 		xohms =     <&rpidisplay_ts>,"ti,x-plate-ohms;0";
 		swapxy =    <&rpidisplay_ts>,"ti,swap-xy?";
 		backlight = <&rpidisplay>,"led-gpios:4",
 		            <&rpi_display_pins>,"brcm,pins:0";
+		drm =       <&rpidisplay>, "compatible=multi-inno,mi0283qt",
+			    <&rpidisplay>, "spi-max-frequency:0=70000000",
+			    <&rpidisplay>, "reset-gpios:8=0", /* GPIO_ACTIVE_HIGH */
+			    <0>, "+10+11";
+		backlight-pwm = <0>, "-10-11+20+21+22+23",
+				<&rpi_display_pins>, "brcm,function:0=2"; /* Alt5 */
 	};
 };


### PR DESCRIPTION
I was inspired by how @pelwell made the [pitft35-resistive](https://github.com/raspberrypi/linux/blob/rpi-5.15.y/arch/arm/boot/dts/overlays/pitft35-resistive-overlay.dts) overlay support both the fbtft and DRM drivers. I mostly use the rpi-display when I test the DRM MIPI DBI code in the kernel and have made an overlay for that. Now with this `drm` parameter I can ditch that and use the stock overlay instead.

I had to revert the backlight workaround since fbtft backlight is now [fixed](https://github.com/notro/fbtft/issues/571#issuecomment-983444543) resulting in inverted backlight.
I don't know if rpi-5.10.y will get any more releases, but if it does the revert patch is needed there as well since the fix was backported in 5.10.83 and rpi-5.10.y is at 5.10.95.
I haven't tested it on 5.10.

Cc: @awatterott
