### PR TITLE
drm/vc4: Set TV margins on the composite connector state

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_vec.c
+++ b/drivers/gpu/drm/vc4/vc4_vec.c
@@ -436,6 +436,9 @@ static void vc4_vec_connector_reset(struct drm_connector *connector)
 	/* preserve TV standard */
 	if (connector->state)
 		connector->state->tv.mode = vc4_vec_get_default_mode(connector);
+
+	/* apply TV margins from the cmdline_mode */
+	drm_atomic_helper_connector_tv_reset(connector);
 }
 
 static int vc4_vec_connector_atomic_check(struct drm_connector *conn,
@@ -482,6 +485,8 @@ static int vc4_vec_connector_init(struct drm_device *dev, struct vc4_vec *vec)
 		return ret;
 
 	drm_connector_helper_add(connector, &vc4_vec_connector_helper_funcs);
+
+	drm_connector_attach_tv_margin_properties(connector);
 
 	drm_object_attach_property(&connector->base,
 				   dev->mode_config.tv_mode_property,


### PR DESCRIPTION
The `overscan_*` settings in the config.txt do not work on the composite video output with the VC4 KMS driver. This patch fixes it (tested on a Raspberry Pi 4). See the commit message for a more detailed description.

Here are some forum entries that I collected where people are reporting this issue:
https://forums.raspberrypi.com/viewtopic.php?t=330579
https://forums.raspberrypi.com/viewtopic.php?t=330924
https://forums.raspberrypi.com/viewtopic.php?t=342062

I did not test this with an upstream kernel, but it already does the necessary `drm_atomic_helper_connector_tv_reset()` in the conncetor reset function. On the other hand it does not call `drm_connector_attach_tv_margin_properties()` in the connector init function, which I think is necessary?!

What is the correct approach here: patch the raspberrypi kernel, then try to send a similar patch upstream?