### PR TITLE
bcm2835-codec encode format fixes

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1899,6 +1899,8 @@ static int vidioc_s_selection(struct file *file, void *priv,
 {
 	struct bcm2835_codec_ctx *ctx = file2ctx(file);
 	struct bcm2835_codec_q_data *q_data = NULL;
+	struct vchiq_mmal_port *port = NULL;
+	int ret;
 
 	/*
 	 * The selection API takes V4L2_BUF_TYPE_VIDEO_CAPTURE and
@@ -1914,12 +1916,16 @@ static int vidioc_s_selection(struct file *file, void *priv,
 		if (ctx->dev->role == ENCODE || ctx->dev->role == ENCODE_IMAGE)
 			return -EINVAL;
 		q_data = &ctx->q_data[V4L2_M2M_DST];
+		if (ctx->component)
+			port = &ctx->component->output[0];
 		break;
 	case V4L2_BUF_TYPE_VIDEO_OUTPUT:
 		/* OUTPUT on deoder is not valid. */
 		if (ctx->dev->role == DECODE)
 			return -EINVAL;
 		q_data = &ctx->q_data[V4L2_M2M_SRC];
+		if (ctx->component)
+			port = &ctx->component->input[0];
 		break;
 	default:
 		return -EINVAL;
@@ -2002,6 +2008,17 @@ static int vidioc_s_selection(struct file *file, void *priv,
 		}
 	case NUM_ROLES:
 		break;
+	}
+
+	if (!port)
+		return 0;
+
+	setup_mmal_port_format(ctx, q_data, port);
+	ret = vchiq_mmal_port_set_format(ctx->dev->instance, port);
+	if (ret) {
+		v4l2_err(&ctx->dev->v4l2_dev, "%s: Failed vchiq_mmal_port_set_format on port, ret %d\n",
+			 __func__, ret);
+		return -EINVAL;
 	}
 
 	return 0;

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1613,7 +1613,8 @@ static int vidioc_s_fmt(struct bcm2835_codec_ctx *ctx, struct v4l2_format *f,
 				  f->type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE);
 	q_data->crop_width = f->fmt.pix_mp.width;
 	q_data->height = f->fmt.pix_mp.height;
-	if (!q_data->selection_set)
+	if (!q_data->selection_set ||
+	    (q_data->fmt->flags & V4L2_FMT_FLAG_COMPRESSED))
 		q_data->crop_height = requested_height;
 
 	/*


### PR DESCRIPTION
@jc-kynesim Hopefully these mean you can set the buffer geometry happily via the selection API.

The encoder is given the resolution specified on the output (V4L2 CAPTURE) side, so that resolution does need to be set correctly.