### PR TITLE
drm/vc4: Calculate bpc based on max_requested_bpc

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -2124,7 +2124,7 @@ vc4_hdmi_encoder_compute_config(const struct vc4_hdmi *vc4_hdmi,
 {
 	struct drm_device *dev = vc4_hdmi->connector.dev;
 	struct drm_connector_state *conn_state = &vc4_state->base;
-	unsigned int max_bpc = clamp_t(unsigned int, conn_state->max_bpc, 8, 12);
+	unsigned int max_bpc = clamp_t(unsigned int, conn_state->max_requested_bpc, 8, 12);
 	unsigned int bpc;
 	int ret;
 


### PR DESCRIPTION
This aligns vc4 with Intel, AMD and Synopsis drivers and fixes max bpc connector property not working as expected as conn_state->max_bpc isn't neccessarily up to date at the point we need the property value.

I initially noticed that on LibreELEC with kernel 6.1 and was wondering why switching to 12bpc didn't work. I've tested this now on RPiOS with 64bit 5.15 kernel on a RPi4 and a 1920x1200 Monitor which supports 12-bit YCC 4:2:2 and it has the same issues.

eg enable drm debugging and set max bpc to 12 - this should switch the output to YCC 422
```
root@raspberrypi:~# echo 0x02 > /sys/module/drm/parameters/debug
root@raspberrypi:~# modetest -M vc4 -w "32:max bpc:12"
```
dmesg shows that vc4 isn't even trying to check for 12-bit support (that's because max_bpc in connector state is stil 8, only max_requested_bpc is 12)
```
[   78.346261] vc4-drm gpu: [drm:vc4_atomic_check [vc4]] crtc-3: Trying to find a channel.
[   78.346376] vc4-drm gpu: [drm:vc4_atomic_check [vc4]] crtc-3: Already enabled, reusing channel 0.
[   78.346504] vc4-drm gpu: [drm:vc4_hdmi_encoder_atomic_check [vc4]] Trying with a 8 bpc output
[   78.346620] vc4-drm gpu: [drm:vc4_hdmi_encoder_atomic_check [vc4]] Trying with an RGB output
[   78.346718] vc4-drm gpu: [drm:vc4_hdmi_sink_supports_format_bpc.isra.29 [vc4]] RGB Format, checking the constraints.
[   78.346790] vc4-drm gpu: [drm:vc4_hdmi_sink_supports_format_bpc.isra.29 [vc4]] RGB format supported in that configuration.
[   78.346862] vc4-drm gpu: [drm:vc4_hdmi_encoder_atomic_check [vc4]] Mode 1920x1200 @ 60Hz: Found configuration: bpc: 8, fmt: RGB, clock: 154000000
```

With this change, using max_requested_bpc, it works as expected:
```
[   53.821214] vc4-drm gpu: [drm:vc4_atomic_check [vc4]] crtc-3: Trying to find a channel.
[   53.821334] vc4-drm gpu: [drm:vc4_atomic_check [vc4]] crtc-3: Already enabled, reusing channel 0.
[   53.821459] vc4-drm gpu: [drm:vc4_hdmi_encoder_atomic_check [vc4]] Trying with a 12 bpc output
[   53.821537] vc4-drm gpu: [drm:vc4_hdmi_encoder_atomic_check [vc4]] Trying with an RGB output
[   53.821634] vc4-drm gpu: [drm:vc4_hdmi_sink_supports_format_bpc.isra.0 [vc4]] RGB Format, checking the constraints.
[   53.821708] vc4-drm gpu: [drm:vc4_hdmi_sink_supports_format_bpc.isra.0 [vc4]] 12 BPC but sink doesn't support Deep Color 36.
[   53.821780] vc4-drm gpu: [drm:vc4_hdmi_encoder_atomic_check [vc4]] Failed, Trying with an YUV422 output
[   53.821870] vc4-drm gpu: [drm:vc4_hdmi_sink_supports_format_bpc.isra.0 [vc4]] YUV422 format, checking the constraints.
[   53.821942] vc4-drm gpu: [drm:vc4_hdmi_sink_supports_format_bpc.isra.0 [vc4]] YUV422 format supported in that configuration.
[   53.822015] vc4-drm gpu: [drm:vc4_hdmi_encoder_atomic_check [vc4]] Mode 1920x1200 @ 60Hz: Found configuration: bpc: 12, fmt: YUV 4:2:2, clock: 154000000
```

The AMD commit 01c22997bed059 has some more info in the commit message and in the comment added to the driver

ping @mripard 