### PR TITLE
Fix FKMS for Pi0-4 and Pi5

### DIFF
--- a/arch/arm/boot/dts/bcm2712.dtsi
+++ b/arch/arm/boot/dts/bcm2712.dtsi
@@ -103,7 +103,7 @@
 		};
 
 		firmwarekms: firmwarekms@7d503000 {
-			compatible = "raspberrypi,rpi-firmware-kms";
+			compatible = "raspberrypi,rpi-firmware-kms-2712";
 			/* SUN_L2 interrupt reg */
 			reg = <0x7d503000 0x18>;
 			interrupt-parent = <&cpu_l2_irq>;

--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -47,9 +47,15 @@ struct get_display_cfg {
 	u32  max_pixel_clock[2];  //Max pixel clock for each display
 };
 
+enum vc4_fkms_revision {
+	BCM2835_6_7,
+	BCM2711,
+	BCM2712,
+};
+
 struct vc4_fkms {
 	struct get_display_cfg cfg;
-	bool bcm2711;
+	enum vc4_fkms_revision revision;
 };
 
 #define PLANES_PER_CRTC		8
@@ -1149,7 +1155,7 @@ vc4_crtc_mode_valid(struct drm_crtc *crtc, const struct drm_display_mode *mode)
 	/* Pi4 can't generate odd horizontal timings on HDMI, so reject modes
 	 * that would set them.
 	 */
-	if (fkms->bcm2711 &&
+	if (fkms->revision >= BCM2711 &&
 	    (vc4_crtc->display_number == 2 || vc4_crtc->display_number == 7) &&
 	    !(mode->flags & DRM_MODE_FLAG_DBLCLK) &&
 	    ((mode->hdisplay |				/* active */
@@ -1267,6 +1273,20 @@ static irqreturn_t vc4_crtc_irq_handler(int irq, void *data)
 	return ret;
 }
 
+static irqreturn_t vc4_crtc2712_irq_handler(int irq, void *data)
+{
+	struct vc4_crtc **crtc_list = data;
+	int i;
+
+	for (i = 0; crtc_list[i]; i++) {
+		if (crtc_list[i]->vblank_enabled)
+			drm_crtc_handle_vblank(&crtc_list[i]->base);
+		vc4_crtc_handle_page_flip(crtc_list[i]);
+	}
+
+	return IRQ_HANDLED;
+}
+
 static int vc4_fkms_page_flip(struct drm_crtc *crtc,
 			      struct drm_framebuffer *fb,
 			      struct drm_pending_vblank_event *event,
@@ -1352,9 +1372,12 @@ static const struct drm_crtc_helper_funcs vc4_crtc_helper_funcs = {
 };
 
 static const struct of_device_id vc4_firmware_kms_dt_match[] = {
-	{ .compatible = "raspberrypi,rpi-firmware-kms" },
+	{ .compatible = "raspberrypi,rpi-firmware-kms",
+	  .data = (void *)BCM2835_6_7 },
 	{ .compatible = "raspberrypi,rpi-firmware-kms-2711",
-	  .data = (void *)1 },
+	  .data = (void *)BCM2711 },
+	{ .compatible = "raspberrypi,rpi-firmware-kms-2712",
+	  .data = (void *)BCM2712 },
 	{}
 };
 
@@ -1924,8 +1947,7 @@ static int vc4_fkms_bind(struct device *dev, struct device *master, void *data)
 	match = of_match_device(vc4_firmware_kms_dt_match, dev);
 	if (!match)
 		return -ENODEV;
-	if (match->data)
-		fkms->bcm2711 = true;
+	fkms->revision = (enum vc4_fkms_revision)match->data;
 
 	firmware_node = of_parse_phandle(dev->of_node, "brcm,firmware", 0);
 	vc4->firmware = devm_rpi_firmware_get(&pdev->dev, firmware_node);
@@ -1992,10 +2014,16 @@ static int vc4_fkms_bind(struct device *dev, struct device *master, void *data)
 		if (IS_ERR(crtc_list[0]->regs))
 			DRM_ERROR("Oh dear, failed to map registers\n");
 
-		writel(0, crtc_list[0]->regs + SMICS);
-		ret = devm_request_irq(dev, platform_get_irq(pdev, 0),
-				       vc4_crtc_irq_handler, 0,
-				       "vc4 firmware kms", crtc_list);
+		if (fkms->revision >= BCM2712) {
+			ret = devm_request_irq(dev, platform_get_irq(pdev, 0),
+					       vc4_crtc2712_irq_handler, 0,
+					       "vc4 firmware kms", crtc_list);
+		} else {
+			writel(0, crtc_list[0]->regs + SMICS);
+			ret = devm_request_irq(dev, platform_get_irq(pdev, 0),
+					       vc4_crtc_irq_handler, 0,
+					       "vc4 firmware kms", crtc_list);
+		}
 		if (ret)
 			DRM_ERROR("Oh dear, failed to register IRQ\n");
 	} else {

--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -255,6 +255,13 @@ static const struct vc_image_format *vc4_get_vc_image_fmt(u32 drm_format)
 /* The firmware delivers a vblank interrupt to us through the SMI
  * hardware, which has only this one register.
  */
+#define SMICS 0x0
+#define SMIDSW0 0x14
+#define SMIDSW1 0x1C
+#define SMICS_INTERRUPTS (BIT(9) | BIT(10) | BIT(11))
+
+/* Flag to denote that the firmware is giving multiple display callbacks */
+#define SMI_NEW 0xabcd0000
 
 #define vc4_crtc vc4_kms_crtc
 #define to_vc4_crtc to_vc4_kms_crtc
@@ -1214,13 +1221,16 @@ static irqreturn_t vc4_crtc_irq_handler(int irq, void *data)
 {
 	struct vc4_crtc **crtc_list = data;
 	int i;
+	u32 stat = readl(crtc_list[0]->regs + SMICS);
 	irqreturn_t ret = IRQ_NONE;
 	u32 chan;
-	if (1) {
 
-		chan = 0;
+	if (stat & SMICS_INTERRUPTS) {
+		writel(0, crtc_list[0]->regs + SMICS);
 
-		if (1) {
+		chan = readl(crtc_list[0]->regs + SMIDSW0);
+
+		if ((chan & 0xFFFF0000) != SMI_NEW) {
 			/* Older firmware. Treat the one interrupt as vblank/
 			 * complete for all crtcs.
 			 */
@@ -1231,7 +1241,7 @@ static irqreturn_t vc4_crtc_irq_handler(int irq, void *data)
 			}
 		} else {
 			if (chan & 1) {
-				//writel(SMI_NEW, crtc_list[0]->regs + SMIDSW0);
+				writel(SMI_NEW, crtc_list[0]->regs + SMIDSW0);
 				if (crtc_list[0]->vblank_enabled)
 					drm_crtc_handle_vblank(&crtc_list[0]->base);
 				vc4_crtc_handle_page_flip(crtc_list[0]);
@@ -1239,10 +1249,10 @@ static irqreturn_t vc4_crtc_irq_handler(int irq, void *data)
 
 			if (crtc_list[1]) {
 				/* Check for the secondary display too */
-				//chan = readl(crtc_list[0]->regs + SMIDSW1);
+				chan = readl(crtc_list[0]->regs + SMIDSW1);
 
 				if (chan & 1) {
-					//writel(SMI_NEW, crtc_list[0]->regs + SMIDSW1);
+					writel(SMI_NEW, crtc_list[0]->regs + SMIDSW1);
 
 					if (crtc_list[1]->vblank_enabled)
 						drm_crtc_handle_vblank(&crtc_list[1]->base);
@@ -1982,7 +1992,7 @@ static int vc4_fkms_bind(struct device *dev, struct device *master, void *data)
 		if (IS_ERR(crtc_list[0]->regs))
 			DRM_ERROR("Oh dear, failed to map registers\n");
 
-		//writel(0, crtc_list[0]->regs + SMICS);
+		writel(0, crtc_list[0]->regs + SMICS);
 		ret = devm_request_irq(dev, platform_get_irq(pdev, 0),
 				       vc4_crtc_irq_handler, 0,
 				       "vc4 firmware kms", crtc_list);


### PR DESCRIPTION
Fixes #5649
The interrupt handler had been updated and become Pi5 only, which wasn't the most helpful situation.