### PR TITLE
overlays: Add disable-emmc2

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -48,6 +48,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	dionaudio-loco.dtbo \
 	dionaudio-loco-v2.dtbo \
 	disable-bt.dtbo \
+	disable-emmc2.dtbo \
 	disable-wifi.dtbo \
 	dpi18.dtbo \
 	dpi18cpadhi.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -873,6 +873,14 @@ Load:   dtoverlay=disable-bt
 Params: <None>
 
 
+Name:   disable-emmc2
+Info:   Disable EMMC2 controller on BCM2711.
+        The allows the onboard EMMC storage on Compute Module 4 to be disabled
+        e.g. if a fault has occurred.
+Load:   dtoverlay=disable-emmc2
+Params: <None>
+
+
 Name:   disable-wifi
 Info:   Disable onboard WLAN on Pi 3B, 3B+, 3A+, 4B and Zero W.
 Load:   dtoverlay=disable-wifi

--- a/arch/arm/boot/dts/overlays/disable-emmc2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/disable-emmc2-overlay.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&emmc2>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -9,6 +9,10 @@
 		bcm2711;
 	};
 
+	disable-emmc2 {
+		bcm2711;
+	};
+
 	highperi {
 		bcm2711;
 	};


### PR DESCRIPTION
Add a new overlay that disables the EMMC2 controller on BCM2711. This can be useful on a Compute Module 4 if the onboard EMMC2 storage is unreliable and the system can be booted by other means e.g Network / USB.

Signed-off-by: Tim Gover <tim.gover@raspberrypi.com>