### PR TITLE
RP1 GPIO header SDIO support

### DIFF
--- a/Documentation/devicetree/bindings/mmc/snps,dwcmshc-sdhci.yaml
+++ b/Documentation/devicetree/bindings/mmc/snps,dwcmshc-sdhci.yaml
@@ -16,6 +16,7 @@ allOf:
 properties:
   compatible:
     enum:
+      - raspberrypi,rp1-dwcmshc
       - rockchip,rk3568-dwcmshc
       - rockchip,rk3588-dwcmshc
       - snps,dwcmshc-sdhci
@@ -34,6 +35,8 @@ properties:
       - description: axi clock for rockchip specified
       - description: block clock for rockchip specified
       - description: timer clock for rockchip specified
+      - description: timeout clock for rp1 specified
+      - description: sdio clock generator for rp1 specified
 
 
   clock-names:
@@ -44,6 +47,8 @@ properties:
       - const: axi
       - const: block
       - const: timer
+      - const: timeout
+      - const: sdio
 
   rockchip,txclk-tapnum:
     description: Specify the number of delay for tx sampling.

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -226,6 +226,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	sc16is752-spi1.dtbo \
 	sdhost.dtbo \
 	sdio.dtbo \
+	sdio-pi5.dtbo \
 	seeed-can-fd-hat-v1.dtbo \
 	seeed-can-fd-hat-v2.dtbo \
 	sh1106-spi.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3936,6 +3936,13 @@ Info:   This overlay is now deprecated. Use
 Load:   <Deprecated>
 
 
+Name:   sdio-pi5
+Info:   Selects the rp1_mmc0 interface and enables it on GPIOs 22-27.
+        Pi 5 only.
+Load:   dtoverlay=sdio-pi5
+Params: <None>
+
+
 Name:   sdtweak
 Info:   This overlay is now deprecated. Use the sd_* dtparams in the
         base DTB, e.g. "dtoverlay=sdtweak,poll_once" becomes

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -260,6 +260,10 @@
 		deprecated = "use sdio,bus_width=1,gpios_22_25";
 	};
 
+	sdio-pi5 {
+		bcm2712;
+	};
+
 	sdtweak {
 		deprecated = "use 'dtparam=sd_poll_once' etc.";
 	};

--- a/arch/arm/boot/dts/overlays/sdio-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sdio-pi5-overlay.dts
@@ -1,0 +1,24 @@
+/dts-v1/;
+/plugin/;
+
+/* SDIO/SD/MMC on RP1 bank 0 */
+
+/{
+	compatible = "brcm,bcm2712";
+
+	fragment@0 {
+		target = <&rp1_mmc0>;
+		frag0: __overlay__ {
+			status = "okay";
+			pinctrl-0 = <&rp1_sdio0_22_27>;
+			pinctrl-names = "default";
+		};
+	};
+
+	fragment@1 {
+		target = <&rp1_sdio_clk0>;
+		frag1: __overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm/boot/dts/rp1.dtsi
+++ b/arch/arm/boot/dts/rp1.dtsi
@@ -962,7 +962,7 @@
 
 		rp1_mmc0: mmc@180000 {
 			reg = <0xc0 0x40180000  0x0 0x100>;
-			compatible = "snps,dwcmshc-sdhci";
+			compatible = "raspberrypi,rp1-dwcmshc";
 			interrupts = <RP1_INT_SDIO0 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_SYS &sdhci_core
 			          &rp1_clocks RP1_CLK_SDIO_TIMER
@@ -978,7 +978,7 @@
 
 		rp1_mmc1: mmc@184000 {
 			reg = <0xc0 0x40184000  0x0 0x100>;
-			compatible = "snps,dwcmshc-sdhci";
+			compatible = "raspberrypi,rp1-dwcmshc";
 			interrupts = <RP1_INT_SDIO1 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_SYS &sdhci_core
 			          &rp1_clocks RP1_CLK_SDIO_TIMER

--- a/drivers/mmc/host/sdhci-of-dwcmshc.c
+++ b/drivers/mmc/host/sdhci-of-dwcmshc.c
@@ -373,6 +373,15 @@ static const struct sdhci_pltfm_data sdhci_dwcmshc_bf3_pdata = {
 };
 #endif
 
+static const struct sdhci_pltfm_data sdhci_dwcmshc_rp1_pdata = {
+	.ops = &sdhci_dwcmshc_ops,
+	.quirks = SDHCI_QUIRK_CAP_CLOCK_BASE_BROKEN |
+		  SDHCI_QUIRK_BROKEN_CARD_DETECTION,
+	.quirks2 = SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+		   SDHCI_QUIRK2_BROKEN_HS200 |
+		   SDHCI_QUIRK2_SPURIOUS_INT_RESP,
+};
+
 static const struct sdhci_pltfm_data sdhci_dwcmshc_rk35xx_pdata = {
 	.ops = &sdhci_dwcmshc_rk35xx_ops,
 	.quirks = SDHCI_QUIRK_CAP_CLOCK_BASE_BROKEN |
@@ -440,6 +449,10 @@ static void dwcmshc_rk35xx_postinit(struct sdhci_host *host, struct dwcmshc_priv
 }
 
 static const struct of_device_id sdhci_dwcmshc_dt_ids[] = {
+	{
+		.compatible = "raspberrypi,rp1-dwcmshc",
+		.data = &sdhci_dwcmshc_rp1_pdata,
+	},
 	{
 		.compatible = "rockchip,rk3588-dwcmshc",
 		.data = &sdhci_dwcmshc_rk35xx_pdata,

--- a/drivers/mmc/host/sdhci.c
+++ b/drivers/mmc/host/sdhci.c
@@ -1728,6 +1728,12 @@ static bool sdhci_send_command(struct sdhci_host *host, struct mmc_command *cmd)
 	if (host->use_external_dma)
 		sdhci_external_dma_pre_transfer(host, cmd);
 
+	if (host->quirks2 & SDHCI_QUIRK2_SPURIOUS_INT_RESP) {
+		host->ier |= SDHCI_INT_RESPONSE;
+		sdhci_writel(host, host->ier, SDHCI_INT_ENABLE);
+		sdhci_writel(host, host->ier, SDHCI_SIGNAL_ENABLE);
+	}
+
 	sdhci_writew(host, SDHCI_MAKE_CMD(cmd->opcode, flags), SDHCI_COMMAND);
 
 	return true;
@@ -3330,6 +3336,11 @@ static void sdhci_cmd_irq(struct sdhci_host *host, u32 intmask, u32 *intmask_p)
 		if (intmask & SDHCI_INT_TIMEOUT) {
 			host->cmd->error = -ETIMEDOUT;
 			sdhci_err_stats_inc(host, CMD_TIMEOUT);
+			if (host->quirks2 & SDHCI_QUIRK2_SPURIOUS_INT_RESP) {
+				host->ier &= ~SDHCI_INT_RESPONSE;
+				sdhci_writel(host, host->ier, SDHCI_INT_ENABLE);
+				sdhci_writel(host, host->ier, SDHCI_SIGNAL_ENABLE);
+			}
 		} else {
 			host->cmd->error = -EILSEQ;
 			if (!mmc_op_tuning(host->cmd->opcode))

--- a/drivers/mmc/host/sdhci.h
+++ b/drivers/mmc/host/sdhci.h
@@ -486,6 +486,9 @@ struct sdhci_host {
 #define SDHCI_QUIRK2_NO_SDR50  (1<<20)
 #define SDHCI_QUIRK2_NO_SDR104	(1<<21)
 
+/* Command timeouts may generate a trailing INT_RESPONSE later */
+#define SDHCI_QUIRK2_SPURIOUS_INT_RESP			(1<<31)
+
 	int irq;		/* Device IRQ */
 	void __iomem *ioaddr;	/* Mapped address */
 	phys_addr_t mapbase;	/* physical address base */


### PR DESCRIPTION
This series pulls forward a workaround that was previously hacked about internally, and adds an overlay for SD/SDIO slot usage on the GPIO header.

Note that you can't boot off the GPIO header interface as the firmware doesn't abstract arbitrary SD interfaces - just supports the brcm ones - so still compiling sdhci-of-dwcmshc as a module is good enough.