### PR TITLE
smsc95xx MAC address cleanups

### DIFF
--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -814,42 +814,11 @@ static int smsc95xx_ioctl(struct net_device *netdev, struct ifreq *rq, int cmd)
 /* Check the macaddr module parameter for a MAC address */
 static int smsc95xx_is_macaddr_param(struct usbnet *dev, struct net_device *nd)
 {
-	int i, j, got_num, num;
 	u8 mtbl[ETH_ALEN];
 
-	if (macaddr[0] == ':')
-		return 0;
-
-	i = 0;
-	j = 0;
-	num = 0;
-	got_num = 0;
-	while (j < ETH_ALEN) {
-		if (macaddr[i] && macaddr[i] != ':') {
-			got_num++;
-			if ('0' <= macaddr[i] && macaddr[i] <= '9')
-				num = num * 16 + macaddr[i] - '0';
-			else if ('A' <= macaddr[i] && macaddr[i] <= 'F')
-				num = num * 16 + 10 + macaddr[i] - 'A';
-			else if ('a' <= macaddr[i] && macaddr[i] <= 'f')
-				num = num * 16 + 10 + macaddr[i] - 'a';
-			else
-				break;
-			i++;
-		} else if (got_num == 2) {
-			mtbl[j++] = (u8) num;
-			num = 0;
-			got_num = 0;
-			i++;
-		} else {
-			break;
-		}
-	}
-
-	if (j == ETH_ALEN) {
-		netif_dbg(dev, ifup, dev->net, "Overriding MAC address with: "
-			  "%02x:%02x:%02x:%02x:%02x:%02x\n", mtbl[0], mtbl[1],
-			  mtbl[2], mtbl[3], mtbl[4], mtbl[5]);
+	if (mac_pton(macaddr, mtbl)) {
+		netif_dbg(dev, ifup, dev->net,
+			  "Overriding MAC address with: %pM\n", mtbl);
 		dev_addr_mod(nd, 0, mtbl, ETH_ALEN);
 		return 1;
 	} else {

--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -814,47 +814,47 @@ static int smsc95xx_ioctl(struct net_device *netdev, struct ifreq *rq, int cmd)
 /* Check the macaddr module parameter for a MAC address */
 static int smsc95xx_is_macaddr_param(struct usbnet *dev, struct net_device *nd)
 {
-       int i, j, got_num, num;
-       u8 mtbl[ETH_ALEN];
+	int i, j, got_num, num;
+	u8 mtbl[ETH_ALEN];
 
-       if (macaddr[0] == ':')
-               return 0;
+	if (macaddr[0] == ':')
+		return 0;
 
-       i = 0;
-       j = 0;
-       num = 0;
-       got_num = 0;
-       while (j < ETH_ALEN) {
-               if (macaddr[i] && macaddr[i] != ':') {
-                       got_num++;
-                       if ('0' <= macaddr[i] && macaddr[i] <= '9')
-                               num = num * 16 + macaddr[i] - '0';
-                       else if ('A' <= macaddr[i] && macaddr[i] <= 'F')
-                               num = num * 16 + 10 + macaddr[i] - 'A';
-                       else if ('a' <= macaddr[i] && macaddr[i] <= 'f')
-                               num = num * 16 + 10 + macaddr[i] - 'a';
-                       else
-                               break;
-                       i++;
-               } else if (got_num == 2) {
-                       mtbl[j++] = (u8) num;
-                       num = 0;
-                       got_num = 0;
-                       i++;
-               } else {
-                       break;
-               }
-       }
+	i = 0;
+	j = 0;
+	num = 0;
+	got_num = 0;
+	while (j < ETH_ALEN) {
+		if (macaddr[i] && macaddr[i] != ':') {
+			got_num++;
+			if ('0' <= macaddr[i] && macaddr[i] <= '9')
+				num = num * 16 + macaddr[i] - '0';
+			else if ('A' <= macaddr[i] && macaddr[i] <= 'F')
+				num = num * 16 + 10 + macaddr[i] - 'A';
+			else if ('a' <= macaddr[i] && macaddr[i] <= 'f')
+				num = num * 16 + 10 + macaddr[i] - 'a';
+			else
+				break;
+			i++;
+		} else if (got_num == 2) {
+			mtbl[j++] = (u8) num;
+			num = 0;
+			got_num = 0;
+			i++;
+		} else {
+			break;
+		}
+	}
 
-       if (j == ETH_ALEN) {
-               netif_dbg(dev, ifup, dev->net, "Overriding MAC address with: "
-               "%02x:%02x:%02x:%02x:%02x:%02x\n", mtbl[0], mtbl[1], mtbl[2],
-                                               mtbl[3], mtbl[4], mtbl[5]);
-	       dev_addr_mod(nd, 0, mtbl, ETH_ALEN);
-               return 1;
-       } else {
-               return 0;
-       }
+	if (j == ETH_ALEN) {
+		netif_dbg(dev, ifup, dev->net, "Overriding MAC address with: "
+			  "%02x:%02x:%02x:%02x:%02x:%02x\n", mtbl[0], mtbl[1],
+			  mtbl[2], mtbl[3], mtbl[4], mtbl[5]);
+		dev_addr_mod(nd, 0, mtbl, ETH_ALEN);
+		return 1;
+	} else {
+		return 0;
+	}
 }
 
 static void smsc95xx_init_mac_address(struct usbnet *dev)

--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -812,7 +812,7 @@ static int smsc95xx_ioctl(struct net_device *netdev, struct ifreq *rq, int cmd)
 }
 
 /* Check the macaddr module parameter for a MAC address */
-static int smsc95xx_is_macaddr_param(struct usbnet *dev, struct net_device *nd)
+static int smsc95xx_macaddr_param(struct usbnet *dev, struct net_device *nd)
 {
 	u8 mtbl[ETH_ALEN];
 
@@ -820,9 +820,9 @@ static int smsc95xx_is_macaddr_param(struct usbnet *dev, struct net_device *nd)
 		netif_dbg(dev, ifup, dev->net,
 			  "Overriding MAC address with: %pM\n", mtbl);
 		dev_addr_mod(nd, 0, mtbl, ETH_ALEN);
-		return 1;
-	} else {
 		return 0;
+	} else {
+		return -EINVAL;
 	}
 }
 
@@ -850,8 +850,12 @@ static void smsc95xx_init_mac_address(struct usbnet *dev)
 	}
 
 	/* Check module parameters */
-	if (smsc95xx_is_macaddr_param(dev, dev->net))
-		return;
+	if (smsc95xx_macaddr_param(dev, dev->net) == 0) {
+		if (is_valid_ether_addr(dev->net->dev_addr)) {
+			netif_dbg(dev, ifup, dev->net, "MAC address read from module parameter\n");
+			return;
+		}
+	}
 
 	/* no useful static MAC address found. generate a random one */
 	eth_hw_addr_random(dev->net);


### PR DESCRIPTION
Here's an assortment of cleanups for the `smsc95xx` driver's parsing of the `smsc95xx.macaddr` command line parameter.

No functional change intended, just cleanups.

I'm unsure whether to submit for rpi-6.4.y or rpi-6.1.y. I'm choosing the former in the hope that this will get the commits applied to future branches such as the forthcoming rpi-6.5.y. (Barring any objections to the commits of course.)

Thanks!