### PR TITLE
drm/edid: Add option to report basic audio support with a generic edid

### DIFF
--- a/drivers/gpu/drm/drm_edid.c
+++ b/drivers/gpu/drm/drm_edid.c
@@ -2090,6 +2090,23 @@ static struct edid *edid_filter_invalid_blocks(struct edid *edid,
 	return new;
 }
 
+/*
+ * add a CTA extension (block) containing audio support
+ * fix up the base extension to include the extra
+ * extension and report as digital (required for audio)
+ * and fix up checksums.
+ */
+void drm_edid_add_audio_extension(void *block)
+{
+	struct edid *edid = block;
+
+	edid->input = DRM_EDID_INPUT_DIGITAL;
+	edid->extensions++;
+	edid->checksum = edid_block_compute_checksum(edid);
+	edid = block + EDID_LENGTH;
+	edid->checksum = edid_block_compute_checksum(edid);
+}
+
 #define DDC_SEGMENT_ADDR 0x30
 /**
  * drm_do_probe_ddc_edid() - get EDID information via I2C

--- a/include/drm/drm_edid.h
+++ b/include/drm/drm_edid.h
@@ -614,4 +614,6 @@ int drm_edid_connector_update(struct drm_connector *connector,
 const u8 *drm_find_edid_extension(const struct drm_edid *drm_edid,
 				  int ext_id, int *ext_index);
 
+void drm_edid_add_audio_extension(void *block);
+
 #endif /* __DRM_EDID_H__ */


### PR DESCRIPTION
Hardware that fails to read the edid is quite common. The kernel provides a mechanism to use one a of a few pre-built generic edid files for getting a basic video mode.

However there is no easy was to add basic audio support, which requires a CTA extension block to report capabilities.

Add an module option to request this.