### PR TITLE
Add panel-dsi for device-tree side configuration of generic DSI panels

### DIFF
--- a/Documentation/devicetree/bindings/display/panel/panel-dsi.yaml
+++ b/Documentation/devicetree/bindings/display/panel/panel-dsi.yaml
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/display/panel/panel-dsi.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Generic MIPI DSI Panel
+
+maintainers:
+  - Timon Skerutsch <kernel@diodes-delight.com>
+
+allOf:
+  - $ref: panel-common.yaml#
+
+properties:
+  compatible:
+    description:
+      Shall contain a panel specific compatible and "panel-dsi"
+      in that order.
+    items:
+      - {}
+      - const: panel-dsi
+
+  dsi-color-format:
+    description: |
+      The color format used by the panel. Only DSI supported formats are allowed.
+    enum:
+      - RGB888
+      - RGB666
+      - RGB666_PACKED
+      - RGB565
+
+  port:
+    $ref: /schemas/graph.yaml#/$defs/port-base
+    unevaluatedProperties: false
+    description:
+      Panel MIPI DSI input
+
+    properties:
+      endpoint:
+        $ref: /schemas/media/video-interfaces.yaml#
+        unevaluatedProperties: false
+
+        properties:
+          data-lanes: true
+
+        required:
+          - data-lanes
+
+  mode:
+    description: |
+      DSI mode flags. See DSI Specs for details.
+      These are driver independent features of the DSI bus.
+    items:
+      - const: MODE_VIDEO
+      - const: MODE_VIDEO_BURST
+      - const: MODE_VIDEO_SYNC_PULSE
+      - const: MODE_VIDEO_AUTO_VERT
+      - const: MODE_VIDEO_HSE
+      - const: MODE_VIDEO_NO_HFP
+      - const: MODE_VIDEO_NO_HBP
+      - const: MODE_VIDEO_NO_HSA
+      - const: MODE_VSYNC_FLUSH
+      - const: MODE_NO_EOT_PACKET
+      - const: CLOCK_NON_CONTINUOUS
+      - const: MODE_LPM
+      - const: HS_PKT_END_ALIGNED
+
+  reg: true
+  backlight: true
+  enable-gpios: true
+  width-mm: true
+  height-mm: true
+  panel-timing: true
+  power-supply: true
+  reset-gpios: true
+  ddc-i2c-bus: true
+
+required:
+  - panel-timing
+  - reg
+  - power-supply
+  - dsi-color-format
+  - port
+
+additionalProperties: false
+
+examples:
+  - |
+    panel {
+        compatible = "panel-mfgr,generic-dsi-panel","panel-dsi";
+        power-supply = <&vcc_supply>;
+        backlight = <&backlight>;
+        dsi-color-format = "RGB888";
+        reg = <0>;
+        mode = "MODE_VIDEO", "MODE_VIDEO_BURST", "MODE_NO_EOT_PACKET";
+
+        port {
+            panel_dsi_port: endpoint {
+                data-lanes = <1 2>;
+                remote-endpoint = <&dsi_out>;
+            };
+        };
+
+        panel-timing {
+            clock-frequency = <9200000>;
+            hactive = <800>;
+            vactive = <480>;
+            hfront-porch = <8>;
+            hback-porch = <4>;
+            hsync-len = <41>;
+            vback-porch = <2>;
+            vfront-porch = <4>;
+            vsync-len = <10>;
+        };
+    };
+
+...

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -294,6 +294,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	vc4-kms-dpi-hyperpixel4sq.dtbo \
 	vc4-kms-dpi-panel.dtbo \
 	vc4-kms-dsi-7inch.dtbo \
+	vc4-kms-dsi-generic.dtbo \
 	vc4-kms-dsi-lt070me05000.dtbo \
 	vc4-kms-dsi-lt070me05000-v2.dtbo \
 	vc4-kms-dsi-waveshare-panel.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4789,6 +4789,37 @@ Params: sizex                   Touchscreen size x (default 800)
                                 the default DSI1 and i2c_csi_dsi).
 
 
+Name:   vc4-kms-dsi-generic
+Info:   Enable a generic DSI display under KMS.
+        Default timings are for a 840x480 RGB888 panel.
+        Requires vc4-kms-v3d to be loaded.
+Load:   dtoverlay=vc4-kms-dsi-generic,<param>=<val>
+Params: clock-frequency         Display clock frequency (Hz)
+        hactive                 Horizontal active pixels
+        hfp                     Horizontal front porch
+        hsync                   Horizontal sync pulse width
+        hbp                     Horizontal back porch
+        vactive                 Vertical active lines
+        vfp                     Vertical front porch
+        vsync                   Vertical sync pulse width
+        vbp                     Vertical back porch
+        width-mm                Define the screen width in mm
+        height-mm               Define the screen height in mm
+        rgb565                  Change to RGB565 output
+        rgb666                  Change to RGB666 output
+        rgb666p                 Change to RGB666 output with pixel packing
+        rgb888                  Change to RGB888 output, this is the default
+        one-lane                Use one DSI lane for data transmission
+                                This is the default
+        two-lane                Use two DSI lanes for data transmission
+        three-lane              Use three DSI lanes for data transmission
+                                Only supported on Pi5 and CM
+        four-lane               Use four DSI lanes for data transmission
+                                Only supported on Pi5 and CM
+        dsi0                    Switch DSI port to DSI0
+                                Only supported on Pi5 and CM
+
+
 Name:   vc4-kms-dsi-lt070me05000
 Info:   Enable a JDI LT070ME05000 DSI display on DSI1.
         Note that this is a 4 lane DSI device, so it will only work on a Compute

--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-generic-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-generic-overlay.dts
@@ -1,0 +1,106 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	dsi_frag: fragment@0 {
+		target = <&dsi1>;
+		__overlay__{
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port {
+				dsi_out:endpoint {
+					remote-endpoint = <&panel_dsi_port>;
+				};
+			};
+			panel: panel-dsi-generic@0 {
+				// See panel-dsi.yaml binding
+				// Using dummy name for panel model
+				compatible = "Generic,panel-dsi","panel-dsi";
+				reg = <0>;
+				power-supply = <0>;
+				backlight = <0>;
+				dsi-color-format = "RGB888";
+				mode = "MODE_VIDEO";
+				width-mm = <0>;
+				height-mm = <0>;
+
+				port {
+					panel_dsi_port: endpoint {
+						data-lanes = <1>;
+						remote-endpoint = <&dsi_out>;
+					};
+				};
+
+				timing: panel-timing {
+					clock-frequency = <30000000>;
+					hactive = <840>;
+					vactive = <480>;
+					hback-porch = <44>;
+					hfront-porch = <46>;
+					hsync-len = <2>;
+					vback-porch = <18>;
+					vfront-porch = <16>;
+					vsync-len = <2>;
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&panel_dsi_port>;
+		__dormant__ {
+			data-lanes = <1>;
+		};
+	};
+
+	fragment@2 {
+		target = <&panel_dsi_port>;
+		__dormant__ {
+			data-lanes = <1 2>;
+		};
+	};
+
+	fragment@3 {
+		target = <&panel_dsi_port>;
+		__dormant__ {
+			data-lanes = <1 2 3>;
+		};
+	};
+
+	fragment@4 {
+		target = <&panel_dsi_port>;
+		__dormant__ {
+			data-lanes = <1 2 3 4>;
+		};
+	};
+
+	__overrides__ {
+		dsi0 = <&dsi_frag>, "target:0=",<&dsi0>;
+
+		clock-frequency = <&timing>, "clock-frequency:0";
+		hactive = <&timing>, "hactive:0";
+		hfp = <&timing>, "hfront-porch:0";
+		hsync = <&timing>, "hsync-len:0";
+		hbp = <&timing>, "hback-porch:0";
+		vactive = <&timing>, "vactive:0";
+		vfp = <&timing>, "vfront-porch:0";
+		vsync = <&timing>, "vsync-len:0";
+		vbp = <&timing>, "vback-porch:0";
+
+		width-mm = <&panel>, "width-mm:0";
+		height-mm = <&panel>, "height-mm:0";
+
+		rgb565 = <&panel>, "dsi-color-format=RGB565";
+		rgb666p = <&panel>, "dsi-color-format=RGB666_PACKED";
+		rgb666 = <&panel>, "dsi-color-format=RGB666";
+		rgb888 = <&panel>, "dsi-color-format=RGB888";
+		one-lane = <0>,"+1";
+		two-lane = <0>,"+2";
+		three-lane = <0>,"+3";
+		four-lane = <0>,"+4";
+	};
+
+};

--- a/drivers/gpu/drm/panel/panel-simple.c
+++ b/drivers/gpu/drm/panel/panel-simple.c
@@ -40,6 +40,7 @@
 #include <drm/drm_edid.h>
 #include <drm/drm_mipi_dsi.h>
 #include <drm/drm_panel.h>
+#include <drm/drm_of.h>
 
 /**
  * struct panel_desc - Describes a simple panel.
@@ -4659,6 +4660,9 @@ static const struct panel_desc_dsi osd101t2045_53ts = {
 	.lanes = 4,
 };
 
+// for panels using generic panel-dsi binding
+static struct panel_desc_dsi panel_dsi;
+
 static const struct of_device_id dsi_of_match[] = {
 	{
 		.compatible = "auo,b080uan01",
@@ -4682,14 +4686,118 @@ static const struct of_device_id dsi_of_match[] = {
 		.compatible = "osddisplays,osd101t2045-53ts",
 		.data = &osd101t2045_53ts
 	}, {
+		/* Must be the last entry */
+		.compatible = "panel-dsi",
+		.data = &panel_dsi,
+	}, {
 		/* sentinel */
 	}
 };
 MODULE_DEVICE_TABLE(of, dsi_of_match);
 
+
+/* Checks for DSI panel definition in device-tree, analog to panel_dpi */
+static int panel_dsi_dt_probe(struct device *dev,
+			  struct panel_desc_dsi *desc_dsi)
+{
+	struct panel_desc *desc;
+	struct display_timing *timing;
+	const struct device_node *np;
+	const char *dsi_color_format;
+	const char *dsi_mode_flags;
+	struct property *prop;
+	int dsi_lanes, ret;
+
+	np = dev->of_node;
+
+	desc = devm_kzalloc(dev, sizeof(*desc), GFP_KERNEL);
+	if (!desc)
+		return -ENOMEM;
+
+	timing = devm_kzalloc(dev, sizeof(*timing), GFP_KERNEL);
+	if (!timing)
+		return -ENOMEM;
+
+	ret = of_get_display_timing(np, "panel-timing", timing);
+	if (ret < 0) {
+		dev_err(dev, "%pOF: no panel-timing node found for \"panel-dsi\" binding\n",
+			np);
+		return ret;
+	}
+
+	desc->timings = timing;
+	desc->num_timings = 1;
+
+	of_property_read_u32(np, "width-mm", &desc->size.width);
+	of_property_read_u32(np, "height-mm", &desc->size.height);
+
+	dsi_lanes = drm_of_get_data_lanes_count_ep(np, 0, 0, 1, 4);
+
+	if (dsi_lanes < 0) {
+		dev_err(dev, "%pOF: no or too many data-lanes defined", np);
+		return dsi_lanes;
+	}
+
+	desc_dsi->lanes = dsi_lanes;
+
+	of_property_read_string(np, "dsi-color-format", &dsi_color_format);
+	if (!strcmp(dsi_color_format, "RGB888")) {
+		desc_dsi->format = MIPI_DSI_FMT_RGB888;
+		desc->bpc = 8;
+	} else if (!strcmp(dsi_color_format, "RGB565")) {
+		desc_dsi->format = MIPI_DSI_FMT_RGB565;
+		desc->bpc = 6;
+	} else if (!strcmp(dsi_color_format, "RGB666")) {
+		desc_dsi->format = MIPI_DSI_FMT_RGB666;
+		desc->bpc = 6;
+	} else if (!strcmp(dsi_color_format, "RGB666_PACKED")) {
+		desc_dsi->format = MIPI_DSI_FMT_RGB666_PACKED;
+		desc->bpc = 6;
+	} else {
+		dev_err(dev, "%pOF: no valid dsi-color-format defined", np);
+		return -EINVAL;
+	}
+
+
+	of_property_for_each_string(np, "mode", prop, dsi_mode_flags) {
+		if (!strcmp(dsi_mode_flags, "MODE_VIDEO"))
+			desc_dsi->flags |= MIPI_DSI_MODE_VIDEO;
+		else if (!strcmp(dsi_mode_flags, "MODE_VIDEO_BURST"))
+			desc_dsi->flags |= MIPI_DSI_MODE_VIDEO_BURST;
+		else if (!strcmp(dsi_mode_flags, "MODE_VIDEO_SYNC_PULSE"))
+			desc_dsi->flags |= MIPI_DSI_MODE_VIDEO_SYNC_PULSE;
+		else if (!strcmp(dsi_mode_flags, "MODE_VIDEO_AUTO_VERT"))
+			desc_dsi->flags |= MIPI_DSI_MODE_VIDEO_AUTO_VERT;
+		else if (!strcmp(dsi_mode_flags, "MODE_VIDEO_HSE"))
+			desc_dsi->flags |= MIPI_DSI_MODE_VIDEO_HSE;
+		else if (!strcmp(dsi_mode_flags, "MODE_VIDEO_NO_HFP"))
+			desc_dsi->flags |= MIPI_DSI_MODE_VIDEO_NO_HFP;
+		else if (!strcmp(dsi_mode_flags, "MODE_VIDEO_NO_HBP"))
+			desc_dsi->flags |= MIPI_DSI_MODE_VIDEO_NO_HBP;
+		else if (!strcmp(dsi_mode_flags, "MODE_VIDEO_NO_HSA"))
+			desc_dsi->flags |= MIPI_DSI_MODE_VIDEO_NO_HSA;
+		else if (!strcmp(dsi_mode_flags, "MODE_VSYNC_FLUSH"))
+			desc_dsi->flags |= MIPI_DSI_MODE_VSYNC_FLUSH;
+		else if (!strcmp(dsi_mode_flags, "MODE_NO_EOT_PACKET"))
+			desc_dsi->flags |= MIPI_DSI_MODE_NO_EOT_PACKET;
+		else if (!strcmp(dsi_mode_flags, "CLOCK_NON_CONTINUOUS"))
+			desc_dsi->flags |= MIPI_DSI_CLOCK_NON_CONTINUOUS;
+		else if (!strcmp(dsi_mode_flags, "MODE_LPM"))
+			desc_dsi->flags |= MIPI_DSI_MODE_LPM;
+		else if (!strcmp(dsi_mode_flags, "HS_PKT_END_ALIGNED"))
+			desc_dsi->flags |= MIPI_DSI_HS_PKT_END_ALIGNED;
+	}
+
+	desc->connector_type = DRM_MODE_CONNECTOR_DSI;
+	desc_dsi->desc = *desc;
+
+	return 0;
+}
+
 static int panel_simple_dsi_probe(struct mipi_dsi_device *dsi)
 {
 	const struct panel_desc_dsi *desc;
+	struct panel_desc_dsi *dt_desc;
 	const struct of_device_id *id;
 	int err;
 
@@ -4697,7 +4805,20 @@ static int panel_simple_dsi_probe(struct mipi_dsi_device *dsi)
 	if (!id)
 		return -ENODEV;
 
-	desc = id->data;
+	if (id->data == &panel_dsi) {
+		/* Handle the generic panel-dsi binding */
+		dt_desc = devm_kzalloc(&dsi->dev, sizeof(*dt_desc), GFP_KERNEL);
+		if (!dt_desc)
+			return -ENOMEM;
+
+		err = panel_dsi_dt_probe(&dsi->dev, dt_desc);
+		if (err < 0)
+			return err;
+
+		desc = dt_desc;
+	} else {
+		desc = id->data;
+	}
 
 	err = panel_simple_probe(&dsi->dev, &desc->desc);
 	if (err < 0)


### PR DESCRIPTION
This adds an analog to the already existing panel-dpi to panel-simple which allows for timing configuration in device-tree for simple DSI panels.
In addition this also allows configuration of the DSI parameters in device tree.
I tried to be as consistent as possible with how panel-dpi was implemented.
Code was tested with a 840x480 panel driven by an externally configured bridge IC.

This addition was discussed with @6by9 over in https://github.com/raspberrypi/firmware/issues/1819#issuecomment-1725769614
The main motivation is with not needing to run custom kernels for simple DSI devices that require nothing but an entry in panel-simple for the timings and DSI config flags.
This becomes very cumbersome when a large amount of displays need to be maintained. Essentially the exact same reasoning that the panel-dpi patch had for the initial implementation for this type of feature in panel-simple but expanding it to also be possible for DSI panels.

Any feedback would be welcome.