### PR TITLE
bcm2835-mmc: Honor return value of mmc_of_parse()

### DIFF
--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -1474,7 +1474,9 @@ static int bcm2835_mmc_probe(struct platform_device *pdev)
 	}
 
 	if (node) {
-		mmc_of_parse(mmc);
+		ret = mmc_of_parse(mmc);
+		if (ret)
+			goto err;
 
 		/* Read any custom properties */
 		of_property_read_u32(node,


### PR DESCRIPTION
bcm2835_mmc_probe() ignores errors returned by mmc_of_parse() and in particular ignores -EPROBE_DEFER, which may be returned if the power sequencing driver configured in the devicetree is compiled as a module.

The user-visible result is that access to the SDIO device fails because its power sequencing requirements have not been observed.  Fix it.