### PR TITLE
media/i2c: ov7251: Switch from V4L2_CID_GAIN to V4L2_CID_ANALOGUE_GAIN

### DIFF
--- a/drivers/media/i2c/ov7251.c
+++ b/drivers/media/i2c/ov7251.c
@@ -1063,7 +1063,7 @@ static int ov7251_s_ctrl(struct v4l2_ctrl *ctrl)
 	case V4L2_CID_EXPOSURE:
 		ret = ov7251_set_exposure(ov7251, ctrl->val);
 		break;
-	case V4L2_CID_GAIN:
+	case V4L2_CID_ANALOGUE_GAIN:
 		ret = ov7251_set_gain(ov7251, ctrl->val);
 		break;
 	case V4L2_CID_TEST_PATTERN:
@@ -1588,7 +1588,7 @@ static int ov7251_init_ctrls(struct ov7251 *ov7251)
 	ov7251->exposure = v4l2_ctrl_new_std(&ov7251->ctrls, &ov7251_ctrl_ops,
 					     V4L2_CID_EXPOSURE, 1, 32, 1, 32);
 	ov7251->gain = v4l2_ctrl_new_std(&ov7251->ctrls, &ov7251_ctrl_ops,
-					 V4L2_CID_GAIN, 16, 1023, 1, 16);
+					 V4L2_CID_ANALOGUE_GAIN, 16, 1023, 1, 16);
 	v4l2_ctrl_new_std_menu_items(&ov7251->ctrls, &ov7251_ctrl_ops,
 				     V4L2_CID_TEST_PATTERN,
 				     ARRAY_SIZE(ov7251_test_pattern_menu) - 1,


### PR DESCRIPTION
The mainline driver has implemented analogue gain using the control V4L2_CID_GAIN instead of V4L2_CID_ANALOGUE_GAIN.

libcamera requires V4L2_CID_ANALOGUE_GAIN, and therefore fails.

Update the driver to use V4L2_CID_ANALOGUE_GAIN.

https://forums.raspberrypi.com/viewtopic.php?p=2157035
Needs to be confirmed to work before merging, but want CI.