### PR TITLE
clk-raspberrypi: Minimise firmware clocks

### DIFF
--- a/drivers/clk/bcm/clk-raspberrypi.c
+++ b/drivers/clk/bcm/clk-raspberrypi.c
@@ -130,18 +130,23 @@ raspberrypi_clk_variants[RPI_FIRMWARE_NUM_CLK_ID] = {
 	},
 	[RPI_FIRMWARE_V3D_CLK_ID] = {
 		.export = true,
+		.minimize = true,
 	},
 	[RPI_FIRMWARE_HEVC_CLK_ID] = {
 		.export = true,
+		.minimize = true,
 	},
 	[RPI_FIRMWARE_PIXEL_BVB_CLK_ID] = {
 		.export = true,
+		.minimize = true,
 	},
 	[RPI_FIRMWARE_VEC_CLK_ID] = {
 		.export = true,
+		.minimize = true,
 	},
 	[RPI_FIRMWARE_PIXEL_CLK_ID] = {
 		.export = true,
+		.minimize = true,
 	},
 };
 

--- a/drivers/gpu/drm/v3d/v3d_drv.c
+++ b/drivers/gpu/drm/v3d/v3d_drv.c
@@ -307,7 +307,7 @@ static int v3d_platform_drm_probe(struct platform_device *pdev)
 			dev_err(dev, "Failed to get clock (%ld)\n", PTR_ERR(v3d->clk));
 		return PTR_ERR(v3d->clk);
 	}
-	v3d->clk_up_rate = clk_get_rate(v3d->clk);
+	v3d->clk_up_rate = clk_get_max_rate(v3d->clk);
 	/* For downclocking, drop it to the minimum frequency we can get from
 	 * the CPRMAN clock generator dividing off our parent.  The divider is
 	 * 4 bits, but ask for just higher than that so that rounding doesn't
@@ -342,7 +342,7 @@ static int v3d_platform_drm_probe(struct platform_device *pdev)
 	if (ret)
 		goto irq_disable;
 
-	ret = clk_set_rate(v3d->clk, v3d->clk_down_rate);
+	ret = clk_set_min_rate(v3d->clk, v3d->clk_down_rate);
 	WARN_ON_ONCE(ret != 0);
 
 	return 0;

--- a/drivers/gpu/drm/v3d/v3d_gem.c
+++ b/drivers/gpu/drm/v3d/v3d_gem.c
@@ -26,7 +26,7 @@ v3d_clock_down_work(struct work_struct *work)
 		container_of(work, struct v3d_dev, clk_down_work.work);
 	int ret;
 
-	ret = clk_set_rate(v3d->clk, v3d->clk_down_rate);
+	ret = clk_set_min_rate(v3d->clk, v3d->clk_down_rate);
 	v3d->clk_up = false;
 	WARN_ON_ONCE(ret != 0);
 }
@@ -40,7 +40,7 @@ v3d_clock_up_get(struct v3d_dev *v3d)
 		if (!v3d->clk_up)  {
 			int ret;
 
-			ret = clk_set_rate(v3d->clk, v3d->clk_up_rate);
+			ret = clk_set_min_rate(v3d->clk, v3d->clk_up_rate);
 			WARN_ON_ONCE(ret != 0);
 			v3d->clk_up = true;
 		}


### PR DESCRIPTION
A follow-on from https://github.com/raspberrypi/linux/pull/4940

Currently, we don't try to minimise most firmware clocks.
e.g. if hevc requests a 550MHz clock, it continues to run at 550MHz after hevc driver has dropped its request,
and the same happens for all other non-minimised clocks.

This results in a higher required chip voltage, and so more heat/power than is necessary.

When minimising clocks you do need to switch from the `clk_set_rate` API, to `clk_set_min_rate` API.
I believe all fw clocks are using that API, apart from v3d which I've updated.