### PR TITLE
Alternative SenseHAT fix for 6.1

### DIFF
--- a/drivers/video/fbdev/core/fb_defio.c
+++ b/drivers/video/fbdev/core/fb_defio.c
@@ -321,7 +321,8 @@ static void fb_deferred_io_lastclose(struct fb_info *info)
 	struct page *page;
 	int i;
 
-	cancel_delayed_work_sync(&info->deferred_work);
+	if (!list_empty(&info->fbdefio->pagereflist))
+		cancel_delayed_work_sync(&info->deferred_work);
 
 	/* clear out the mapping that we setup */
 	for (i = 0 ; i < info->fix.smem_len; i += PAGE_SIZE) {

--- a/drivers/video/fbdev/rpisense-fb.c
+++ b/drivers/video/fbdev/rpisense-fb.c
@@ -183,18 +183,8 @@ static int rpisense_fb_ioctl(struct fb_info *info, unsigned int cmd,
 	return 0;
 }
 
-static int rpisense_fb_release(struct fb_info *info, int user)
-{
-	/* Flush any pending updates */
-	cancel_delayed_work(&info->deferred_work);
-	schedule_delayed_work(&info->deferred_work, 0);
-
-	return 0;
-}
-
 static struct fb_ops rpisense_fb_ops = {
 	.owner		= THIS_MODULE,
-	.fb_release	= rpisense_fb_release,
 	.fb_read	= fb_sys_read,
 	.fb_write	= rpisense_fb_write,
 	.fb_fillrect	= rpisense_fb_fillrect,


### PR DESCRIPTION
Since [1], the fbdev deferred IO framework is careful to cancel
pending updates on close to prevent dirty pages being accessed after
they may have been reused. However, this is not necessary in the case
that the pagelist is empty, and drivers that don't make use of the
pagelist may have wanted updates cancelled for no good reason.

Avoid penalising fbdev drivers that don't make use of the pagelist by
making the cancelling of deferred IO on close conditional on there
being a non-empty pagelist.

See: https://github.com/raspberrypi/linux/issues/5398

Signed-off-by: Phil Elwell <phil@raspberrypi.com>

[1] https://github.com/raspberrypi/linux/commit/3efc61d95259956db25347e2a9562c3e54546e20 ("fbdev: Fix invalid page access after closing deferred I/O devices")