### PR TITLE
drivers/gpu/drm/vc4: Add missing 32-bit RGB formats

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -181,18 +181,22 @@ static const struct vc_image_format {
 		.drm = DRM_FORMAT_ARGB8888,
 		.vc_image = VC_IMAGE_ARGB8888,
 	},
-/*
- *	FIXME: Need to resolve which DRM format goes to which vc_image format
- *	for the remaining RGBA and RGBX formats.
- *	{
- *		.drm = DRM_FORMAT_ABGR8888,
- *		.vc_image = VC_IMAGE_RGBA8888,
- *	},
- *	{
- *		.drm = DRM_FORMAT_XBGR8888,
- *		.vc_image = VC_IMAGE_RGBA8888,
- *	},
- */
+	{
+		.drm = DRM_FORMAT_XBGR8888,
+		.vc_image = VC_IMAGE_RGBX32,
+	},
+	{
+		.drm = DRM_FORMAT_ABGR8888,
+		.vc_image = VC_IMAGE_RGBA32,
+	},
+	{
+		.drm = DRM_FORMAT_RGBX8888,
+		.vc_image = VC_IMAGE_BGRX8888,
+	},
+	{
+		.drm = DRM_FORMAT_BGRX8888,
+		.vc_image = VC_IMAGE_RGBX8888,
+	},
 	{
 		.drm = DRM_FORMAT_RGB565,
 		.vc_image = VC_IMAGE_RGB565,


### PR DESCRIPTION
The missing 32-bit per pixel ABGR and various "RGB with an X value" formats are added. Change sent by Dave Stevenson.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>