### PR TITLE
ARM: dts: Enable PMU on Cortex-A72 in AArch32 state

### DIFF
--- a/arch/arm/boot/dts/bcm2711.dtsi
+++ b/arch/arm/boot/dts/bcm2711.dtsi
@@ -445,7 +445,7 @@
 	};
 
 	arm-pmu {
-		compatible = "arm,cortex-a72-pmu", "arm,armv8-pmuv3";
+		compatible = "arm,cortex-a72-pmu", "arm,armv8-pmuv3", "arm,cortex-a7-pmu";
 		interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL_HIGH>,
 			<GIC_SPI 17 IRQ_TYPE_LEVEL_HIGH>,
 			<GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>,


### PR DESCRIPTION
There is no specific AArch32 driver for the Cortex-A72 PMU, but the
Cortex-A7 one works and is much better than no PMU driver at all.

Signed-off-by: Ben Avison <bavison@riscosopen.org>