### PR TITLE
ARM: dts: bcm2835: Switch HSM clock to firmware

### DIFF
--- a/arch/arm/boot/dts/bcm2835-common.dtsi
+++ b/arch/arm/boot/dts/bcm2835-common.dtsi
@@ -129,7 +129,7 @@
 			interrupts = <2 8>, <2 9>;
 			ddc = <&i2c2>;
 			clocks = <&firmware_clocks 9>,
-				 <&clocks BCM2835_CLOCK_HSM>;
+				 <&firmware_clocks 13>;
 			clock-names = "pixel", "hdmi";
 			dmas = <&dma (17|(1<<27)|(1<<24))>;
 			dma-names = "audio-rx";


### PR DESCRIPTION
This is a PR to fix a stall on the Pi3 when it boots without an HDMI display connected.

It was reported in the PR #4940