### PR TITLE
fixup! arch/arm64: Add Revision, Serial, Model to cpuinfo

### DIFF
--- a/arch/arm64/kernel/cpuinfo.c
+++ b/arch/arm64/kernel/cpuinfo.c
@@ -224,8 +224,6 @@ static int c_show(struct seq_file *m, void *v)
 		seq_printf(m, "CPU revision\t: %d\n\n", MIDR_REVISION(midr));
 	}
 
-	seq_printf(m, "Hardware\t: BCM2835\n");
-
 	np = of_find_node_by_path("/system");
 	if (np) {
 		if (!of_property_read_u32(np, "linux,revision", &revision))


### PR DESCRIPTION
Delete the Hardware string, which is pointless and misleading.

See: https://github.com/raspberrypi/bookworm-feedback/issues/129