### PR TITLE
media: bcm2835-unicam: Start and stop media_pipeline with same node

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -2524,7 +2524,8 @@ static int unicam_start_streaming(struct vb2_queue *vq, unsigned int count)
 		goto err_streaming;
 	}
 
-	ret = media_pipeline_start(node->video_dev.entity.pads, &node->pipe);
+	ret = media_pipeline_start(dev->node[IMAGE_PAD].video_dev.entity.pads,
+				   &dev->node[IMAGE_PAD].pipe);
 	if (ret < 0) {
 		unicam_err(dev, "Failed to start media pipeline: %d\n", ret);
 		goto err_pm_put;
@@ -2618,7 +2619,8 @@ err_vpu_clock:
 		unicam_err(dev, "failed to reset the VPU clock\n");
 	clk_disable_unprepare(dev->vpu_clock);
 error_pipeline:
-	media_pipeline_stop(node->video_dev.entity.pads);
+	if (node->pad_id == IMAGE_PAD)
+		media_pipeline_stop(dev->node[IMAGE_PAD].video_dev.entity.pads);
 err_pm_put:
 	unicam_runtime_put(dev);
 err_streaming:


### PR DESCRIPTION
media_pipeline_start and media_pipeline_stop now validate that the pipeline is being started and stopped with the same pipe and pad handles.
When running with embedded metadata (eg imx477 and imx708), the start typically happens from the metadata pad, whilst stop is always from the image pad.

Always pass the image pad to media_pipeline_start to ensure that the calls are balanced.