### PR TITLE
overlays: Add Pi 5 version of dwc2

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -59,6 +59,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	draws.dtbo \
 	dwc-otg.dtbo \
 	dwc2.dtbo \
+	dwc2-pi5.dtbo \
 	edt-ft5406.dtbo \
 	enc28j60.dtbo \
 	enc28j60-spi2.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1107,6 +1107,10 @@ Params: dr_mode                 Dual role mode: "host", "peripheral" or "otg"
                                 mode
 
 
+Name:   dwc2-pi5
+Info:   See dwc2 (this is the Pi 5 version)
+
+
 [ The ds1307-rtc overlay has been deleted. See i2c-rtc. ]
 
 

--- a/arch/arm/boot/dts/overlays/dwc2-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/dwc2-pi5-overlay.dts
@@ -1,0 +1,18 @@
+#include "dwc2-overlay.dts"
+
+/{
+	fragment@1 {
+		target = <&soc>;
+		__overlay__ {
+			/*
+			 * Add a node with a dma-ranges value that exists only to be found
+			 * by of_dma_get_max_cpu_address, and hence limit the DMA zone.
+			 */
+			zone_dma {
+				 #address-cells = <1>;
+				 #size-cells = <1>;
+				 dma-ranges = <0x0  0x0 0x0  0x40000000>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -48,6 +48,16 @@
 		bcm2712;
 	};
 
+	dwc2 {
+		bcm2835;
+		bcm2711;
+		bcm2712 = "dwc2-pi5";
+	};
+
+	dwc2-pi5 {
+		bcm2712;
+	};
+
 	highperi {
 		bcm2711;
 	};


### PR DESCRIPTION
Most bus masters on Pi 5 have access to at least the lower 4GB, but the old DWC OTG controller is still restricted to the first 1GB. Create a Pi 5-specific version of the overlay including a fragment that ensures the swiotlb bounce buffers are allocated in that area.

This PR replaces https://github.com/raspberrypi/linux/pull/5658.