### PR TITLE
ARM: dts: Fix missing rpi CM4 serial console

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
@@ -270,6 +270,10 @@
 #include "bcm283x-rpi-i2c0mux_0_44.dtsi"
 
 / {
+	chosen {
+		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
+	};
+
 	aliases {
 		serial0 = &uart1;
 		serial1 = &uart0;


### PR DESCRIPTION
Without commandline argument '8250.nr_uarts=1' there is no 8250 UART and hence no serial console on the CM4. Add it back.

Fixes: b9e62329e096 ("ARM: dts: Adopt the upstream snd_bcm2835 handling")
Signed-off-by: Juerg Haefliger <juerg.haefliger@canonical.com>