### PR TITLE
ARM: dts: bcm27xx: Add i2c_arm/vc and friends

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-plus.dts
@@ -186,6 +186,12 @@
 cam0_reg: &cam_dummy_reg {
 };
 
+i2c_arm: &i2c1 {
+};
+
+i2c_vc: &i2c0 {
+};
+
 / {
 	__overrides__ {
 		audio = <&chosen>,"bootargs{on='snd_bcm2835.enable_headphones=1 snd_bcm2835.enable_hdmi=1',off='snd_bcm2835.enable_headphones=0 snd_bcm2835.enable_hdmi=0'}";

--- a/arch/arm/boot/dts/bcm2708-rpi-b-rev1.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b-rev1.dts
@@ -197,6 +197,12 @@ i2c_csi_dsi: &i2c1 {
 cam0_reg: &cam_dummy_reg {
 };
 
+i2c_arm: &i2c0 {
+};
+
+i2c_vc: &i2c1 {
+};
+
 / {
 	__overrides__ {
 		audio = <&chosen>,"bootargs{on='snd_bcm2835.enable_headphones=1 snd_bcm2835.enable_hdmi=1',off='snd_bcm2835.enable_headphones=0 snd_bcm2835.enable_hdmi=0'}";
@@ -204,5 +210,12 @@ cam0_reg: &cam_dummy_reg {
 		act_led_gpio = <&act_led>,"gpios:4";
 		act_led_activelow = <&act_led>,"gpios:8";
 		act_led_trigger = <&act_led>,"linux,default-trigger";
+
+		i2c = <&i2c0>,"status";
+		i2c_arm = <&i2c0>,"status";
+		i2c_vc = <&i2c1>,"status";
+		i2c_baudrate = <&i2c0>,"clock-frequency:0";
+		i2c_arm_baudrate = <&i2c0>,"clock-frequency:0";
+		i2c_vc_baudrate = <&i2c1>,"clock-frequency:0";
 	};
 };

--- a/arch/arm/boot/dts/bcm2708-rpi-b.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-b.dts
@@ -179,6 +179,12 @@
 cam0_reg: &cam_dummy_reg {
 };
 
+i2c_arm: &i2c1 {
+};
+
+i2c_vc: &i2c0 {
+};
+
 / {
 	__overrides__ {
 		audio = <&chosen>,"bootargs{on='snd_bcm2835.enable_headphones=1 snd_bcm2835.enable_hdmi=1',off='snd_bcm2835.enable_headphones=0 snd_bcm2835.enable_hdmi=0'}";

--- a/arch/arm/boot/dts/bcm2708-rpi-cm.dtsi
+++ b/arch/arm/boot/dts/bcm2708-rpi-cm.dtsi
@@ -9,6 +9,12 @@
 	};
 };
 
+i2c_arm: &i2c1 {
+};
+
+i2c_vc: &i2c0 {
+};
+
 / {
 	__overrides__ {
 		act_led_gpio = <&act_led>,"gpios:4";

--- a/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
@@ -235,6 +235,9 @@
 cam0_reg: &cam_dummy_reg {
 };
 
+i2c_arm: &i2c1 {};
+i2c_vc: &i2c0 {};
+
 / {
 	__overrides__ {
 		audio = <&chosen>,"bootargs{on='snd_bcm2835.enable_hdmi=1',off='snd_bcm2835.enable_hdmi=0'}";

--- a/arch/arm/boot/dts/bcm2708-rpi-zero.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero.dts
@@ -176,6 +176,9 @@
 cam0_reg: &cam_dummy_reg {
 };
 
+i2c_arm: &i2c1 {};
+i2c_vc: &i2c0 {};
+
 / {
 	__overrides__ {
 		audio = <&chosen>,"bootargs{on='snd_bcm2835.enable_hdmi=1',off='snd_bcm2835.enable_hdmi=0'}";

--- a/arch/arm/boot/dts/bcm2709-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2709-rpi.dtsi
@@ -3,3 +3,6 @@
 &vchiq {
 	compatible = "brcm,bcm2836-vchiq", "brcm,bcm2835-vchiq";
 };
+
+i2c_arm: &i2c1 {};
+i2c_vc: &i2c0 {};

--- a/arch/arm/boot/dts/bcm270x-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm270x-rpi.dtsi
@@ -21,6 +21,7 @@
 		i2c0 = &i2c0;
 		i2c1 = &i2c1;
 		i2c10 = &i2c_csi_dsi;
+		i2c = &i2c_arm;
 		spi0 = &spi0;
 		spi1 = &spi1;
 		spi2 = &spi2;
@@ -79,8 +80,14 @@
 		spi = <&spi0>,"status";
 		i2c0 = <&i2c0if>,"status",<&i2c0mux>,"status";
 		i2c1 = <&i2c1>,"status";
+		i2c = <&i2c1>,"status";
+		i2c_arm = <&i2c1>,"status";
+		i2c_vc = <&i2c0if>,"status",<&i2c0mux>,"status";
 		i2c0_baudrate = <&i2c0if>,"clock-frequency:0";
 		i2c1_baudrate = <&i2c1>,"clock-frequency:0";
+		i2c_baudrate = <&i2c1>,"clock-frequency:0";
+		i2c_arm_baudrate = <&i2c1>,"clock-frequency:0";
+		i2c_vc_baudrate = <&i2c0if>,"clock-frequency:0";
 
 		watchdog = <&watchdog>,"status";
 		random = <&random>,"status";

--- a/arch/arm/boot/dts/bcm2711-rpi-ds.dtsi
+++ b/arch/arm/boot/dts/bcm2711-rpi-ds.dtsi
@@ -267,6 +267,9 @@
 	interrupts = <GIC_SPI 117 IRQ_TYPE_LEVEL_HIGH>;
 };
 
+i2c_arm: &i2c1 {};
+i2c_vc: &i2c0 {};
+
 /delete-node/ &v3d;
 
 / {


### PR DESCRIPTION
Since there is now a dedicated dts file for the rev1 Model B (the only Pi to drive the primary camera with i2c1), move the creation of the i2c_arm, i2c_vc and i2c labels, aliases and overrides into the base dts files.