### PR TITLE
 rpi-simple-soundcard: limits sample rate of Merus Amp board

### DIFF
--- a/sound/soc/bcm/rpi-simple-soundcard.c
+++ b/sound/soc/bcm/rpi-simple-soundcard.c
@@ -145,6 +145,26 @@ static struct snd_soc_ops snd_rpi_simple_ops = {
 	.hw_params = snd_rpi_simple_hw_params,
 };
 
+static int snd_merus_amp_hw_params(struct snd_pcm_substream *substream,
+		struct snd_pcm_hw_params *params)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	int rate;
+
+	rate = params_rate(params);
+	if (rate > 48000) {
+		dev_err(rtd->card->dev,
+		"Unsupported samplerate %d\n",
+		rate);
+		return -EINVAL;
+	}
+	return 0;
+}
+
+static struct snd_soc_ops snd_merus_amp_ops = {
+	.hw_params = snd_merus_amp_hw_params,
+};
+
 enum adau1977_clk_id {
 	ADAU1977_SYSCLK,
 };
@@ -340,13 +360,14 @@ static struct snd_rpi_simple_drvdata drvdata_rpi_dac = {
 
 SND_SOC_DAILINK_DEFS(merus_amp,
 	DAILINK_COMP_ARRAY(COMP_EMPTY()),
-	DAILINK_COMP_ARRAY(COMP_CODEC("ma120x0p.1-0020","ma120x0p-amp")),
+	DAILINK_COMP_ARRAY(COMP_CODEC("ma120x0p.1-0020", "ma120x0p-amp")),
 	DAILINK_COMP_ARRAY(COMP_EMPTY()));
 
 static struct snd_soc_dai_link snd_merus_amp_dai[] = {
 	{
 		.name           = "MerusAmp",
 		.stream_name    = "Merus Audio Amp",
+		.ops		= &snd_merus_amp_ops,
 		.dai_fmt        = SND_SOC_DAIFMT_I2S |
 					SND_SOC_DAIFMT_NB_NF |
 					SND_SOC_DAIFMT_CBS_CFS,


### PR DESCRIPTION
Adding a dedicated hw_params function to limit the maximum sample
rate of the IFX/Merus board to 48000ksps.

Thanks to Ariel Muszkat for the support.

Signed-off-by: Joerg Schambacher <joerg@hifiberry.com>