### PR TITLE
ARM: dts: Disable uart1 in the CM4 dts

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
@@ -254,13 +254,6 @@
 	};
 };
 
-/* uart1 is mapped to the pin header */
-&uart1 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&uart1_gpio14>;
-	status = "okay";
-};
-
 &vchiq {
 	interrupts = <GIC_SPI 34 IRQ_TYPE_LEVEL_HIGH>;
 };


### PR DESCRIPTION
It is a wrong assumption that a CM4 based device usese uart1. As the comment in the dts says the uart1 is enabled, because it is mapped to the pin header. This is not a valid assumption for the CM4. It might do more harm then good to eneable uart1. Even more that the BCM2711 has more uarts which better features then the mini uart.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>