### PR TITLE
dts: bcm2712-rpi-5-b: Create some dummy nodes

### DIFF
--- a/arch/arm/boot/dts/bcm2712-rpi-5-b.dts
+++ b/arch/arm/boot/dts/bcm2712-rpi-5-b.dts
@@ -157,6 +157,12 @@
 	dummy: dummy {
 		// A target for unwanted overlay fragments
 	};
+
+
+	// A few extra labels to keep overlays happy
+
+	i2c0if: i2c0if {};
+	i2c0mux: i2c0mux {};
 };
 
 rp1_target: &pcie2 {
@@ -242,11 +248,6 @@ aux: &dummy {};
 };
 
 #include "bcm2712-rpi.dtsi"
-
-// A few extra labels to keep overlays happy
-
-i2c0if: &rp1_gpio {};
-i2c0mux: &rp1_gpio {};
 
 i2c_csi_dsi0: &i2c6 { // Note: This is for MIPI0 connector only
 	pinctrl-0 = <&rp1_i2c6_38_39>;

--- a/arch/arm/boot/dts/rp1.dtsi
+++ b/arch/arm/boot/dts/rp1.dtsi
@@ -187,7 +187,7 @@
 			interrupts = <RP1_INT_SPI1 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
 			clock-names = "ssi_clk";
-			#address-cells = <0>;
+			#address-cells = <1>;
 			#size-cells = <0>;
 			num-cs = <2>;
 			dmas = <&rp1_dma RP1_DMA_SPI1_TX>,
@@ -259,6 +259,21 @@
 			num-cs = <2>;
 			dmas = <&rp1_dma RP1_DMA_SPI5_TX>,
 			       <&rp1_dma RP1_DMA_SPI5_RX>;
+			dma-names = "tx", "rx";
+			status = "disabled";
+		};
+
+		rp1_spi6: spi@68000 {
+			reg = <0xc0 0x40068000  0x0 0x130>;
+			compatible = "snps,dw-apb-ssi";
+			interrupts = <RP1_INT_SPI6 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&rp1_clocks RP1_CLK_SYS>;
+			clock-names = "ssi_clk";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			num-cs = <2>;
+			dmas = <&rp1_dma RP1_DMA_SPI6_TX>,
+			       <&rp1_dma RP1_DMA_SPI6_RX>;
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};


### PR DESCRIPTION
The kernel now treats multiple fragments targeting the same node as an error. For this reason, it is important that labels created just for compatibility with other systems (e.g. i2c0if and i2c0mux) are attached to unique nodes, not just tacked onto existing nodes.