### PR TITLE
drm/vc4: Force trigger of dlist update on margins change

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -728,12 +728,10 @@ static int vc4_crtc_atomic_check(struct drm_crtc *crtc,
 		if (conn_state->crtc != crtc)
 			continue;
 
-		if (memcmp(&conn_state->tv.margins, &vc4_state->margins,
+		if (memcmp(&vc4_state->margins, &conn_state->tv.margins,
 			   sizeof(vc4_state->margins))) {
-			vc4_state->margins.left = conn_state->tv.margins.left;
-			vc4_state->margins.right = conn_state->tv.margins.right;
-			vc4_state->margins.top = conn_state->tv.margins.top;
-			vc4_state->margins.bottom = conn_state->tv.margins.bottom;
+			memcpy(&vc4_state->margins, &conn_state->tv.margins,
+			       sizeof(vc4_state->margins));
 
 			/* Need to force the dlist entries for all planes to be
 			 * updated so that the dest rectangles are changed.

--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -728,10 +728,18 @@ static int vc4_crtc_atomic_check(struct drm_crtc *crtc,
 		if (conn_state->crtc != crtc)
 			continue;
 
-		vc4_state->margins.left = conn_state->tv.margins.left;
-		vc4_state->margins.right = conn_state->tv.margins.right;
-		vc4_state->margins.top = conn_state->tv.margins.top;
-		vc4_state->margins.bottom = conn_state->tv.margins.bottom;
+		if (memcmp(&conn_state->tv.margins, &vc4_state->margins,
+			   sizeof(vc4_state->margins))) {
+			vc4_state->margins.left = conn_state->tv.margins.left;
+			vc4_state->margins.right = conn_state->tv.margins.right;
+			vc4_state->margins.top = conn_state->tv.margins.top;
+			vc4_state->margins.bottom = conn_state->tv.margins.bottom;
+
+			/* Need to force the dlist entries for all planes to be
+			 * updated so that the dest rectangles are changed.
+			 */
+			crtc_state->zpos_changed = true;
+		}
 		break;
 	}
 

--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -589,12 +589,7 @@ struct vc4_crtc_state {
 	bool txp_armed;
 	unsigned int assigned_channel;
 
-	struct {
-		unsigned int left;
-		unsigned int right;
-		unsigned int top;
-		unsigned int bottom;
-	} margins;
+	struct drm_connector_tv_margins margins;
 
 	unsigned long hvs_load;
 


### PR DESCRIPTION
When the margins are changed, the dlist needs to be regenerated
with the changed updated dest regions for each of the planes.

Setting the zpos_changed flag is sufficient to trigger that
without doing a full modeset, therefore set it should the
margins be changed.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>

Requested by @spl237