### PR TITLE
WIP: HDMI HPD debounce

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -2870,12 +2870,14 @@ static void vc4_hdmi_hpd_con_wq(struct work_struct *work)
 		drm_connector_helper_hpd_irq_event(connector);
 }
 
-#define HPD_DEBOUNCE_DELAY_MS 250
+#define HPD_DEBOUNCE_DELAY_MS 2500
 
 static irqreturn_t vc4_hdmi_hpd_irq_con_thread(int irq, void *priv)
 {
 	struct vc4_hdmi *vc4_hdmi = priv;
+	struct device *pdev = &vc4_hdmi->pdev->dev;
 
+	dev_err(pdev, "HPD IRQ status conn\n");
 	mod_delayed_work(system_wq, &vc4_hdmi->hpd_con_work,
 			 msecs_to_jiffies(HPD_DEBOUNCE_DELAY_MS));
 
@@ -2887,7 +2889,9 @@ static irqreturn_t vc4_hdmi_hpd_irq_disconn_thread(int irq, void *priv)
 	struct vc4_hdmi *vc4_hdmi = priv;
 	struct drm_connector *connector = &vc4_hdmi->connector;
 	struct drm_device *dev = connector->dev;
+	struct device *pdev = &vc4_hdmi->pdev->dev;
 
+	dev_err(pdev, "HPD IRQ status disconn\n");
 	if (dev && dev->registered)
 		drm_connector_helper_hpd_irq_event(connector);
 

--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -2858,7 +2858,31 @@ static int vc4_hdmi_audio_init(struct vc4_hdmi *vc4_hdmi)
 
 }
 
-static irqreturn_t vc4_hdmi_hpd_irq_thread(int irq, void *priv)
+static void vc4_hdmi_hpd_con_wq(struct work_struct *work)
+{
+	struct vc4_hdmi *vc4_hdmi = container_of(to_delayed_work(work),
+						 struct vc4_hdmi,
+						 hpd_con_work);
+	struct drm_connector *connector = &vc4_hdmi->connector;
+	struct drm_device *dev = connector->dev;
+
+	if (dev && dev->registered)
+		drm_connector_helper_hpd_irq_event(connector);
+}
+
+#define HPD_DEBOUNCE_DELAY_MS 250
+
+static irqreturn_t vc4_hdmi_hpd_irq_con_thread(int irq, void *priv)
+{
+	struct vc4_hdmi *vc4_hdmi = priv;
+
+	mod_delayed_work(system_wq, &vc4_hdmi->hpd_con_work,
+			 msecs_to_jiffies(HPD_DEBOUNCE_DELAY_MS));
+
+	return IRQ_HANDLED;
+}
+
+static irqreturn_t vc4_hdmi_hpd_irq_disconn_thread(int irq, void *priv)
 {
 	struct vc4_hdmi *vc4_hdmi = priv;
 	struct drm_connector *connector = &vc4_hdmi->connector;
@@ -2880,16 +2904,16 @@ static int vc4_hdmi_hotplug_init(struct vc4_hdmi *vc4_hdmi)
 		unsigned int hpd_con = platform_get_irq_byname(pdev, "hpd-connected");
 		unsigned int hpd_rm = platform_get_irq_byname(pdev, "hpd-removed");
 
-		ret = devm_request_threaded_irq(&pdev->dev, hpd_con,
-						NULL,
-						vc4_hdmi_hpd_irq_thread, IRQF_ONESHOT,
+		ret = devm_request_threaded_irq(&pdev->dev, hpd_con, NULL,
+						vc4_hdmi_hpd_irq_con_thread,
+						IRQF_ONESHOT,
 						"vc4 hdmi hpd connected", vc4_hdmi);
 		if (ret)
 			return ret;
 
-		ret = devm_request_threaded_irq(&pdev->dev, hpd_rm,
-						NULL,
-						vc4_hdmi_hpd_irq_thread, IRQF_ONESHOT,
+		ret = devm_request_threaded_irq(&pdev->dev, hpd_rm, NULL,
+						vc4_hdmi_hpd_irq_disconn_thread,
+						IRQF_ONESHOT,
 						"vc4 hdmi hpd disconnected", vc4_hdmi);
 		if (ret)
 			return ret;
@@ -3714,6 +3738,7 @@ static int vc4_hdmi_bind(struct device *dev, struct device *master, void *data)
 
 	spin_lock_init(&vc4_hdmi->hw_lock);
 	INIT_DELAYED_WORK(&vc4_hdmi->scrambling_work, vc4_hdmi_scrambling_wq);
+	INIT_DELAYED_WORK(&vc4_hdmi->hpd_con_work, vc4_hdmi_hpd_con_wq);
 
 	dev_set_drvdata(dev, vc4_hdmi);
 	encoder = &vc4_hdmi->encoder.base;

--- a/drivers/gpu/drm/vc4/vc4_hdmi.h
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.h
@@ -129,6 +129,7 @@ struct vc4_hdmi {
 	struct drm_connector connector;
 
 	struct delayed_work scrambling_work;
+	struct delayed_work hpd_con_work;
 
 	struct drm_property *broadcast_rgb_property;
 	struct drm_property *output_format_property;


### PR DESCRIPTION
Debounce the HPD signal for those people with dodgy cables.

WIP as the second patch pushes the delay up to 2.5secs. 250ms should be sufficient in most cases and not cause a noticeable delay.