### PR TITLE
Fix productName for JMS578

### DIFF
--- a/drivers/usb/storage/unusual_devs.h
+++ b/drivers/usb/storage/unusual_devs.h
@@ -2126,7 +2126,7 @@ UNUSUAL_DEV(  0x152d, 0x0567, 0x0114, 0x0117,
 /* Reported by David Kozub <zub@linux.fjfi.cvut.cz> */
 UNUSUAL_DEV(0x152d, 0x0578, 0x0000, 0x9999,
 		"JMicron",
-		"JMS567",
+		"JMS578",
 		USB_SC_DEVICE, USB_PR_DEVICE, NULL,
 		US_FL_BROKEN_FUA),
 

--- a/drivers/usb/storage/unusual_uas.h
+++ b/drivers/usb/storage/unusual_uas.h
@@ -114,7 +114,7 @@ UNUSUAL_DEV(0x152d, 0x0567, 0x0000, 0x9999,
 /* Reported-by: David Kozub <zub@linux.fjfi.cvut.cz> */
 UNUSUAL_DEV(0x152d, 0x0578, 0x0000, 0x9999,
 		"JMicron",
-		"JMS567",
+		"JMS578",
 		USB_SC_DEVICE, USB_PR_DEVICE, NULL,
 		US_FL_BROKEN_FUA),
 


### PR DESCRIPTION
Quirk detection did not work correctly for my device, leading to UAS being used, which in turn led to a lot of troubleshooting of random failures. Since adding a quirk override to `cmdline.txt`, my device has been working flawlessly in BOT mode.

I suspect the quirk did not get applied automatically because the `productName` value is incorrectly recorded in the kernel entry. Even if I'm wrong, there is no harm in making this change - this name _is_ wrong, and was probably a copy-paste mistake.