### PR TITLE
Camera dt muxing options for CMs

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-cm.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-cm.dts
@@ -11,12 +11,12 @@
 };
 
 &cam1_reg {
-	gpio = <&gpio 2 GPIO_ACTIVE_HIGH>;
+	gpio = <&gpio 3 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 };
 
 cam0_reg: &cam0_regulator {
-	gpio = <&gpio 30 GPIO_ACTIVE_HIGH>;
+	gpio = <&gpio 31 GPIO_ACTIVE_HIGH>;
 };
 
 &uart0 {

--- a/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
@@ -11,12 +11,12 @@
 };
 
 &cam1_reg {
-	gpio = <&gpio 2 GPIO_ACTIVE_HIGH>;
+	gpio = <&gpio 3 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 };
 
 cam0_reg: &cam0_regulator {
-	gpio = <&gpio 30 GPIO_ACTIVE_HIGH>;
+	gpio = <&gpio 31 GPIO_ACTIVE_HIGH>;
 };
 
 &uart0 {

--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
@@ -594,5 +594,12 @@ cam0_reg: &cam1_reg {
 		sd_poll_once = <&emmc2>, "non-removable?";
 		spi_dma4 = <&spi0>, "dmas:0=", <&dma40>,
 			   <&spi0>, "dmas:8=", <&dma40>;
+
+		cam0_reg = <&cam0_reg>,"status";
+		cam0_reg_gpio = <&cam0_reg>,"gpio:4",
+				  <&cam0_reg>,"gpio:0=", <&gpio>;
+		cam1_reg = <&cam1_reg>,"status";
+		cam1_reg_gpio = <&cam1_reg>,"gpio:4",
+				  <&cam1_reg>,"gpio:0=", <&gpio>;
 	};
 };

--- a/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
@@ -400,12 +400,12 @@
 };
 
 &cam1_reg {
-	gpio = <&gpio 2 GPIO_ACTIVE_HIGH>;
+	gpio = <&gpio 3 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 };
 
 cam0_reg: &cam0_regulator {
-	gpio = <&gpio 30 GPIO_ACTIVE_HIGH>;
+	gpio = <&gpio 31 GPIO_ACTIVE_HIGH>;
 	status = "disabled";
 };
 
@@ -418,5 +418,10 @@ cam0_reg: &cam0_regulator {
 		sd_poll_once = <&emmc2>, "non-removable?";
 		spi_dma4 = <&spi0>, "dmas:0=", <&dma40>,
 			   <&spi0>, "dmas:8=", <&dma40>;
+
+		cam0_reg = <&cam0_reg>,"status";
+		cam0_reg_gpio = <&cam0_reg>,"gpio:4";
+		cam1_reg = <&cam1_reg>,"status";
+		cam1_reg_gpio = <&cam1_reg>,"gpio:4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -39,6 +39,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	cap1106.dtbo \
 	chipdip-dac.dtbo \
 	cirrus-wm5102.dtbo \
+	cm-swap-i2c0.dtbo \
 	cma.dtbo \
 	crystalfontz-cfa050_pi_m.dtbo \
 	cutiepi-panel.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -146,12 +146,12 @@ Params:
 
         cam0_reg                Enables CAM 0 regulator. CM1 & 3 only.
 
-        cam0_reg_gpio           Set GPIO for CAM 0 regulator. Default 30.
+        cam0_reg_gpio           Set GPIO for CAM 0 regulator. Default 31.
                                 CM1 & 3 only.
 
         cam1_reg                Enables CAM 1 regulator. CM1 & 3 only.
 
-        cam1_reg_gpio           Set GPIO for CAM 1 regulator. Default 2.
+        cam1_reg_gpio           Set GPIO for CAM 1 regulator. Default 3.
                                 CM1 & 3 only.
 
         eee                     Enable Energy Efficient Ethernet support for

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -148,7 +148,7 @@ Params:
                                 Only required on CM1 & 3.
 
         cam0_reg_gpio           Set GPIO for CAM 0 regulator.
-                                Default 31 on CM1 & 3.
+                                Default 31 on CM1, 3, and 4S.
                                 Default of GPIO expander 5 on CM4, but override
                                 switches to normal GPIO.
 
@@ -156,7 +156,7 @@ Params:
                                 Only required on CM1 & 3.
 
         cam1_reg_gpio           Set GPIO for CAM 1 regulator.
-                                Default 3 on CM1 & 3.
+                                Default 3 on CM1, 3, and 4S.
                                 Default of GPIO expander 5 on CM4, but override
                                 switches to normal GPIO.
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -144,15 +144,21 @@ Params:
                                 See /sys/kernel/debug/raspberrypi_axi_monitor
                                 for the results.
 
-        cam0_reg                Enables CAM 0 regulator. CM1 & 3 only.
+        cam0_reg                Enables CAM 0 regulator.
+                                Only required on CM1 & 3.
 
-        cam0_reg_gpio           Set GPIO for CAM 0 regulator. Default 31.
-                                CM1 & 3 only.
+        cam0_reg_gpio           Set GPIO for CAM 0 regulator.
+                                Default 31 on CM1 & 3.
+                                Default of GPIO expander 5 on CM4, but override
+                                switches to normal GPIO.
 
-        cam1_reg                Enables CAM 1 regulator. CM1 & 3 only.
+        cam1_reg                Enables CAM 1 regulator.
+                                Only required on CM1 & 3.
 
-        cam1_reg_gpio           Set GPIO for CAM 1 regulator. Default 3.
-                                CM1 & 3 only.
+        cam1_reg_gpio           Set GPIO for CAM 1 regulator.
+                                Default 3 on CM1 & 3.
+                                Default of GPIO expander 5 on CM4, but override
+                                switches to normal GPIO.
 
         eee                     Enable Energy Efficient Ethernet support for
                                 compatible devices (default "on"). See also

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -787,6 +787,22 @@ Load:   dtoverlay=cirrus-wm5102
 Params: <None>
 
 
+Name:   cm-swap-i2c0
+Info:   Largely for Compute Modules 1&3 where the original instructions for
+        adding a camera used GPIOs 0&1 for CAM1 and 28&29 for CAM0, whilst all
+        other platforms use 28&29 (or 44&45) for CAM1.
+        The default assignment through using this overlay is for
+        i2c0 to use 28&29, and i2c10 (aka i2c_csi_dsi) to use 28&29, but the
+        overrides allow this to be changed.
+Load:   dtoverlay=cm-swap-i2c0,<param>=<val>
+Params: i2c0-gpio0              Use GPIOs 0&1 for i2c0
+        i2c0-gpio28             Use GPIOs 28&29 for i2c0 (default)
+        i2c0-gpio44             Use GPIOs 44&45 for i2c0
+        i2c10-gpio0             Use GPIOs 0&1 for i2c0 (default)
+        i2c10-gpio28            Use GPIOs 28&29 for i2c0
+        i2c10-gpio44            Use GPIOs 44&45 for i2c0
+
+
 Name:   cma
 Info:   Set custom CMA sizes, only use if you know what you are doing, might
         clash with other overlays like vc4-fkms-v3d and vc4-kms-v3d.

--- a/arch/arm/boot/dts/overlays/cm-swap-i2c0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/cm-swap-i2c0-overlay.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Definitions for IMX708 camera module on VC I2C bus
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+/{
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c0mux>;
+		i2c0mux_frag: __overlay__ {
+			pinctrl-0 = <&i2c0_gpio28>;
+			pinctrl-1 = <&i2c0_gpio0>;
+		};
+	};
+
+	__overrides__ {
+		i2c0-gpio0 = <&i2c0mux_frag>, "pinctrl-0:0=",<&i2c0_gpio0>;
+		i2c0-gpio28 = <&i2c0mux_frag>, "pinctrl-0:0=",<&i2c0_gpio28>;
+		i2c0-gpio44 = <&i2c0mux_frag>, "pinctrl-0:0=",<&i2c0_gpio44>;
+		i2c10-gpio0 = <&i2c0mux_frag>, "pinctrl-1:0=",<&i2c0_gpio0>;
+		i2c10-gpio28 = <&i2c0mux_frag>, "pinctrl-1:0=",<&i2c0_gpio28>;
+		i2c10-gpio44 = <&i2c0mux_frag>, "pinctrl-1:0=",<&i2c0_gpio44>;
+	};
+};


### PR DESCRIPTION
Make life easier for using cameras on CM1, 3, and 4S by providing easy options for rerouting the I2C.

Corrects the default shutdown GPIO on CM1&3

Adds overrides for CM4 and 4S to reassign the camera shutdown GPIOs.