### PR TITLE
Let the kernel initialise the onboard Bluetooth modem by default

### DIFF
--- a/arch/arm/boot/dts/bcm2708-rpi-bt.dtsi
+++ b/arch/arm/boot/dts/bcm2708-rpi-bt.dtsi
@@ -5,22 +5,34 @@
 		compatible = "brcm,bcm43438-bt";
 		max-speed = <3000000>;
 		shutdown-gpios = <&gpio 45 GPIO_ACTIVE_HIGH>;
-		status = "disabled";
+		local-bd-address = [ 00 00 00 00 00 00 ];
+		fallback-bd-address; // Don't override a valid address
+		status = "okay";
 	};
 };
 
 &uart1 {
 	minibt: bluetooth {
 		compatible = "brcm,bcm43438-bt";
-		max-speed = <460800>;
+		max-speed = <230400>;
 		shutdown-gpios = <&gpio 45 GPIO_ACTIVE_HIGH>;
+		local-bd-address = [ 00 00 00 00 00 00 ];
+		fallback-bd-address; // Don't override a valid address
 		status = "disabled";
 	};
 };
 
 / {
+	aliases {
+		bluetooth = &bt;
+	};
+
 	__overrides__ {
+		bdaddr = <&bt>,"local-bd-address[",
+		       <&bt>,"fallback-bd-address?=0",
+		       <&minibt>,"local-bd-address[",
+		       <&minibt>,"fallback-bd-address?=0";
 		krnbt = <&bt>,"status";
-		krnbt_baudrate = <&bt>,"max-speed:0";
+		krnbt_baudrate = <&bt>,"max-speed:0", <&minibt>,"max-speed:0";
 	};
 };

--- a/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
+++ b/arch/arm/boot/dts/bcm2708-rpi-zero-w.dts
@@ -138,6 +138,12 @@
 		brcm,pull;
 	};
 
+	uart1_bt_pins: uart1_bt_pins {
+		brcm,pins = <32 33 30 31>;
+		brcm,function = <BCM2835_FSEL_ALT5>; /* alt5=UART1 */
+		brcm,pull = <0 2 2 0>;
+	};
+
 	audio_pins: audio_pins {
 		brcm,pins = <>;
 		brcm,function = <>;

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b-plus.dts
@@ -140,6 +140,12 @@
 		brcm,pull;
 	};
 
+	uart1_bt_pins: uart1_bt_pins {
+		brcm,pins = <32 33 30 31>;
+		brcm,function = <BCM2835_FSEL_ALT5>; /* alt5=UART1 */
+		brcm,pull = <0 2 2 0>;
+	};
+
 	audio_pins: audio_pins {
 		brcm,pins = <40 41>;
 		brcm,function = <4>;

--- a/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
@@ -140,6 +140,12 @@
 		brcm,pull;
 	};
 
+	uart1_bt_pins: uart1_bt_pins {
+		brcm,pins = <32 33>;
+		brcm,function = <BCM2835_FSEL_ALT5>; /* alt5=UART1 */
+		brcm,pull = <0 2>;
+	};
+
 	audio_pins: audio_pins {
 		brcm,pins = <40 41>;
 		brcm,function = <4>;

--- a/arch/arm/boot/dts/bcm2710-rpi-zero-2-w.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-zero-2-w.dts
@@ -138,6 +138,12 @@
 		brcm,pull;
 	};
 
+	uart1_bt_pins: uart1_bt_pins {
+		brcm,pins = <32 33 30 31>;
+		brcm,function = <BCM2835_FSEL_ALT5>; /* alt5=UART1 */
+		brcm,pull = <0 2 2 0>;
+	};
+
 	audio_pins: audio_pins {
 		brcm,pins = <>;
 		brcm,function = <>;

--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
@@ -445,6 +445,12 @@
 		brcm,pull;
 	};
 
+	uart1_bt_pins: uart1_bt_pins {
+		brcm,pins = <32 33 30 31>;
+		brcm,function = <BCM2835_FSEL_ALT5>; /* alt5=UART1 */
+		brcm,pull = <0 2 2 0>;
+	};
+
 	uart2_pins: uart2_pins {
 		brcm,pins = <0 1>;
 		brcm,function = <BCM2835_FSEL_ALT4>;

--- a/arch/arm/boot/dts/bcm2711-rpi-400.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-400.dts
@@ -445,6 +445,12 @@
 		brcm,pull;
 	};
 
+	uart1_bt_pins: uart1_bt_pins {
+		brcm,pins = <32 33 30 31>;
+		brcm,function = <BCM2835_FSEL_ALT5>; /* alt5=UART1 */
+		brcm,pull = <0 2 2 0>;
+	};
+
 	uart2_pins: uart2_pins {
 		brcm,pins = <0 1>;
 		brcm,function = <BCM2835_FSEL_ALT4>;

--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
@@ -454,6 +454,12 @@
 		brcm,pull;
 	};
 
+	uart1_bt_pins: uart1_bt_pins {
+		brcm,pins = <32 33 30 31>;
+		brcm,function = <BCM2835_FSEL_ALT5>; /* alt5=UART1 */
+		brcm,pull = <0 2 2 0>;
+	};
+
 	uart2_pins: uart2_pins {
 		brcm,pins = <0 1>;
 		brcm,function = <BCM2835_FSEL_ALT4>;

--- a/arch/arm/boot/dts/bcm271x-rpi-bt.dtsi
+++ b/arch/arm/boot/dts/bcm271x-rpi-bt.dtsi
@@ -5,22 +5,34 @@
 		compatible = "brcm,bcm43438-bt";
 		max-speed = <3000000>;
 		shutdown-gpios = <&expgpio 0 GPIO_ACTIVE_HIGH>;
-		status = "disabled";
+		local-bd-address = [ 00 00 00 00 00 00 ];
+		fallback-bd-address; // Don't override a valid address
+		status = "okay";
 	};
 };
 
 &uart1 {
 	minibt: bluetooth {
 		compatible = "brcm,bcm43438-bt";
-		max-speed = <460800>;
+		max-speed = <230400>;
 		shutdown-gpios = <&expgpio 0 GPIO_ACTIVE_HIGH>;
+		local-bd-address = [ 00 00 00 00 00 00 ];
+		fallback-bd-address; // Don't override a valid address
 		status = "disabled";
 	};
 };
 
 / {
+	aliases {
+		bluetooth = &bt;
+	};
+
 	__overrides__ {
+		bdaddr = <&bt>,"local-bd-address[",
+		       <&bt>,"fallback-bd-address?=0",
+		       <&minibt>,"local-bd-address[",
+		       <&minibt>,"fallback-bd-address?=0";
 		krnbt = <&bt>,"status";
-		krnbt_baudrate = <&bt>,"max-speed:0";
+		krnbt_baudrate = <&bt>,"max-speed:0", <&minibt>,"max-speed:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2887,17 +2887,12 @@ Params: speed                   SPI bus speed (default 32000000)
 
 
 Name:   miniuart-bt
-Info:   Switch the onboard Bluetooth function on Pi 3B, 3B+, 3A+, 4B and Zero W
+Info:   Switch the onboard Bluetooth function of a BT-equipped Raspberry Pi
         to use the mini-UART (ttyS0) and restore UART0/ttyAMA0 over GPIOs 14 &
-        15. Note that this may reduce the maximum usable baudrate.
-        N.B. It is also necessary to edit /lib/systemd/system/hciuart.service
-        and replace ttyAMA0 with ttyS0, unless using Raspbian or another
-        distribution with udev rules that create /dev/serial0 and /dev/serial1,
-        in which case use /dev/serial1 instead because it will always be
-        correct. Furthermore, you must also set core_freq and core_freq_min to
-        the same value in config.txt or the miniuart will not work.
+        15. Note that this option uses a lower baudrate, and should only be used
+        with low-bandwidth peripherals.
 Load:   dtoverlay=miniuart-bt,<param>=<val>
-Params: krnbt                   Set to "on" to enable autoprobing of Bluetooth
+Params: krnbt                   Set to "off" to disable autoprobing of Bluetooth
                                 driver without need of hciattach/btattach
 
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -144,6 +144,13 @@ Params:
                                 See /sys/kernel/debug/raspberrypi_axi_monitor
                                 for the results.
 
+        bdaddr                  Set an alternative Bluetooth address (BDADDR).
+                                The value should be a 6-byte hexadecimal value,
+                                with or without colon separators, written least-
+                                significant-byte first. For example,
+                                bdaddr=06:05:04:03:02:01
+                                will set the BDADDR to 01:02:03:04:05:06.
+
         cam0_reg                Enables CAM 0 regulator.
                                 Only required on CM1 & 3.
 
@@ -219,9 +226,9 @@ Params:
         i2s                     Set to "on" to enable the i2s interface
                                 (default "off")
 
-        krnbt                   Set to "on" to enable autoprobing of Bluetooth
+        krnbt                   Set to "off" to disable autoprobing of Bluetooth
                                 driver without need of hciattach/btattach
-                                (default "off")
+                                (default "on")
 
         krnbt_baudrate          Set the baudrate of the PL011 UART when used
                                 with krnbt=on

--- a/arch/arm/boot/dts/overlays/disable-bt-overlay.dts
+++ b/arch/arm/boot/dts/overlays/disable-bt-overlay.dts
@@ -1,12 +1,7 @@
 /dts-v1/;
 /plugin/;
 
-/* Disable Bluetooth and restore UART0/ttyAMA0 over GPIOs 14 & 15.
-   To disable the systemd service that initialises the modem so it doesn't use
-   the UART:
-
-       sudo systemctl disable hciuart
-*/
+/* Disable Bluetooth and restore UART0/ttyAMA0 over GPIOs 14 & 15. */
 
 #include <dt-bindings/gpio/gpio.h>
 

--- a/arch/arm/boot/dts/overlays/miniuart-bt-overlay.dts
+++ b/arch/arm/boot/dts/overlays/miniuart-bt-overlay.dts
@@ -55,11 +55,9 @@
 	};
 
 	fragment@4 {
-		target = <&uart1_pins>;
+		target = <&uart1>;
 		__overlay__ {
-			brcm,pins = <32 33 30 31>;
-			brcm,function = <2>; /* alt5=UART1 */
-			brcm,pull = <0 2 2 0>;
+			pinctrl-0 = <&uart1_bt_pins>;
 		};
 	};
 
@@ -68,6 +66,7 @@
 		__overlay__ {
 			serial0 = "/soc/serial@7e201000";
 			serial1 = "/soc/serial@7e215040";
+			bluetooth = "/soc/serial@7e215040/bluetooth";
 		};
 	};
 
@@ -80,6 +79,5 @@
 
 	__overrides__ {
 		krnbt = <&minibt_frag>,"status";
-		krnbt_baudrate = <&minibt_frag>,"max-speed:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/miniuart-bt-overlay.dts
+++ b/arch/arm/boot/dts/overlays/miniuart-bt-overlay.dts
@@ -40,7 +40,7 @@
 		target = <&uart1>;
 		__overlay__ {
 			pinctrl-names = "default";
-			pinctrl-0 = <&uart1_pins &bt_pins &fake_bt_cts>;
+			pinctrl-0 = <&uart1_pins>;
 			status = "okay";
 		};
 	};
@@ -57,23 +57,13 @@
 	fragment@4 {
 		target = <&uart1_pins>;
 		__overlay__ {
-			brcm,pins = <32 33>;
+			brcm,pins = <32 33 30 31>;
 			brcm,function = <2>; /* alt5=UART1 */
-			brcm,pull = <0 2>;
+			brcm,pull = <0 2 2 0>;
 		};
 	};
 
 	fragment@5 {
-		target = <&gpio>;
-		__overlay__ {
-			fake_bt_cts: fake_bt_cts {
-				brcm,pins = <31>;
-				brcm,function = <1>; /* output */
-			};
-		};
-	};
-
-	fragment@6 {
 		target-path = "/aliases";
 		__overlay__ {
 			serial0 = "/soc/serial@7e201000";
@@ -81,13 +71,15 @@
 		};
 	};
 
-	fragment@7 {
+	fragment@6 {
 		target = <&minibt>;
 		minibt_frag: __overlay__ {
+			status = "okay";
 		};
 	};
 
 	__overrides__ {
 		krnbt = <&minibt_frag>,"status";
+		krnbt_baudrate = <&minibt_frag>,"max-speed:0";
 	};
 };

--- a/drivers/bluetooth/btbcm.c
+++ b/drivers/bluetooth/btbcm.c
@@ -23,11 +23,15 @@
 #define BDADDR_BCM20702A1 (&(bdaddr_t) {{0x00, 0x00, 0xa0, 0x02, 0x70, 0x20}})
 #define BDADDR_BCM2076B1 (&(bdaddr_t) {{0x79, 0x56, 0x00, 0xa0, 0x76, 0x20}})
 #define BDADDR_BCM43430A0 (&(bdaddr_t) {{0xac, 0x1f, 0x12, 0xa0, 0x43, 0x43}})
+#define BDADDR_BCM43430A1 (&(bdaddr_t) {{0xac, 0x1f, 0x12, 0xa1, 0x43, 0x43}})
+#define BDADDR_BCM43430B0 (&(bdaddr_t) {{0xac, 0x1f, 0x37, 0xb0, 0x43, 0x43}})
 #define BDADDR_BCM4324B3 (&(bdaddr_t) {{0x00, 0x00, 0x00, 0xb3, 0x24, 0x43}})
 #define BDADDR_BCM4330B1 (&(bdaddr_t) {{0x00, 0x00, 0x00, 0xb1, 0x30, 0x43}})
 #define BDADDR_BCM4334B0 (&(bdaddr_t) {{0x00, 0x00, 0x00, 0xb0, 0x34, 0x43}})
+#define BDADDR_BCM4345C0 (&(bdaddr_t) {{0xac, 0x1f, 0x00, 0xc0, 0x45, 0x43}})
 #define BDADDR_BCM4345C5 (&(bdaddr_t) {{0xac, 0x1f, 0x00, 0xc5, 0x45, 0x43}})
 #define BDADDR_BCM43341B (&(bdaddr_t) {{0xac, 0x1f, 0x00, 0x1b, 0x34, 0x43}})
+#define BDADDR_BCM43438 (&(bdaddr_t) {{0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa}})
 
 #define BCM_FW_NAME_LEN			64
 #define BCM_FW_NAME_COUNT_MAX		4
@@ -84,8 +88,12 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
 	    !bacmp(&bda->bdaddr, BDADDR_BCM4324B3) ||
 	    !bacmp(&bda->bdaddr, BDADDR_BCM4330B1) ||
 	    !bacmp(&bda->bdaddr, BDADDR_BCM4334B0) ||
+	    !bacmp(&bda->bdaddr, BDADDR_BCM4345C0) ||
 	    !bacmp(&bda->bdaddr, BDADDR_BCM4345C5) ||
 	    !bacmp(&bda->bdaddr, BDADDR_BCM43430A0) ||
+	    !bacmp(&bda->bdaddr, BDADDR_BCM43430A1) ||
+	    !bacmp(&bda->bdaddr, BDADDR_BCM43430B0) ||
+	    !bacmp(&bda->bdaddr, BDADDR_BCM43438) ||
 	    !bacmp(&bda->bdaddr, BDADDR_BCM43341B)) {
 		bt_dev_info(hdev, "BCM: Using default device address (%pMR)",
 			    &bda->bdaddr);

--- a/drivers/tty/serial/8250/8250.h
+++ b/drivers/tty/serial/8250/8250.h
@@ -93,6 +93,7 @@ struct serial8250_config {
 #define UART_BUG_THRE	BIT(3)	/* UART has buggy THRE reassertion */
 #define UART_BUG_PARITY	BIT(4)	/* UART mishandles parity if FIFO enabled */
 #define UART_BUG_TXRACE	BIT(5)	/* UART Tx fails to set remote DR */
+#define UART_BUG_NOMSI	BIT(6)	/* UART has no modem status interrupt */
 
 
 #ifdef CONFIG_SERIAL_8250_SHARE_IRQ

--- a/drivers/tty/serial/8250/8250_bcm2835aux.c
+++ b/drivers/tty/serial/8250/8250_bcm2835aux.c
@@ -109,6 +109,7 @@ static int bcm2835aux_serial_probe(struct platform_device *pdev)
 			UPF_SKIP_TEST | UPF_IOREMAP;
 	up.port.rs485_config = serial8250_em485_config;
 	up.port.rs485_supported = serial8250_em485_supported;
+	up.bugs |= UART_BUG_NOMSI;
 	up.rs485_start_tx = bcm2835aux_rs485_start_tx;
 	up.rs485_stop_tx = bcm2835aux_rs485_stop_tx;
 

--- a/drivers/tty/serial/8250/8250_core.c
+++ b/drivers/tty/serial/8250/8250_core.c
@@ -252,6 +252,18 @@ static void serial8250_timeout(struct timer_list *t)
 	mod_timer(&up->timer, jiffies + uart_poll_timeout(&up->port));
 }
 
+static void serial8250_cts_poll_timeout(struct timer_list *t)
+{
+	struct uart_8250_port *up = from_timer(up, t, timer);
+	unsigned long flags;
+
+	spin_lock_irqsave(&up->port.lock, flags);
+	serial8250_modem_status(up);
+	spin_unlock_irqrestore(&up->port.lock, flags);
+	if (up->port.hw_stopped)
+		mod_timer(&up->timer, jiffies + 1);
+}
+
 static void serial8250_backup_timeout(struct timer_list *t)
 {
 	struct uart_8250_port *up = from_timer(up, t, timer);
@@ -313,6 +325,9 @@ static void univ8250_setup_timer(struct uart_8250_port *up)
 		mod_timer(&up->timer, jiffies +
 			  uart_poll_timeout(port) + HZ / 5);
 	}
+
+	if (up->bugs & UART_BUG_NOMSI)
+		up->timer.function = serial8250_cts_poll_timeout;
 
 	/*
 	 * If the "interrupt" for this port doesn't correspond with any

--- a/net/bluetooth/hci_sync.c
+++ b/net/bluetooth/hci_sync.c
@@ -4525,6 +4525,7 @@ static const struct {
  */
 static int hci_dev_setup_sync(struct hci_dev *hdev)
 {
+	struct fwnode_handle *fwnode = dev_fwnode(hdev->dev.parent);
 	int ret = 0;
 	bool invalid_bdaddr;
 	size_t i;
@@ -4553,7 +4554,9 @@ static int hci_dev_setup_sync(struct hci_dev *hdev)
 
 	if (!ret) {
 		if (test_bit(HCI_QUIRK_USE_BDADDR_PROPERTY, &hdev->quirks)) {
-			if (!bacmp(&hdev->public_addr, BDADDR_ANY))
+			if (!bacmp(&hdev->public_addr, BDADDR_ANY) &&
+			    (invalid_bdaddr ||
+			     !fwnode_property_present(fwnode, "fallback-bd-address")))
 				hci_dev_get_bd_addr_from_property(hdev);
 
 			if (bacmp(&hdev->public_addr, BDADDR_ANY) &&


### PR DESCRIPTION
Allowing the kernel to initialise the Bluetooth modem means it can be reset and reloaded if necessary, and eventually we'll be able to get rid of the commands `hciattach` and `btuart`, and the `hciuart` service that calls them.