### PR TITLE
arch/arm/lib: Fix the assembly sources for the kernel build by LLVM

### DIFF
--- a/arch/arm/lib/arm-mem.h
+++ b/arch/arm/lib/arm-mem.h
@@ -27,9 +27,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 .macro myfunc fname
- .func fname
- .global fname
-fname:
+ .func \fname
+ .global \fname
+\fname:
 .endm
 
 .macro preload_leading_step1  backwards, ptr, base
@@ -37,16 +37,16 @@ fname:
  * between 0 and prefetch_distance (inclusive) cache lines ahead so there
  * are no gaps when the inner loop starts.
  */
- .if backwards
-        sub     ptr, base, #1
-        bic     ptr, ptr, #31
+ .if \backwards
+        sub     \ptr, \base, #1
+        bic     \ptr, \ptr, #31
  .else
-        bic     ptr, base, #31
+        bic     \ptr, \base, #31
  .endif
  .set OFFSET, 0
  .rept prefetch_distance+1
-        pld     [ptr, #OFFSET]
-  .if backwards
+        pld     [\ptr, #OFFSET]
+  .if \backwards
    .set OFFSET, OFFSET-32
   .else
    .set OFFSET, OFFSET+32
@@ -61,7 +61,7 @@ fname:
  * pointer will be rounded down for preloading, and if so, by how many
  * cache lines?
  */
- .if backwards
+ .if \backwards
 /* Here we compare against how many bytes we are into the
  * cache line, counting down from the highest such address.
  * Effectively, we want to calculate
@@ -71,11 +71,11 @@ fname:
  * and test if extra_needed is <= 0, or rearranging:
  *     leading_bytes + (src-leading_bytes-1)&31 <= 31
  */
-        mov     tmp, base, lsl #32-5
-        sbc     tmp, tmp, leading_bytes, lsl #32-5
-        adds    tmp, tmp, leading_bytes, lsl #32-5
+        mov     \tmp, \base, lsl #32-5
+        sbc     \tmp, \tmp, \leading_bytes, lsl #32-5
+        adds    \tmp, \tmp, \leading_bytes, lsl #32-5
         bcc     61f
-        pld     [ptr, #-32*(prefetch_distance+1)]
+        pld     [\ptr, #-32*(prefetch_distance+1)]
  .else
 /* Effectively, we want to calculate
  *     leading_bytes = (-dst)&15
@@ -83,76 +83,76 @@ fname:
  *     extra_needed = leading_bytes - cacheline_offset
  * and test if extra_needed is <= 0.
  */
-        mov     tmp, base, lsl #32-5
-        add     tmp, tmp, leading_bytes, lsl #32-5
-        rsbs    tmp, tmp, leading_bytes, lsl #32-5
+        mov     \tmp, \base, lsl #32-5
+        add     \tmp, \tmp, \leading_bytes, lsl #32-5
+        rsbs    \tmp, \tmp, \leading_bytes, lsl #32-5
         bls     61f
-        pld     [ptr, #32*(prefetch_distance+1)]
+        pld     [\ptr, #32*(prefetch_distance+1)]
  .endif
 61:
 .endm
 
 .macro preload_trailing  backwards, base, remain, tmp
         /* We need either 0, 1 or 2 extra preloads */
- .if backwards
-        rsb     tmp, base, #0
-        mov     tmp, tmp, lsl #32-5
+ .if \backwards
+        rsb     \tmp, \base, #0
+        mov     \tmp, \tmp, lsl #32-5
  .else
-        mov     tmp, base, lsl #32-5
+        mov     \tmp, \base, lsl #32-5
  .endif
-        adds    tmp, tmp, remain, lsl #32-5
-        adceqs  tmp, tmp, #0
+        adds    \tmp, \tmp, \remain, lsl #32-5
+        adcseq  \tmp, \tmp, #0
         /* The instruction above has two effects: ensures Z is only
          * set if C was clear (so Z indicates that both shifted quantities
          * were 0), and clears C if Z was set (so C indicates that the sum
          * of the shifted quantities was greater and not equal to 32) */
         beq     82f
- .if backwards
-        sub     tmp, base, #1
-        bic     tmp, tmp, #31
+ .if \backwards
+        sub     \tmp, \base, #1
+        bic     \tmp, \tmp, #31
  .else
-        bic     tmp, base, #31
+        bic     \tmp, \base, #31
  .endif
         bcc     81f
- .if backwards
-        pld     [tmp, #-32*(prefetch_distance+1)]
+ .if \backwards
+        pld     [\tmp, #-32*(prefetch_distance+1)]
 81:
-        pld     [tmp, #-32*prefetch_distance]
+        pld     [\tmp, #-32*prefetch_distance]
  .else
-        pld     [tmp, #32*(prefetch_distance+2)]
+        pld     [\tmp, #32*(prefetch_distance+2)]
 81:
-        pld     [tmp, #32*(prefetch_distance+1)]
+        pld     [\tmp, #32*(prefetch_distance+1)]
  .endif
 82:
 .endm
 
 .macro preload_all    backwards, narrow_case, shift, base, remain, tmp0, tmp1
- .if backwards
-        sub     tmp0, base, #1
-        bic     tmp0, tmp0, #31
-        pld     [tmp0]
-        sub     tmp1, base, remain, lsl #shift
+ .if \backwards
+        sub     \tmp0, \base, #1
+        bic     \tmp0, \tmp0, #31
+        pld     [\tmp0]
+        sub     \tmp1, \base, \remain, lsl #\shift
  .else
-        bic     tmp0, base, #31
-        pld     [tmp0]
-        add     tmp1, base, remain, lsl #shift
-        sub     tmp1, tmp1, #1
+        bic     \tmp0, \base, #31
+        pld     [\tmp0]
+        add     \tmp1, \base, \remain, lsl #\shift
+        sub     \tmp1, \tmp1, #1
  .endif
-        bic     tmp1, tmp1, #31
-        cmp     tmp1, tmp0
+        bic     \tmp1, \tmp1, #31
+        cmp     \tmp1, \tmp0
         beq     92f
- .if narrow_case
+ .if \narrow_case
         /* In this case, all the data fits in either 1 or 2 cache lines */
-        pld     [tmp1]
+        pld     [\tmp1]
  .else
 91:
-  .if backwards
-        sub     tmp0, tmp0, #32
+  .if \backwards
+        sub     \tmp0, \tmp0, #32
   .else
-        add     tmp0, tmp0, #32
+        add     \tmp0, \tmp0, #32
   .endif
-        cmp     tmp0, tmp1
-        pld     [tmp0]
+        cmp     \tmp0, \tmp1
+        pld     [\tmp0]
         bne     91b
  .endif
 92:

--- a/arch/arm/lib/memcmp_rpi.S
+++ b/arch/arm/lib/memcmp_rpi.S
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     .p2align 2
 
 .macro memcmp_process_head  unaligned
- .if unaligned
+ .if \unaligned
         ldr     DAT0, [S_1], #4
         ldr     DAT1, [S_1], #4
         ldr     DAT2, [S_1], #4
@@ -63,10 +63,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .macro memcmp_leading_31bytes
         movs    DAT0, OFF, lsl #31
-        ldrmib  DAT0, [S_1], #1
-        ldrcsh  DAT1, [S_1], #2
-        ldrmib  DAT4, [S_2], #1
-        ldrcsh  DAT5, [S_2], #2
+        ldrbmi  DAT0, [S_1], #1
+        ldrhcs  DAT1, [S_1], #2
+        ldrbmi  DAT4, [S_2], #1
+        ldrhcs  DAT5, [S_2], #2
         movpl   DAT0, #0
         movcc   DAT1, #0
         movpl   DAT4, #0
@@ -81,7 +81,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         ldrcs   DAT1, [S_1], #4
         ldrcs   DAT2, [S_1], #4
         ldrmi   DAT4, [S_2], #4
-        ldmcsia S_2!, {DAT5, DAT6}
+        ldmiacs S_2!, {DAT5, DAT6}
         movpl   DAT0, #0
         movcc   DAT1, #0
         movcc   DAT2, #0
@@ -104,14 +104,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .macro memcmp_trailing_15bytes  unaligned
         movs    N, N, lsl #29
- .if unaligned
+ .if \unaligned
         ldrcs   DAT0, [S_1], #4
         ldrcs   DAT1, [S_1], #4
  .else
-        ldmcsia S_1!, {DAT0, DAT1}
+        ldmiacs S_1!, {DAT0, DAT1}
  .endif
         ldrmi   DAT2, [S_1], #4
-        ldmcsia S_2!, {DAT4, DAT5}
+        ldmiacs S_2!, {DAT4, DAT5}
         ldrmi   DAT6, [S_2], #4
         movcc   DAT0, #0
         movcc   DAT1, #0
@@ -124,10 +124,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         cmpeq   DAT2, DAT6
         bne     200f
         movs    N, N, lsl #2
-        ldrcsh  DAT0, [S_1], #2
-        ldrmib  DAT1, [S_1]
-        ldrcsh  DAT4, [S_2], #2
-        ldrmib  DAT5, [S_2]
+        ldrhcs  DAT0, [S_1], #2
+        ldrbmi  DAT1, [S_1]
+        ldrhcs  DAT4, [S_2], #2
+        ldrbmi  DAT5, [S_2]
         movcc   DAT0, #0
         movpl   DAT1, #0
         movcc   DAT4, #0
@@ -139,10 +139,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .macro memcmp_long_inner_loop  unaligned
 110:
-        memcmp_process_head  unaligned
+        memcmp_process_head  \unaligned
         pld     [S_2, #prefetch_distance*32 + 16]
         memcmp_process_tail
-        memcmp_process_head  unaligned
+        memcmp_process_head  \unaligned
         pld     [S_1, OFF]
         memcmp_process_tail
         subs    N, N, #32
@@ -153,14 +153,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         preload_trailing  0, S_2, N, DAT0
         add     N, N, #(prefetch_distance+2)*32 - 16
 120:
-        memcmp_process_head  unaligned
+        memcmp_process_head  \unaligned
         memcmp_process_tail
         subs    N, N, #16
         bhs     120b
         /* Trailing words and bytes */
         tst     N, #15
         beq     199f
-        memcmp_trailing_15bytes  unaligned
+        memcmp_trailing_15bytes  \unaligned
 199:    /* Reached end without detecting a difference */
         mov     a1, #0
         setend  le
@@ -171,14 +171,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         subs    N, N, #16     /* simplifies inner loop termination */
         blo     122f
 120:
-        memcmp_process_head  unaligned
+        memcmp_process_head  \unaligned
         memcmp_process_tail
         subs    N, N, #16
         bhs     120b
 122:    /* Trailing words and bytes */
         tst     N, #15
         beq     199f
-        memcmp_trailing_15bytes  unaligned
+        memcmp_trailing_15bytes  \unaligned
 199:    /* Reached end without detecting a difference */
         mov     a1, #0
         setend  le

--- a/arch/arm/lib/memcpymove.h
+++ b/arch/arm/lib/memcpymove.h
@@ -27,111 +27,111 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 .macro unaligned_words  backwards, align, use_pld, words, r0, r1, r2, r3, r4, r5, r6, r7, r8
- .if words == 1
-  .if backwards
-        mov     r1, r0, lsl #32-align*8
+ .if \words == 1
+  .if \backwards
+        mov     \r1, \r0, lsl #32-\align*8
         ldr     r0, [S, #-4]!
-        orr     r1, r1, r0, lsr #align*8
-        str     r1, [D, #-4]!
+        orr     \r1, \r1, \r0, lsr #\align*8
+        str     \r1, [D, #-4]!
   .else
-        mov     r0, r1, lsr #align*8
-        ldr     r1, [S, #4]!
-        orr     r0, r0, r1, lsl #32-align*8
-        str     r0, [D], #4
+        mov     \r0, \r1, lsr #\align*8
+        ldr     \r1, [S, #4]!
+        orr     \r0, \r0, \r1, lsl #32-\align*8
+        str     \r0, [D], #4
   .endif
- .elseif words == 2
-  .if backwards
-        ldr     r1, [S, #-4]!
-        mov     r2, r0, lsl #32-align*8
-        ldr     r0, [S, #-4]!
-        orr     r2, r2, r1, lsr #align*8
-        mov     r1, r1, lsl #32-align*8
-        orr     r1, r1, r0, lsr #align*8
-        stmdb   D!, {r1, r2}
+ .elseif \words == 2
+  .if \backwards
+        ldr     \r1, [S, #-4]!
+        mov     \r2, \r0, lsl #32-\align*8
+        ldr     \r0, [S, #-4]!
+        orr     \r2, \r2, \r1, lsr #\align*8
+        mov     \r1, \r1, lsl #32-\align*8
+        orr     \r1, \r1, \r0, lsr #\align*8
+        stmdb   D!, {\r1, \r2}
   .else
-        ldr     r1, [S, #4]!
-        mov     r0, r2, lsr #align*8
-        ldr     r2, [S, #4]!
-        orr     r0, r0, r1, lsl #32-align*8
-        mov     r1, r1, lsr #align*8
-        orr     r1, r1, r2, lsl #32-align*8
-        stmia   D!, {r0, r1}
+        ldr     \r1, [S, #4]!
+        mov     \r0, \r2, lsr #\align*8
+        ldr     \r2, [S, #4]!
+        orr     \r0, \r0, \r1, lsl #32-\align*8
+        mov     \r1, \r1, lsr #\align*8
+        orr     \r1, \r1, \r2, lsl #32-\align*8
+        stmia   D!, {\r0, \r1}
   .endif
- .elseif words == 4
-  .if backwards
-        ldmdb   S!, {r2, r3}
-        mov     r4, r0, lsl #32-align*8
-        ldmdb   S!, {r0, r1}
-        orr     r4, r4, r3, lsr #align*8
-        mov     r3, r3, lsl #32-align*8
-        orr     r3, r3, r2, lsr #align*8
-        mov     r2, r2, lsl #32-align*8
-        orr     r2, r2, r1, lsr #align*8
-        mov     r1, r1, lsl #32-align*8
-        orr     r1, r1, r0, lsr #align*8
-        stmdb   D!, {r1, r2, r3, r4}
+ .elseif \words == 4
+  .if \backwards
+        ldmdb   S!, {\r2, \r3}
+        mov     \r4, \r0, lsl #32-\align*8
+        ldmdb   S!, {\r0, \r1}
+        orr     \r4, \r4, \r3, lsr #\align*8
+        mov     \r3, \r3, lsl #32-\align*8
+        orr     \r3, \r3, \r2, lsr #\align*8
+        mov     \r2, \r2, lsl #32-\align*8
+        orr     \r2, \r2, \r1, lsr #\align*8
+        mov     \r1, \r1, lsl #32-\align*8
+        orr     \r1, \r1, \r0, lsr #\align*8
+        stmdb   D!, {\r1, \r2, \r3, \r4}
   .else
-        ldmib   S!, {r1, r2}
-        mov     r0, r4, lsr #align*8
-        ldmib   S!, {r3, r4}
-        orr     r0, r0, r1, lsl #32-align*8
-        mov     r1, r1, lsr #align*8
-        orr     r1, r1, r2, lsl #32-align*8
-        mov     r2, r2, lsr #align*8
-        orr     r2, r2, r3, lsl #32-align*8
-        mov     r3, r3, lsr #align*8
-        orr     r3, r3, r4, lsl #32-align*8
-        stmia   D!, {r0, r1, r2, r3}
+        ldmib   S!, {\r1, \r2}
+        mov     \r0, \r4, lsr #\align*8
+        ldmib   S!, {\r3, \r4}
+        orr     \r0, \r0, \r1, lsl #32-\align*8
+        mov     \r1, \r1, lsr #\align*8
+        orr     \r1, \r1, \r2, lsl #32-\align*8
+        mov     \r2, \r2, lsr #\align*8
+        orr     \r2, \r2, \r3, lsl #32-\align*8
+        mov     \r3, \r3, lsr #\align*8
+        orr     \r3, \r3, \r4, lsl #32-\align*8
+        stmia   D!, {\r0, \r1, \r2, \r3}
   .endif
- .elseif words == 8
-  .if backwards
-        ldmdb   S!, {r4, r5, r6, r7}
-        mov     r8, r0, lsl #32-align*8
-        ldmdb   S!, {r0, r1, r2, r3}
-   .if use_pld
+ .elseif \words == 8
+  .if \backwards
+        ldmdb   S!, {\r4, \r5, \r6, \r7}
+        mov     \r8, \r0, lsl #32-\align*8
+        ldmdb   S!, {\r0, \r1, \r2, \r3}
+   .if \use_pld
         pld     [S, OFF]
    .endif
-        orr     r8, r8, r7, lsr #align*8
-        mov     r7, r7, lsl #32-align*8
-        orr     r7, r7, r6, lsr #align*8
-        mov     r6, r6, lsl #32-align*8
-        orr     r6, r6, r5, lsr #align*8
-        mov     r5, r5, lsl #32-align*8
-        orr     r5, r5, r4, lsr #align*8
-        mov     r4, r4, lsl #32-align*8
-        orr     r4, r4, r3, lsr #align*8
-        mov     r3, r3, lsl #32-align*8
-        orr     r3, r3, r2, lsr #align*8
-        mov     r2, r2, lsl #32-align*8
-        orr     r2, r2, r1, lsr #align*8
-        mov     r1, r1, lsl #32-align*8
-        orr     r1, r1, r0, lsr #align*8
-        stmdb   D!, {r5, r6, r7, r8}
-        stmdb   D!, {r1, r2, r3, r4}
+        orr     \r8, \r8, \r7, lsr #\align*8
+        mov     \r7, \r7, lsl #32-\align*8
+        orr     \r7, \r7, \r6, lsr #\align*8
+        mov     \r6, \r6, lsl #32-\align*8
+        orr     \r6, \r6, \r5, lsr #\align*8
+        mov     \r5, \r5, lsl #32-\align*8
+        orr     \r5, \r5, \r4, lsr #\align*8
+        mov     \r4, \r4, lsl #32-\align*8
+        orr     \r4, \r4, \r3, lsr #\align*8
+        mov     \r3, \r3, lsl #32-\align*8
+        orr     \r3, \r3, \r2, lsr #\align*8
+        mov     \r2, \r2, lsl #32-\align*8
+        orr     \r2, \r2, \r1, lsr #\align*8
+        mov     \r1, \r1, lsl #32-\align*8
+        orr     \r1, \r1, \r0, lsr #\align*8
+        stmdb   D!, {\r5, \r6, \r7, \r8}
+        stmdb   D!, {\r1, \r2, \r3, \r4}
   .else
-        ldmib   S!, {r1, r2, r3, r4}
-        mov     r0, r8, lsr #align*8
-        ldmib   S!, {r5, r6, r7, r8}
-   .if use_pld
+        ldmib   S!, {\r1, \r2, \r3, \r4}
+        mov     \r0, \r8, lsr #\align*8
+        ldmib   S!, {\r5, \r6, \r7, \r8}
+   .if \use_pld
         pld     [S, OFF]
    .endif
-        orr     r0, r0, r1, lsl #32-align*8
-        mov     r1, r1, lsr #align*8
-        orr     r1, r1, r2, lsl #32-align*8
-        mov     r2, r2, lsr #align*8
-        orr     r2, r2, r3, lsl #32-align*8
-        mov     r3, r3, lsr #align*8
-        orr     r3, r3, r4, lsl #32-align*8
-        mov     r4, r4, lsr #align*8
-        orr     r4, r4, r5, lsl #32-align*8
-        mov     r5, r5, lsr #align*8
-        orr     r5, r5, r6, lsl #32-align*8
-        mov     r6, r6, lsr #align*8
-        orr     r6, r6, r7, lsl #32-align*8
-        mov     r7, r7, lsr #align*8
-        orr     r7, r7, r8, lsl #32-align*8
-        stmia   D!, {r0, r1, r2, r3}
-        stmia   D!, {r4, r5, r6, r7}
+        orr     \r0, \r0, \r1, lsl #32-\align*8
+        mov     \r1, \r1, lsr #\align*8
+        orr     \r1, \r1, \r2, lsl #32-\align*8
+        mov     \r2, \r2, lsr #\align*8
+        orr     \r2, \r2, \r3, lsl #32-\align*8
+        mov     \r3, \r3, lsr #\align*8
+        orr     \r3, \r3, \r4, lsl #32-\align*8
+        mov     \r4, \r4, lsr #\align*8
+        orr     \r4, \r4, \r5, lsl #32-\align*8
+        mov     \r5, \r5, lsr #\align*8
+        orr     \r5, \r5, \r6, lsl #32-\align*8
+        mov     \r6, \r6, lsr #\align*8
+        orr     \r6, \r6, \r7, lsl #32-\align*8
+        mov     \r7, \r7, lsr #\align*8
+        orr     \r7, \r7, \r8, lsl #32-\align*8
+        stmia   D!, {\r0, \r1, \r2, \r3}
+        stmia   D!, {\r4, \r5, \r6, \r7}
   .endif
  .endif
 .endm
@@ -139,89 +139,89 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .macro memcpy_leading_15bytes  backwards, align
         movs    DAT1, DAT2, lsl #31
         sub     N, N, DAT2
- .if backwards
-        ldrmib  DAT0, [S, #-1]!
-        ldrcsh  DAT1, [S, #-2]!
-        strmib  DAT0, [D, #-1]!
-        strcsh  DAT1, [D, #-2]!
+ .if \backwards
+        ldrbmi  DAT0, [S, #-1]!
+        ldrhcs  DAT1, [S, #-2]!
+        strbmi  DAT0, [D, #-1]!
+        strhcs  DAT1, [D, #-2]!
  .else
-        ldrmib  DAT0, [S], #1
-        ldrcsh  DAT1, [S], #2
-        strmib  DAT0, [D], #1
-        strcsh  DAT1, [D], #2
+        ldrbmi  DAT0, [S], #1
+        ldrhcs  DAT1, [S], #2
+        strbmi  DAT0, [D], #1
+        strhcs  DAT1, [D], #2
  .endif
         movs    DAT1, DAT2, lsl #29
- .if backwards
+ .if \backwards
         ldrmi   DAT0, [S, #-4]!
-  .if align == 0
+  .if \align == 0
         ldmcsdb S!, {DAT1, DAT2}
   .else
         ldrcs   DAT2, [S, #-4]!
         ldrcs   DAT1, [S, #-4]!
   .endif
         strmi   DAT0, [D, #-4]!
-        stmcsdb D!, {DAT1, DAT2}
+        stmdbcs D!, {DAT1, DAT2}
  .else
         ldrmi   DAT0, [S], #4
-  .if align == 0
-        ldmcsia S!, {DAT1, DAT2}
+  .if \align == 0
+        ldmiacs S!, {DAT1, DAT2}
   .else
         ldrcs   DAT1, [S], #4
         ldrcs   DAT2, [S], #4
   .endif
         strmi   DAT0, [D], #4
-        stmcsia D!, {DAT1, DAT2}
+        stmiacs D!, {DAT1, DAT2}
  .endif
 .endm
 
 .macro memcpy_trailing_15bytes  backwards, align
         movs    N, N, lsl #29
- .if backwards
-  .if align == 0
-        ldmcsdb S!, {DAT0, DAT1}
+ .if \backwards
+  .if \align == 0
+        ldmdbcs S!, {DAT0, DAT1}
   .else
         ldrcs   DAT1, [S, #-4]!
         ldrcs   DAT0, [S, #-4]!
   .endif
         ldrmi   DAT2, [S, #-4]!
-        stmcsdb D!, {DAT0, DAT1}
+        stmdbcs D!, {DAT0, DAT1}
         strmi   DAT2, [D, #-4]!
  .else
-  .if align == 0
-        ldmcsia S!, {DAT0, DAT1}
+  .if \align == 0
+        ldmiacs S!, {DAT0, DAT1}
   .else
         ldrcs   DAT0, [S], #4
         ldrcs   DAT1, [S], #4
   .endif
         ldrmi   DAT2, [S], #4
-        stmcsia D!, {DAT0, DAT1}
+        stmiacs D!, {DAT0, DAT1}
         strmi   DAT2, [D], #4
  .endif
         movs    N, N, lsl #2
- .if backwards
-        ldrcsh  DAT0, [S, #-2]!
-        ldrmib  DAT1, [S, #-1]
-        strcsh  DAT0, [D, #-2]!
-        strmib  DAT1, [D, #-1]
+ .if \backwards
+        ldrhcs  DAT0, [S, #-2]!
+        ldrbmi  DAT1, [S, #-1]
+        strhcs  DAT0, [D, #-2]!
+        strbmi  DAT1, [D, #-1]
  .else
-        ldrcsh  DAT0, [S], #2
-        ldrmib  DAT1, [S]
-        strcsh  DAT0, [D], #2
-        strmib  DAT1, [D]
+        ldrhcs  DAT0, [S], #2
+        ldrbmi  DAT1, [S]
+        strhcs  DAT0, [D], #2
+        strbmi  DAT1, [D]
  .endif
 .endm
 
 .macro memcpy_long_inner_loop  backwards, align
- .if align != 0
-  .if backwards
-        ldr     DAT0, [S, #-align]!
+ .if \align != 0
+  .if \backwards
+        ldr     DAT0, [S, #-\align]!
   .else
-        ldr     LAST, [S, #-align]!
+        ldr     LAST, [S, #-\align]!
   .endif
  .endif
 110:
- .if align == 0
-  .if backwards
+ .if \align == 0
+  .if \backwards
         ldmdb   S!, {DAT0, DAT1, DAT2, DAT3, DAT4, DAT5, DAT6, LAST}
         pld     [S, OFF]
         stmdb   D!, {DAT4, DAT5, DAT6, LAST}
@@ -233,16 +233,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         stmia   D!, {DAT4, DAT5, DAT6, LAST}
   .endif
  .else
-        unaligned_words  backwards, align, 1, 8, DAT0, DAT1, DAT2, DAT3, DAT4, DAT5, DAT6, DAT7, LAST
+        unaligned_words  \backwards, \align, 1, 8, DAT0, DAT1, DAT2, DAT3, DAT4, DAT5, DAT6, DAT7, LAST
  .endif
         subs    N, N, #32
         bhs     110b
         /* Just before the final (prefetch_distance+1) 32-byte blocks, deal with final preloads */
-        preload_trailing  backwards, S, N, OFF
+        preload_trailing  \backwards, S, N, OFF
         add     N, N, #(prefetch_distance+2)*32 - 32
 120:
- .if align == 0
-  .if backwards
+ .if \align == 0
+  .if \backwards
         ldmdb   S!, {DAT0, DAT1, DAT2, DAT3, DAT4, DAT5, DAT6, LAST}
         stmdb   D!, {DAT4, DAT5, DAT6, LAST}
         stmdb   D!, {DAT0, DAT1, DAT2, DAT3}
@@ -252,31 +252,31 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         stmia   D!, {DAT4, DAT5, DAT6, LAST}
   .endif
  .else
-        unaligned_words  backwards, align, 0, 8, DAT0, DAT1, DAT2, DAT3, DAT4, DAT5, DAT6, DAT7, LAST
+        unaligned_words  \backwards, \align, 0, 8, DAT0, DAT1, DAT2, DAT3, DAT4, DAT5, DAT6, DAT7, LAST
  .endif
         subs    N, N, #32
         bhs     120b
         tst     N, #16
- .if align == 0
-  .if backwards
-        ldmnedb S!, {DAT0, DAT1, DAT2, LAST}
-        stmnedb D!, {DAT0, DAT1, DAT2, LAST}
+ .if \align == 0
+  .if \backwards
+        ldmdbne S!, {DAT0, DAT1, DAT2, LAST}
+        stmdbne D!, {DAT0, DAT1, DAT2, LAST}
   .else
-        ldmneia S!, {DAT0, DAT1, DAT2, LAST}
-        stmneia D!, {DAT0, DAT1, DAT2, LAST}
+        ldmiane S!, {DAT0, DAT1, DAT2, LAST}
+        stmiane D!, {DAT0, DAT1, DAT2, LAST}
   .endif
  .else
         beq     130f
-        unaligned_words  backwards, align, 0, 4, DAT0, DAT1, DAT2, DAT3, LAST
+        unaligned_words  \backwards, \align, 0, 4, DAT0, DAT1, DAT2, DAT3, LAST
 130:
  .endif
         /* Trailing words and bytes */
         tst      N, #15
         beq      199f
- .if align != 0
-        add     S, S, #align
+ .if \align != 0
+        add     S, S, #\align
  .endif
-        memcpy_trailing_15bytes  backwards, align
+        memcpy_trailing_15bytes  \backwards, \align
 199:
         pop     {DAT3, DAT4, DAT5, DAT6, DAT7}
         pop     {D, DAT1, DAT2, pc}
@@ -284,8 +284,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .macro memcpy_medium_inner_loop  backwards, align
 120:
- .if backwards
-  .if align == 0
+ .if \backwards
+  .if \align == 0
         ldmdb   S!, {DAT0, DAT1, DAT2, LAST}
   .else
         ldr     LAST, [S, #-4]!
@@ -295,7 +295,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   .endif
         stmdb   D!, {DAT0, DAT1, DAT2, LAST}
  .else
-  .if align == 0
+  .if \align == 0
         ldmia   S!, {DAT0, DAT1, DAT2, LAST}
   .else
         ldr     DAT0, [S], #4
@@ -310,35 +310,35 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         /* Trailing words and bytes */
         tst      N, #15
         beq      199f
-        memcpy_trailing_15bytes  backwards, align
+        memcpy_trailing_15bytes  \backwards, \align
 199:
         pop     {D, DAT1, DAT2, pc}
 .endm
 
 .macro memcpy_short_inner_loop  backwards, align
         tst     N, #16
- .if backwards
-  .if align == 0
-        ldmnedb S!, {DAT0, DAT1, DAT2, LAST}
+ .if \backwards
+  .if \align == 0
+        ldmdbne S!, {DAT0, DAT1, DAT2, LAST}
   .else
         ldrne   LAST, [S, #-4]!
         ldrne   DAT2, [S, #-4]!
         ldrne   DAT1, [S, #-4]!
         ldrne   DAT0, [S, #-4]!
   .endif
-        stmnedb D!, {DAT0, DAT1, DAT2, LAST}
+        stmdbne D!, {DAT0, DAT1, DAT2, LAST}
  .else
-  .if align == 0
-        ldmneia S!, {DAT0, DAT1, DAT2, LAST}
+  .if \align == 0
+        ldmiane S!, {DAT0, DAT1, DAT2, LAST}
   .else
         ldrne   DAT0, [S], #4
         ldrne   DAT1, [S], #4
         ldrne   DAT2, [S], #4
         ldrne   LAST, [S], #4
   .endif
-        stmneia D!, {DAT0, DAT1, DAT2, LAST}
+        stmiane D!, {DAT0, DAT1, DAT2, LAST}
  .endif
-        memcpy_trailing_15bytes  backwards, align
+        memcpy_trailing_15bytes  \backwards, \align
 199:
         pop     {D, DAT1, DAT2, pc}
 .endm
@@ -366,7 +366,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         UNWIND( .fnstart )
         UNWIND( .save {D, DAT1, DAT2, lr} )
 
- .if backwards
+ .if \backwards
         add     D, D, N
         add     S, S, N
  .endif
@@ -390,8 +390,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
          * inner loop termination. We want it to stop when there are
          * (prefetch_distance+1) complete blocks to go. */
         sub     N, N, #(prefetch_distance+2)*32
-        preload_leading_step1  backwards, DAT0, S
- .if backwards
+        preload_leading_step1  \backwards, DAT0, S
+ .if \backwards
         /* Bug in GAS: it accepts, but mis-assembles the instruction
          * ands    DAT2, D, #60, 2
          * which sets DAT2 to the number of leading bytes until destination is aligned and also clears C (sets borrow)
@@ -403,11 +403,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         beq     154f
         rsb     DAT2, DAT2, #16 /* number of leading bytes until destination aligned */
  .endif
-        preload_leading_step2  backwards, DAT0, S, DAT2, OFF
-        memcpy_leading_15bytes backwards, 1
+        preload_leading_step2  \backwards, DAT0, S, DAT2, OFF
+        memcpy_leading_15bytes \backwards, 1
 154:    /* Destination now 16-byte aligned; we have at least one prefetch as well as at least one 16-byte output block */
         /* Prefetch offset is best selected such that it lies in the first 8 of each 32 bytes - but it's just as easy to aim for the first one */
- .if backwards
+ .if \backwards
         rsb     OFF, S, #3
         and     OFF, OFF, #28
         sub     OFF, OFF, #32*(prefetch_distance+1)
@@ -419,10 +419,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         bhi     157f
         bcs     156f
         bmi     155f
-        memcpy_long_inner_loop  backwards, 0
-155:    memcpy_long_inner_loop  backwards, 1
-156:    memcpy_long_inner_loop  backwards, 2
-157:    memcpy_long_inner_loop  backwards, 3
+        memcpy_long_inner_loop  \backwards, 0
+155:    memcpy_long_inner_loop  \backwards, 1
+156:    memcpy_long_inner_loop  \backwards, 2
+157:    memcpy_long_inner_loop  \backwards, 3
 
         UNWIND( .fnend )
 
@@ -430,9 +430,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         UNWIND( .save {D, DAT1, DAT2, lr} )
 
 160:    /* Medium case */
-        preload_all  backwards, 0, 0, S, N, DAT2, OFF
+        preload_all  \backwards, 0, 0, S, N, DAT2, OFF
         sub     N, N, #16     /* simplifies inner loop termination */
- .if backwards
+ .if \backwards
         ands    DAT2, D, #15
         beq     164f
  .else
@@ -440,22 +440,22 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         beq     164f
         rsb     DAT2, DAT2, #16
  .endif
-        memcpy_leading_15bytes backwards, align
+        memcpy_leading_15bytes \backwards, 1
 164:    /* Destination now 16-byte aligned; we have at least one 16-byte output block */
         tst     S, #3
         bne     140f
-        memcpy_medium_inner_loop  backwards, 0
-140:    memcpy_medium_inner_loop  backwards, 1
+        memcpy_medium_inner_loop  \backwards, 0
+140:    memcpy_medium_inner_loop  \backwards, 1
 
 170:    /* Short case, less than 31 bytes, so no guarantee of at least one 16-byte block */
         teq     N, #0
         beq     199f
-        preload_all  backwards, 1, 0, S, N, DAT2, LAST
+        preload_all  \backwards, 1, 0, S, N, DAT2, LAST
         tst     D, #3
         beq     174f
 172:    subs    N, N, #1
         blo     199f
- .if backwards
+ .if \backwards
         ldrb    DAT0, [S, #-1]!
         strb    DAT0, [D, #-1]!
  .else
@@ -467,8 +467,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 174:    /* Destination now 4-byte aligned; we have 0 or more output bytes to go */
         tst     S, #3
         bne     140f
-        memcpy_short_inner_loop  backwards, 0
-140:    memcpy_short_inner_loop  backwards, 1
+        memcpy_short_inner_loop  \backwards, 0
+140:    memcpy_short_inner_loop  \backwards, 1
 
         UNWIND( .fnend )
 

--- a/arch/arm/lib/memset_rpi.S
+++ b/arch/arm/lib/memset_rpi.S
@@ -81,14 +81,14 @@ ENTRY(__memset64)
         rsb     DAT3, S, #0   /* bits 0-3 = number of leading bytes until aligned */
         movs    DAT2, DAT3, lsl #31
         submi   N, N, #1
-        strmib  DAT0, [S], #1
+        strbmi  DAT0, [S], #1
         subcs   N, N, #2
-        strcsh  DAT0, [S], #2
+        strhcs  DAT0, [S], #2
         movs    DAT2, DAT3, lsl #29
         submi   N, N, #4
         strmi   DAT0, [S], #4
         subcs   N, N, #8
-        stmcsia S!, {DAT0, DAT1}
+        stmiacs S!, {DAT0, DAT1}
 164:    /* Delayed set up of DAT2 and DAT3 so we could use them as scratch registers above */
         mov     DAT2, DAT0
         mov     DAT3, DAT1
@@ -98,11 +98,11 @@ ENTRY(__memset64)
         bhs     165b
 166:    /* Trailing words and bytes */
         movs    N, N, lsl #29
-        stmcsia S!, {DAT0, DAT1}
+        stmiacs S!, {DAT0, DAT1}
         strmi   DAT0, [S], #4
         movs    N, N, lsl #2
-        strcsh  DAT0, [S], #2
-        strmib  DAT0, [S]
+        strhcs  DAT0, [S], #2
+        strbmi  DAT0, [S]
 199:    pop     {S, pc}
 
 170:    /* Short case */
@@ -116,7 +116,7 @@ ENTRY(__memset64)
         tst     S, #3
         bne     172b
 174:    tst     N, #16
-        stmneia S!, {DAT0, DAT1, DAT2, DAT3}
+        stmiane S!, {DAT0, DAT1, DAT2, DAT3}
         b       166b
 
         .unreq  S


### PR DESCRIPTION
The LLVM assembler is stricter on the source syntax than GCC.

- Prepend a backslash (\) to each macro argument.

- The condition field is always the last portion of an instruction mnemonic.

- The terms of the relational operators in a conditional assemble directive are integers, not strings.

The assembly source files complying above assemble by both LLVM and GCC / Binutils.

Issue: [5295](https://github.com/raspberrypi/linux/issues/5295)
Build tested on: clang 14.0.6 and gcc Raspbian 12.2.0-14+rpi1, both armhf native on qemu-static.
Kernel exec tested on: Raspberry Pi 3B+ and Zero W.