### PR TITLE
dtoverlay: Update vc4-kms-dpi-generic for changed mediabus formats

### DIFF
--- a/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
@@ -65,10 +65,10 @@
 
 		rgb565 = <&panel_generic>, "bus-format:0=0x1017",
 			<&dpi_node_generic>, "pinctrl-0:0=",<&dpi_16bit_gpio0>;
-		rgb565-padhi = <&panel_generic>, "bus-format:0=0x1020",
+		rgb565-padhi = <&panel_generic>, "bus-format:0=0x1022",
 			<&dpi_node_generic>, "pinctrl-0:0=",<&dpi_16bit_cpadhi_gpio0>;
-		bgr666 = <&panel_generic>, "bus-format:0=0x101f";
-		bgr666-padhi = <&panel_generic>, "bus-format:0=0x101e",
+		bgr666 = <&panel_generic>, "bus-format:0=0x1023";
+		bgr666-padhi = <&panel_generic>, "bus-format:0=0x1024",
 			<&dpi_node_generic>, "pinctrl-0:0=",<&dpi_18bit_cpadhi_gpio0>;
 		rgb666-padhi = <&panel_generic>, "bus-format:0=0x1015",
 			<&dpi_node_generic>, "pinctrl-0:0=",<&dpi_18bit_cpadhi_gpio0>;


### PR DESCRIPTION
Several of the media bus formats aren't merged upstream yet, therefore the values change when upstream does introduce new formats.

As vc4-kms-dpi-generic references the media bus formats explicitly by number, update it to match.

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>