### PR TITLE
drm/vc4: Limit max_bpc to 8 on Pi0-3

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -783,7 +783,6 @@ static int vc4_hdmi_connector_init(struct drm_device *dev,
 
 	drm_connector_attach_colorspace_property(connector);
 	drm_connector_attach_tv_margin_properties(connector);
-	drm_connector_attach_max_bpc_property(connector, 8, 12);
 
 	connector->polled = (DRM_CONNECTOR_POLL_CONNECT |
 			     DRM_CONNECTOR_POLL_DISCONNECT);
@@ -792,8 +791,12 @@ static int vc4_hdmi_connector_init(struct drm_device *dev,
 	connector->doublescan_allowed = 0;
 	connector->stereo_allowed = 1;
 
-	if (vc4_hdmi->variant->supports_hdr)
+	if (vc4_hdmi->variant->supports_hdr) {
+		drm_connector_attach_max_bpc_property(connector, 8, 12);
 		drm_connector_attach_hdr_output_metadata_property(connector);
+	} else {
+		drm_connector_attach_max_bpc_property(connector, 8, 8);
+	}
 
 	vc4_hdmi_attach_broadcast_rgb_property(dev, vc4_hdmi);
 	vc4_hdmi_attach_output_format_property(dev, vc4_hdmi);


### PR DESCRIPTION
Pi 0-3 have no deep colour support and only 24bpp output, so max_bpc should remain as 8.