### PR TITLE
Revert: bcm2708_fb: Hack out dma support

### DIFF
--- a/drivers/video/fbdev/bcm2708_fb.c
+++ b/drivers/video/fbdev/bcm2708_fb.c
@@ -955,7 +955,6 @@ static void bcm2708_fb_imageblit(struct fb_info *info,
 	cfb_imageblit(info, image);
 }
 
-#if 0
 static irqreturn_t bcm2708_fb_dma_irq(int irq, void *cxt)
 {
 	struct bcm2708_fb_dev *fbdev = cxt;
@@ -973,7 +972,6 @@ static irqreturn_t bcm2708_fb_dma_irq(int irq, void *cxt)
 	wake_up(&fbdev->dma_waitq);
 	return IRQ_HANDLED;
 }
-#endif
 
 static struct fb_ops bcm2708_fb_ops = {
 	.owner = THIS_MODULE,
@@ -1197,12 +1195,12 @@ static int bcm2708_fb_probe(struct platform_device *dev)
 		return ret;
 	}
 
-//free_dma_chan:
+free_dma_chan:
 	bcm_dma_chan_free(fbdev->dma_chan);
-//free_cb:
+free_cb:
 	dma_free_wc(&dev->dev, SZ_64K, fbdev->cb_base,
 			      fbdev->cb_handle);
-//free_fb:
+free_fb:
 	dev_err(&dev->dev, "probe failed, err %d\n", ret);
 
 	return ret;

--- a/drivers/video/fbdev/bcm2708_fb.c
+++ b/drivers/video/fbdev/bcm2708_fb.c
@@ -657,8 +657,6 @@ static long vc_mem_copy(struct bcm2708_fb *fb, struct fb_dmacopy *ioparam)
 	long rc = 0;
 	size_t offset;
 
-return -EFAULT;
-
 	/* restrict this to root user */
 	if (!uid_eq(current_euid(), GLOBAL_ROOT_UID)) {
 		rc = -EFAULT;
@@ -1111,7 +1109,6 @@ static int bcm2708_fb_probe(struct platform_device *dev)
 
 	dev_info(&dev->dev, "FB found %d display(s)\n", num_displays);
 
-#if 0
 	/* Set up the DMA information. Note we have just one set of DMA
 	 * parameters to work with all the FB's so requires synchronising when
 	 * being used
@@ -1144,7 +1141,7 @@ static int bcm2708_fb_probe(struct platform_device *dev)
 			"Failed to request DMA irq\n");
 		goto free_dma_chan;
 	}
-#endif
+
 	rpi_firmware_property(fbdev->fw,
 			      RPI_FIRMWARE_GET_VC_MEMORY,
 			      &gpu_mem, sizeof(gpu_mem));


### PR DESCRIPTION
This was hacked out for pi5 bringup, but breaks vclog on Pi2/3.

I've tested with this back in on Pi3, Pi4, and Pi5. (with kms driver disabled, as kms stops bcm2708_fb from being used).

Pi3 and Pi4 work correctly. vclog now uses the dma interface correctly.

Pi5 fails harmlessly with vclog.

As the bootloader firmware only reports the initial framebuffer through RPI_FIRMWARE_GET_VC_MEMORY
(and actually uses the uncached alias, where bcm2708_fb expects cached), any dma ioctl's just fail with `Invalid memory access`.

Fixing the bootloader to report the expected VC_MEMORY range does allow the vc_mem_copy code path to run and it goes badly, as this driver directly writes DMA control blocks which have changed on bcm2712.

I suspect this should be updated to use a higher level dma interface, but if that comes with the vc_mem driver, we can just drop (or copy) support here. After that point `RPI_FIRMWARE_GET_VC_MEMORY` could be fixed.