### PR TITLE
Add sub address support to SPI driver enabling multiple devices to be be accessed using the minimum of GPIO

### DIFF
--- a/drivers/spi/spi-bcm2835.c
+++ b/drivers/spi/spi-bcm2835.c
@@ -1276,16 +1276,14 @@ static int bcm2835_spi_setup(struct spi_device *spi)
 	 */
 	if (spi->cs_gpiod)
 		return 0;
-	if (spi->chip_select > 1) {
-		/* error in the case of native CS requested with CS > 1
-		 * officially there is a CS2, but it is not documented
-		 * which GPIO is connected with that...
-		 */
+
+	if(spi->chip_select >= ctlr->num_chip_selects << ctlr->num_sub_addr_selects)
+	{
 		dev_err(&spi->dev,
-			"setup: only two native chip-selects are supported\n");
+			"setup: Too man chip selects\n");
 		ret = -EINVAL;
 		goto err_cleanup;
-	}
+    }
 
 	/*
 	 * Translate native CS to GPIO
@@ -1301,7 +1299,7 @@ static int bcm2835_spi_setup(struct spi_device *spi)
 	if (!chip)
 		return 0;
 
-	spi->cs_gpiod = gpiochip_request_own_desc(chip, 8 - spi->chip_select,
+	spi->cs_gpiod = gpiochip_request_own_desc(chip, 8 - (spi->chip_select % ctlr->num_chip_selects),
 						  DRV_NAME,
 						  GPIO_LOOKUP_FLAGS_DEFAULT,
 						  GPIOD_OUT_LOW);

--- a/include/linux/spi/spi.h
+++ b/include/linux/spi/spi.h
@@ -472,6 +472,10 @@ extern struct spi_device *spi_new_ancillary_device(struct spi_device *spi, u8 ch
  * @queue_empty: signal green light for opportunistically skipping the queue
  *	for spi_sync transfers.
  * @must_async: disable all fast paths in the core
+*
+ * @num_chip_selects: Number of GPIO's used for chip selects
+ * @num_sub_addr_selects: Number of GPIO's used for sub address selects
+ * @sa_gpiods: Array of GPIOs descriptors to use as sub address select lines
  *
  * Each SPI controller can communicate with one or more @spi_device
  * children.  These make a small bus, sharing MOSI, MISO and SCK signals
@@ -696,6 +700,11 @@ struct spi_controller {
 	/* Flag for enabling opportunistic skipping of the queue in spi_sync */
 	bool			queue_empty;
 	bool			must_async;
+
+    /* gpio sub address select */
+	u16     num_chip_selects;
+	u16     num_sub_addr_selects;
+	struct gpio_desc **sa_gpiods;
 };
 
 static inline void *spi_controller_get_devdata(struct spi_controller *ctlr)


### PR DESCRIPTION
This is a modification I have used to access multiple SPI devices on the same SPI bus by using the minimum of SPI chip selects.
I have seen requests for this type of access and use this to access my range of addon boards, but every time a new release comes out I have to cut and paste in the code and rebuild the kernel.
It would be nice if the was included in the master source code and I'm sure others would benifit from this change.

An example is to use one chip select as default GPIO 8 and then add additional sub address lines using other nominated GPIO's.
For example adding 2 additional GPIO's as spi addresses this give the possible selection of 4 SPI devices using just 3 GPIO lines.
The target additional hardware would decode the 2 address lines along with the chip select to qualify device access, an example is a TTL 2 to 4 decoder.
Currently it is possible to create up to 32 devices, this is set by the N_SPI_MINORS value in spidev.c, this can be increased if required.
With the example above this will create spidev0.0 to spidev0.3.
If 4 address lines and 1 chip select is used this changes to spidev0.0 to spidev0.15, uses only 5 GPIO's
If 4 address lines and 2 chip selects are used this changes to spidev0.0 to spidev0.31 uses only 6 GPIO's

I have added an example DTS file showing the configuration using 2 chip selects and 4 address lines.
Similar to the use of multiple chip selects, there is no limit to the number of address lines used.

[spi0-hw-sa32-overlay.zip](https://github.com/raspberrypi/linux/files/12551464/spi0-hw-sa32-overlay.zip)

Thanks Mark
