### PR TITLE
drm_probe_helper: Cancel previous job before starting new one

### DIFF
--- a/drivers/gpu/drm/drm_probe_helper.c
+++ b/drivers/gpu/drm/drm_probe_helper.c
@@ -487,9 +487,11 @@ retry:
 		 * disable itself again.
 		 */
 		dev->mode_config.delayed_event = true;
-		if (dev->mode_config.poll_enabled)
+		if (dev->mode_config.poll_enabled) {
+			cancel_delayed_work_sync(&dev->mode_config.output_poll_work);
 			schedule_delayed_work(&dev->mode_config.output_poll_work,
 					      0);
+		}
 	}
 
 	/* Re-enable polling in case the global poll config changed. */


### PR DESCRIPTION
Currently we schedule a call to output_poll_execute from drm_kms_helper_poll_enable for 10s in future. Later we try to replace that in drm_helper_probe_single_connector_modes with a 0s schedule with delayed_event set.

But as there is already a job in the queue this fails, and the immediate job we wanted with delayed_event set doesn't occur until 10s later.

And that call acts as if connector state has changed, reprobing modes. This has a side effect of waking up a display that has been blanked.

Make sure we cancel the old job before submitting the immediate one.

Signed-off-by: Dom Cobley <popcornmix@gmail.com>