### PR TITLE
rpi-simple-soundcard: adds definitions for the HiFiBerry AMP3

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -75,6 +75,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	hdmi-backlight-hwhack-gpio.dtbo \
 	hifiberry-amp.dtbo \
 	hifiberry-amp100.dtbo \
+	hifiberry-amp3.dtbo \
 	hifiberry-dac.dtbo \
 	hifiberry-dacplus.dtbo \
 	hifiberry-dacplusadc.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1408,6 +1408,12 @@ Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
                                 Will be overwritten by ALSA user settings.
 
 
+Name:   hifiberry-amp3
+Info:   Configures the HifiBerry Amp3 audio card
+Load:   dtoverlay=hifiberry-amp3
+Params: <None>
+
+
 Name:   hifiberry-dac
 Info:   Configures the HifiBerry DAC audio cards
 Load:   dtoverlay=hifiberry-dac

--- a/arch/arm/boot/dts/overlays/hifiberry-amp3-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-amp3-overlay.dts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Definitions for HiFiBerry's Amp3
+/dts-v1/;
+/plugin/;
+#include <dt-bindings/pinctrl/bcm2835.h>
+#include <dt-bindings/gpio/gpio.h>
+
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2s>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			hifiberry_amp3_pins: hifiberry_amp3_pins {
+				brcm,pins = <23 17>;
+				brcm,function = <0 1>;
+				brcm,pull = <2 1>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			hifiberry_amp2: ma120x0p@20 {
+				#sound-dai-cells = <0>;
+				compatible = "ma,ma120x0p";
+				reg = <0x20>;
+				status = "okay";
+				pinctrl-names = "default";
+				pinctrl-0 = <&hifiberry_amp3_pins>;
+				error_gp-gpios = <&gpio 23 GPIO_ACTIVE_HIGH>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&sound>;
+		__overlay__ {
+			compatible = "hifiberry,hifiberry-amp3";
+			i2s-controller = <&i2s>;
+			status = "okay";
+		};
+	};
+};

--- a/sound/soc/bcm/rpi-simple-soundcard.c
+++ b/sound/soc/bcm/rpi-simple-soundcard.c
@@ -253,6 +253,28 @@ static struct snd_rpi_simple_drvdata drvdata_hifiberry_amp = {
 	.fixed_bclk_ratio = 64,
 };
 
+SND_SOC_DAILINK_DEFS(hifiberry_amp3,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_CODEC("ma120x0p.1-0020", "ma120x0p-amp")),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
+static struct snd_soc_dai_link snd_hifiberry_amp3_dai[] = {
+	{
+		.name		= "HifiberryAmp3",
+		.stream_name	= "Hifiberry Amp3",
+		.dai_fmt	= SND_SOC_DAIFMT_I2S |
+					SND_SOC_DAIFMT_NB_NF |
+					SND_SOC_DAIFMT_CBS_CFS,
+		SND_SOC_DAILINK_REG(hifiberry_amp3),
+	},
+};
+
+static struct snd_rpi_simple_drvdata drvdata_hifiberry_amp3 = {
+	.card_name	 = "snd_rpi_hifiberry_amp3",
+	.dai		 = snd_hifiberry_amp3_dai,
+	.fixed_bclk_ratio = 64,
+};
+
 SND_SOC_DAILINK_DEFS(hifiberry_dac,
 	DAILINK_COMP_ARRAY(COMP_EMPTY()),
 	DAILINK_COMP_ARRAY(COMP_CODEC("pcm5102a-codec", "pcm5102a-hifi")),
@@ -370,6 +392,8 @@ static const struct of_device_id snd_rpi_simple_of_match[] = {
 		.data = (void *) &drvdata_hifiberrydacplusdsp },
 	{ .compatible = "hifiberry,hifiberry-amp",
 		.data = (void *) &drvdata_hifiberry_amp },
+	{ .compatible = "hifiberry,hifiberry-amp3",
+		.data = (void *) &drvdata_hifiberry_amp3 },
 	{ .compatible = "hifiberry,hifiberry-dac",
 		.data = (void *) &drvdata_hifiberry_dac },
 	{ .compatible = "dionaudio,dionaudio-kiwi",


### PR DESCRIPTION
Currently, the definition is a copy of the the Infineon Merus AMP, but it supports the devices full sample rate of 192ksps. The Infineon/Merus card allows a maximum of 96ksps and we are working with Infineon to fix their definition. (We will issue a PR later.) The Hifiberry card does use also different GPIOs in line with our other products.