### PR TITLE
spi: dw-dma: Get the last DMA scoop out of the FIFO

### DIFF
--- a/drivers/spi/spi-dw-dma.c
+++ b/drivers/spi/spi-dw-dma.c
@@ -275,8 +275,10 @@ static void dw_spi_dma_tx_done(void *arg)
 	struct dw_spi *dws = arg;
 
 	clear_bit(DW_SPI_TX_BUSY, &dws->dma_chan_busy);
-	if (test_bit(DW_SPI_RX_BUSY, &dws->dma_chan_busy))
+	if (test_bit(DW_SPI_RX_BUSY, &dws->dma_chan_busy)) {
+		dw_writel(dws, DW_SPI_DMARDLR, 0);
 		return;
+	}
 
 	complete(&dws->dma_completion);
 }
@@ -601,6 +603,8 @@ static int dw_spi_dma_transfer(struct dw_spi *dws, struct spi_transfer *xfer)
 	int ret;
 
 	nents = max(xfer->tx_sg.nents, xfer->rx_sg.nents);
+
+	dw_writel(dws, DW_SPI_DMARDLR, xfer->tx_buf ? (dws->rxburst - 1) : 0);
 
 	/*
 	 * Execute normal DMA-based transfer (which submits the Rx and Tx SG


### PR DESCRIPTION
With a DMA FIFO threshold greater than 1 (encoded as 0), it is possible for data in the FIFO to be inaccessible, causing the transfer to fail after a timeout. If the transfer includes a transmission, reduce the RX threshold when the TX completes, otherwise use 1 for the whole transfer (inefficient, but not catastrophic at SPI data rates).

See: https://github.com/raspberrypi/linux/issues/5696