### PR TITLE
Further EMC2305 tweaks

### DIFF
--- a/arch/arm/boot/dts/overlays/i2c-fan-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-fan-overlay.dts
@@ -94,8 +94,8 @@
 		i2c6 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c6";
 		addr =		<&emc2301>,"reg:0";
-		minpwm =	<&emc2301>,"emc2305,pwm-min;0";
-		maxpwm =	<&emc2301>,"emc2305,pwm-max;0";
+		minpwm =	<&emc2301>,"emc2305,pwm-min.0";
+		maxpwm =	<&emc2301>,"emc2305,pwm-max.0";
 		midtemp =	<&fanmid0>,"temperature:0";
 		midtemp_hyst =	<&fanmid0>,"hysteresis:0";
 		maxtemp =	<&fanmax0>,"temperature:0";

--- a/drivers/hwmon/emc2305.c
+++ b/drivers/hwmon/emc2305.c
@@ -301,36 +301,36 @@ static int emc2305_get_tz_of(struct device *dev)
 	struct device_node *np = dev->of_node;
 	struct emc2305_data *data = dev_get_drvdata(dev);
 	int ret = 0;
-	u32 val;
+	u8 val;
 	int i;
 
 	/* OF parameters are optional - overwrite default setting
 	 * if some of them are provided.
 	 */
 
-	ret = of_property_read_u32(np, "emc2305,cooling-levels", &val);
+	ret = of_property_read_u8(np, "emc2305,cooling-levels", &val);
 	if (!ret)
-		data->max_state = (u8)val;
+		data->max_state = val;
 	else if (ret != -EINVAL)
 		return ret;
 
-	ret = of_property_read_u32(np, "emc2305,pwm-max", &val);
+	ret = of_property_read_u8(np, "emc2305,pwm-max", &val);
 	if (!ret)
-		data->pwm_max = (u8)val;
+		data->pwm_max = val;
 	else if (ret != -EINVAL)
 		return ret;
 
-	ret = of_property_read_u32(np, "emc2305,pwm-min", &val);
+	ret = of_property_read_u8(np, "emc2305,pwm-min", &val);
 	if (!ret)
 		for (i = 0; i < EMC2305_PWM_MAX; i++)
-			data->pwm_min[i] = (u8)val;
+			data->pwm_min[i] = val;
 	else if (ret != -EINVAL)
 		return ret;
 
 	/* Not defined or 0 means one thermal zone over all cooling devices.
 	 * Otherwise - separated thermal zones for each PWM channel.
 	 */
-	ret = of_property_read_u32(np, "emc2305,pwm-channel", &val);
+	ret = of_property_read_u8(np, "emc2305,pwm-channel", &val);
 	if (!ret)
 		data->pwm_separate = (val != 0);
 	else if (ret != -EINVAL)


### PR DESCRIPTION
The thermal subsystem and this driver still feel a little odd, so followups or amendments to this PR are likely.

The emc2305,pwm-max value only clips the max speed that can be set via sysfs (sys/class/hwmon/hwmonX/pwm), not the max state that can be requested by the thermal side.
emc2305,pwm-min does appear to set the minimum state that can be used.

I'm not fully understanding how the thermal subsystem is intending to control a fan such as this where we have 10 states. The PoE HAT fan driver maps specific trip temperatures to specific state values. That works, but feels a little course.
In defining the map as eg ```cooling-device = <&emc2301 2 6>;```, once the trip is hit the subsystem is allowed to use states 2 to 6 to cool the device. The second trip then allows states 7 to max (10) once hit. Which state appears to be controlled via a PID loop, but the exact properties for that loop and how it chooses the state seem ill-defined.

If anyone has more knowledge on the thermal subsystem and fan control, then I'm open to input.