### PR TITLE
drm/vc4: drop unnecessary and harmful HDMI RGB format check

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -1962,9 +1962,6 @@ vc4_hdmi_sink_supports_format_bpc(const struct vc4_hdmi *vc4_hdmi,
 	case VC4_HDMI_OUTPUT_RGB:
 		drm_dbg(dev, "RGB Format, checking the constraints.\n");
 
-		if (!(info->color_formats & DRM_COLOR_FORMAT_RGB444))
-			return false;
-
 		if (bpc == 10 && !(info->edid_hdmi_rgb444_dc_modes & DRM_EDID_HDMI_DC_30)) {
 			drm_dbg(dev, "10 BPC but sink doesn't support Deep Color 30.\n");
 			return false;


### PR DESCRIPTION
RGB is a mandatory format for all DVI and HDMI monitors so there's no need to check for presence of the DRM_COLOR_FORMAT_RGB444 bit in color_formats.

More importantly this checks breaks working around EDID issues with eg video=HDMI-A-1:1024x768D or drm.edid_firmware=edid/1024x768.bin as the RGB444 bit is only set when a valid EDID with digital bit set in the input byte is present - which isn't the case when no EDID can be read from the display device at all or with the in-built kernel EDIDs, which mimic analog (VGA) displays without the digital bit set.

So drop the check, if we output video on the HDMI connector we can assume that the display can accept 8bit RGB.

ping @mripard 

Note: for a simple test power up RPi without HDMI cable attached, add eg `video=HDMI-A-1:1024x768D drm.debug=0x04` to cmdline.txt and watch vc4 rejecting RGB mode in dmesg without this PR. With this PR the forced video mode is accepted and after attaching the cable to RPi3B+ I got a 1024x768 display just fine