### PR TITLE
Add the ability to disable EEE on Pi 4s

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-ds.dtsi
+++ b/arch/arm/boot/dts/bcm2711-rpi-ds.dtsi
@@ -2,8 +2,12 @@
 #include "bcm270x-rpi.dtsi"
 
 / {
+	chosen: chosen {
+	};
+
 	__overrides__ {
 		arm_freq;
+		eee = <&chosen>,"bootargs{on='',off='genet.eee=N'}";
 		hdmi = <&hdmi0>,"status",
 		       <&hdmi1>,"status";
 		pcie = <&pcie0>,"status";


### PR DESCRIPTION
The EEE implementation on BCM2711 doesn't work well with all switches. Add a module parameter and dtparam that allows it to be disabled without the need for a service to run ethtool after boot.

See #4289 for more details.
