### PR TITLE
media: i2c: ov9282: Read chip ID via 2 reads

### DIFF
--- a/drivers/media/i2c/ov9282.c
+++ b/drivers/media/i2c/ov9282.c
@@ -1078,12 +1078,16 @@ error_unlock:
 static int ov9282_detect(struct ov9282 *ov9282)
 {
 	int ret;
-	u32 val;
+	u32 val, msb;
 
-	ret = ov9282_read_reg(ov9282, OV9282_REG_ID, 2, &val);
+	ret = ov9282_read_reg(ov9282, OV9282_REG_ID + 1, 1, &val);
+	if (ret)
+		return ret;
+	ret = ov9282_read_reg(ov9282, OV9282_REG_ID, 1, &msb);
 	if (ret)
 		return ret;
 
+	val |= (msb << 8);
 	if (val != OV9282_ID) {
 		dev_err(ov9282->dev, "chip id mismatch: %x!=%x",
 			OV9282_ID, val);


### PR DESCRIPTION
Vision Components have made an OV9281 module which blocks reading back the majority of registers to comply with NDAs, and in doing so doesn't allow auto-increment register reading as used when reading the chip ID.

Use two reads and manually combine the results.


We used to have an equivalent patch for this for the downstream ov9281 driver. Mainline view Vision Components' icky I2C behaviour as needing to be supported in either regmap or the v4l2_cci helpers, but doing so looks fairly non-trivial to me, and needs this driver converting to use either of those.