### PR TITLE
imx708: Do not reset vblank to a default value

### DIFF
--- a/drivers/media/i2c/imx708.c
+++ b/drivers/media/i2c/imx708.c
@@ -1041,9 +1041,6 @@ static void imx708_set_framing_limits(struct imx708 *imx708)
 				 IMX708_FRAME_LENGTH_MAX - mode->height,
 				 1, mode->vblank_default);
 
-	/* Setting this will adjust the exposure limits as well. */
-	__v4l2_ctrl_s_ctrl(imx708->vblank, mode->vblank_default);
-
 	/*
 	 * Currently PPL is fixed to the mode specified value, so hblank
 	 * depends on mode->width only, and is not changeable in any


### PR DESCRIPTION
imx708_set_framing_limits resets the vblank control to the mode default
value unconditionally. This causes it to overwrite the user specified
vblank and exposure control values when starting the sensor, since
it is called when handling V4L2_CID_WIDE_DYNAMIC_RANGE.

Remove this call to s_ctrl as it is unnecessary.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>
