### PR TITLE
bcm2835-unicam.c pixel formats code tidy + 16-bit support

### DIFF
--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -405,10 +405,33 @@ static const struct unicam_fmt formats[] = {
 		.csi_dt		= MIPI_CSI2_DT_RAW14,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
+		.fourcc		= V4L2_PIX_FMT_SBGGR16,
+		.code		= MEDIA_BUS_FMT_SBGGR16_1X16,
+		.depth		= 16,
+		.csi_dt		= MIPI_CSI2_DT_RAW16,
+		.valid_colorspaces = MASK_CS_RAW,
+	}, {
+		.fourcc		= V4L2_PIX_FMT_SGBRG16,
+		.code		= MEDIA_BUS_FMT_SGBRG16_1X16,
+		.depth		= 16,
+		.csi_dt		= MIPI_CSI2_DT_RAW16,
+		.valid_colorspaces = MASK_CS_RAW,
+	}, {
+		.fourcc		= V4L2_PIX_FMT_SGRBG16,
+		.code		= MEDIA_BUS_FMT_SGRBG16_1X16,
+		.depth		= 16,
+		.csi_dt		= MIPI_CSI2_DT_RAW16,
+		.valid_colorspaces = MASK_CS_RAW,
+	}, {
+		.fourcc		= V4L2_PIX_FMT_SRGGB16,
+		.code		= MEDIA_BUS_FMT_SRGGB16_1X16,
+		.depth		= 16,
+		.csi_dt		= MIPI_CSI2_DT_RAW16,
+		.valid_colorspaces = MASK_CS_RAW,
+	}, {
 	/*
-	 * 16 bit Bayer formats could be supported, but there is no CSI2
-	 * data_type defined for raw 16, and no sensors that produce it at
-	 * present.
+	 * Bayer formats greater than 16 bit could be supported, but the formats haven't been 
+  	 * defined in Media Bus or V4L2 yet.
 	 */
 
 	/* Greyscale formats */

--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -430,8 +430,8 @@ static const struct unicam_fmt formats[] = {
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 	/*
-	 * Bayer formats greater than 16 bit could be supported, but the formats haven't been 
-  	 * defined in Media Bus or V4L2 yet.
+	 * Bayer formats greater than 16 bit could be supported, but the formats haven't been
+	 * defined in Media Bus or V4L2 yet.
 	 */
 
 	/* Greyscale formats */

--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -62,6 +62,7 @@
 #include <linux/uaccess.h>
 #include <linux/videodev2.h>
 
+#include <media/mipi-cs2.h>
 #include <media/v4l2-common.h>
 #include <media/v4l2-ctrls.h>
 #include <media/v4l2-dev.h>
@@ -191,7 +192,7 @@ static const struct unicam_fmt formats[] = {
 		.fourcc		= V4L2_PIX_FMT_YUYV,
 		.code		= MEDIA_BUS_FMT_YUYV8_2X8,
 		.depth		= 16,
-		.csi_dt		= 0x1e,
+		.csi_dt		= MIPI_CSI2_DT_YUV422_8B,
 		.check_variants = 1,
 		.valid_colorspaces = MASK_CS_SMPTE170M | MASK_CS_REC709 |
 				     MASK_CS_JPEG,
@@ -199,7 +200,7 @@ static const struct unicam_fmt formats[] = {
 		.fourcc		= V4L2_PIX_FMT_UYVY,
 		.code		= MEDIA_BUS_FMT_UYVY8_2X8,
 		.depth		= 16,
-		.csi_dt		= 0x1e,
+		.csi_dt		= MIPI_CSI2_DT_YUV422_8B,
 		.check_variants = 1,
 		.valid_colorspaces = MASK_CS_SMPTE170M | MASK_CS_REC709 |
 				     MASK_CS_JPEG,
@@ -207,7 +208,7 @@ static const struct unicam_fmt formats[] = {
 		.fourcc		= V4L2_PIX_FMT_YVYU,
 		.code		= MEDIA_BUS_FMT_YVYU8_2X8,
 		.depth		= 16,
-		.csi_dt		= 0x1e,
+		.csi_dt		= MIPI_CSI2_DT_YUV422_8B,
 		.check_variants = 1,
 		.valid_colorspaces = MASK_CS_SMPTE170M | MASK_CS_REC709 |
 				     MASK_CS_JPEG,
@@ -215,7 +216,7 @@ static const struct unicam_fmt formats[] = {
 		.fourcc		= V4L2_PIX_FMT_VYUY,
 		.code		= MEDIA_BUS_FMT_VYUY8_2X8,
 		.depth		= 16,
-		.csi_dt		= 0x1e,
+		.csi_dt		= MIPI_CSI2_DT_YUV422_8B,
 		.check_variants = 1,
 		.valid_colorspaces = MASK_CS_SMPTE170M | MASK_CS_REC709 |
 				     MASK_CS_JPEG,
@@ -223,7 +224,7 @@ static const struct unicam_fmt formats[] = {
 		.fourcc		= V4L2_PIX_FMT_YUYV,
 		.code		= MEDIA_BUS_FMT_YUYV8_1X16,
 		.depth		= 16,
-		.csi_dt		= 0x1e,
+		.csi_dt		= MIPI_CSI2_DT_YUV422_8B,
 		.mc_skip	= 1,
 		.valid_colorspaces = MASK_CS_SMPTE170M | MASK_CS_REC709 |
 				     MASK_CS_JPEG,
@@ -231,7 +232,7 @@ static const struct unicam_fmt formats[] = {
 		.fourcc		= V4L2_PIX_FMT_UYVY,
 		.code		= MEDIA_BUS_FMT_UYVY8_1X16,
 		.depth		= 16,
-		.csi_dt		= 0x1e,
+		.csi_dt		= MIPI_CSI2_DT_YUV422_8B,
 		.mc_skip	= 1,
 		.valid_colorspaces = MASK_CS_SMPTE170M | MASK_CS_REC709 |
 				     MASK_CS_JPEG,
@@ -239,7 +240,7 @@ static const struct unicam_fmt formats[] = {
 		.fourcc		= V4L2_PIX_FMT_YVYU,
 		.code		= MEDIA_BUS_FMT_YVYU8_1X16,
 		.depth		= 16,
-		.csi_dt		= 0x1e,
+		.csi_dt		= MIPI_CSI2_DT_YUV422_8B,
 		.mc_skip	= 1,
 		.valid_colorspaces = MASK_CS_SMPTE170M | MASK_CS_REC709 |
 				     MASK_CS_JPEG,
@@ -247,7 +248,7 @@ static const struct unicam_fmt formats[] = {
 		.fourcc		= V4L2_PIX_FMT_VYUY,
 		.code		= MEDIA_BUS_FMT_VYUY8_1X16,
 		.depth		= 16,
-		.csi_dt		= 0x1e,
+		.csi_dt		= MIPI_CSI2_DT_YUV422_8B,
 		.mc_skip	= 1,
 		.valid_colorspaces = MASK_CS_SMPTE170M | MASK_CS_REC709 |
 				     MASK_CS_JPEG,
@@ -256,37 +257,37 @@ static const struct unicam_fmt formats[] = {
 		.fourcc		= V4L2_PIX_FMT_RGB565, /* gggbbbbb rrrrrggg */
 		.code		= MEDIA_BUS_FMT_RGB565_2X8_LE,
 		.depth		= 16,
-		.csi_dt		= 0x22,
+		.csi_dt		= MIPI_CSI2_DT_RGB565,
 		.valid_colorspaces = MASK_CS_SRGB,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_RGB565X, /* rrrrrggg gggbbbbb */
 		.code		= MEDIA_BUS_FMT_RGB565_2X8_BE,
 		.depth		= 16,
-		.csi_dt		= 0x22,
+		.csi_dt		= MIPI_CSI2_DT_RGB565,
 		.valid_colorspaces = MASK_CS_SRGB,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_RGB555, /* gggbbbbb arrrrrgg */
 		.code		= MEDIA_BUS_FMT_RGB555_2X8_PADHI_LE,
 		.depth		= 16,
-		.csi_dt		= 0x21,
+		.csi_dt		= MIPI_CSI2_DT_RGB555,
 		.valid_colorspaces = MASK_CS_SRGB,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_RGB555X, /* arrrrrgg gggbbbbb */
 		.code		= MEDIA_BUS_FMT_RGB555_2X8_PADHI_BE,
 		.depth		= 16,
-		.csi_dt		= 0x21,
+		.csi_dt		= MIPI_CSI2_DT_RGB555,
 		.valid_colorspaces = MASK_CS_SRGB,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_RGB24, /* rgb */
 		.code		= MEDIA_BUS_FMT_RGB888_1X24,
 		.depth		= 24,
-		.csi_dt		= 0x24,
+		.csi_dt		= MIPI_CSI2_DT_RGB888,
 		.valid_colorspaces = MASK_CS_SRGB,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_BGR24, /* bgr */
 		.code		= MEDIA_BUS_FMT_BGR888_1X24,
 		.depth		= 24,
-		.csi_dt		= 0x24,
+		.csi_dt		= MIPI_CSI2_DT_RGB888,
 		.valid_colorspaces = MASK_CS_SRGB,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_RGB32, /* argb */
@@ -299,109 +300,109 @@ static const struct unicam_fmt formats[] = {
 		.fourcc		= V4L2_PIX_FMT_SBGGR8,
 		.code		= MEDIA_BUS_FMT_SBGGR8_1X8,
 		.depth		= 8,
-		.csi_dt		= 0x2a,
+		.csi_dt		= MIPI_CSI2_DT_RAW8,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SGBRG8,
 		.code		= MEDIA_BUS_FMT_SGBRG8_1X8,
 		.depth		= 8,
-		.csi_dt		= 0x2a,
+		.csi_dt		= MIPI_CSI2_DT_RAW8,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SGRBG8,
 		.code		= MEDIA_BUS_FMT_SGRBG8_1X8,
 		.depth		= 8,
-		.csi_dt		= 0x2a,
+		.csi_dt		= MIPI_CSI2_DT_RAW8,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SRGGB8,
 		.code		= MEDIA_BUS_FMT_SRGGB8_1X8,
 		.depth		= 8,
-		.csi_dt		= 0x2a,
+		.csi_dt		= MIPI_CSI2_DT_RAW8,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SBGGR10P,
 		.repacked_fourcc = V4L2_PIX_FMT_SBGGR10,
 		.code		= MEDIA_BUS_FMT_SBGGR10_1X10,
 		.depth		= 10,
-		.csi_dt		= 0x2b,
+		.csi_dt		= MIPI_CSI2_DT_RAW10,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SGBRG10P,
 		.repacked_fourcc = V4L2_PIX_FMT_SGBRG10,
 		.code		= MEDIA_BUS_FMT_SGBRG10_1X10,
 		.depth		= 10,
-		.csi_dt		= 0x2b,
+		.csi_dt		= MIPI_CSI2_DT_RAW10,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SGRBG10P,
 		.repacked_fourcc = V4L2_PIX_FMT_SGRBG10,
 		.code		= MEDIA_BUS_FMT_SGRBG10_1X10,
 		.depth		= 10,
-		.csi_dt		= 0x2b,
+		.csi_dt		= MIPI_CSI2_DT_RAW10,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SRGGB10P,
 		.repacked_fourcc = V4L2_PIX_FMT_SRGGB10,
 		.code		= MEDIA_BUS_FMT_SRGGB10_1X10,
 		.depth		= 10,
-		.csi_dt		= 0x2b,
+		.csi_dt		= MIPI_CSI2_DT_RAW10,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SBGGR12P,
 		.repacked_fourcc = V4L2_PIX_FMT_SBGGR12,
 		.code		= MEDIA_BUS_FMT_SBGGR12_1X12,
 		.depth		= 12,
-		.csi_dt		= 0x2c,
+		.csi_dt		= MIPI_CSI2_DT_RAW12,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SGBRG12P,
 		.repacked_fourcc = V4L2_PIX_FMT_SGBRG12,
 		.code		= MEDIA_BUS_FMT_SGBRG12_1X12,
 		.depth		= 12,
-		.csi_dt		= 0x2c,
+		.csi_dt		= MIPI_CSI2_DT_RAW12,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SGRBG12P,
 		.repacked_fourcc = V4L2_PIX_FMT_SGRBG12,
 		.code		= MEDIA_BUS_FMT_SGRBG12_1X12,
 		.depth		= 12,
-		.csi_dt		= 0x2c,
+		.csi_dt		= MIPI_CSI2_DT_RAW12,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SRGGB12P,
 		.repacked_fourcc = V4L2_PIX_FMT_SRGGB12,
 		.code		= MEDIA_BUS_FMT_SRGGB12_1X12,
 		.depth		= 12,
-		.csi_dt		= 0x2c,
+		.csi_dt		= MIPI_CSI2_DT_RAW12,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SBGGR14P,
 		.repacked_fourcc = V4L2_PIX_FMT_SBGGR14,
 		.code		= MEDIA_BUS_FMT_SBGGR14_1X14,
 		.depth		= 14,
-		.csi_dt		= 0x2d,
+		.csi_dt		= MIPI_CSI2_DT_RAW14,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SGBRG14P,
 		.repacked_fourcc = V4L2_PIX_FMT_SGBRG14,
 		.code		= MEDIA_BUS_FMT_SGBRG14_1X14,
 		.depth		= 14,
-		.csi_dt		= 0x2d,
+		.csi_dt		= MIPI_CSI2_DT_RAW14,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SGRBG14P,
 		.repacked_fourcc = V4L2_PIX_FMT_SGRBG14,
 		.code		= MEDIA_BUS_FMT_SGRBG14_1X14,
 		.depth		= 14,
-		.csi_dt		= 0x2d,
+		.csi_dt		= MIPI_CSI2_DT_RAW14,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_SRGGB14P,
 		.repacked_fourcc = V4L2_PIX_FMT_SRGGB14,
 		.code		= MEDIA_BUS_FMT_SRGGB14_1X14,
 		.depth		= 14,
-		.csi_dt		= 0x2d,
+		.csi_dt		= MIPI_CSI2_DT_RAW14,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 	/*
@@ -414,28 +415,28 @@ static const struct unicam_fmt formats[] = {
 		.fourcc		= V4L2_PIX_FMT_GREY,
 		.code		= MEDIA_BUS_FMT_Y8_1X8,
 		.depth		= 8,
-		.csi_dt		= 0x2a,
+		.csi_dt		= MIPI_CSI2_DT_RAW8,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_Y10P,
 		.repacked_fourcc = V4L2_PIX_FMT_Y10,
 		.code		= MEDIA_BUS_FMT_Y10_1X10,
 		.depth		= 10,
-		.csi_dt		= 0x2b,
+		.csi_dt		= MIPI_CSI2_DT_RAW10,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_Y12P,
 		.repacked_fourcc = V4L2_PIX_FMT_Y12,
 		.code		= MEDIA_BUS_FMT_Y12_1X12,
 		.depth		= 12,
-		.csi_dt		= 0x2c,
+		.csi_dt		= MIPI_CSI2_DT_RAW12,
 		.valid_colorspaces = MASK_CS_RAW,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_Y14P,
 		.repacked_fourcc = V4L2_PIX_FMT_Y14,
 		.code		= MEDIA_BUS_FMT_Y14_1X14,
 		.depth		= 14,
-		.csi_dt		= 0x2d,
+		.csi_dt		= MIPI_CSI2_DT_RAW14,
 		.valid_colorspaces = MASK_CS_RAW,
 	},
 	/* Embedded data format */

--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -62,7 +62,7 @@
 #include <linux/uaccess.h>
 #include <linux/videodev2.h>
 
-#include <media/mipi-cs2.h>
+#include <media/mipi-csi2.h>
 #include <media/v4l2-common.h>
 #include <media/v4l2-ctrls.h>
 #include <media/v4l2-dev.h>


### PR DESCRIPTION
Replaces hardcoded CSI-2 data type literals with defines from mipi-csi2.h and adds missing 16-bit Bayer formats