### PR TITLE
ARM: dts: Set the LED default-state to "off"

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
@@ -158,12 +158,14 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&gpio 47 0>;
 	};
 
 	pwr_led: led-pwr {
 		label = "led1";
+		default-state = "off";
 		linux,default-trigger = "input";
 		gpios = <&gpio 35 0>;
 	};

--- a/arch/arm/boot/dts/bcm2708-rpi-b-rev1.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-rev1.dts
@@ -176,6 +176,7 @@ i2c_csi_dsi: &i2c1 {
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&gpio 16 1>;
 	};

--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -158,6 +158,7 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&gpio 16 1>;
 	};

--- a/arch/arm/boot/dts/bcm2708-rpi-cm.dtsi
+++ b/arch/arm/boot/dts/bcm2708-rpi-cm.dtsi
@@ -4,6 +4,7 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&gpio 47 0>;
 	};

--- a/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
@@ -214,6 +214,7 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "actpwr";
 		gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
 	};

--- a/arch/arm/boot/dts/bcm2708-rpi-zero.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero.dts
@@ -155,6 +155,7 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "actpwr";
 		gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
 	};

--- a/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2709-rpi-2-b.dts
@@ -158,12 +158,14 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&gpio 47 0>;
 	};
 
 	pwr_led: led-pwr {
 		label = "led1";
+		default-state = "off";
 		linux,default-trigger = "input";
 		gpios = <&gpio 35 0>;
 	};

--- a/arch/arm/boot/dts/bcm2709-rpi-cm2.dts
+++ b/arch/arm/boot/dts/bcm2709-rpi-cm2.dts
@@ -192,6 +192,7 @@ cam0_reg: &cam0_regulator {
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&virtgpio 0 0>;
 	};

--- a/arch/arm/boot/dts/bcm2710-rpi-2-b.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-2-b.dts
@@ -158,12 +158,14 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&gpio 47 0>;
 	};
 
 	pwr_led: led-pwr {
 		label = "led1";
+		default-state = "off";
 		linux,default-trigger = "input";
 		gpios = <&gpio 35 0>;
 	};

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
@@ -234,12 +234,14 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&gpio 29 0>;
 	};
 
 	pwr_led: led-pwr {
 		label = "led1";
+		default-state = "off";
 		linux,default-trigger = "default-on";
 		gpios = <&expgpio 2 GPIO_ACTIVE_LOW>;
 	};

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
@@ -249,12 +249,14 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&virtgpio 0 0>;
 	};
 
 	pwr_led: led-pwr {
 		label = "led1";
+		default-state = "off";
 		linux,default-trigger = "input";
 		gpios = <&expgpio 7 0>;
 	};

--- a/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
@@ -191,6 +191,7 @@ cam0_reg: &cam0_regulator {
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&virtgpio 0 0>;
 	};

--- a/arch/arm/boot/dts/bcm2710-rpi-zero-2-w.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-zero-2-w.dts
@@ -227,6 +227,7 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "actpwr";
 		gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
 	};

--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
@@ -507,12 +507,14 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
 	};
 
 	pwr_led: led-pwr {
 		label = "led1";
+		default-state = "off";
 		linux,default-trigger = "default-on";
 		gpios = <&expgpio 2 GPIO_ACTIVE_LOW>;
 	};

--- a/arch/arm/boot/dts/bcm2711-rpi-400.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-400.dts
@@ -514,13 +514,14 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "default-on";
-		default-state = "on";
 		gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
 	};
 
 	pwr_led: led-pwr {
 		label = "led1";
+		default-state = "off";
 		linux,default-trigger = "default-on";
 		gpios = <&expgpio 2 GPIO_ACTIVE_LOW>;
 	};

--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
@@ -519,12 +519,14 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 		gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
 	};
 
 	pwr_led: led-pwr {
 		label = "led1";
+		default-state = "off";
 		linux,default-trigger = "default-on";
 		gpios = <&expgpio 2 GPIO_ACTIVE_LOW>;
 	};

--- a/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
@@ -389,6 +389,7 @@
 &leds {
 	act_led: led-act {
 		label = "led0";
+		default-state = "off";
 		linux,default-trigger = "mmc0";
 	};
 };


### PR DESCRIPTION
The default-state property for an LED determines the state of the LED when its trigger is set to "none". Many users expect that specifying a trigger of "none" means that the LED will be off, and there is a logic to that assumption, but the current default of "keep" makes the assumption false.

Given that no Pi models have a default-trigger of "none", changing the default-state should have no visible impact for most people, but doing so will permit a more obvious and more consistent way of turning off the LEDs.

Note that 6.2 included an upstream DT reorganisation that required some downstream changes, and while doing that I changed the default states. This commit brings rpi-6.1.y into line with rpi-6.2.y.

See: https://github.com/raspberrypi/firmware/issues/1742

Signed-off-by: Phil Elwell <phil@raspberrypi.com>