### PR TITLE
.github/workflows: Set warnings-as-errors for builds

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -38,6 +38,7 @@ jobs:
       run: |
         mkdir ${{github.workspace}}/build
         make ARCH=arm KERNEL=kernel CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcm2835_defconfig
+        scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
         make ARCH=arm KERNEL=kernel CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} Image modules dtbs
         mkdir -p ${{github.workspace}}/install/boot
         make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
@@ -78,6 +79,7 @@ jobs:
       run: |
         mkdir ${{github.workspace}}/build
         make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build defconfig
+        scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
         make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} Image.gz modules dtbs
         mkdir -p ${{github.workspace}}/install/boot
         make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
@@ -118,6 +120,7 @@ jobs:
       run: |
         mkdir ${{github.workspace}}/build
         make ARCH=arm KERNEL=kernel CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcm2711_defconfig
+        scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
         make ARCH=arm KERNEL=kernel CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} zImage modules dtbs
         mkdir -p ${{github.workspace}}/install/boot
         make ARCH=arm KERNEL=kernel CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
@@ -158,6 +161,7 @@ jobs:
       run: |
         mkdir ${{github.workspace}}/build
         make ARCH=arm KERNEL=kernel7 CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcm2709_defconfig
+        scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
         make ARCH=arm KERNEL=kernel7 CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} zImage modules dtbs
         mkdir -p ${{github.workspace}}/install/boot
         make ARCH=arm KERNEL=kernel7 CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
@@ -198,6 +202,7 @@ jobs:
       run: |
         mkdir ${{github.workspace}}/build
         make ARCH=arm KERNEL=kernel7l CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcm2711_defconfig
+        scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
         make ARCH=arm KERNEL=kernel7l CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} zImage modules dtbs
         mkdir -p ${{github.workspace}}/install/boot
         make ARCH=arm KERNEL=kernel7l CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
@@ -248,6 +253,7 @@ jobs:
       run: |
         mkdir ${{github.workspace}}/build
         make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build bcm2711_defconfig
+        scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
         make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} Image.gz modules dtbs
         mkdir -p ${{github.workspace}}/install/boot
         make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install


### PR DESCRIPTION
To avoid code with build warnings being introduced into the tree, force
CONFIG_WERROR=y in the build workflow.

The second commit, reverting a fix that fixed a warning, will be dropped once the workflow change has been shown to be successful.