### PR TITLE
rpisense-fb: Flush any deferred updates on release

### DIFF
--- a/drivers/video/fbdev/rpisense-fb.c
+++ b/drivers/video/fbdev/rpisense-fb.c
@@ -183,8 +183,18 @@ static int rpisense_fb_ioctl(struct fb_info *info, unsigned int cmd,
 	return 0;
 }
 
+static int rpisense_fb_release(struct fb_info *info, int user)
+{
+	/* Flush any pending updates */
+	cancel_delayed_work(&info->deferred_work);
+	schedule_delayed_work(&info->deferred_work, 0);
+
+	return 0;
+}
+
 static struct fb_ops rpisense_fb_ops = {
 	.owner		= THIS_MODULE,
+	.fb_release	= rpisense_fb_release,
 	.fb_read	= fb_sys_read,
 	.fb_write	= rpisense_fb_write,
 	.fb_fillrect	= rpisense_fb_fillrect,


### PR DESCRIPTION
Since [1], writing to the Sense HAT framebuffer and immediately closing the file descriptor is likely to have no effect. This is because the framebuffer deferred IO framework is now careful to cancel pending updates.

To retain the old behaviour, add an fb_release method that flushes the updates instead.

See: https://github.com/raspberrypi/linux/issues/5398
Signed-off-by: Phil Elwell <phil@raspberrypi.com>

[1] 3efc61d95259 ("fbdev: Fix invalid page access after closing deferred I/O devices")