### PR TITLE
drivers: media: imx296: Disable 2x2 binned mode

### DIFF
--- a/drivers/media/i2c/imx296.c
+++ b/drivers/media/i2c/imx296.c
@@ -745,12 +745,14 @@ static int imx296_enum_frame_size(struct v4l2_subdev *sd,
 {
 	const struct imx296 *sensor = to_imx296(sd);
 	const struct v4l2_mbus_framefmt *format;
-	/* Binning only works on the mono sensor variant */
-	unsigned int max_index = sensor->mono ? 2 : 1;
 
 	format = v4l2_subdev_get_pad_format(sd, state, fse->pad);
 
-	if (fse->index >= max_index || fse->code != imx296_mbus_code(sensor))
+	/*
+	 * Binning does not seem to work on either mono or colour sensor
+	 * variants. Disable enumerating the binned frame size for now.
+	 */
+	if (fse->index >= 1 || fse->code != imx296_mbus_code(sensor))
 		return -EINVAL;
 
 	fse->min_width = IMX296_PIXEL_ARRAY_WIDTH / (fse->index + 1);
@@ -781,32 +783,8 @@ static int imx296_set_format(struct v4l2_subdev *sd,
 	crop = v4l2_subdev_get_pad_crop(sd, state, fmt->pad);
 	format = v4l2_subdev_get_pad_format(sd, state, fmt->pad);
 
-	/*
-	 * Binning is only allowed when cropping is disabled according to the
-	 * documentation. This should be double-checked.
-	 */
-	if (crop->width == IMX296_PIXEL_ARRAY_WIDTH &&
-	    crop->height == IMX296_PIXEL_ARRAY_HEIGHT) {
-		unsigned int width;
-		unsigned int height;
-		unsigned int hratio;
-		unsigned int vratio;
-
-		/* Clamp the width and height to avoid dividing by zero. */
-		width = clamp_t(unsigned int, fmt->format.width,
-				crop->width / 2, crop->width);
-		height = clamp_t(unsigned int, fmt->format.height,
-				 crop->height / 2, crop->height);
-
-		hratio = DIV_ROUND_CLOSEST(crop->width, width);
-		vratio = DIV_ROUND_CLOSEST(crop->height, height);
-
-		format->width = crop->width / hratio;
-		format->height = crop->height / vratio;
-	} else {
-		format->width = crop->width;
-		format->height = crop->height;
-	}
+	format->width = crop->width;
+	format->height = crop->height;
 
 	imx296_setup_hblank(sensor, format->width);
 


### PR DESCRIPTION
Disable enumerating the 2x2 binned mode entirely as it does not seem to work for either mono or colour sensor variants.