### PR TITLE
Fix HDMI audio passthrough issues

### DIFF
--- a/sound/core/pcm_drm_eld.c
+++ b/sound/core/pcm_drm_eld.c
@@ -2,10 +2,24 @@
 /*
  *  PCM DRM helpers
  */
+#include <linux/bitfield.h>
 #include <linux/export.h>
+#include <linux/hdmi.h>
 #include <drm/drm_edid.h>
 #include <sound/pcm.h>
 #include <sound/pcm_drm_eld.h>
+
+#define SAD0_CHANNELS_MASK	GENMASK(2, 0) /* max number of channels - 1 */
+#define SAD0_FORMAT_MASK	GENMASK(6, 3) /* audio format */
+
+#define SAD1_RATE_MASK		GENMASK(6, 0) /* bitfield of supported rates */
+#define SAD1_RATE_32000_MASK	BIT(0)
+#define SAD1_RATE_44100_MASK	BIT(1)
+#define SAD1_RATE_48000_MASK	BIT(2)
+#define SAD1_RATE_88200_MASK	BIT(3)
+#define SAD1_RATE_96000_MASK	BIT(4)
+#define SAD1_RATE_176400_MASK	BIT(5)
+#define SAD1_RATE_192000_MASK	BIT(6)
 
 static const unsigned int eld_rates[] = {
 	32000,
@@ -17,9 +31,62 @@ static const unsigned int eld_rates[] = {
 	192000,
 };
 
+static unsigned int map_rate_families(const u8 *sad,
+				      unsigned int mask_32000,
+				      unsigned int mask_44100,
+				      unsigned int mask_48000)
+{
+	unsigned int rate_mask = 0;
+
+	if (sad[1] & SAD1_RATE_32000_MASK)
+		rate_mask |= mask_32000;
+	if (sad[1] & (SAD1_RATE_44100_MASK | SAD1_RATE_88200_MASK | SAD1_RATE_176400_MASK))
+		rate_mask |= mask_44100;
+	if (sad[1] & (SAD1_RATE_48000_MASK | SAD1_RATE_96000_MASK | SAD1_RATE_192000_MASK))
+		rate_mask |= mask_48000;
+	return rate_mask;
+}
+
+static unsigned int sad_rate_mask(const u8 *sad)
+{
+	switch (FIELD_GET(SAD0_FORMAT_MASK, sad[0])) {
+	case HDMI_AUDIO_CODING_TYPE_PCM:
+		return sad[1] & SAD1_RATE_MASK;
+	case HDMI_AUDIO_CODING_TYPE_AC3:
+	case HDMI_AUDIO_CODING_TYPE_DTS:
+		return map_rate_families(sad,
+					 SAD1_RATE_32000_MASK,
+					 SAD1_RATE_44100_MASK,
+					 SAD1_RATE_48000_MASK);
+	case HDMI_AUDIO_CODING_TYPE_EAC3:
+	case HDMI_AUDIO_CODING_TYPE_DTS_HD:
+	case HDMI_AUDIO_CODING_TYPE_MLP:
+		return map_rate_families(sad,
+					 0,
+					 SAD1_RATE_176400_MASK,
+					 SAD1_RATE_192000_MASK);
+	default:
+		/* TODO adjust for other compressed formats as well */
+		return sad[1] & SAD1_RATE_MASK;
+	}
+}
+
 static unsigned int sad_max_channels(const u8 *sad)
 {
-	return 1 + (sad[0] & 7);
+	switch (FIELD_GET(SAD0_FORMAT_MASK, sad[0])) {
+	case HDMI_AUDIO_CODING_TYPE_PCM:
+		return 1 + FIELD_GET(SAD0_CHANNELS_MASK, sad[0]);
+	case HDMI_AUDIO_CODING_TYPE_AC3:
+	case HDMI_AUDIO_CODING_TYPE_DTS:
+	case HDMI_AUDIO_CODING_TYPE_EAC3:
+		return 2;
+	case HDMI_AUDIO_CODING_TYPE_DTS_HD:
+	case HDMI_AUDIO_CODING_TYPE_MLP:
+		return 8;
+	default:
+		/* TODO adjust for other compressed formats as well */
+		return 1 + FIELD_GET(SAD0_CHANNELS_MASK, sad[0]);
+	}
 }
 
 static int eld_limit_rates(struct snd_pcm_hw_params *params,
@@ -42,7 +109,7 @@ static int eld_limit_rates(struct snd_pcm_hw_params *params,
 			 * requested number of channels.
 			 */
 			if (c->min <= max_channels)
-				rate_mask |= sad[1];
+				rate_mask |= sad_rate_mask(sad);
 		}
 	}
 
@@ -70,7 +137,7 @@ static int eld_limit_channels(struct snd_pcm_hw_params *params,
 				rate_mask |= BIT(i);
 
 		for (i = drm_eld_sad_count(eld); i > 0; i--, sad += 3)
-			if (rate_mask & sad[1])
+			if (rate_mask & sad_rate_mask(sad))
 				t.max = max(t.max, sad_max_channels(sad));
 	}
 

--- a/sound/soc/codecs/hdmi-codec.c
+++ b/sound/soc/codecs/hdmi-codec.c
@@ -484,31 +484,43 @@ static int hdmi_codec_fill_codec_params(struct snd_soc_dai *dai,
 					struct hdmi_codec_params *hp)
 {
 	struct hdmi_codec_priv *hcp = snd_soc_dai_get_drvdata(dai);
-	int idx;
+	int idx = HDMI_CODEC_CHMAP_IDX_UNKNOWN;
+	u8 ca_id = 0;
+	bool pcm_audio = !(hcp->iec_status[0] & IEC958_AES0_NONAUDIO);
 
-	/* Select a channel allocation that matches with ELD and pcm channels */
-	idx = hdmi_codec_get_ch_alloc_table_idx(hcp, channels);
-	if (idx < 0) {
-		dev_err(dai->dev, "Not able to map channels to speakers (%d)\n",
-			idx);
-		hcp->chmap_idx = HDMI_CODEC_CHMAP_IDX_UNKNOWN;
-		return idx;
+	if (pcm_audio) {
+		/* Select a channel allocation that matches with ELD and pcm channels */
+		idx = hdmi_codec_get_ch_alloc_table_idx(hcp, channels);
+
+		if (idx < 0) {
+			dev_err(dai->dev, "Not able to map channels to speakers (%d)\n",
+				idx);
+			hcp->chmap_idx = HDMI_CODEC_CHMAP_IDX_UNKNOWN;
+			return idx;
+		}
+
+		ca_id = hdmi_codec_channel_alloc[idx].ca_id;
 	}
 
 	memset(hp, 0, sizeof(*hp));
 
 	hdmi_audio_infoframe_init(&hp->cea);
-	hp->cea.channels = channels;
+
+	if (pcm_audio)
+		hp->cea.channels = channels;
+	else
+		hp->cea.channels = 0;
+
 	hp->cea.coding_type = HDMI_AUDIO_CODING_TYPE_STREAM;
 	hp->cea.sample_size = HDMI_AUDIO_SAMPLE_SIZE_STREAM;
 	hp->cea.sample_frequency = HDMI_AUDIO_SAMPLE_FREQUENCY_STREAM;
-	hp->cea.channel_allocation = hdmi_codec_channel_alloc[idx].ca_id;
+	hp->cea.channel_allocation = ca_id;
 
 	hp->sample_width = sample_width;
 	hp->sample_rate = sample_rate;
 	hp->channels = channels;
 
-	hcp->chmap_idx = hdmi_codec_channel_alloc[idx].ca_id;
+	hcp->chmap_idx = idx;
 
 	return 0;
 }


### PR DESCRIPTION
ALSA didn't set up proper constraints for compressed audio (eg 192kHz 8ch for DTS-HD and Dolby TrueHD) which prevented applications like kodi to pass through those stream to TVs/AVRs.

@popcornmix also reported that his Sony TV refused to decode TrueHD streams because the channel info in the audio infoframe was incorrect.

We've carried both fixes in LibreELEC for a while and they were just accepted upstream and have been queued up for linux-next
