### PR TITLE
overlays: Add trickle-voltage-mv parameter to RTCs

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1957,13 +1957,15 @@ Params: abx80x                  Select one of the ABx80x family:
                                 "schottky" (ABx80x and RV1805 only)
 
         trickle-resistor-ohms   Resistor value for trickle charge (DS1339,
-                                ABx80x, RV1805, RV3028)
+                                ABx80x, BQ32000, RV1805, RV3028, RV3032)
+
+        trickle-voltage-mv      Charge pump voltage for trickle charge (RV3032)
 
         wakeup-source           Specify that the RTC can be used as a wakeup
                                 source
 
         backup-switchover-mode  Backup power supply switch mode. Must be 0 for
-                                off or 1 for Vdd < VBackup (RV3028 only)
+                                off or 1 for Vdd < VBackup (RV3028, RV3032)
 
 
 Name:   i2c-rtc-gpio
@@ -2027,13 +2029,15 @@ Params: abx80x                  Select one of the ABx80x family:
                                 "schottky" (ABx80x and RV1805 only)
 
         trickle-resistor-ohms   Resistor value for trickle charge (DS1339,
-                                ABx80x, RV1805, RV3028)
+                                ABx80x, BQ32000, RV1805, RV3028, RV3032)
+
+        trickle-voltage-mv      Charge pump voltage for trickle charge (RV3032)
 
         wakeup-source           Specify that the RTC can be used as a wakeup
                                 source
 
         backup-switchover-mode  Backup power supply switch mode. Must be 0 for
-                                off or 1 for Vdd < VBackup (RV3028 only)
+                                off or 1 for Vdd < VBackup (RV3028, RV3032)
 
         i2c_gpio_sda            GPIO used for I2C data (default "23")
 

--- a/arch/arm/boot/dts/overlays/i2c-rtc-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-rtc-common.dtsi
@@ -339,8 +339,10 @@
 					<&ds1340>,"trickle-resistor-ohms:0",
 					<&abx80x>,"abracon,tc-resistor:0",
 					<&rv3028>,"trickle-resistor-ohms:0",
+					<&rv3032>,"trickle-resistor-ohms:0",
 					<&rv1805>,"abracon,tc-resistor:0",
 					<&bq32000>,"abracon,tc-resistor:0";
+		trickle-voltage-mv = <&rv3032>,"trickle-voltage-millivolts:0";
 		backup-switchover-mode = <&rv3028>,"backup-switchover-mode:0";
 		wakeup-source = <&ds1339>,"wakeup-source?",
 				<&ds3231>,"wakeup-source?",


### PR DESCRIPTION
The RV3032 RTC requires an additional DT property to enable trickle charging. Add a parameter - trickle-voltage-mv - to set it.

See: https://github.com/raspberrypi/linux/issues/5547