### PR TITLE
ARM: dts: Disable headphone audio on CM, CM2 and CM3

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-cm.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-cm.dts
@@ -164,6 +164,7 @@ cam0_reg: &cam0_regulator {
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+	brcm,disable-headphones = <1>;
 };
 
 &hdmi {

--- a/arch/arm/boot/dts/bcm2709-rpi-cm2.dts
+++ b/arch/arm/boot/dts/bcm2709-rpi-cm2.dts
@@ -204,6 +204,7 @@ cam0_reg: &cam0_regulator {
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+	brcm,disable-headphones = <1>;
 };
 
 / {

--- a/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-cm3.dts
@@ -203,6 +203,7 @@ cam0_reg: &cam0_regulator {
 &audio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&audio_pins>;
+	brcm,disable-headphones = <1>;
 };
 
 / {


### PR DESCRIPTION
Similar to 79075960b723b3b0c15fad27bc555ab4385ae4ab. Not sure why this wasn't done back then.