### PR TITLE
Rpi 5.19/bcm2835 audio fixes

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
+++ b/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
@@ -299,21 +299,28 @@ static void set_hdmi_enables(struct device *dev)
 		of_node_put(firmware_node);
 	}
 
-	if (!firmware)
+	if (!firmware) {
+		dev_err(dev, "Failed to get fw structure\n");
 		return;
+	}
 
 	ret = rpi_firmware_property(firmware,
 				    RPI_FIRMWARE_FRAMEBUFFER_GET_NUM_DISPLAYS,
 				    &num_displays, sizeof(u32));
-	if (ret)
+	if (ret) {
+		dev_err(dev, "Failed to get fw property NUM_DISPLAYS\n");
 		goto out_rpi_fw_put;
+	}
 
 	for (i = 0; i < num_displays; i++) {
 		display_id = i;
 		ret = rpi_firmware_property(firmware,
 				RPI_FIRMWARE_FRAMEBUFFER_GET_DISPLAY_ID,
 				&display_id, sizeof(display_id));
-		if (!ret) {
+		if (ret) {
+			dev_err(dev, "Failed to get fw property DISPLAY_ID "
+				"(i = %d)\n", i);
+		} else {
 			if (display_id == 2)
 				enable_hdmi0 = true;
 			if (display_id == 7)

--- a/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
+++ b/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
@@ -360,10 +360,12 @@ static int snd_bcm2835_alsa_probe(struct platform_device *pdev)
 	    !of_property_read_bool(dev->of_node, "brcm,disable-hdmi"))
 		set_hdmi_enables(dev);
 
-	of_property_read_u32(dev->of_node,
-			     "brcm,disable-headphones",
-			     &disable_headphones);
-	enable_headphones = !disable_headphones;
+	if (enable_headphones) {
+		of_property_read_u32(dev->of_node,
+				     "brcm,disable-headphones",
+				     &disable_headphones);
+		enable_headphones = !disable_headphones;
+	}
 
 	err = bcm2835_devm_add_vchi_ctx(dev);
 	if (err)

--- a/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
+++ b/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
@@ -292,7 +292,8 @@ static void set_hdmi_enables(struct device *dev)
 	u32 num_displays, i, display_id;
 	int ret;
 
-	firmware_node = of_parse_phandle(dev->of_node, "brcm,firmware", 0);
+	firmware_node = of_find_compatible_node(NULL, NULL,
+					"raspberrypi,bcm2835-firmware");
 	firmware = rpi_firmware_get(firmware_node);
 
 	if (!firmware)

--- a/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
+++ b/drivers/staging/vc04_services/bcm2835-audio/bcm2835.c
@@ -356,7 +356,8 @@ static int snd_bcm2835_alsa_probe(struct platform_device *pdev)
 			 num_channels);
 	}
 
-	if (!of_property_read_bool(dev->of_node, "brcm,disable-hdmi"))
+	if (enable_hdmi &&
+	    !of_property_read_bool(dev->of_node, "brcm,disable-hdmi"))
 		set_hdmi_enables(dev);
 
 	of_property_read_u32(dev->of_node,


### PR DESCRIPTION
On 5.19, HDMI audio outputs are always disabled. This PR fixes that plus some other minor issues.