### PR TITLE
overlays: mipi-dbi-spi: width-mm and height-mm are mandatory

### DIFF
--- a/arch/arm/boot/dts/overlays/mipi-dbi-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mipi-dbi-spi-overlay.dts
@@ -31,6 +31,9 @@
 				reg = <0>;
 				spi-max-frequency = <32000000>;
 
+				width-mm = <0>;
+				height-mm = <0>;
+
 				timing: panel-timing {
 					hactive = <320>;
 					vactive = <240>;


### PR DESCRIPTION
There was a last minute change to the binding in commit 1ecc0c09f19f
("dt-bindings: display: panel: mipi-dbi-spi: Make width-mm/height-mm mandatory").
This was done so userspace can calculate DPI.

Update the overlay to ensure it will work with future kernels.
The driver changes won't be backported to rpi-5.15.

Signed-off-by: Noralf Trønnes <noralf@tronnes.org>