### PR TITLE
bcm2835-v4l2-codec: support H.264 5.0 and 5.1 levels

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -2189,6 +2189,12 @@ static int bcm2835_codec_set_level_profile(struct bcm2835_codec_ctx *ctx,
 		case V4L2_MPEG_VIDEO_H264_LEVEL_4_2:
 			param.level = MMAL_VIDEO_LEVEL_H264_42;
 			break;
+		case V4L2_MPEG_VIDEO_H264_LEVEL_5_0:
+			param.level = MMAL_VIDEO_LEVEL_H264_5;
+			break;
+		case V4L2_MPEG_VIDEO_H264_LEVEL_5_1:
+			param.level = MMAL_VIDEO_LEVEL_H264_51;
+			break;
 		default:
 			/* Should never get here */
 			break;
@@ -3276,7 +3282,7 @@ static int bcm2835_codec_open(struct file *file)
 				  1, 60);
 		v4l2_ctrl_new_std_menu(hdl, &bcm2835_codec_ctrl_ops,
 				       V4L2_CID_MPEG_VIDEO_H264_LEVEL,
-				       V4L2_MPEG_VIDEO_H264_LEVEL_4_2,
+				       V4L2_MPEG_VIDEO_H264_LEVEL_5_1,
 				       ~(BIT(V4L2_MPEG_VIDEO_H264_LEVEL_1_0) |
 					 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_1B) |
 					 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_1_1) |
@@ -3290,7 +3296,9 @@ static int bcm2835_codec_open(struct file *file)
 					 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_3_2) |
 					 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_4_0) |
 					 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_4_1) |
-					 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_4_2)),
+					 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_4_2) |
+					 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_5_0) |
+					 BIT(V4L2_MPEG_VIDEO_H264_LEVEL_5_1)),
 				       V4L2_MPEG_VIDEO_H264_LEVEL_4_0);
 		v4l2_ctrl_new_std_menu(hdl, &bcm2835_codec_ctrl_ops,
 				       V4L2_CID_MPEG_VIDEO_H264_PROFILE,


### PR DESCRIPTION
For TC358743, we needed to support a capture resolution of 1920x1200 and encode it to H.264. Following [that](https://forums.raspberrypi.com/viewtopic.php?t=291447#p1762296), for resolutions greater than 1080p, we need to use H.264 levels 5.0 and 5.1. This is supported by the firmware, so I've just added the appropriate control values to the driver.

Tested on RPi4 with PiKVM V3 HAT and uStreamer. Both modes are working perfectly.