### PR TITLE
overlays: Add a sample hat_map

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -1,6 +1,6 @@
 # Overlays for the Raspberry Pi platform
 
-dtb-$(CONFIG_ARCH_BCM2835) += overlay_map.dtb
+dtb-$(CONFIG_ARCH_BCM2835) += overlay_map.dtb hat_map.dtb
 
 dtbo-$(CONFIG_ARCH_BCM2835) += \
 	act-led.dtbo \

--- a/arch/arm/boot/dts/overlays/hat_map.dts
+++ b/arch/arm/boot/dts/overlays/hat_map.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+
+/ {
+	iqaudio-pi-codecplus {
+		uuid = [ dc1c9594 c1ab 4c6c acda a88dc59a3c5b ];
+		overlay = "iqaudio-codec";
+	};
+
+	recalbox-rgbdual {
+		uuid = [ 1c955808 681f 4bbc a2ef b7ea47cd388e ];
+		overlay = "recalboxrgbdual";
+	};
+};


### PR DESCRIPTION
The HAT map is way of associating named overlays with HATs whose EEPROMs were programmed with the contents of the overlay. Unfortunately, change in the DT and kernel drivers has meant that some of these embedded overlays no longer function, or even don't apply.

The HAT map is a mapping from HAT UUIDs to overlay names. If a HAT with a listed UUID is detected, the embedded overlay is ignored and the overlay named in the mapping is loaded in its place.