### PR TITLE
[media][imx219] selection API

### DIFF
--- a/drivers/media/i2c/imx219.c
+++ b/drivers/media/i2c/imx219.c
@@ -26,6 +26,7 @@
 #include <media/v4l2-event.h>
 #include <media/v4l2-fwnode.h>
 #include <media/v4l2-mediabus.h>
+#include <media/v4l2-rect.h>
 #include <asm/unaligned.h>
 
 #define IMX219_REG_VALUE_08BIT		1
@@ -964,7 +965,10 @@ static int imx219_set_pad_format(struct v4l2_subdev *sd,
 							      fmt->pad);
 			*framefmt = fmt->format;
 		} else if (imx219->mode != mode ||
-			   imx219->fmt.code != fmt->format.code) {
+			   imx219->fmt.code != fmt->format.code ||
+			   !v4l2_rect_equal(&imx219->crop, &mode->crop) ||
+			   imx219->compose.height != mode->height ||
+			   imx219->compose.width != mode->width) {
 			struct v4l2_rect curr_compose = imx219->compose;
 
 			imx219->mode = mode;

--- a/drivers/media/i2c/imx219.c
+++ b/drivers/media/i2c/imx219.c
@@ -420,6 +420,12 @@ struct imx219 {
 	/* Current mode */
 	const struct imx219_mode *mode;
 
+	/* Current crop rectangle. */
+	struct v4l2_rect crop;
+
+	/* Current compose rectangle. */
+	struct v4l2_rect compose;
+
 	/*
 	 * Mutex for serialized access:
 	 * Protect sensor module set pad format and start/stop streaming safely.
@@ -895,6 +901,9 @@ static int imx219_set_pad_format(struct v4l2_subdev *sd,
 
 			imx219->fmt = fmt->format;
 			imx219->mode = mode;
+			imx219->compose.height = mode->height;
+			imx219->compose.width = mode->width;
+			imx219->crop = mode->crop;
 			rate_factor = imx219_get_rate_factor(imx219);
 			if (rate_factor < 0)
 				return rate_factor;
@@ -1575,6 +1584,11 @@ static int imx219_probe(struct i2c_client *client)
 
 	/* Set default mode to max resolution */
 	imx219->mode = &supported_modes[0];
+	imx219->crop = imx219->mode->crop;
+	imx219->compose.top = 0;
+	imx219->compose.left = 0;
+	imx219->compose.width = imx219->mode->width;
+	imx219->compose.height = imx219->mode->height;
 
 	/* sensor doesn't enter LP-11 state upon power up until and unless
 	 * streaming is started, so upon power up switch the modes to:

--- a/drivers/media/i2c/imx219.c
+++ b/drivers/media/i2c/imx219.c
@@ -1054,7 +1054,7 @@ __imx219_get_pad_crop(struct imx219 *imx219,
 	case V4L2_SUBDEV_FORMAT_TRY:
 		return v4l2_subdev_get_try_crop(&imx219->sd, sd_state, pad);
 	case V4L2_SUBDEV_FORMAT_ACTIVE:
-		return &imx219->mode->crop;
+		return &imx219->crop;
 	}
 
 	return NULL;

--- a/drivers/media/i2c/imx219.c
+++ b/drivers/media/i2c/imx219.c
@@ -118,6 +118,16 @@
 #define IMX219_TESTP_BLUE_DEFAULT	0
 #define IMX219_TESTP_GREENB_DEFAULT	0
 
+/* IMX219 left, top, height, width registers */
+#define IMX219_REG_X_START 0x0164
+#define IMX219_REG_X_END 0x0166
+#define IMX219_REG_Y_START 0x0168
+#define IMX219_REG_Y_END 0x016a
+#define IMX219_REG_WIDTH 0x016c
+#define IMX219_REG_HEIGHT 0x016e
+#define IMX219_REG_TEST_WIDTH 0x0624
+#define IMX219_REG_TEST_HEIGHT 0x0626
+
 /* IMX219 native and active pixel array size. */
 #define IMX219_NATIVE_WIDTH		3296U
 #define IMX219_NATIVE_HEIGHT		2480U
@@ -153,6 +163,11 @@ struct imx219_reg {
 	u8 val;
 };
 
+struct imx219_reg_16bit_val {
+	u16 address;
+	u16 val;
+};
+
 struct imx219_reg_list {
 	unsigned int num_of_regs;
 	const struct imx219_reg *regs;
@@ -170,9 +185,6 @@ struct imx219_mode {
 
 	/* V-timing */
 	unsigned int vts_def;
-
-	/* Default register values */
-	struct imx219_reg_list reg_list;
 
 	/* binning mode based on format code */
 	enum binning_mode binning[BINNING_IDX_MAX];
@@ -223,87 +235,6 @@ static const struct imx219_reg imx219_common_regs[] = {
 	{0x0128, 0x00},	/* DPHY Auto Mode */
 	{0x012a, 0x18},	/* EXCK_Freq */
 	{0x012b, 0x00},
-};
-
-/*
- * Register sets lifted off the i2C interface from the Raspberry Pi firmware
- * driver.
- * 3280x2464 = mode 2, 1920x1080 = mode 1, 1640x1232 = mode 4, 640x480 = mode 7.
- */
-static const struct imx219_reg mode_3280x2464_regs[] = {
-	{0x0164, 0x00},
-	{0x0165, 0x00},
-	{0x0166, 0x0c},
-	{0x0167, 0xcf},
-	{0x0168, 0x00},
-	{0x0169, 0x00},
-	{0x016a, 0x09},
-	{0x016b, 0x9f},
-	{0x016c, 0x0c},
-	{0x016d, 0xd0},
-	{0x016e, 0x09},
-	{0x016f, 0xa0},
-	{0x0624, 0x0c},
-	{0x0625, 0xd0},
-	{0x0626, 0x09},
-	{0x0627, 0xa0},
-};
-
-static const struct imx219_reg mode_1920_1080_regs[] = {
-	{0x0164, 0x02},
-	{0x0165, 0xa8},
-	{0x0166, 0x0a},
-	{0x0167, 0x27},
-	{0x0168, 0x02},
-	{0x0169, 0xb4},
-	{0x016a, 0x06},
-	{0x016b, 0xeb},
-	{0x016c, 0x07},
-	{0x016d, 0x80},
-	{0x016e, 0x04},
-	{0x016f, 0x38},
-	{0x0624, 0x07},
-	{0x0625, 0x80},
-	{0x0626, 0x04},
-	{0x0627, 0x38},
-};
-
-static const struct imx219_reg mode_1640_1232_regs[] = {
-	{0x0164, 0x00},
-	{0x0165, 0x00},
-	{0x0166, 0x0c},
-	{0x0167, 0xcf},
-	{0x0168, 0x00},
-	{0x0169, 0x00},
-	{0x016a, 0x09},
-	{0x016b, 0x9f},
-	{0x016c, 0x06},
-	{0x016d, 0x68},
-	{0x016e, 0x04},
-	{0x016f, 0xd0},
-	{0x0624, 0x06},
-	{0x0625, 0x68},
-	{0x0626, 0x04},
-	{0x0627, 0xd0},
-};
-
-static const struct imx219_reg mode_640_480_regs[] = {
-	{0x0164, 0x03},
-	{0x0165, 0xe8},
-	{0x0166, 0x08},
-	{0x0167, 0xe7},
-	{0x0168, 0x02},
-	{0x0169, 0xf0},
-	{0x016a, 0x06},
-	{0x016b, 0xaf},
-	{0x016c, 0x02},
-	{0x016d, 0x80},
-	{0x016e, 0x01},
-	{0x016f, 0xe0},
-	{0x0624, 0x06},
-	{0x0625, 0x68},
-	{0x0626, 0x04},
-	{0x0627, 0xd0},
 };
 
 static const struct imx219_reg raw8_framefmt_regs[] = {
@@ -409,10 +340,6 @@ static const struct imx219_mode supported_modes[] = {
 			.height = 2464
 		},
 		.vts_def = IMX219_VTS_15FPS,
-		.reg_list = {
-			.num_of_regs = ARRAY_SIZE(mode_3280x2464_regs),
-			.regs = mode_3280x2464_regs,
-		},
 		.binning = {
 			[BINNING_IDX_8_BIT] = BINNING_NONE,
 			[BINNING_IDX_10_BIT] = BINNING_NONE,
@@ -429,10 +356,6 @@ static const struct imx219_mode supported_modes[] = {
 			.height = 1080
 		},
 		.vts_def = IMX219_VTS_30FPS_1080P,
-		.reg_list = {
-			.num_of_regs = ARRAY_SIZE(mode_1920_1080_regs),
-			.regs = mode_1920_1080_regs,
-		},
 		.binning = {
 			[BINNING_IDX_8_BIT] = BINNING_NONE,
 			[BINNING_IDX_10_BIT] = BINNING_NONE,
@@ -449,10 +372,6 @@ static const struct imx219_mode supported_modes[] = {
 			.height = 2464
 		},
 		.vts_def = IMX219_VTS_30FPS_BINNED,
-		.reg_list = {
-			.num_of_regs = ARRAY_SIZE(mode_1640_1232_regs),
-			.regs = mode_1640_1232_regs,
-		},
 		.binning = {
 			[BINNING_IDX_8_BIT] = BINNING_ANALOG_2x2,
 			[BINNING_IDX_10_BIT] = BINNING_DIGITAL_2x2,
@@ -469,10 +388,6 @@ static const struct imx219_mode supported_modes[] = {
 			.height = 960
 		},
 		.vts_def = IMX219_VTS_30FPS_640x480,
-		.reg_list = {
-			.num_of_regs = ARRAY_SIZE(mode_640_480_regs),
-			.regs = mode_640_480_regs,
-		},
 		.binning = {
 			[BINNING_IDX_8_BIT] = BINNING_ANALOG_2x2,
 			[BINNING_IDX_10_BIT] = BINNING_ANALOG_2x2,
@@ -1133,10 +1048,55 @@ static int imx219_get_selection(struct v4l2_subdev *sd,
 	return -EINVAL;
 }
 
+static int imx219_apply_crop_reg(struct imx219 *imx219, s32 x_start, s32 x_end,
+			     s32 y_start, s32 y_end, u32 height, u32 width)
+{
+	struct imx219_reg_16bit_val regs[8] = {
+		{ IMX219_REG_X_START, x_start },
+		{ IMX219_REG_X_END, x_end },
+		{ IMX219_REG_Y_START, y_start },
+		{ IMX219_REG_Y_END, y_end },
+		{ IMX219_REG_WIDTH, width },
+		{ IMX219_REG_HEIGHT, height },
+		{ IMX219_REG_TEST_HEIGHT, height },
+		{ IMX219_REG_TEST_WIDTH, width }
+	};
+	struct i2c_client *client = v4l2_get_subdevdata(&imx219->sd);
+	unsigned int i;
+	int ret;
+
+	for (i = 0; i < ARRAY_SIZE(regs); i++) {
+		ret = imx219_write_reg(imx219, regs[i].address,
+				       IMX219_REG_VALUE_16BIT, regs[i].val);
+		if (ret) {
+			dev_err_ratelimited(
+				&client->dev,
+				"Failed to write reg 0x%4.4x. error = %d\n",
+				regs[i].address, ret);
+
+			return ret;
+		}
+	}
+	return 0;
+}
+
+static int imx219_apply_crop(struct imx219 *imx219)
+{
+	u32 width, height, x_start, x_end, y_start, y_end;
+
+	width = imx219->mode->width;
+	height = imx219->mode->height;
+	x_start = imx219->mode->crop.left - IMX219_PIXEL_ARRAY_LEFT;
+	x_end = x_start + imx219->mode->crop.width - 1;
+	y_start = imx219->mode->crop.top - IMX219_PIXEL_ARRAY_TOP;
+	y_end = y_start + imx219->mode->crop.height - 1;
+	return imx219_apply_crop_reg(imx219, x_start, x_end, y_start, y_end,
+				     height, width);
+}
+
 static int imx219_start_streaming(struct imx219 *imx219)
 {
 	struct i2c_client *client = v4l2_get_subdevdata(&imx219->sd);
-	const struct imx219_reg_list *reg_list;
 	int ret;
 
 	ret = pm_runtime_resume_and_get(&client->dev);
@@ -1151,10 +1111,10 @@ static int imx219_start_streaming(struct imx219 *imx219)
 	}
 
 	/* Apply default values of current mode */
-	reg_list = &imx219->mode->reg_list;
-	ret = imx219_write_regs(imx219, reg_list->regs, reg_list->num_of_regs);
+	ret = imx219_apply_crop(imx219);
 	if (ret) {
-		dev_err(&client->dev, "%s failed to set mode\n", __func__);
+		dev_err(&client->dev, "%s failed to set crop registers\n",
+			__func__);
 		goto err_rpm_put;
 	}
 

--- a/drivers/media/i2c/imx219.c
+++ b/drivers/media/i2c/imx219.c
@@ -887,7 +887,11 @@ static int imx219_refresh_ctrls(struct imx219 *imx219,
 {
 	int exposure_max, exposure_def, hblank, pixel_rate, rate_factor;
 	u32 prev_hts = prev_compose->width + imx219->hblank->val;
-	u32 prev_vts = prev_compose->height + imx219->vblank->val;
+	u32 vts = imx219->vblank->val + prev_compose->height <
+				  IMX219_VBLANK_MIN + imx219->compose.height ?
+			  IMX219_VBLANK_MIN :
+			  imx219->vblank->val + prev_compose->height -
+				  imx219->compose.height;
 
 	rate_factor = imx219_get_rate_factor(imx219);
 	if (rate_factor < 0)
@@ -895,10 +899,10 @@ static int imx219_refresh_ctrls(struct imx219 *imx219,
 	/* Update limits and set FPS to default */
 	__v4l2_ctrl_modify_range(imx219->vblank, IMX219_VBLANK_MIN,
 				 IMX219_VTS_MAX - imx219->compose.height, 1,
-				 prev_vts - imx219->compose.height);
-	__v4l2_ctrl_s_ctrl(imx219->vblank, prev_vts - imx219->compose.height);
+				 vts);
+	__v4l2_ctrl_s_ctrl(imx219->vblank, vts);
 	/* Update max exposure while meeting expected vblanking */
-	exposure_max = prev_vts - 4;
+	exposure_max = vts - 4;
 	exposure_def = (exposure_max < IMX219_EXPOSURE_DEFAULT) ?
 			       exposure_max :
 			       IMX219_EXPOSURE_DEFAULT;

--- a/drivers/media/i2c/imx219.c
+++ b/drivers/media/i2c/imx219.c
@@ -1023,39 +1023,45 @@ static int imx219_set_binning(struct imx219 *imx219)
 {
 	enum binning_mode binning_x = BINNING_NONE;
 	enum binning_mode binning_y = BINNING_NONE;
+	u32 binning_x_val = IMX219_BINNING_NONE;
+	u32 binning_y_val = IMX219_BINNING_NONE;
+
 	int ret = imx219_resolve_binning(imx219, &binning_x, &binning_y);
 
 	if (ret < 0)
 		return ret;
 	switch (binning_x) {
-	case BINNING_NONE:
-		return imx219_write_reg(imx219, IMX219_REG_BINNING_MODE_X,
-					IMX219_REG_VALUE_08BIT,
-					IMX219_BINNING_NONE);
 	case BINNING_DIGITAL_2x2:
-		return imx219_write_reg(imx219, IMX219_REG_BINNING_MODE_X,
-					IMX219_REG_VALUE_08BIT,
-					IMX219_BINNING_2X2);
+		binning_x_val = IMX219_BINNING_2X2;
+		break;
 	case BINNING_ANALOG_2x2:
-		return imx219_write_reg(imx219, IMX219_REG_BINNING_MODE_X,
-					IMX219_REG_VALUE_08BIT,
-					IMX219_BINNING_2X2_ANALOG);
+		binning_x_val = IMX219_BINNING_2X2_ANALOG;
+		break;
+	case BINNING_NONE:
+		binning_x_val = IMX219_BINNING_NONE;
+		break;
+	default:
+		return -EINVAL;
 	}
 	switch (binning_y) {
-	case BINNING_NONE:
-		return imx219_write_reg(imx219, IMX219_REG_BINNING_MODE_Y,
-					IMX219_REG_VALUE_08BIT,
-					IMX219_BINNING_NONE);
 	case BINNING_DIGITAL_2x2:
-		return imx219_write_reg(imx219, IMX219_REG_BINNING_MODE_Y,
-					IMX219_REG_VALUE_08BIT,
-					IMX219_BINNING_2X2);
+		binning_y_val = IMX219_BINNING_2X2;
+		break;
 	case BINNING_ANALOG_2x2:
-		return imx219_write_reg(imx219, IMX219_REG_BINNING_MODE_Y,
-					IMX219_REG_VALUE_08BIT,
-					IMX219_BINNING_2X2_ANALOG);
+		binning_y_val = IMX219_BINNING_2X2_ANALOG;
+		break;
+	case BINNING_NONE:
+		binning_y_val = IMX219_BINNING_NONE;
+		break;
+	default:
+		return -EINVAL;
 	}
-	return -EINVAL;
+	ret = imx219_write_reg(imx219, IMX219_REG_BINNING_MODE_X,
+			       IMX219_REG_VALUE_08BIT, binning_x_val);
+	if (ret < 0)
+		return ret;
+	return imx219_write_reg(imx219, IMX219_REG_BINNING_MODE_Y,
+				IMX219_REG_VALUE_08BIT, binning_y_val);
 }
 
 static const struct v4l2_rect *

--- a/drivers/media/i2c/imx219.c
+++ b/drivers/media/i2c/imx219.c
@@ -1095,12 +1095,12 @@ static int imx219_apply_crop(struct imx219 *imx219)
 {
 	u32 width, height, x_start, x_end, y_start, y_end;
 
-	width = imx219->mode->width;
-	height = imx219->mode->height;
-	x_start = imx219->mode->crop.left - IMX219_PIXEL_ARRAY_LEFT;
-	x_end = x_start + imx219->mode->crop.width - 1;
-	y_start = imx219->mode->crop.top - IMX219_PIXEL_ARRAY_TOP;
-	y_end = y_start + imx219->mode->crop.height - 1;
+	width = imx219->compose.width;
+	height = imx219->compose.height;
+	x_start = imx219->crop.left - IMX219_PIXEL_ARRAY_LEFT;
+	x_end = x_start + imx219->crop.width - 1;
+	y_start = imx219->crop.top - IMX219_PIXEL_ARRAY_TOP;
+	y_end = y_start + imx219->crop.height - 1;
 	return imx219_apply_crop_reg(imx219, x_start, x_end, y_start, y_end,
 				     height, width);
 }

--- a/drivers/media/platform/bcm2835/bcm2835-unicam.c
+++ b/drivers/media/platform/bcm2835/bcm2835-unicam.c
@@ -1549,6 +1549,7 @@ static int unicam_g_edid(struct file *file, void *priv, struct v4l2_edid *edid)
 static int unicam_s_selection(struct file *file, void *priv,
 			      struct v4l2_selection *sel)
 {
+	int ret;
 	struct unicam_node *node = video_drvdata(file);
 	struct unicam_device *dev = node->dev;
 	struct v4l2_subdev_selection sdsel = {
@@ -1561,7 +1562,12 @@ static int unicam_s_selection(struct file *file, void *priv,
 	if (sel->type != V4L2_BUF_TYPE_VIDEO_CAPTURE)
 		return -EINVAL;
 
-	return v4l2_subdev_call(dev->sensor, pad, set_selection, NULL, &sdsel);
+	ret = v4l2_subdev_call(dev->sensor, pad, set_selection, NULL, &sdsel);
+	if (ret < 0)
+		return ret;
+
+	node->v_fmt.fmt.pix.bytesperline = 0;
+	return unicam_reset_format(node);
 }
 
 static int unicam_g_selection(struct file *file, void *priv,


### PR DESCRIPTION
This change primarily adds the set_selection APIs (crop and compose). While the hardware supports other binning ratios, only the `BINNING_NONE`, `BINNING_2x2` and `BINNING_2x2_ANALOG` are supported. The rule to use the "special binning" is based on the frame size and whether it is an 8-bit format. At the same time with this change, the driver allows binning on x or y dimensions or both based on the crop and compose fields. 

The biggest change in terms of the implementation is to reduce the scope of `imx219->mode`. Instead, the `crop` and `compose` are stored in the `imx219` struct. All the usages of `imx219->mode` have been transitioned to use these fields instead except in the `imx219_init_controls` to set defaults. The `supported_modes` continues to be used for `S_FMT` operations.

One change in the API is that the v_blank value is not set to the default of the mode selected on `S_FMT` but is based on whatever the user set last. It should be possible to avoid this if not maintaining the `v_blanking` in the `S_FMT` op is a required feature.

### Note
The commits are separated out in order to help review the code. I plan to squash all of them into 1 or 2 commits if and when it's close to getting approval unless the reviewers prefer I squash it right away.

### Links
- https://github.com/raspberrypi/linux/pull/4935
