### PR TITLE
dts: bcm2712: Set default I2C baudrates to 100kHz

### DIFF
--- a/arch/arm/boot/dts/bcm2712-rpi-5-b.dts
+++ b/arch/arm/boot/dts/bcm2712-rpi-5-b.dts
@@ -250,11 +250,13 @@ i2c0mux: &rp1_gpio {};
 i2c_csi_dsi0: &i2c6 { // Note: This is for MIPI0 connector only
 	pinctrl-0 = <&rp1_i2c6_38_39>;
 	pinctrl-names = "default";
+	clock-frequency = <100000>;
 };
 
 i2c_csi_dsi1: &i2c4 { // Note: This is for MIPI1 connector only
 	pinctrl-0 = <&rp1_i2c4_40_41>;
 	pinctrl-names = "default";
+	clock-frequency = <100000>;
 };
 
 i2c_csi_dsi: &i2c_csi_dsi1 { }; // An alias for compatibility

--- a/arch/arm/boot/dts/bcm2712-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2712-rpi.dtsi
@@ -204,11 +204,13 @@ uart4: &rp1_uart4 { };
 i2c_vc: &i2c0 {      // This is pins 27,28 on the header (not MIPI)
 	pinctrl-0 = <&rp1_i2c0_0_1>;
 	pinctrl-names = "default";
+	clock-frequency = <100000>;
 };
 
 i2c_arm: &i2c1 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&rp1_i2c1_2_3>;
+	clock-frequency = <100000>;
 };
 
 &i2c2 {


### PR DESCRIPTION
The RP1 I2C interfaces were being left with their default clock rates, apparently 400kHz.