### PR TITLE
dtoverlays: Add VCM option to Arducam64MP

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -613,6 +613,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 configuring the sensor (default on)
         cam0                    Adopt the default configuration for CAM0 on a
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
+        vcm                     Select lens driver state. Default is enabled,
+                                but vcm=off will disable.
 
 
 Name:   arducam-pivariety

--- a/arch/arm/boot/dts/overlays/arducam-64mp-overlay.dts
+++ b/arch/arm/boot/dts/overlays/arducam-64mp-overlay.dts
@@ -39,6 +39,13 @@
 					};
 				};
 			};
+
+			vcm: dw9817@c {
+				compatible = "dongwoon,dw9817-vcm";
+				reg = <0x0c>;
+				status = "disabled";
+				VDD-supply = <&cam1_reg>;
+			};
 		};
 	};
 
@@ -81,6 +88,13 @@
 		};
 	};
 
+	fragment@5 {
+		target = <&arducam_64mp>;
+		__overlay__ {
+			lens-focus = <&vcm>;
+		};
+	};
+
 	__overrides__ {
 		rotation = <&arducam_64mp>,"rotation:0";
 		orientation = <&arducam_64mp>,"orientation:0";
@@ -89,6 +103,13 @@
 		       <&csi_frag>, "target:0=",<&csi0>,
 		       <&clk_frag>, "target:0=",<&cam0_clk>,
 		       <&arducam_64mp>, "clocks:0=",<&cam0_clk>,
-		       <&arducam_64mp>, "VANA-supply:0=",<&cam0_reg>;
+		       <&arducam_64mp>, "VANA-supply:0=",<&cam0_reg>,
+		       <&vcm>, "VDD-supply:0=", <&cam0_reg>;
+		vcm = <&vcm>, "status",
+		      <0>, "=5";
 	};
+};
+
+&vcm {
+	status = "okay";
 };


### PR DESCRIPTION
VCM is enabled by default, but you can use 'vcm=off' to disable VCM support.