### PR TITLE
dtoverlays: Add inverted override property to ssd1306-spi

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4074,6 +4074,8 @@ Params: speed                   SPI bus speed (default 10000000)
         dc_pin                  GPIO pin for D/C (default 24)
         reset_pin               GPIO pin for RESET (default 25)
         height                  Display height (32 or 64; default 64)
+        inverted                Set this if display is inverted and mirrored.
+                                (default=not set)
 
 
 Name:   ssd1331-spi

--- a/arch/arm/boot/dts/overlays/ssd1306-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ssd1306-spi-overlay.dts
@@ -80,5 +80,6 @@
 		reset_pin = <&ssd1306>,"reset-gpios:4",
 		            <&ssd1306_pins>,"brcm,pins:0";
 		height    = <&ssd1306>,"solomon,height:0";
+		inverted = <&ssd1306>,"solomon,com-invdir?";
 	};
 };


### PR DESCRIPTION
The new ssd130x DRM driver supports both SSD1306 I2C and SPI panels and is compatible with the ssd1307fb driver bindings. So the "solomon,com-invdir" DT property (to invert the COM pin scan dir) can also be used for SPI now.

This allows to configure panels whose scan direction needs to be inverted.