### PR TITLE
Typo in overlays README

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3742,7 +3742,7 @@ Name:   rpi-ft5406
 Info:   Official Raspberry Pi display touchscreen
 Load:   dtoverlay=rpi-ft5406,<param>=<val>
 Params: touchscreen-size-x      Touchscreen X resolution (default 800)
-        touchscreen-size-y      Touchscreen Y resolution (default 600);
+        touchscreen-size-y      Touchscreen Y resolution (default 480);
         touchscreen-inverted-x  Invert touchscreen X coordinates (default 0);
         touchscreen-inverted-y  Invert touchscreen Y coordinates (default 0);
         touchscreen-swapped-x-y Swap X and Y cordinates (default 0);


### PR DESCRIPTION
touchscreen-size-y for rpi-ft5406 defaults to 480, not 600

I _assume_ this is a typo, as https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/edt-ft5406.dtsi and https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/overlays/rpi-ft5406-overlay.dts both say the touchscreen is 800x480, and that's also the pixel-resolution of the [DSI screen](https://www.raspberrypi.com/products/raspberry-pi-touch-display/).