### PR TITLE
vc-sm-cma: Restore correct cache maintainance operations

### DIFF
--- a/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
+++ b/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
@@ -1247,7 +1247,9 @@ static void (*cache_op_to_func(const unsigned int cache_op))
 		return NULL;
 
 	case VC_SM_CACHE_OP_INV:
+		return dmac_inv_range;
 	case VC_SM_CACHE_OP_CLEAN:
+		return dmac_clean_range;
 	case VC_SM_CACHE_OP_FLUSH:
 		return dmac_flush_range;
 


### PR DESCRIPTION
We have been using the more expensive flush operations rather than
invalidate and clean since kernel rpi-5.9.y

These are exposed with:
52f1453513ba95084ab811a030032fe605b0cbe2 Re-expose some dmi APIs for use in VCSM

But I believe that commit was dropped when (non-cma) vc-sm was dropped,
and didn't get updated when the commit was restored

Signed-off-by: Dom Cobley <popcornmix@gmail.com>