### PR TITLE
rpisense-fb: Add explicit fb_deferred_io_mmap hook

### DIFF
--- a/drivers/video/fbdev/rpisense-fb.c
+++ b/drivers/video/fbdev/rpisense-fb.c
@@ -201,6 +201,7 @@ static struct fb_ops rpisense_fb_ops = {
 	.fb_copyarea	= rpisense_fb_copyarea,
 	.fb_imageblit	= rpisense_fb_imageblit,
 	.fb_ioctl	= rpisense_fb_ioctl,
+	.fb_mmap	= fb_deferred_io_mmap,
 };
 
 static int rpisense_fb_probe(struct platform_device *pdev)


### PR DESCRIPTION
As of commit [1], introduced in 5.18, fbdev drivers that use deferred IO and need mmap support must include an explicit fb_mmap pointer to the fb_deferred_io_mmap.

Signed-off-by: Phil Elwell <phil@raspberrypi.com>

[1] 590558510327 ("fbdev: Put mmap for deferred I/O into drivers")