### PR TITLE
fixup! gpio-fsm: Avoid truncation of delay jiffies

### DIFF
--- a/drivers/gpio/gpio-fsm.c
+++ b/drivers/gpio/gpio-fsm.c
@@ -121,7 +121,7 @@ struct gpio_fsm {
 	struct fsm_state *current_state;
 	struct fsm_state *next_state;
 	struct fsm_state *delay_target_state;
-	unsigned int delay_jiffies;
+	unsigned long delay_jiffies;
 	int delay_ms;
 	unsigned int debug;
 	bool shutting_down;


### PR DESCRIPTION
The kernel's time unit of jiffies should be stored as an unsigned long value. Storing it as an unsigned int, as gpio-fsm did, leads to truncation and malfunction when the kernel is built for a 64-bit platform.