### PR TITLE
dtoverlays: Add i2c bus overrides to edt-ft5406 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1800,10 +1800,10 @@ Params: addr                    Sets the address for the fan controller. Note
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
 
-        i2c4                    Choose the I2C3 bus (configure with the i2c3
+        i2c4                    Choose the I2C4 bus (configure with the i2c4
                                 overlay - BCM2711 only)
 
-        i2c5                    Choose the I2C5 bus (configure with the i2c4
+        i2c5                    Choose the I2C5 bus (configure with the i2c5
                                 overlay - BCM2711 only)
 
         i2c6                    Choose the I2C6 bus (configure with the i2c6

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1040,9 +1040,11 @@ Params: dr_mode                 Dual role mode: "host", "peripheral" or "otg"
 
 
 Name:   edt-ft5406
-Info:   Overlay for the EDT FT5406 touchscreen on the CSI/DSI I2C interface.
+Info:   Overlay for the EDT FT5406 touchscreen.
         This works with the Raspberry Pi 7" touchscreen when not being polled
         by the firmware.
+        By default the overlay uses the i2c_csi_dsi I2C interface, but this
+        can be overridden
         You MUST use either "disable_touchscreen=1" or "ignore_lcd=1" in
         config.txt to stop the firmware polling the touchscreen.
 Load:   dtoverlay=edt-ft5406,<param>=<val>
@@ -1051,6 +1053,19 @@ Params: sizex                   Touchscreen size x (default 800)
         invx                    Touchscreen inverted x axis
         invy                    Touchscreen inverted y axis
         swapxy                  Touchscreen swapped x y axis
+        i2c0                    Choose the I2C0 bus on GPIOs 0&1
+        i2c1                    Choose the I2C1 bus on GPIOs 2&3
+        i2c3                    Choose the I2C3 bus (configure with the i2c3
+                                overlay - BCM2711 only)
+        i2c4                    Choose the I2C4 bus (configure with the i2c4
+                                overlay - BCM2711 only)
+        i2c5                    Choose the I2C5 bus (configure with the i2c5
+                                overlay - BCM2711 only)
+        i2c6                    Choose the I2C6 bus (configure with the i2c6
+                                overlay - BCM2711 only)
+        addr                    Sets the address for the touch controller. Note
+                                that the device must be configured to use the
+                                specified address.
 
 
 Name:   enc28j60

--- a/arch/arm/boot/dts/overlays/edt-ft5406-overlay.dts
+++ b/arch/arm/boot/dts/overlays/edt-ft5406-overlay.dts
@@ -23,4 +23,24 @@
 			status = "okay";
 		};
 	};
+
+	__overrides__ {
+		i2c0 = <&frag13>,"target:0=",<&i2c0>;
+		i2c1 = <&frag13>, "target?=0",
+		       <&frag13>, "target-path=i2c1",
+		       <0>,"-0-1";
+		i2c3 = <&frag13>, "target?=0",
+		       <&frag13>, "target-path=i2c3",
+		       <0>,"-0-1";
+		i2c4 = <&frag13>, "target?=0",
+		       <&frag13>, "target-path=i2c4",
+		       <0>,"-0-1";
+		i2c5 = <&frag13>, "target?=0",
+		       <&frag13>, "target-path=i2c5",
+		       <0>,"-0-1";
+		i2c6 = <&frag13>, "target?=0",
+		       <&frag13>, "target-path=i2c6",
+		       <0>,"-0-1";
+		addr = <&ft5406>,"reg:0";
+	};
 };

--- a/arch/arm/boot/dts/overlays/edt-ft5406.dtsi
+++ b/arch/arm/boot/dts/overlays/edt-ft5406.dtsi
@@ -23,7 +23,7 @@
 	};
 
 	fragment@12 {
-		target = <&i2c_csi_dsi>;
+		target = <&i2cbus>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -34,6 +34,13 @@
 				touchscreen-size-x = < 800 >;
 				touchscreen-size-y = < 480 >;
 			};
+		};
+	};
+
+	frag13: fragment@13 {
+		target = <&i2c_csi_dsi>;
+		i2cbus: __overlay__ {
+			status = "okay";
 		};
 	};
 


### PR DESCRIPTION
Adds the option for the touch controller to be connected to any of the I2C ports.

Draft for https://forums.raspberrypi.com/viewtopic.php?t=352426