### PR TITLE
media/rpivid: Make iommu work on rpivid

### DIFF
--- a/arch/arm/boot/dts/bcm2712.dtsi
+++ b/arch/arm/boot/dts/bcm2712.dtsi
@@ -1158,6 +1158,7 @@
 			clocks = <&firmware_clocks 11>;
 			clock-names = "hevc";
 			status = "disabled";
+			iommus = <&iommu2>;
 		};
 
 		sdio1: mmc@fff000 {

--- a/drivers/staging/media/rpivid/rpivid.c
+++ b/drivers/staging/media/rpivid/rpivid.c
@@ -360,6 +360,13 @@ static int rpivid_probe(struct platform_device *pdev)
 	snprintf(vfd->name, sizeof(vfd->name), "%s", rpivid_video_device.name);
 	video_set_drvdata(vfd, dev);
 
+	ret = dma_set_mask_and_coherent(dev->dev, DMA_BIT_MASK(36));
+	if (ret) {
+		v4l2_err(&dev->v4l2_dev,
+			 "Failed dma_set_mask_and_coherent\n");
+		goto err_v4l2;
+	}
+
 	dev->m2m_dev = v4l2_m2m_init(&rpivid_m2m_ops);
 	if (IS_ERR(dev->m2m_dev)) {
 		v4l2_err(&dev->v4l2_dev,

--- a/drivers/staging/media/rpivid/rpivid_h265.c
+++ b/drivers/staging/media/rpivid/rpivid_h265.c
@@ -2495,11 +2495,19 @@ static int rpivid_h265_start(struct rpivid_ctx *ctx)
 	for (i = 0; i != ARRAY_SIZE(ctx->pu_bufs); ++i) {
 		// Don't actually need a kernel mapping here
 		if (gptr_alloc(dev, ctx->pu_bufs + i, pu_alloc,
-			       DMA_ATTR_NO_KERNEL_MAPPING))
+			       DMA_ATTR_NO_KERNEL_MAPPING)) {
+			v4l2_err(&dev->v4l2_dev,
+				 "Failed to alloc %#zx PU%d buffer\n",
+				 pu_alloc, i);
 			goto fail;
+		}
 		if (gptr_alloc(dev, ctx->coeff_bufs + i, coeff_alloc,
-			       DMA_ATTR_NO_KERNEL_MAPPING))
+			       DMA_ATTR_NO_KERNEL_MAPPING)) {
+			v4l2_err(&dev->v4l2_dev,
+				 "Failed to alloc %#zx Coeff%d buffer\n",
+				 pu_alloc, i);
 			goto fail;
+		}
 	}
 	aux_q_init(ctx);
 


### PR DESCRIPTION
In order to use iommu on hevc add appropriate iommu to dts description and set dma mask_and_coherent in probe.
I am assured dma_set_mask_and_coherent is benign on Pi4 (which has no iommu) and it seems to be so in practice.
Also adds a bit of debug to make internal buffer allocation failure easier to spot in future.