### PR TITLE
mmc: sdhci: fix max req size based on spec

### DIFF
--- a/drivers/mmc/host/sdhci.h
+++ b/drivers/mmc/host/sdhci.h
@@ -339,11 +339,11 @@ struct sdhci_adma2_64_desc {
 #define ADMA2_END		0x2
 
 /*
- * Maximum segments assuming a 512KiB maximum requisition size and a minimum
+ * Maximum segments assuming a 16MiB maximum requisition size and a minimum
  * 4KiB page size. Note this also allows enough for multiple descriptors in
  * case of PAGE_SIZE >= 64KiB.
  */
-#define SDHCI_MAX_SEGS		128
+#define SDHCI_MAX_SEGS		4096
 
 /* Allow for a a command request and a data request at the same time */
 #define SDHCI_MAX_MRQS		2


### PR DESCRIPTION
THIS NEEDS A CORRECT SoB BEFORE BEING CONSIDERED FOR MERGE.

https://forums.raspberrypi.com/viewtopic.php?t=354518 for testing.

For almost 2 decades, the max allowed requests were limited to 512KB because of SDMA's max 512KiB boundary limit.

ADMA2 and ADMA3 do not have such limits and were effectively made so any kind of block count would not impose interrupt and managing stress to the host.

By limiting that to 512KiB, it effectively downgrades these DMA modes to SDMA.

Fix that by actually following the spec:
When ADMA is selected tuning mode is advised.
On lesser modes 4MiB transfers is selected as max, so re-tuning if timer trigger or if requested by host interrupt, can be done in time. Otherwise, the only limit is the variable size of types used. In this implementation, 16MiB is used as maximum since tests showed that after that point, there are diminishing returns.

Also 16MiB in worst case scenarios, when card is eMMC and its max speed is a generous 350MiB/s, will generate interrupts every 45ms on huge data transfers.

A new `adma_get_req_limit` sdhci host function was also introduced, to let vendors override imposed limits by the generic implementation if needed.

For example, on local tests with rigorous CPU/GPU burn-in tests and abrupt cut-offs to generate huge temperature changes (upwards/downwards) to the card, tested host was fine up to 128MB/s transfers on slow cards that used SDR104 bus timing without re-tuning.
In that case the 4MiB limit was overridden with a more than safe 8MiB value.

In all testing cases and boards, that change brought the following:

Depending on bus timing and eMMC/SD specs:
* Max Read throughput increased by 2-20%
* Max Write throughput increased by 50-200% Depending on CPU frequency and transfer sizes:
* Reduced mmcqd cpu core usage by 4-50%