### PR TITLE
media: adv7180: Nasty hack to allow input selection.

### DIFF
--- a/drivers/media/i2c/adv7180.c
+++ b/drivers/media/i2c/adv7180.c
@@ -184,6 +184,10 @@
 /* Initial number of frames to skip to avoid possible garbage */
 #define ADV7180_NUM_OF_SKIP_FRAMES       2
 
+static int dbg_input;
+module_param(dbg_input, int, 0644);
+MODULE_PARM_DESC(dbg_input, "Input number (0-31)");
+
 struct adv7180_state;
 
 #define ADV7180_FLAG_RESET_POWERED	BIT(0)
@@ -402,10 +406,24 @@ out:
 	return ret;
 }
 
+static void adv7180_check_input(struct v4l2_subdev *sd)
+{
+	struct adv7180_state *state = to_state(sd);
+
+	if (state->input != dbg_input)
+		if (adv7180_s_routing(sd, dbg_input, 0, 0))
+			/* Failed - reset dbg_input */
+			dbg_input = state->input;
+}
+
 static int adv7180_g_input_status(struct v4l2_subdev *sd, u32 *status)
 {
 	struct adv7180_state *state = to_state(sd);
-	int ret = mutex_lock_interruptible(&state->mutex);
+	int ret;
+
+	adv7180_check_input(sd);
+
+	ret = mutex_lock_interruptible(&state->mutex);
 	if (ret)
 		return ret;
 
@@ -431,7 +449,11 @@ static int adv7180_program_std(struct adv7180_state *state)
 static int adv7180_s_std(struct v4l2_subdev *sd, v4l2_std_id std)
 {
 	struct adv7180_state *state = to_state(sd);
-	int ret = mutex_lock_interruptible(&state->mutex);
+	int ret;
+
+	adv7180_check_input(sd);
+
+	ret = mutex_lock_interruptible(&state->mutex);
 
 	if (ret)
 		return ret;
@@ -452,6 +474,8 @@ out:
 static int adv7180_g_std(struct v4l2_subdev *sd, v4l2_std_id *norm)
 {
 	struct adv7180_state *state = to_state(sd);
+
+	adv7180_check_input(sd);
 
 	*norm = state->curr_norm;
 
@@ -838,6 +862,8 @@ static int adv7180_s_stream(struct v4l2_subdev *sd, int enable)
 		state->streaming = enable;
 		return 0;
 	}
+
+	adv7180_check_input(sd);
 
 	/* Must wait until querystd released the lock */
 	ret = mutex_lock_interruptible(&state->mutex);


### PR DESCRIPTION
Old patch that got dropped somewhere between 4.19 and 5.4.
I ought to have the conversation with mainline again, or we just ignore them and implement VIDIOC_S_INPUT on bcm2835-unicam to call s_routing.

Whilst the adv7180 driver support s_routing, nothing else does, and there is a missing lump of framework code to define the mapping from connectors on a board to the inputs they represent on the ADV7180.

Add a nasty hack to take a module parameter that is passed in to s_routing on any call to G_STD, or S_STD (or subdev g_input_status call).

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.org>