### PR TITLE
arm/boot/dts/overlays/mipi-dbi-spi: fix default brightness

### DIFF
--- a/arch/arm/boot/dts/overlays/mipi-dbi-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mipi-dbi-spi-overlay.dts
@@ -80,7 +80,7 @@
 			backlight_pwm: backlight_pwm {
 				compatible = "pwm-backlight";
 				brightness-levels = <0 6 8 12 16 24 32 40 48 64 96 128 160 192 224 255>;
-				default-brightness-level = <16>;
+				default-brightness-level = <15>;
 				pwms = <&pwm 0 200000>;
 			};
 		};


### PR DESCRIPTION
There is an off-by-one error in the default brightness for the PWM backlight in the MIPI DBI SPI overlay that produces the following message in the kernel logs:

    pwm-backlight backlight_pwm: invalid default brightness level: 16, using 15

The value is 0-based, so the max brightness is 15, not 16.