### PR TITLE
media: bcm2835-v4l2-codec: Enable selection ioctl for ISP

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -1855,7 +1855,6 @@ static int vidioc_g_selection(struct file *file, void *priv,
 		}
 		break;
 	case ISP:
-		break;
 	case DEINTERLACE:
 		if (s->type == V4L2_BUF_TYPE_VIDEO_CAPTURE) {
 			switch (s->target) {
@@ -1979,7 +1978,6 @@ static int vidioc_s_selection(struct file *file, void *priv,
 		}
 		break;
 	case ISP:
-		break;
 	case DEINTERLACE:
 		if (s->type == V4L2_BUF_TYPE_VIDEO_CAPTURE) {
 			switch (s->target) {


### PR DESCRIPTION
The ISP cases do nothing. Remove the break that separates them from the deinterlace case so they now do the same as deinterlace. This enables simple width & height setting, but does not enable setting left and top coordinates.

Signed-off-by: John Cox <jc@kynesim.co.uk>