### PR TITLE
drm/vc4_hdmi: Force a modeset when Broadcast RGB setting changes

### DIFF
--- a/drivers/gpu/drm/drm_atomic_uapi.c
+++ b/drivers/gpu/drm/drm_atomic_uapi.c
@@ -715,6 +715,7 @@ static int drm_atomic_connector_set_property(struct drm_connector *connector,
 {
 	struct drm_device *dev = connector->dev;
 	struct drm_mode_config *config = &dev->mode_config;
+	bool margins_updated = false;
 	bool replaced = false;
 	int ret;
 
@@ -734,12 +735,16 @@ static int drm_atomic_connector_set_property(struct drm_connector *connector,
 		state->tv.subconnector = val;
 	} else if (property == config->tv_left_margin_property) {
 		state->tv.margins.left = val;
+		margins_updated = true;
 	} else if (property == config->tv_right_margin_property) {
 		state->tv.margins.right = val;
+		margins_updated = true;
 	} else if (property == config->tv_top_margin_property) {
 		state->tv.margins.top = val;
+		margins_updated = true;
 	} else if (property == config->tv_bottom_margin_property) {
 		state->tv.margins.bottom = val;
+		margins_updated = true;
 	} else if (property == config->tv_mode_property) {
 		state->tv.mode = val;
 	} else if (property == config->tv_brightness_property) {
@@ -816,6 +821,12 @@ static int drm_atomic_connector_set_property(struct drm_connector *connector,
 			       connector->base.id, connector->name,
 			       property->base.id, property->name);
 		return -EINVAL;
+	}
+
+	if (margins_updated && state->crtc) {
+		ret = drm_atomic_add_affected_planes(state->state, state->crtc);
+
+		return ret;
 	}
 
 	return 0;

--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -333,14 +333,17 @@ static int vc4_hdmi_connector_atomic_check(struct drm_connector *connector,
 {
 	struct drm_connector_state *old_state =
 		drm_atomic_get_old_connector_state(state, connector);
+	struct vc4_hdmi_connector_state *old_vc4_state = conn_state_to_vc4_hdmi_conn_state(old_state);
 	struct drm_connector_state *new_state =
 		drm_atomic_get_new_connector_state(state, connector);
+	struct vc4_hdmi_connector_state *new_vc4_state = conn_state_to_vc4_hdmi_conn_state(new_state);
 	struct drm_crtc *crtc = new_state->crtc;
 
 	if (!crtc)
 		return 0;
 
 	if (old_state->colorspace != new_state->colorspace ||
+	    old_vc4_state->broadcast_rgb != new_vc4_state->broadcast_rgb ||
 	    !drm_connector_atomic_hdr_metadata_equal(old_state, new_state)) {
 		struct drm_crtc_state *crtc_state;
 


### PR DESCRIPTION
Without this the change is not visible until the next modeset

Signed-off-by: Dom Cobley <popcornmix@gmail.com>