### PR TITLE
Fixed SMI driver issue when writing and using DMA

### DIFF
--- a/drivers/misc/bcm2835_smi.c
+++ b/drivers/misc/bcm2835_smi.c
@@ -666,6 +666,12 @@ out:
 }
 EXPORT_SYMBOL(bcm2835_smi_user_dma);
 
+struct bcm2835_smi_bounce_info* bcm2835_smi_get_bounce(struct bcm2835_smi_instance* inst)
+{
+	return &inst->bounce;
+}
+EXPORT_SYMBOL(bcm2835_smi_get_bounce);
+
 
 /****************************************************************************
 *

--- a/include/linux/broadcom/bcm2835_smi.h
+++ b/include/linux/broadcom/bcm2835_smi.h
@@ -148,6 +148,8 @@ ssize_t bcm2835_smi_user_dma(
 
 struct bcm2835_smi_instance *bcm2835_smi_get(struct device_node *node);
 
+struct bcm2835_smi_bounce_info *bcm2835_smi_get_bounce(struct bcm2835_smi_instance *inst);
+
 #endif /* __KERNEL__ */
 
 /****************************************************************


### PR DESCRIPTION
When using the SMI device and writing data larger than DMA_THRESHOLD_BYTES, the data was copied from user space to kernel space after the DMA had already completed. This means that the data written out will not be the data stored in user_ptr, but whatever was already in the kernel buffers.

I've added code that will first copy the user data from user space to kernel space before starting the DMA transfer. The code I've added may not be the best way to handle the problem, but I didn't want to change the files too much.