### PR TITLE
Add workflow for checkpatch on PRs

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,18 @@
+name: Advisory checkpatch review
+on: [pull_request]
+
+jobs:
+  review:
+    name: checkpatch review
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Calculate PR commits + 1'
+      run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> $GITHUB_ENV
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+    - name: Copy checkpatch.conf
+      run: cp ${{github.workspace}}/.github/workflows/ci_checkpatch.conf ${{github.workspace}}/.checkpatch.conf
+    - name: Run checkpatch review
+      uses: webispy/checkpatch-action@v9

--- a/.github/workflows/ci_checkpatch.conf
+++ b/.github/workflows/ci_checkpatch.conf
@@ -1,0 +1,4 @@
+--no-tree
+--ignore FILE_PATH_CHANGES
+--ignore GIT_COMMIT_ID
+--ignore SPDX_LICENSE_TAG


### PR DESCRIPTION
Sorry for the noise earlier.

This workflow can only be triggered on PR as it uses the Github REST API to retrieve specifically a "pull" list of commits.

We may also need to add "webispy/checkpatch-action@v9" under settings/actions/general/"allow specified actions and reusable workflows", or we fork it into our own repo for security.

The two patches to the rpi-panel-attiny are largely so that the workflow has something to test, but they will also want to be merged in due course.