### PR TITLE
serial: sc16is7xx: Read modem line state at startup

### DIFF
--- a/drivers/tty/serial/sc16is7xx.c
+++ b/drivers/tty/serial/sc16is7xx.c
@@ -1212,6 +1212,9 @@ static int sc16is7xx_startup(struct uart_port *port)
 	      SC16IS7XX_IER_MSI_BIT;
 	sc16is7xx_port_write(port, SC16IS7XX_IER_REG, val);
 
+	/* Initialize the Modem Control signals to current status */
+	one->old_mctrl = sc16is7xx_get_hwmctrl(port);
+
 	/* Enable modem status polling */
 	spin_lock_irqsave(&port->lock, flags);
 	sc16is7xx_enable_ms(port);


### PR DESCRIPTION
This patch sets the driver modem line state to the actual line state at driver startup.

See: https://github.com/raspberrypi/linux/issues/5501