### PR TITLE
pps: Compatibility hack should be X86-specific

### DIFF
--- a/drivers/pps/pps.c
+++ b/drivers/pps/pps.c
@@ -249,12 +249,13 @@ static long pps_cdev_ioctl(struct file *file,
 static long pps_cdev_compat_ioctl(struct file *file,
 		unsigned int cmd, unsigned long arg)
 {
-	struct pps_device *pps = file->private_data;
-	void __user *uarg = (void __user *) arg;
 
 	cmd = _IOC(_IOC_DIR(cmd), _IOC_TYPE(cmd), _IOC_NR(cmd), sizeof(void *));
 
+#ifdef CONFIG_X86_64
 	if (cmd == PPS_FETCH) {
+		struct pps_device *pps = file->private_data;
+		void __user *uarg = (void __user *) arg;
 		struct pps_fdata_compat compat;
 		struct pps_fdata fdata;
 		int err;
@@ -289,6 +290,7 @@ static long pps_cdev_compat_ioctl(struct file *file,
 		return copy_to_user(uarg, &compat,
 				sizeof(struct pps_fdata_compat)) ? -EFAULT : 0;
 	}
+#endif
 
 	return pps_cdev_ioctl(file, cmd, arg);
 }


### PR DESCRIPTION
As of [1], using PPS_FETCH on a 64-bit ARM kernel with a 32-bit userland is broken, returning a timeout. This is because the requested 4-byte alignment for struct pps_ktime_compat (illegal on arm64) results in the timeout flags field being uninitialised.

Make the hack specific to X86_64 builds with CONFIG_COMPAT defined.

[1] commit c2a49fe8eeef ("pps: fix padding issue with PPS_FETCH for
    ioctl_compat")

See: https://github.com/raspberrypi/linux/issues/5430
Fixes: c2a49fe8eeef ("pps: fix padding issue with PPS_FETCH for ioctl_compat")