### PR TITLE
dtoverlays: Fix pitft[28|35] overlays for 6.1 driver change.

### DIFF
--- a/arch/arm/boot/dts/overlays/pitft28-resistive-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pitft28-resistive-overlay.dts
@@ -68,7 +68,6 @@
 				reg = <1>;
 
 				spi-max-frequency = <500000>;
-				irq-gpio = <&gpio 24 0x2>; /* IRQF_TRIGGER_FALLING */
 				interrupts = <24 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
 				interrupt-controller;

--- a/arch/arm/boot/dts/overlays/pitft35-resistive-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pitft35-resistive-overlay.dts
@@ -68,7 +68,6 @@
 				reg = <1>;
 
 				spi-max-frequency = <500000>;
-				irq-gpio = <&gpio 24 0x2>; /* IRQF_TRIGGER_FALLING */
 				interrupts = <24 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
 				interrupt-controller;


### PR DESCRIPTION
The overlays configured both irq-gpio and an interrupts/ interrupt-parent configuration for the stmpe MFD device.

irq-gpio was reworked in 6.1 and has issues with the configuration as provided. Removing it and using the interrupts/interrupt-parent configuration works fine, so do that.