### PR TITLE
dtoverlays: Add VCM option to imx519

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2384,6 +2384,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 configuring the sensor (default on)
         cam0                    Adopt the default configuration for CAM0 on a
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
+        vcm                     Select lens driver state. Default is enabled,
+                                but vcm=off will disable.
 
 
 Name:   imx708

--- a/arch/arm/boot/dts/overlays/imx519-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx519-overlay.dts
@@ -15,32 +15,7 @@
 			#size-cells = <0>;
 			status = "okay";
 
-			imx519: imx519@1a {
-				compatible = "sony,imx519";
-				reg = <0x1a>;
-				status = "okay";
-
-				clocks = <&cam1_clk>;
-				clock-names = "xclk";
-
-				VANA-supply = <&cam1_reg>;	/* 2.8v */
-				VDIG-supply = <&cam_dummy_reg>;	/* 1.8v */
-				VDDL-supply = <&cam_dummy_reg>;	/* 1.2v */
-
-				rotation = <0>;
-				orientation = <2>;
-
-				port {
-					imx519_0: endpoint {
-						remote-endpoint = <&csi1_ep>;
-						clock-lanes = <0>;
-						data-lanes = <1 2>;
-						clock-noncontinuous;
-						link-frequencies =
-							/bits/ 64 <493500000>;
-					};
-				};
-			};
+			#include "imx519.dtsi"
 		};
 	};
 
@@ -51,8 +26,8 @@
 			brcm,media-controller;
 
 			port{
-				csi1_ep: endpoint{
-					remote-endpoint = <&imx519_0>;
+				csi_ep: endpoint{
+					remote-endpoint = <&cam_endpoint>;
 					clock-lanes = <0>;
 					data-lanes = <1 2>;
 					clock-noncontinuous;
@@ -83,14 +58,36 @@
 		};
 	};
 
+	fragment@5 {
+		target = <&cam_node>;
+		__overlay__ {
+			lens-focus = <&vcm_node>;
+		};
+	};
+
 	__overrides__ {
-		rotation = <&imx519>,"rotation:0";
-		orientation = <&imx519>,"orientation:0";
+		rotation = <&cam_node>,"rotation:0";
+		orientation = <&cam_node>,"orientation:0";
 		media-controller = <&csi>,"brcm,media-controller?";
 		cam0 = <&i2c_frag>, "target:0=",<&i2c_vc>,
 		       <&csi_frag>, "target:0=",<&csi0>,
 		       <&clk_frag>, "target:0=",<&cam0_clk>,
-		       <&imx519>, "clocks:0=",<&cam0_clk>,
-		       <&imx519>, "VANA-supply:0=",<&cam0_reg>;
+		       <&cam_node>, "clocks:0=",<&cam0_clk>,
+		       <&cam_node>, "VANA-supply:0=",<&cam0_reg>,
+		       <&vcm_node>, "vdd-supply:0=",<&cam0_reg>;
+		vcm = <&vcm_node>, "status",
+		      <0>, "=5";
 	};
+};
+
+&cam_node {
+	status = "okay";
+};
+
+&cam_endpoint {
+	remote-endpoint = <&csi_ep>;
+};
+
+&vcm_node {
+	status = "okay";
 };

--- a/arch/arm/boot/dts/overlays/imx519.dtsi
+++ b/arch/arm/boot/dts/overlays/imx519.dtsi
@@ -1,0 +1,34 @@
+// Fragment that configures a Sony IMX519
+
+cam_node: imx519@1a {
+	compatible = "sony,imx519";
+	reg = <0x1a>;
+	status = "disabled";
+
+	clocks = <&cam1_clk>;
+	clock-names = "xclk";
+
+	VANA-supply = <&cam1_reg>;	/* 2.8v */
+	VDIG-supply = <&cam_dummy_reg>;	/* 1.8v */
+	VDDL-supply = <&cam_dummy_reg>;	/* 1.2v */
+
+	rotation = <0>;
+	orientation = <2>;
+
+	port {
+		cam_endpoint: endpoint {
+			clock-lanes = <0>;
+			data-lanes = <1 2>;
+			clock-noncontinuous;
+			link-frequencies =
+				/bits/ 64 <493500000>;
+		};
+	};
+};
+
+vcm_node: ak7375@c {
+	compatible = "asahi-kasei,ak7375";
+	reg = <0x0c>;
+	status = "disabled";
+	vdd-supply = <&cam1_reg>;
+};


### PR DESCRIPTION
VCM is enabled by default, but you can use 'vcm=off' to disable VCM support.

vcm related PR: #5351