### PR TITLE
Replace hdmi-codec channel map fix with accepted verison

### DIFF
--- a/sound/soc/codecs/hdmi-codec.c
+++ b/sound/soc/codecs/hdmi-codec.c
@@ -520,7 +520,7 @@ static int hdmi_codec_fill_codec_params(struct snd_soc_dai *dai,
 	hp->sample_rate = sample_rate;
 	hp->channels = channels;
 
-	hcp->chmap_idx = ca_id;
+	hcp->chmap_idx = idx;
 
 	return 0;
 }

--- a/sound/soc/codecs/hdmi-codec.c
+++ b/sound/soc/codecs/hdmi-codec.c
@@ -520,7 +520,10 @@ static int hdmi_codec_fill_codec_params(struct snd_soc_dai *dai,
 	hp->sample_rate = sample_rate;
 	hp->channels = channels;
 
-	hcp->chmap_idx = idx;
+	if (pcm_audio)
+		hcp->chmap_idx = ca_id;
+	else
+		hcp->chmap_idx = HDMI_CODEC_CHMAP_IDX_UNKNOWN;
 
 	return 0;
 }


### PR DESCRIPTION
v2 of the patch, with a minor change (report "unknown" channel mappings in case of non-pcm audio) has been accepted for 6.7:

https://lore.kernel.org/alsa-devel/169625985045.65718.7789607105387288563.b4-ty@kernel.org/

Replace the v1 version in the RPi tree so we are up to date