### PR TITLE
vc4_hdmi: Avoid log spam for audio start failure

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -2359,7 +2359,7 @@ static int vc4_hdmi_audio_startup(struct device *dev, void *data)
 	}
 
 	if (!vc4_hdmi_audio_can_stream(vc4_hdmi)) {
-		ret = -ENODEV;
+		ret = -ENOTSUPP;
 		goto out_dev_exit;
 	}
 


### PR DESCRIPTION
We regularly get dmesg error reports of:
[   18.184066] hdmi-audio-codec hdmi-audio-codec.3.auto: ASoC: error at snd_soc_dai_startup on i2s-hifi: -19
[   18.184098]  MAI: soc_pcm_open() failed (-19)

Currently I get 30 of these when booting to desktop. We always say, ignore they are harmless, but removing them would be good.

A bit of investigation shows, for me, the errors are all generated by second, unused hdmi interface.

It shows as an alsa device, and pulseaudio attempts to open it (numerous times), generating a kernel error message each time.

systemctl --user restart pulseaudio.service generates 6 additional error messages.

The error messages all come through:
https://github.com/raspberrypi/linux/blob/a009a9c0d79dfec114ee5102ec3d3325a172c952/sound/soc/soc-pcm.c#L39

which suggests returning ENOTSUPP, rather that ENODEV will be quiet. And indeed it is.

Note: earlier kernels do not have the quiet ENOTSUPP, so additional cherry-picks will be needed to backport
Signed-off-by: Dom Cobley <popcornmix@gmail.com>