### PR TITLE
stop GCC from patching FIQ functions

### DIFF
--- a/drivers/usb/host/dwc_otg/Makefile
+++ b/drivers/usb/host/dwc_otg/Makefile
@@ -28,6 +28,7 @@ ccflags-y   	+= -DDWC_LINUX
 ccflags-y   	+= $(CFI)
 ccflags-y	+= $(BUS_INTERFACE)
 #ccflags-y	+= -DDWC_DEV_SRPCAP
+CFLAGS_dwc_otg_fiq_fsm.o += -fno-stack-protector
 
 obj-$(CONFIG_USB_DWCOTG) += dwc_otg.o
 

--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
@@ -142,7 +142,7 @@ inline void fiq_fsm_spin_unlock(fiq_lock_t *lock) { }
  * fiq_fsm_restart_channel() - Poke channel enable bit for a split transaction
  * @channel: channel to re-enable
  */
-static void fiq_fsm_restart_channel(struct fiq_state *st, int n, int force)
+static void notrace fiq_fsm_restart_channel(struct fiq_state *st, int n, int force)
 {
 	hcchar_data_t hcchar = { .d32 = FIQ_READ(st->dwc_regs_base + HC_START + (HC_OFFSET * n) + HCCHAR) };
 


### PR DESCRIPTION
Round 2 for https://github.com/raspberrypi/linux/issues/5189

Patching the option in the makefile rather than using explicit attributes preserves the remaining compile options.