### PR TITLE
Revert "Revert "arm64: cache: Lower ARCH_DMA_MINALIGN to 64 (L1_CACHE…

### DIFF
--- a/arch/arm64/include/asm/cache.h
+++ b/arch/arm64/include/asm/cache.h
@@ -47,7 +47,7 @@
  * cache before the transfer is done, causing old data to be seen by
  * the CPU.
  */
-#define ARCH_DMA_MINALIGN	(128)
+#define ARCH_DMA_MINALIGN	L1_CACHE_BYTES
 
 #ifdef CONFIG_KASAN_SW_TAGS
 #define ARCH_SLAB_MINALIGN	(1ULL << KASAN_SHADOW_SCALE_SHIFT)


### PR DESCRIPTION
…_BYTES)""

Based on commit messsages in this chain of reverts, upstream
would prefer to reduce ARCH_DMA_MINALIGN to 64 bytes. Since most
of the hardware that requires this increase seem unrelated to rpi,
it should be safe to decrease here.

This reverts commit c1132702c71f4b95db9435bac5fdc912881563e0.