### PR TITLE
Fan/thermal fix

### DIFF
--- a/drivers/thermal/gov_step_wise.c
+++ b/drivers/thermal/gov_step_wise.c
@@ -98,7 +98,7 @@ static void thermal_zone_trip_update(struct thermal_zone_device *tz, int trip_id
 		trace_thermal_zone_trip(tz, trip_id, trip.type);
 	}
 
-	hyst_temp = trip.temperature;
+	hyst_temp = trip_temp = trip.temperature;
 	if (tz->ops->get_trip_hyst) {
 		tz->ops->get_trip_hyst(tz, trip_id, &hyst_temp);
 		hyst_temp = trip_temp - hyst_temp;

--- a/drivers/thermal/gov_step_wise.c
+++ b/drivers/thermal/gov_step_wise.c
@@ -105,8 +105,6 @@ static void thermal_zone_trip_update(struct thermal_zone_device *tz, int trip_id
 	}
 	trip_type = trip.type;
 
-	trend = get_tz_trend(tz, trip_id);
-
 	dev_dbg(&tz->device,
 		"Trip%d[type=%d,temp=%d,hyst=%d]:trend=%d,throttle=%d\n",
 		trip_id, trip_type, trip.temperature, hyst_temp, trend, throttle);


### PR DESCRIPTION
Since 6.3, the thermal/cooling fan support has been broken due to an uninitialised variable. Fix it, and remove a spurious duplicate function call.