### PR TITLE
drivers: usb: dwc_otg: fix incorrect reference passing when checking bandwidth

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
@@ -807,7 +807,6 @@ static int dwc_otg_urb_enqueue(struct usb_hcd *hcd,
 	struct usb_host_endpoint *ep = urb->ep;
 #endif
 	dwc_irqflags_t irqflags;
-        void **ref_ep_hcpriv = &ep->hcpriv;
 	dwc_otg_hcd_t *dwc_otg_hcd = hcd_to_dwc_otg_hcd(hcd);
 	dwc_otg_hcd_urb_t *dwc_otg_urb;
 	int i;
@@ -824,7 +823,7 @@ static int dwc_otg_urb_enqueue(struct usb_hcd *hcd,
 	if ((usb_pipetype(urb->pipe) == PIPE_ISOCHRONOUS)
 	    || (usb_pipetype(urb->pipe) == PIPE_INTERRUPT)) {
 		if (!dwc_otg_hcd_is_bandwidth_allocated
-		    (dwc_otg_hcd, ref_ep_hcpriv)) {
+		    (dwc_otg_hcd, ep->hcpriv)) {
 			alloc_bandwidth = 1;
 		}
 	}
@@ -910,13 +909,12 @@ static int dwc_otg_urb_enqueue(struct usb_hcd *hcd,
 #endif
 	{
 		retval = dwc_otg_hcd_urb_enqueue(dwc_otg_hcd, dwc_otg_urb,
-						/*(dwc_otg_qh_t **)*/
-						ref_ep_hcpriv, 1);
+						&ep->hcpriv, 1);
 		if (0 == retval) {
 			if (alloc_bandwidth) {
 				allocate_bus_bandwidth(hcd,
 						dwc_otg_hcd_get_ep_bandwidth(
-							dwc_otg_hcd, *ref_ep_hcpriv),
+							dwc_otg_hcd, ep->hcpriv),
 						urb);
 			}
 		} else {


### PR DESCRIPTION
This was an obvious bug (since January 2012), but I'm a bit skeptical that a wild read could cause lockups. Normally you get some sort of kernel splat...