### PR TITLE
fixup! overlays: mcp23017: allow specification of the i2c bus

### DIFF
--- a/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
@@ -24,30 +24,13 @@
 	};
 
 	fragment@2 {
-		target = <&i2cbus>;
-		__overlay__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			mcp23017: mcp@20 {
-				compatible = "microchip,mcp23017";
-				reg = <0x20>;
-				gpio-controller;
-				#gpio-cells = <2>;
-
-				status = "okay";
-			};
-		};
-	};
-
-	fragment@3 {
 		target = <&mcp23017>;
 		__dormant__ {
 			compatible = "microchip,mcp23008";
 		};
 	};
 
-	fragment@4 {
+	fragment@3 {
 		target = <&mcp23017>;
 		mcp23017_irq: __overlay__ {
 			#interrupt-cells=<2>;
@@ -55,6 +38,25 @@
 			interrupts = <4 2>;
 			interrupt-controller;
 			microchip,irq-mirror;
+		};
+	};
+
+	fragment@4 {
+		target = <&i2cbus>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mcp23017: mcp@20 {
+				compatible = "microchip,mcp23017";
+				pinctrl-name = "default";
+				pinctrl-0 = <&mcp23017_pins>;
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+
+				status = "okay";
+			};
 		};
 	};
 
@@ -83,8 +85,8 @@
 		gpiopin = <&mcp23017_pins>,"brcm,pins:0",
 				<&mcp23017_irq>,"interrupts:0";
 		addr = <&mcp23017>,"reg:0", <&mcp23017_pins>,"reg:0";
-		mcp23008 = <0>,"=3";
-		noints = <0>,"!1!4";
+		mcp23008 = <0>,"=2";
+		noints = <0>,"!1!3";
 		i2c0 = <&frag100>, "target:0=",<&i2c0>;
 		i2c_csi_dsi = <&frag100>, "target:0=",<&i2c_csi_dsi>,
 			      <0>,"+101+102";


### PR DESCRIPTION
The incorrect fragment order (*) caused broke the interrupt usage, and while it was being fixed the lack of a reference to the pinctrl declaration was noticed.

See: https://github.com/raspberrypi/linux/issues/5677

Signed-off-by: Phil Elwell <phil@raspberrypi.com>

(*) Ideally all fragments would appear in the file in the order in which they should be merged, but that is easy to forget and can be awkward, so the firmware merges all "intra" fragments (those that target other fragments in the overlay) before "inter" fragments (those that target the base DTB). However, intra fragments that target other intra fragments is a level of nesting too far for this logic to cope, so they must appear before the fragments they target.