### PR TITLE
mmc: block: Don't do single-sector reads during recovery

### DIFF
--- a/drivers/mmc/core/block.c
+++ b/drivers/mmc/core/block.c
@@ -1871,7 +1871,11 @@ static void mmc_blk_mq_rw_recovery(struct mmc_queue *mq, struct request *req)
 	}
 
 	/* FIXME: Missing single sector read for large sector size */
-	if (!mmc_large_sector(card) && rq_data_dir(req) == READ &&
+	/*
+	 * XXX: don't do single-sector reads, as it leaks a SG DMA
+	 * mapping when reusing the still-pending req.
+	 */
+	if (0 && !mmc_large_sector(card) && rq_data_dir(req) == READ &&
 	    brq->data.blocks > 1) {
 		/* Read one sector at a time */
 		mmc_blk_read_single(mq, req);


### PR DESCRIPTION
See https://github.com/raspberrypi/linux/issues/5019

If an SD card has degraded performance such that IO operations time out
then the MMC block layer will leak SG DMA mappings during recovery. It
retries the same SG and this causes the leak, as it is mapped twice -
once in sdhci_pre_req() and again during single-block reads in
sdhci_prepare_data().

Resetting the card (including power-cycling if a regulator for vmmc is
present) ought to be enough to recover a stuck state, so for now remove
the call to mmc_blk_read_single().

Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>