### PR TITLE
Added Digi2 Pro audio card

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1606,7 +1606,7 @@ Params: <None>
 
 
 Name:   hifiberry-digi-pro
-Info:   Configures the HifiBerry Digi+ Pro audio card
+Info:   Configures the HifiBerry Digi+ Pro and Digi2 Pro audio card
 Load:   dtoverlay=hifiberry-digi-pro
 Params: <None>
 


### PR DESCRIPTION
Back in 2021 Hifiberry released a new card called `Digi2 Pro` ([ref](
https://www.hifiberry.com/blog/the-new-digi2-pro/)). It uses the same dtoverlay as their `Digi+ Pro` card. To reduce confusion about whether `Digi2 Pro` is supported, I've extended the README to explicitly mention also `Digi2 Pro`.