### PR TITLE
.github/workflows: Correct kernel builds artifacts

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -37,14 +37,15 @@ jobs:
     - name: Build kernel
       run: |
         mkdir ${{github.workspace}}/build
-        make ARCH=arm KERNEL=kernel CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcm2835_defconfig
+        make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcm2835_defconfig
         scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
-        make ARCH=arm KERNEL=kernel CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} Image modules dtbs
-        mkdir -p ${{github.workspace}}/install/boot
+        make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} zImage modules dtbs
+        mkdir -p ${{github.workspace}}/install/boot/overlays
         make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
         cp ${{github.workspace}}/build/arch/arm/boot/dts/*.dtb ${{github.workspace}}/install/boot/
-        cp -r ${{github.workspace}}/build/arch/arm/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/
-        cp ${{github.workspace}}/build/arch/arm/boot/Image ${{github.workspace}}/install/boot/
+        cp ${{github.workspace}}/build/arch/arm/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/arch/arm/boot/dts/overlays/README ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/build/arch/arm/boot/zImage ${{github.workspace}}/install/boot/kernel.img
 
     - name: Tar build
       run: tar -cvf bcm2835_build.tar -C ${{github.workspace}}/install .
@@ -78,14 +79,15 @@ jobs:
     - name: Build kernel
       run: |
         mkdir ${{github.workspace}}/build
-        make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build defconfig
+        make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build defconfig
         scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
-        make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} Image.gz modules dtbs
-        mkdir -p ${{github.workspace}}/install/boot
-        make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
+        make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} Image.gz modules dtbs
+        mkdir -p ${{github.workspace}}/install/boot/overlays
+        make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
         cp ${{github.workspace}}/build/arch/arm64/boot/dts/broadcom/*.dtb ${{github.workspace}}/install/boot/
-        cp -r ${{github.workspace}}/build/arch/arm64/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/
-        cp ${{github.workspace}}/build/arch/arm64/boot/Image.gz ${{github.workspace}}/install/boot/
+        cp ${{github.workspace}}/build/arch/arm64/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/arch/arm64/boot/dts/overlays/README ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/build/arch/arm64/boot/Image.gz ${{github.workspace}}/install/boot/kernel8.img
 
     - name: Tar build
       run: tar -cvf arm64_build.tar -C ${{github.workspace}}/install .
@@ -119,14 +121,15 @@ jobs:
     - name: Build kernel
       run: |
         mkdir ${{github.workspace}}/build
-        make ARCH=arm KERNEL=kernel CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcm2711_defconfig
+        make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcmrpi_defconfig
         scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
-        make ARCH=arm KERNEL=kernel CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} zImage modules dtbs
-        mkdir -p ${{github.workspace}}/install/boot
-        make ARCH=arm KERNEL=kernel CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
+        make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} zImage modules dtbs
+        mkdir -p ${{github.workspace}}/install/boot/overlays
+        make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
         cp ${{github.workspace}}/build/arch/arm/boot/dts/*.dtb ${{github.workspace}}/install/boot/
-        cp -r ${{github.workspace}}/build/arch/arm/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/
-        cp ${{github.workspace}}/build/arch/arm/boot/zImage ${{github.workspace}}/install/boot/
+        cp ${{github.workspace}}/build/arch/arm/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/arch/arm/boot/dts/overlays/README ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/build/arch/arm/boot/zImage ${{github.workspace}}/install/boot/kernel.img
 
     - name: Tar build
       run: tar -cvf bcmrpi_build.tar -C ${{github.workspace}}/install .
@@ -160,14 +163,15 @@ jobs:
     - name: Build kernel
       run: |
         mkdir ${{github.workspace}}/build
-        make ARCH=arm KERNEL=kernel7 CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcm2709_defconfig
+        make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcm2709_defconfig
         scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
-        make ARCH=arm KERNEL=kernel7 CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} zImage modules dtbs
-        mkdir -p ${{github.workspace}}/install/boot
-        make ARCH=arm KERNEL=kernel7 CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
+        make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} zImage modules dtbs
+        mkdir -p ${{github.workspace}}/install/boot/overlays
+        make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
         cp ${{github.workspace}}/build/arch/arm/boot/dts/*.dtb ${{github.workspace}}/install/boot/
-        cp -r ${{github.workspace}}/build/arch/arm/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/
-        cp ${{github.workspace}}/build/arch/arm/boot/zImage ${{github.workspace}}/install/boot/
+        cp ${{github.workspace}}/build/arch/arm/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/arch/arm/boot/dts/overlays/README ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/build/arch/arm/boot/zImage ${{github.workspace}}/install/boot/kernel7.img
 
     - name: Tar build
       run: tar -cvf bcm2709_build.tar -C ${{github.workspace}}/install .
@@ -201,14 +205,15 @@ jobs:
     - name: Build kernel
       run: |
         mkdir ${{github.workspace}}/build
-        make ARCH=arm KERNEL=kernel7l CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcm2711_defconfig
+        make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build bcm2711_defconfig
         scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
-        make ARCH=arm KERNEL=kernel7l CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} zImage modules dtbs
-        mkdir -p ${{github.workspace}}/install/boot
-        make ARCH=arm KERNEL=kernel7l CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
+        make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} zImage modules dtbs
+        mkdir -p ${{github.workspace}}/install/boot/overlays
+        make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
         cp ${{github.workspace}}/build/arch/arm/boot/dts/*.dtb ${{github.workspace}}/install/boot/
-        cp -r ${{github.workspace}}/build/arch/arm/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/
-        cp ${{github.workspace}}/build/arch/arm/boot/zImage ${{github.workspace}}/install/boot/
+        cp ${{github.workspace}}/build/arch/arm/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/arch/arm/boot/dts/overlays/README ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/build/arch/arm/boot/zImage ${{github.workspace}}/install/boot/kernel7l.img
 
     - name: Tar build
       run: tar -cvf bcm2711_build.tar -C ${{github.workspace}}/install .
@@ -252,14 +257,15 @@ jobs:
     - name: Build kernel
       run: |
         mkdir ${{github.workspace}}/build
-        make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build bcm2711_defconfig
+        make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build bcm2711_defconfig
         scripts/config --file ${{github.workspace}}/build/.config --set-val CONFIG_WERROR y
-        make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} Image.gz modules dtbs
-        mkdir -p ${{github.workspace}}/install/boot
-        make ARCH=arm64 KERNEL=kernel8 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
+        make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build -j ${{env.NUM_JOBS}} Image.gz modules dtbs
+        mkdir -p ${{github.workspace}}/install/boot/overlays
+        make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- O=${{github.workspace}}/build INSTALL_MOD_PATH=${{github.workspace}}/install modules_install
         cp ${{github.workspace}}/build/arch/arm64/boot/dts/broadcom/*.dtb ${{github.workspace}}/install/boot/
-        cp -r ${{github.workspace}}/build/arch/arm64/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/
-        cp ${{github.workspace}}/build/arch/arm64/boot/Image.gz ${{github.workspace}}/install/boot/
+        cp ${{github.workspace}}/build/arch/arm64/boot/dts/overlays/*.dtb* ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/arch/arm64/boot/dts/overlays/README ${{github.workspace}}/install/boot/overlays/
+        cp ${{github.workspace}}/build/arch/arm64/boot/Image.gz ${{github.workspace}}/install/boot/kernel8.img
 
     - name: Tar build
       run: tar -cvf bcm2711_arm64_build.tar -C ${{github.workspace}}/install .


### PR DESCRIPTION
Modify the kernel build workflow to create artifacts with the correct names and structure, both as an example of what we expect and in case anyone wants to use the output.

Signed-off-by: Phil Elwell <phil@raspberrypi.com>