### PR TITLE
kms/vc4_hdmi: Refuse 4096x2160@60 hdmi modes

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -351,6 +351,12 @@ struct vc4_hvs {
 	 * available.
 	 */
 	bool vc5_hdmi_enable_scrambling;
+
+	/*
+	 * 4096x2160@60 requires a core overclock to work, so register
+	 * whether that is sufficient.
+	 */
+	bool vc5_hdmi_enable_4096by2160;
 };
 
 struct vc4_plane {

--- a/drivers/gpu/drm/vc4/vc4_hvs.c
+++ b/drivers/gpu/drm/vc4/vc4_hvs.c
@@ -897,6 +897,7 @@ static int vc4_hvs_bind(struct device *dev, struct device *master, void *data)
 	hvs->regset.nregs = ARRAY_SIZE(hvs_regs);
 
 	if (vc4->is_vc5) {
+		unsigned long min_rate;
 		unsigned long max_rate;
 
 		hvs->core_clk = devm_clk_get(&pdev->dev, NULL);
@@ -908,6 +909,10 @@ static int vc4_hvs_bind(struct device *dev, struct device *master, void *data)
 		max_rate = clk_get_max_rate(hvs->core_clk);
 		if (max_rate >= 550000000)
 			hvs->vc5_hdmi_enable_scrambling = true;
+
+		min_rate = clk_get_min_rate(hvs->core_clk);
+		if (min_rate >= 600000000)
+			hvs->vc5_hdmi_enable_4096by2160 = true;
 
 		ret = clk_prepare_enable(hvs->core_clk);
 		if (ret) {


### PR DESCRIPTION
These are no reliable without overclocking.
See: https://github.com/raspberrypi/linux/issues/5034

Signed-off-by: Dom Cobley <popcornmix@gmail.com>