### PR TITLE
ARM: dts: Add nvmem node for BCM2711 bootloader public key

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2711-rpi.dtsi
@@ -15,6 +15,7 @@
 		ethernet0 = &genet;
 		pcie0 = &pcie0;
 		blconfig = &blconfig;
+		blpubkey = &blpubkey;
 	};
 };
 
@@ -61,6 +62,18 @@
 	 */
 	blconfig: nvram@0 {
 		compatible = "raspberrypi,bootloader-config", "nvmem-rmem";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0x0 0x0 0x0>;
+		no-map;
+		status = "disabled";
+	};
+	/*
+	 * RPi4 will copy the binary public key blob (if present) from the bootloader
+	 * into memory for use by the OS.
+	 */
+	blpubkey: nvram@1 {
+		compatible = "raspberrypi,bootloader-public-key", "nvmem-rmem";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		reg = <0x0 0x0 0x0>;


### PR DESCRIPTION
Make a copy of the bootloader secure-boot public key available to the OS via an nvmem node. The placement information is populated by the Raspberry Pi firmware if a public key is present in the BCM2711 bootloader EEPROM.

Signed-off-by: Tim Gover <tim.gover@raspberrypi.com>