### PR TITLE
xhci: constrain XHCI_VLI_HUB_TT_QUIRK to old firmware versions

### DIFF
--- a/drivers/usb/host/xhci-pci.c
+++ b/drivers/usb/host/xhci-pci.c
@@ -26,6 +26,8 @@
 #define SPARSE_DISABLE_BIT	17
 #define SPARSE_CNTL_ENABLE	0xC12C
 
+#define VL805_FW_VER_0138C0	0x0138C0
+
 /* Device for a quirk */
 #define PCI_VENDOR_ID_FRESCO_LOGIC	0x1b73
 #define PCI_DEVICE_ID_FRESCO_LOGIC_PDK	0x1000
@@ -97,6 +99,16 @@ static int xhci_pci_reinit(struct xhci_hcd *xhci, struct pci_dev *pdev)
 
 	xhci_dbg(xhci, "Finished xhci_pci_reinit\n");
 	return 0;
+}
+
+static u32 xhci_vl805_get_fw_version(struct pci_dev *dev)
+{
+	int ret;
+	u32 ver;
+
+	ret = pci_read_config_dword(dev, 0x50, &ver);
+	/* Default to a fw version of 0 instead of ~0 */
+	return ret ? 0 : ver;
 }
 
 static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
@@ -294,7 +306,8 @@ static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
 		xhci->quirks |= XHCI_AVOID_DQ_ON_LINK;
 		xhci->quirks |= XHCI_VLI_TRB_CACHE_BUG;
 		xhci->quirks |= XHCI_VLI_SS_BULK_OUT_BUG;
-		xhci->quirks |= XHCI_VLI_HUB_TT_QUIRK;
+		if (xhci_vl805_get_fw_version(pdev) < VL805_FW_VER_0138C0)
+			xhci->quirks |= XHCI_VLI_HUB_TT_QUIRK;
 	}
 
 	if (pdev->vendor == PCI_VENDOR_ID_ASMEDIA &&


### PR DESCRIPTION
When the firmware eventually filters out through rpi-eeprom-update, we should stop busy-waiting in a spinlock as it's no longer necessary.