### PR TITLE
usb: xhci: drop and add the endpoint context in xhci_fixup_endpoint()

### DIFF
--- a/drivers/usb/host/xhci.c
+++ b/drivers/usb/host/xhci.c
@@ -1726,7 +1726,7 @@ static void xhci_fixup_endpoint(struct usb_hcd *hcd, struct usb_device *udev,
 		return;
 	}
 	ctrl_ctx->add_flags = xhci_get_endpoint_flag_from_index(ep_index);
-	ctrl_ctx->drop_flags = 0;
+	ctrl_ctx->drop_flags = ctrl_ctx->add_flags;
 
 	spin_unlock_irqrestore(&xhci->lock, flags);
 


### PR DESCRIPTION
Setting both the Drop and Add bits on the input context prevents the corruption of split transactions seen with the BCM2711 XHCI controller, which is a dwc3 variant.

This is a downstream feature that allows usbhid to restrict polling intervals on mice and keyboards, and was only tested on a VL805 which didn't complain about the fact the endpoint got added twice.

![broken_split_tx](https://user-images.githubusercontent.com/2474547/228832156-6ff807b2-d443-4c10-83e5-9b32bc732b15.png)

