### PR TITLE
Add a pullup/down parameter to PPS DTBO

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3102,8 +3102,8 @@ Params: gpiopin                 Input GPIO (default "18")
                                 off)
         capture_clear           Generate clear events on the trailing edge
                                 (default off)
-        pull                    Specify whether the pin is pulled up (2), down
-                                (1), or neither (0, default)
+        pull                    Desired pull-up/down state (off, down, up)
+                                Default is "off".
 
 
 Name:   pwm

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3102,6 +3102,8 @@ Params: gpiopin                 Input GPIO (default "18")
                                 off)
         capture_clear           Generate clear events on the trailing edge
                                 (default off)
+        pull                    Specify whether the pin is pulled up (2), down
+                                (1), or neither (0, default)
 
 
 Name:   pwm

--- a/arch/arm/boot/dts/overlays/pps-gpio-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pps-gpio-overlay.dts
@@ -34,5 +34,6 @@
 			  <&pps_pins>,"reg:0";
 		assert_falling_edge = <&pps>,"assert-falling-edge?";
 		capture_clear = <&pps>,"capture-clear?";
+		pull = <&pps_pins>,"brcm,pull:0";
 	};
 };


### PR DESCRIPTION
Square wave output from RTCs such as the DS3231 requires a pullup resistor, this commit allows the pin's internal pullup resistor to be used by specifying "pull=2" in the parameters, or "pull=1" for pulldown if necessary on other parts