### PR TITLE
drm/panel: Fix default values for Waveshare 7.9 inch DSI touchscreen

### DIFF
--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
@@ -92,11 +92,11 @@
 		7_0_inchC = <&panel>, "compatible=waveshare,7.0inch-c-panel",
 				   <&touch>, "touchscreen-size-x:0=800",
 				   <&touch>, "touchscreen-size-y:0=480";
-		7_9_inch = <&panel>, "compatible=waveshare,7.9inch-panel",
-				   <&touch>, "touchscreen-size-x:0=400",
-				   <&touch>, "touchscreen-size-y:0=1280",
-				   <&touch>, "touchscreen-inverted-x?",
-				   <&touch>, "touchscreen-inverted-y?";
+                7_9_inch = <&panel>, "compatible=waveshare,7.9inch-panel",
+                                   <&touch>, "touchscreen-size-x:0=4096",
+                                   <&touch>, "touchscreen-size-y:0=4096",
+                                   <&touch>, "touchscreen-inverted-x?",
+                                   <&touch>, "touchscreen-swapped-x-y?";
 		8_0_inch = <&panel>, "compatible=waveshare,8.0inch-panel",
 				   <&touch>, "touchscreen-size-x:0=800",
 				   <&touch>, "touchscreen-size-y:0=1280",

--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
@@ -92,11 +92,11 @@
 		7_0_inchC = <&panel>, "compatible=waveshare,7.0inch-c-panel",
 				   <&touch>, "touchscreen-size-x:0=800",
 				   <&touch>, "touchscreen-size-y:0=480";
-                7_9_inch = <&panel>, "compatible=waveshare,7.9inch-panel",
-                                   <&touch>, "touchscreen-size-x:0=4096",
-                                   <&touch>, "touchscreen-size-y:0=4096",
-                                   <&touch>, "touchscreen-inverted-x?",
-                                   <&touch>, "touchscreen-swapped-x-y?";
+		7_9_inch = <&panel>, "compatible=waveshare,7.9inch-panel",
+				   <&touch>, "touchscreen-size-x:0=4096",
+				   <&touch>, "touchscreen-size-y:0=4096",
+				   <&touch>, "touchscreen-inverted-x?",
+				   <&touch>, "touchscreen-swapped-x-y?";
 		8_0_inch = <&panel>, "compatible=waveshare,8.0inch-panel",
 				   <&touch>, "touchscreen-size-x:0=800",
 				   <&touch>, "touchscreen-size-y:0=1280",


### PR DESCRIPTION
This fixes touchscreen calibration, axis swapping and inversion.

As referenced in https://github.com/raspberrypi/linux/issues/5550