### PR TITLE
overlays: audremap: Fix setting of the pin function

### DIFF
--- a/arch/arm/boot/dts/overlays/audremap-overlay.dts
+++ b/arch/arm/boot/dts/overlays/audremap-overlay.dts
@@ -8,6 +8,7 @@
                 target = <&audio_pins>;
                 frag0: __overlay__ {
                         brcm,pins = <12 13>;
+                        brcm,function = <4>; /* alt0 alt0 */
                 };
         };
 


### PR DESCRIPTION
The `brcm,function` property must be set in the overlay fragment too - otherwise the parametrization won't work. At least that's the case for bcm2711-rpi-cm4.dts which starts with empty properties:

```
&gpio {
        audio_pins: audio_pins {
                brcm,pins = <>;
                brcm,function = <>;
        };
};
```

This was broken since a56df85d2f42fd461fdc05f33617141aca5ba465.

/cc @pelwell