### PR TITLE
amba_pl011: Do use DT aliases for numbering

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
@@ -268,25 +268,6 @@
 		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
 	};
 
-	aliases {
-		serial0 = &uart1;
-		serial1 = &uart0;
-		mmc0 = &emmc2;
-		mmc1 = &mmcnr;
-		mmc2 = &sdhost;
-		i2c3 = &i2c3;
-		i2c4 = &i2c4;
-		i2c5 = &i2c5;
-		i2c6 = &i2c6;
-		i2c20 = &ddc0;
-		i2c21 = &ddc1;
-		spi3 = &spi3;
-		spi4 = &spi4;
-		spi5 = &spi5;
-		spi6 = &spi6;
-		/delete-property/ intc;
-	};
-
 	/delete-node/ wifi-pwrseq;
 };
 

--- a/arch/arm/boot/dts/bcm2711-rpi-400.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-400.dts
@@ -268,25 +268,6 @@
 		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
 	};
 
-	aliases {
-		serial0 = &uart1;
-		serial1 = &uart0;
-		mmc0 = &emmc2;
-		mmc1 = &mmcnr;
-		mmc2 = &sdhost;
-		i2c3 = &i2c3;
-		i2c4 = &i2c4;
-		i2c5 = &i2c5;
-		i2c6 = &i2c6;
-		i2c20 = &ddc0;
-		i2c21 = &ddc1;
-		spi3 = &spi3;
-		spi4 = &spi4;
-		spi5 = &spi5;
-		spi6 = &spi6;
-		/delete-property/ intc;
-	};
-
 	/delete-node/ wifi-pwrseq;
 };
 

--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
@@ -277,25 +277,6 @@
 		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
 	};
 
-	aliases {
-		serial0 = &uart1;
-		serial1 = &uart0;
-		mmc0 = &emmc2;
-		mmc1 = &mmcnr;
-		mmc2 = &sdhost;
-		i2c3 = &i2c3;
-		i2c4 = &i2c4;
-		i2c5 = &i2c5;
-		i2c6 = &i2c6;
-		i2c20 = &ddc0;
-		i2c21 = &ddc1;
-		spi3 = &spi3;
-		spi4 = &spi4;
-		spi5 = &spi5;
-		spi6 = &spi6;
-		/delete-property/ intc;
-	};
-
 	/delete-node/ wifi-pwrseq;
 };
 

--- a/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
@@ -163,18 +163,9 @@
 
 	aliases {
 		serial0 = &uart0;
-		mmc0 = &emmc2;
-		mmc1 = &mmcnr;
-		mmc2 = &sdhost;
-		i2c3 = &i2c3;
-		i2c4 = &i2c4;
-		i2c5 = &i2c5;
-		i2c6 = &i2c6;
-		spi3 = &spi3;
-		spi4 = &spi4;
-		spi5 = &spi5;
-		spi6 = &spi6;
-		/delete-property/ intc;
+		serial1 = &uart1;
+		/delete-property/ i2c20;
+		/delete-property/ i2c21;
 	};
 
 	/delete-node/ wifi-pwrseq;

--- a/arch/arm/boot/dts/bcm2711-rpi-ds.dtsi
+++ b/arch/arm/boot/dts/bcm2711-rpi-ds.dtsi
@@ -26,6 +26,33 @@
 	chosen {
 		/delete-property/ stdout-path;
 	};
+
+	aliases {
+		uart2 = &uart2;
+		uart3 = &uart3;
+		uart4 = &uart4;
+		uart5 = &uart5;
+		serial0 = &uart1;
+		serial1 = &uart0;
+		serial2 = &uart2;
+		serial3 = &uart3;
+		serial4 = &uart4;
+		serial5 = &uart5;
+		mmc0 = &emmc2;
+		mmc1 = &mmcnr;
+		mmc2 = &sdhost;
+		i2c3 = &i2c3;
+		i2c4 = &i2c4;
+		i2c5 = &i2c5;
+		i2c6 = &i2c6;
+		i2c20 = &ddc0;
+		i2c21 = &ddc1;
+		spi3 = &spi3;
+		spi4 = &spi4;
+		spi5 = &spi5;
+		spi6 = &spi6;
+		/delete-property/ intc;
+	};
 };
 
 &vc4 {

--- a/drivers/tty/serial/amba-pl011.c
+++ b/drivers/tty/serial/amba-pl011.c
@@ -2654,7 +2654,6 @@ static struct uart_driver amba_reg = {
 	.cons			= AMBA_CONSOLE,
 };
 
-#if 0
 static int pl011_probe_dt_alias(int index, struct device *dev)
 {
 	struct device_node *np;
@@ -2686,7 +2685,6 @@ static int pl011_probe_dt_alias(int index, struct device *dev)
 
 	return ret;
 }
-#endif
 
 /* unregisters the driver also if no more ports are left */
 static void pl011_unregister_port(struct uart_amba_port *uap)
@@ -2738,12 +2736,7 @@ static int pl011_setup_port(struct device *dev, struct uart_amba_port *uap,
 	if (IS_ERR(base))
 		return PTR_ERR(base);
 
-	/* Don't use DT serial<n> aliases - it causes the device to
-	   be renumbered to ttyAMA1 if it is the second serial port in the
-	   system, even though the other one is ttyS0. The 8250 driver
-	   doesn't use this logic, so always remains ttyS0.
 	index = pl011_probe_dt_alias(index, dev);
-	*/
 
 	uap->port.dev = dev;
 	uap->port.mapbase = mmiobase->start;


### PR DESCRIPTION
Consistent, logical UART numbering is desirable, so remove the effective revert of an upstream change that enabled it.

Along with the added DT aliases, `dtoverlay=uart4` will result in /dev/ttyAMA4 appearing.

See: https://forums.raspberrypi.com/viewtopic.php?t=347868
