### PR TITLE
drm: panel: jdi-lt070me05000: Add prepare_upstream_first flag

### DIFF
--- a/drivers/gpu/drm/panel/panel-jdi-lt070me05000.c
+++ b/drivers/gpu/drm/panel/panel-jdi-lt070me05000.c
@@ -437,6 +437,7 @@ static int jdi_panel_add(struct jdi_panel *jdi)
 		return ret;
 	}
 
+	jdi->base.prepare_upstream_first = true;
 	drm_panel_init(&jdi->base, &jdi->dsi->dev, &jdi_panel_funcs,
 		       DRM_MODE_CONNECTOR_DSI);
 


### PR DESCRIPTION
The panel driver wants to send DCS commands from the prepare hook, therefore the DSI host wants to be pre_enabled first. Set the flag to achieve this.

https://forums.raspberrypi.com/viewtopic.php?t=354708