### PR TITLE
reboot: Use power off rather than busy spinning when halt is requested

### DIFF
--- a/arch/arm64/kernel/process.c
+++ b/arch/arm64/kernel/process.c
@@ -96,9 +96,7 @@ void machine_shutdown(void)
  */
 void machine_halt(void)
 {
-	local_irq_disable();
-	smp_send_stop();
-	while (1);
+	machine_power_off();
 }
 
 /*


### PR DESCRIPTION
Busy spinning after halt is dumb
We've previously applied this patch to arch/arm
but it is currenltly missing in arch/arm64

Pi4 after "sudo halt" uses 520mA
Pi4 after "sudo shutdown now" uses 310mA

Make them both use the lower powered option