### PR TITLE
drm/vc4: Correct address offset for planes with src_[xy] offsets

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -1447,9 +1447,9 @@ static int vc4_plane_mode_set(struct drm_plane *plane,
 	vc4_state->ptr0_offset[0] = vc4_state->dlist_count;
 
 	for (i = 0; i < num_planes; i++) {
-		dma_addr_t paddr = drm_fb_dma_get_gem_addr(fb, state, i);
+		struct drm_gem_dma_object *bo = drm_fb_dma_get_gem_obj(fb, i);
 
-		vc4_dlist_write(vc4_state, paddr + offsets[i]);
+		vc4_dlist_write(vc4_state, bo->dma_addr + fb->offsets[i] + offsets[i]);
 	}
 
 	/* Pointer Context Word 0/1/2: Written by the HVS */
@@ -1842,9 +1842,8 @@ static int vc6_plane_mode_set(struct drm_plane *plane,
 	 * TODO: This only covers Raster Scan Order planes
 	 */
 	for (i = 0; i < num_planes; i++) {
-		dma_addr_t paddr = drm_fb_dma_get_gem_addr(fb, state, i);
-
-		paddr += offsets[i];
+		struct drm_gem_dma_object *bo = drm_fb_dma_get_gem_obj(fb, i);
+		dma_addr_t paddr = bo->dma_addr + fb->offsets[i] + offsets[i];
 
 		/* Pointer Word 0 */
 		vc4_state->ptr0_offset[i] = vc4_state->dlist_count;


### PR DESCRIPTION
11cf37e741b4 switched to using drm_fb_dma_get_gem_addr instead of drm_fb_dma_get_gem_obj and adding fb->offset[].

However the tiled formats need to compute the offset in a more involved manner than drm_fb_dma_get_gem_addr applies, and we were ending up with the offset for src_[xy] being applied twice.

Switch back to using drm_fb_dma_get_gem_obj and fully computing the offsets ourselves.

Fixes: 11cf37e741b4 ("drm/vc4: Move the buffer offset out of the vc4_plane_state")