### PR TITLE
ARM: dts: bcm27xx: Add stdout-path to serial0

### DIFF
--- a/arch/arm/boot/dts/bcm270x.dtsi
+++ b/arch/arm/boot/dts/bcm270x.dtsi
@@ -5,7 +5,7 @@
 	chosen: chosen {
 		// Disable audio by default
 		bootargs = "coherent_pool=1M snd_bcm2835.enable_headphones=0";
-		/delete-property/ stdout-path;
+		stdout-path = "serial0:115200n8";
 	};
 
 	soc: soc {

--- a/arch/arm/boot/dts/bcm2711-rpi-ds.dtsi
+++ b/arch/arm/boot/dts/bcm2711-rpi-ds.dtsi
@@ -34,7 +34,7 @@
 	};
 
 	chosen {
-		/delete-property/ stdout-path;
+		stdout-path = "serial0:115200n8";
 	};
 
 	aliases {


### PR DESCRIPTION
Rather than deleting the upstream stdout-path declaration, overwrite it with one selecting serial0, which will always be the UART mapped to the 40-pin header (provided enable_uart=1 is specified). Doing so has the advantage that earlycon can be configured just by adding "earlycon" to the command line.