### PR TITLE
dtoverlays: Add VCM option to Arducam64MP and Add  Arducam64MP support to camera mux overlays 

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -613,6 +613,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 configuring the sensor (default on)
         cam0                    Adopt the default configuration for CAM0 on a
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
+        vcm                     Select lens driver state. Default is enabled,
+                                but vcm=off will disable.
 
 
 Name:   arducam-pivariety

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -714,7 +714,8 @@ Info:   Configures a 2 port camera multiplexer
         Note that currently ALL IMX290 modules share a common clock, therefore
         all modules will need to have the same clock frequency.
 Load:   dtoverlay=camera-mux-2port,<param>=<val>
-Params: cam0-imx219             Select IMX219 for camera on port 0
+Params: cam0-arducam-64mp       Select Arducam64MP for camera on port 0
+        cam0-imx219             Select IMX219 for camera on port 0
         cam0-imx258             Select IMX258 for camera on port 0
         cam0-imx290             Select IMX290 for camera on port 0
         cam0-imx477             Select IMX477 for camera on port 0
@@ -725,6 +726,7 @@ Params: cam0-imx219             Select IMX219 for camera on port 0
         cam0-ov7251             Select OV7251 for camera on port 0
         cam0-ov9281             Select OV9281 for camera on port 0
         cam0-imx290-clk-freq    Set clock frequency for an IMX290 on port 0
+        cam1-arducam-64mp       Select Arducam64MP for camera on port 1
         cam1-imx219             Select IMX219 for camera on port 1
         cam1-imx258             Select IMX258 for camera on port 1
         cam1-imx290             Select IMX290 for camera on port 1
@@ -743,7 +745,8 @@ Info:   Configures a 4 port camera multiplexer
         Note that currently ALL IMX290 modules share a common clock, therefore
         all modules will need to have the same clock frequency.
 Load:   dtoverlay=camera-mux-4port,<param>=<val>
-Params: cam0-imx219             Select IMX219 for camera on port 0
+Params: cam0-arducam-64mp       Select Arducam64MP for camera on port 0
+        cam0-imx219             Select IMX219 for camera on port 0
         cam0-imx258             Select IMX258 for camera on port 0
         cam0-imx290             Select IMX290 for camera on port 0
         cam0-imx477             Select IMX477 for camera on port 0
@@ -754,6 +757,7 @@ Params: cam0-imx219             Select IMX219 for camera on port 0
         cam0-ov7251             Select OV7251 for camera on port 0
         cam0-ov9281             Select OV9281 for camera on port 0
         cam0-imx290-clk-freq    Set clock frequency for an IMX290 on port 0
+        cam1-arducam-64mp       Select Arducam64MP for camera on port 1
         cam1-imx219             Select IMX219 for camera on port 1
         cam1-imx258             Select IMX258 for camera on port 1
         cam1-imx290             Select IMX290 for camera on port 1
@@ -765,6 +769,7 @@ Params: cam0-imx219             Select IMX219 for camera on port 0
         cam1-ov7251             Select OV7251 for camera on port 1
         cam1-ov9281             Select OV9281 for camera on port 1
         cam1-imx290-clk-freq    Set clock frequency for an IMX290 on port 1
+        cam2-arducam-64mp       Select Arducam64MP for camera on port 2
         cam2-imx219             Select IMX219 for camera on port 2
         cam2-imx258             Select IMX258 for camera on port 2
         cam2-imx290             Select IMX290 for camera on port 2
@@ -776,6 +781,7 @@ Params: cam0-imx219             Select IMX219 for camera on port 0
         cam2-ov7251             Select OV7251 for camera on port 2
         cam2-ov9281             Select OV9281 for camera on port 2
         cam2-imx290-clk-freq    Set clock frequency for an IMX290 on port 2
+        cam3-arducam-64mp       Select Arducam64MP for camera on port 3
         cam3-imx219             Select IMX219 for camera on port 3
         cam3-imx258             Select IMX258 for camera on port 3
         cam3-imx290             Select IMX290 for camera on port 3

--- a/arch/arm/boot/dts/overlays/arducam-64mp-overlay.dts
+++ b/arch/arm/boot/dts/overlays/arducam-64mp-overlay.dts
@@ -13,32 +13,7 @@
 			#size-cells = <0>;
 			status = "okay";
 
-			arducam_64mp: arducam_64mp@1a {
-				compatible = "arducam,64mp";
-				reg = <0x1a>;
-				status = "okay";
-
-				clocks = <&cam1_clk>;
-				clock-names = "xclk";
-
-				VANA-supply = <&cam1_reg>;	/* 2.8v */
-				VDIG-supply = <&cam_dummy_reg>;	/* 1.8v */
-				VDDL-supply = <&cam_dummy_reg>;	/* 1.2v */
-
-				rotation = <0>;
-				orientation = <2>;
-
-				port {
-					arducam_64mp_0: endpoint {
-						remote-endpoint = <&csi1_ep>;
-						clock-lanes = <0>;
-						data-lanes = <1 2>;
-						clock-noncontinuous;
-						link-frequencies =
-							/bits/ 64 <456000000>;
-					};
-				};
-			};
+			#include "arducam-64mp.dtsi"
 		};
 	};
 
@@ -49,8 +24,8 @@
 			brcm,media-controller;
 
 			port{
-				csi1_ep: endpoint{
-					remote-endpoint = <&arducam_64mp_0>;
+				csi_ep: endpoint{
+					remote-endpoint = <&cam_endpoint>;
 					clock-lanes = <0>;
 					data-lanes = <1 2>;
 					clock-noncontinuous;
@@ -81,14 +56,36 @@
 		};
 	};
 
+	fragment@5 {
+		target = <&cam_node>;
+		__overlay__ {
+			lens-focus = <&vcm_node>;
+		};
+	};
+
 	__overrides__ {
-		rotation = <&arducam_64mp>,"rotation:0";
-		orientation = <&arducam_64mp>,"orientation:0";
+		rotation = <&cam_node>,"rotation:0";
+		orientation = <&cam_node>,"orientation:0";
 		media-controller = <&csi>,"brcm,media-controller?";
 		cam0 = <&i2c_frag>, "target:0=",<&i2c_vc>,
 		       <&csi_frag>, "target:0=",<&csi0>,
 		       <&clk_frag>, "target:0=",<&cam0_clk>,
-		       <&arducam_64mp>, "clocks:0=",<&cam0_clk>,
-		       <&arducam_64mp>, "VANA-supply:0=",<&cam0_reg>;
+		       <&cam_node>, "clocks:0=",<&cam0_clk>,
+		       <&cam_node>, "VANA-supply:0=",<&cam0_reg>,
+		       <&vcm_node>, "VDD-supply:0=", <&cam0_reg>;
+		vcm = <&vcm_node>, "status",
+		      <0>, "=5";
 	};
+};
+
+&cam_node {
+	status = "okay";
+};
+
+&cam_endpoint {
+	remote-endpoint = <&csi_ep>;
+};
+
+&vcm_node {
+	status = "okay";
 };

--- a/arch/arm/boot/dts/overlays/arducam-64mp.dtsi
+++ b/arch/arm/boot/dts/overlays/arducam-64mp.dtsi
@@ -1,0 +1,34 @@
+// Fragment that configures a Arducam64MP
+
+cam_node: arducam_64mp@1a {
+	compatible = "arducam,64mp";
+	reg = <0x1a>;
+	status = "disabled";
+
+	clocks = <&cam1_clk>;
+	clock-names = "xclk";
+
+	VANA-supply = <&cam1_reg>;	/* 2.8v */
+	VDIG-supply = <&cam_dummy_reg>;	/* 1.8v */
+	VDDL-supply = <&cam_dummy_reg>;	/* 1.2v */
+
+	rotation = <0>;
+	orientation = <2>;
+
+	port {
+		cam_endpoint: endpoint {
+			clock-lanes = <0>;
+			data-lanes = <1 2>;
+			clock-noncontinuous;
+			link-frequencies =
+				/bits/ 64 <456000000>;
+		};
+	};
+};
+
+vcm_node: dw9817_arducam64mp@c {
+	compatible = "dongwoon,dw9817-vcm";
+	reg = <0x0c>;
+	status = "disabled";
+	VDD-supply = <&cam1_reg>;
+};

--- a/arch/arm/boot/dts/overlays/camera-mux-2port-overlay.dts
+++ b/arch/arm/boot/dts/overlays/camera-mux-2port-overlay.dts
@@ -96,6 +96,16 @@
 					#address-cells = <1>;
 					#size-cells = <0>;
 
+					#define cam_node arducam_64mp_0
+					#define cam_endpoint arducam_64mp_0_ep
+					#define vcm_node arducam_64mp_0_vcm
+					#define cam1_clk clk_24mhz
+					#include "arducam-64mp.dtsi"
+					#undef cam_node
+					#undef cam_endpoint
+					#undef vcm_node
+					#undef cam1_clk
+
 					#define cam_node imx219_0
 					#define cam_endpoint imx219_0_ep
 					#define cam1_clk clk_24mhz
@@ -185,6 +195,16 @@
 					reg = <1>;
 					#address-cells = <1>;
 					#size-cells = <0>;
+
+					#define cam_node arducam_64mp_1
+					#define cam_endpoint arducam_64mp_1_ep
+					#define vcm_node arducam_64mp_1_vcm
+					#define cam1_clk clk_24mhz
+					#include "arducam-64mp.dtsi"
+					#undef cam_node
+					#undef cam_endpoint
+					#undef vcm_node
+					#undef cam1_clk
 
 					#define cam_node imx219_1
 					#define cam_endpoint imx219_1_ep
@@ -385,6 +405,12 @@
 	};
 
 	__overrides__ {
+		cam0-arducam-64mp = <&mux_in0>, "remote-endpoint:0=",<&arducam_64mp_0_ep>,
+				    <&arducam_64mp_0_ep>, "remote-endpoint:0=",<&mux_in0>,
+				    <&mux_in0>, "clock-noncontinuous?",
+				    <&arducam_64mp_0>, "status=okay",
+				    <&arducam_64mp_0_vcm>, "status=okay",
+				    <&arducam_64mp_0>,"lens-focus:0=", <&arducam_64mp_0_vcm>;
 		cam0-imx219 = <&mux_in0>, "remote-endpoint:0=",<&imx219_0_ep>,
 			      <&imx219_0_ep>, "remote-endpoint:0=",<&mux_in0>,
 			      <&mux_in0>, "clock-noncontinuous?",
@@ -425,6 +451,12 @@
 			      <&ov2311_0_ep>, "remote-endpoint:0=",<&mux_in0>,
 			      <&ov2311_0>, "status=okay";
 
+		cam1-arducam-64mp = <&mux_in1>, "remote-endpoint:0=",<&arducam_64mp_1_ep>,
+				    <&arducam_64mp_1_ep>, "remote-endpoint:0=",<&mux_in1>,
+				    <&mux_in1>, "clock-noncontinuous?",
+				    <&arducam_64mp_1>, "status=okay",
+				    <&arducam_64mp_1_vcm>, "status=okay",
+				    <&arducam_64mp_1>,"lens-focus:0=", <&arducam_64mp_1_vcm>;
 		cam1-imx219 = <&mux_in1>, "remote-endpoint:0=",<&imx219_1_ep>,
 			      <&imx219_1_ep>, "remote-endpoint:0=",<&mux_in1>,
 			      <&mux_in1>, "clock-noncontinuous?",

--- a/arch/arm/boot/dts/overlays/camera-mux-4port-overlay.dts
+++ b/arch/arm/boot/dts/overlays/camera-mux-4port-overlay.dts
@@ -154,6 +154,16 @@
 					#address-cells = <1>;
 					#size-cells = <0>;
 
+					#define cam_node arducam_64mp_0
+					#define cam_endpoint arducam_64mp_0_ep
+					#define vcm_node arducam_64mp_0_vcm
+					#define cam1_clk clk_24mhz
+					#include "arducam-64mp.dtsi"
+					#undef cam_node
+					#undef cam_endpoint
+					#undef vcm_node
+					#undef cam1_clk
+
 					#define cam_node imx219_0
 					#define cam_endpoint imx219_0_ep
 					#define cam1_clk clk_24mhz
@@ -243,6 +253,16 @@
 					reg = <1>;
 					#address-cells = <1>;
 					#size-cells = <0>;
+
+					#define cam_node arducam_64mp_1
+					#define cam_endpoint arducam_64mp_1_ep
+					#define vcm_node arducam_64mp_1_vcm
+					#define cam1_clk clk_24mhz
+					#include "arducam-64mp.dtsi"
+					#undef cam_node
+					#undef cam_endpoint
+					#undef vcm_node
+					#undef cam1_clk
 
 					#define cam_node imx219_1
 					#define cam_endpoint imx219_1_ep
@@ -334,6 +354,16 @@
 					#address-cells = <1>;
 					#size-cells = <0>;
 
+					#define cam_node arducam_64mp_2
+					#define cam_endpoint arducam_64mp_2_ep
+					#define vcm_node arducam_64mp_2_vcm
+					#define cam1_clk clk_24mhz
+					#include "arducam-64mp.dtsi"
+					#undef cam_node
+					#undef cam_endpoint
+					#undef vcm_node
+					#undef cam1_clk
+
 					#define cam_node imx219_2
 					#define cam_endpoint imx219_2_ep
 					#define cam1_clk clk_24mhz
@@ -423,6 +453,16 @@
 					reg = <3>;
 					#address-cells = <1>;
 					#size-cells = <0>;
+
+					#define cam_node arducam_64mp_3
+					#define cam_endpoint arducam_64mp_3_ep
+					#define vcm_node arducam_64mp_3_vcm
+					#define cam1_clk clk_24mhz
+					#include "arducam-64mp.dtsi"
+					#undef cam_node
+					#undef cam_endpoint
+					#undef vcm_node
+					#undef cam1_clk
 
 					#define cam_node imx219_3
 					#define cam_endpoint imx219_3_ep
@@ -640,6 +680,12 @@
 	};
 
 	__overrides__ {
+		cam0-arducam-64mp = <&mux_in0>, "remote-endpoint:0=",<&arducam_64mp_0_ep>,
+				    <&arducam_64mp_0_ep>, "remote-endpoint:0=",<&mux_in0>,
+				    <&mux_in0>, "clock-noncontinuous?",
+				    <&arducam_64mp_0>, "status=okay",
+				    <&arducam_64mp_0_vcm>, "status=okay",
+				    <&arducam_64mp_0>,"lens-focus:0=", <&arducam_64mp_0_vcm>;
 		cam0-imx219 = <&mux_in0>, "remote-endpoint:0=",<&imx219_0_ep>,
 			      <&imx219_0_ep>, "remote-endpoint:0=",<&mux_in0>,
 			      <&mux_in0>, "clock-noncontinuous?",
@@ -680,6 +726,12 @@
 			      <&ov2311_0_ep>, "remote-endpoint:0=",<&mux_in0>,
 			      <&ov2311_0>, "status=okay";
 
+		cam1-arducam-64mp = <&mux_in1>, "remote-endpoint:0=",<&arducam_64mp_1_ep>,
+				    <&arducam_64mp_1_ep>, "remote-endpoint:0=",<&mux_in1>,
+				    <&mux_in1>, "clock-noncontinuous?",
+				    <&arducam_64mp_1>, "status=okay",
+				    <&arducam_64mp_1_vcm>, "status=okay",
+				    <&arducam_64mp_1>,"lens-focus:0=", <&arducam_64mp_1_vcm>;
 		cam1-imx219 = <&mux_in1>, "remote-endpoint:0=",<&imx219_1_ep>,
 			      <&imx219_1_ep>, "remote-endpoint:0=",<&mux_in1>,
 			      <&mux_in1>, "clock-noncontinuous?",
@@ -720,6 +772,12 @@
 			      <&ov2311_1_ep>, "remote-endpoint:0=",<&mux_in1>,
 			      <&ov2311_1>, "status=okay";
 
+		cam2-arducam-64mp = <&mux_in2>, "remote-endpoint:0=",<&arducam_64mp_2_ep>,
+				    <&arducam_64mp_2_ep>, "remote-endpoint:0=",<&mux_in2>,
+				    <&mux_in2>, "clock-noncontinuous?",
+				    <&arducam_64mp_2>, "status=okay",
+				    <&arducam_64mp_2_vcm>, "status=okay",
+				    <&arducam_64mp_2>,"lens-focus:0=", <&arducam_64mp_2_vcm>;
 		cam2-imx219 = <&mux_in2>, "remote-endpoint:0=",<&imx219_2_ep>,
 			      <&imx219_2_ep>, "remote-endpoint:0=",<&mux_in2>,
 			      <&mux_in2>, "clock-noncontinuous?",
@@ -760,6 +818,12 @@
 			      <&ov2311_2_ep>, "remote-endpoint:0=",<&mux_in2>,
 			      <&ov2311_2>, "status=okay";
 
+		cam3-arducam-64mp = <&mux_in3>, "remote-endpoint:0=",<&arducam_64mp_3_ep>,
+				    <&arducam_64mp_3_ep>, "remote-endpoint:0=",<&mux_in3>,
+				    <&mux_in3>, "clock-noncontinuous?",
+				    <&arducam_64mp_3>, "status=okay",
+				    <&arducam_64mp_3_vcm>, "status=okay",
+				    <&arducam_64mp_3>,"lens-focus:0=", <&arducam_64mp_3_vcm>;
 		cam3-imx219 = <&mux_in3>, "remote-endpoint:0=",<&imx219_3_ep>,
 			      <&imx219_3_ep>, "remote-endpoint:0=",<&mux_in3>,
 			      <&mux_in3>, "clock-noncontinuous?",


### PR DESCRIPTION
VCM is enabled by default, but you can use 'vcm=off' to disable VCM support.