### PR TITLE
Increase number of DRM planes supported per device

### DIFF
--- a/drivers/gpu/drm/drm_atomic.c
+++ b/drivers/gpu/drm/drm_atomic.c
@@ -451,7 +451,7 @@ static void drm_atomic_crtc_print_state(struct drm_printer *p,
 	drm_printf(p, "\tactive_changed=%d\n", state->active_changed);
 	drm_printf(p, "\tconnectors_changed=%d\n", state->connectors_changed);
 	drm_printf(p, "\tcolor_mgmt_changed=%d\n", state->color_mgmt_changed);
-	drm_printf(p, "\tplane_mask=%x\n", state->plane_mask);
+	drm_printf(p, "\tplane_mask=%llx\n", state->plane_mask);
 	drm_printf(p, "\tconnector_mask=%x\n", state->connector_mask);
 	drm_printf(p, "\tencoder_mask=%x\n", state->encoder_mask);
 	drm_printf(p, "\tmode: " DRM_MODE_FMT "\n", DRM_MODE_ARG(&state->mode));

--- a/drivers/gpu/drm/drm_framebuffer.c
+++ b/drivers/gpu/drm/drm_framebuffer.c
@@ -959,7 +959,7 @@ static int atomic_remove_fb(struct drm_framebuffer *fb)
 	struct drm_connector *conn __maybe_unused;
 	struct drm_connector_state *conn_state;
 	int i, ret;
-	unsigned plane_mask;
+	u64 plane_mask;
 	bool disable_crtcs = false;
 
 retry_disable:

--- a/drivers/gpu/drm/drm_mode_config.c
+++ b/drivers/gpu/drm/drm_mode_config.c
@@ -634,7 +634,7 @@ void drm_mode_config_validate(struct drm_device *dev)
 	struct drm_encoder *encoder;
 	struct drm_crtc *crtc;
 	struct drm_plane *plane;
-	u32 primary_with_crtc = 0, cursor_with_crtc = 0;
+	u64 primary_with_crtc = 0, cursor_with_crtc = 0;
 	unsigned int num_primary = 0;
 
 	if (!drm_core_check_feature(dev, DRIVER_MODESET))

--- a/drivers/gpu/drm/drm_plane.c
+++ b/drivers/gpu/drm/drm_plane.c
@@ -244,7 +244,7 @@ static int __drm_universal_plane_init(struct drm_device *dev,
 	int ret;
 
 	/* plane index is used with 32bit bitmasks */
-	if (WARN_ON(config->num_total_plane >= 32))
+	if (WARN_ON(config->num_total_plane >= 64))
 		return -EINVAL;
 
 	/*

--- a/drivers/gpu/drm/imx/ipuv3-crtc.c
+++ b/drivers/gpu/drm/imx/ipuv3-crtc.c
@@ -230,7 +230,7 @@ static int ipu_crtc_atomic_check(struct drm_crtc *crtc,
 {
 	struct drm_crtc_state *crtc_state = drm_atomic_get_new_crtc_state(state,
 									  crtc);
-	u32 primary_plane_mask = drm_plane_mask(crtc->primary);
+	u64 primary_plane_mask = drm_plane_mask(crtc->primary);
 
 	if (crtc_state->active && (primary_plane_mask & crtc_state->plane_mask) == 0)
 		return -EINVAL;

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -2385,7 +2385,7 @@ struct drm_plane *vc4_plane_init(struct drm_device *dev,
 	return plane;
 }
 
-#define VC4_NUM_OVERLAY_PLANES	16
+#define VC4_NUM_OVERLAY_PLANES	48
 
 int vc4_plane_create_additional_planes(struct drm_device *drm)
 {

--- a/include/drm/drm_crtc.h
+++ b/include/drm/drm_crtc.h
@@ -197,7 +197,7 @@ struct drm_crtc_state {
 	 * @plane_mask: Bitmask of drm_plane_mask(plane) of planes attached to
 	 * this CRTC.
 	 */
-	u32 plane_mask;
+	u64 plane_mask;
 
 	/**
 	 * @connector_mask: Bitmask of drm_connector_mask(connector) of

--- a/include/drm/drm_plane.h
+++ b/include/drm/drm_plane.h
@@ -697,7 +697,7 @@ struct drm_plane {
 	 * @index: Position inside the mode_config.list, can be used as an array
 	 * index. It is invariant over the lifetime of the plane.
 	 */
-	unsigned index;
+	uint64_t index;
 
 	/** @helper_private: mid-layer private data */
 	const struct drm_plane_helper_funcs *helper_private;
@@ -905,9 +905,9 @@ static inline unsigned int drm_plane_index(const struct drm_plane *plane)
  * drm_plane_mask - find the mask of a registered plane
  * @plane: plane to find mask for
  */
-static inline u32 drm_plane_mask(const struct drm_plane *plane)
+static inline u64 drm_plane_mask(const struct drm_plane *plane)
 {
-	return 1 << drm_plane_index(plane);
+	return 1ULL << drm_plane_index(plane);
 }
 
 struct drm_plane * drm_plane_from_index(struct drm_device *dev, int idx);


### PR DESCRIPTION
DRM had a somewhat arbitrary limit of 32 planes per device due to internally using a u32 for a bitmask.

HVS can support more planes than that, so switch to a u64 and increase the limit to 64.

@mripard thoughts?
I don't see the bitmask being exported to uapi, therefore this shouldn't cause grief.
