### PR TITLE
Include I2C bus details in ft5x06 and goodix touch driver names

### DIFF
--- a/drivers/input/touchscreen/edt-ft5x06.c
+++ b/drivers/input/touchscreen/edt-ft5x06.c
@@ -67,6 +67,7 @@
 #define TOUCH_EVENT_RESERVED		0x03
 
 #define EDT_NAME_LEN			23
+#define EDT_NAME_PREFIX_LEN		8
 #define EDT_SWITCH_MODE_RETRIES		10
 #define EDT_SWITCH_MODE_DELAY		5 /* msec */
 #define EDT_RAW_DATA_RETRIES		100
@@ -134,7 +135,7 @@ struct edt_ft5x06_ts_data {
 	int max_support_points;
 	unsigned int known_ids;
 
-	char name[EDT_NAME_LEN];
+	char name[EDT_NAME_PREFIX_LEN + EDT_NAME_LEN];
 	char fw_version[EDT_NAME_LEN];
 	int init_td_status;
 
@@ -964,6 +965,9 @@ static int edt_ft5x06_ts_identify(struct i2c_client *client,
 	int error;
 	char *model_name = tsdata->name;
 	char *fw_version = tsdata->fw_version;
+
+	snprintf(model_name, EDT_NAME_PREFIX_LEN, "%s ", dev_name(&client->dev));
+	model_name += strlen(model_name);
 
 	/* see what we find if we assume it is a M06 *
 	 * if we get less than EDT_NAME_LEN, we don't want

--- a/drivers/input/touchscreen/goodix.c
+++ b/drivers/input/touchscreen/goodix.c
@@ -1211,7 +1211,10 @@ static int goodix_configure_dev(struct goodix_ts_data *ts)
 		return -ENOMEM;
 	}
 
-	ts->input_dev->name = "Goodix Capacitive TouchScreen";
+	snprintf(ts->name, GOODIX_NAME_MAX_LEN, "%s Goodix Capacitive TouchScreen",
+		 dev_name(&ts->client->dev));
+
+	ts->input_dev->name = ts->name;
 	ts->input_dev->phys = "input/ts";
 	ts->input_dev->id.bustype = BUS_I2C;
 	ts->input_dev->id.vendor = 0x0416;

--- a/drivers/input/touchscreen/goodix.h
+++ b/drivers/input/touchscreen/goodix.h
@@ -57,6 +57,8 @@
 #define GOODIX_CONFIG_MAX_LENGTH		240
 #define GOODIX_MAX_KEYS				7
 
+#define GOODIX_NAME_MAX_LEN			38
+
 enum goodix_irq_pin_access_method {
 	IRQ_PIN_ACCESS_NONE,
 	IRQ_PIN_ACCESS_GPIO,
@@ -91,6 +93,7 @@ struct goodix_ts_data {
 	enum gpiod_flags gpiod_rst_flags;
 	char id[GOODIX_ID_MAX_LEN + 1];
 	char cfg_name[64];
+	char name[GOODIX_NAME_MAX_LEN];
 	u16 version;
 	bool reset_controller_at_probe;
 	bool load_cfg_from_disk;


### PR DESCRIPTION
https://github.com/raspberrypi/bookworm-feedback/issues/138

The name is only taken as a `const char *`, so there's no easy way for the framework to do this munge.

Adds the I2C bus number and address to the name, so DSI-2 wants to be associated with `4-0038 generic ft5x06 (79)`, and DSI-1 with `6-0038 generic ft5x06 (79)` for Pi5, and `10-0038 generic ft5x06 (79)` with DSI-1 on Pi0-4.
Goodix is used by the HyperPixel and a few other displays, hence converted that one too.

Needs the relevant wayfire.ini updates before merging / releasing, hence draft for now.