### PR TITLE
bcm2835-v4l2-codec: Fix alignment of frames for deinterlace

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1482,12 +1482,14 @@ static int vidioc_try_fmt(struct bcm2835_codec_ctx *ctx, struct v4l2_format *f,
 			f->fmt.pix_mp.height = MIN_H;
 
 		/*
-		 * For decoders and image encoders the buffer must have
-		 * a vertical alignment of 16 lines.
+		 * For decoders, deinterlacers and image encoders the buffer
+		 * must have a vertical alignment of 16 lines.
 		 * The selection will reflect any cropping rectangle when only
 		 * some of the pixels are active.
 		 */
-		if (ctx->dev->role == DECODE || ctx->dev->role == ENCODE_IMAGE)
+		if (ctx->dev->role == DECODE ||
+		    ctx->dev->role == ENCODE_IMAGE ||
+		    ctx->dev->role == DEINTERLACE)
 			f->fmt.pix_mp.height = ALIGN(f->fmt.pix_mp.height, 16);
 	}
 	f->fmt.pix_mp.num_planes = 1;


### PR DESCRIPTION
The deinterlacer requires a height alignment of 16 so add it to the list of roles that get fixed up.

Signed-off-by: John Cox <jc@kynesim.co.uk>