### PR TITLE
staging: bcm2835-codec: Add missing alignment for V4L2_PIX_FMT_RGBA32

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -263,7 +263,7 @@ static const struct bcm2835_codec_fmt supported_formats[] = {
 	}, {
 		.fourcc			= V4L2_PIX_FMT_RGBA32,
 		.depth			= 32,
-		.bytesperline_align	= { 32, 32, 32, 32 },
+		.bytesperline_align	= { 32, 32, 32, 32, 32 },
 		.flags			= 0,
 		.mmal_fmt		= MMAL_ENCODING_RGBA,
 		.size_multiplier_x2	= 2,


### PR DESCRIPTION
The patch adding image encode (JPEG) to the driver missed adding the alignment constraint for V4L2_PIX_FMT_RGBA32, which meant it ended up giving a stride and size of 0.