### PR TITLE
ARM: dts: bcm2712-rpi: Set a 1GB ZONE_DMA limit

### DIFF
--- a/arch/arm/boot/dts/bcm2712-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2712-rpi.dtsi
@@ -64,6 +64,16 @@
 };
 
 / {
+	/*
+	 * Add a node with a dma-ranges value that exists only to be found
+	 * by of_dma_get_max_cpu_address, and hence limit the DMA zone.
+	 */
+	zone_dma {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		dma-ranges = <0x0  0x0 0x0  0x40000000>;
+	};
+
 	__overrides__ {
 		arm_freq;
 	};


### PR DESCRIPTION
The arm64 initialisation uses the physical address reachable by all DMA controllers to set the size of ZONE_DMA. This fails on BCM2712 with the current dts files because the declaration of the I/O space fools it into thinking the legacy 30-bit DMA channels can see most of the 32-bit space.

Take advantage of the simple nature of the implementation by adding a node with a restricted dma-ranges property solely so as to act as the limiting factor in the calculation.

See: https://github.com/raspberrypi/linux/issues/5470