### PR TITLE
drm/vc4_kms: Protect hvs dereference on fkms

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -354,7 +354,7 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 	struct vc4_hvs_state *new_hvs_state;
 	struct drm_crtc *crtc;
 	struct vc4_hvs_state *old_hvs_state;
-	unsigned long max_clock_rate = clk_get_max_rate(hvs->core_clk);
+	unsigned long max_clock_rate = hvs ? clk_get_max_rate(hvs->core_clk) : 0;
 	unsigned int channel;
 	int i;
 


### PR DESCRIPTION
fkms has a null hvs pointer so this crashes. Protect against it

Signed-off-by: Dom Cobley <popcornmix@gmail.com>