### PR TITLE
overlays: ov5647: cam0 mode should use cam0_reg

### DIFF
--- a/arch/arm/boot/dts/overlays/ov5647-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov5647-overlay.dts
@@ -15,7 +15,7 @@
 
 			#include "ov5647.dtsi"
 
-			vcm: ad5398@c {
+			vcm_node: ad5398@c {
 				compatible = "adi,ad5398";
 				reg = <0x0c>;
 				status = "disabled";
@@ -78,8 +78,8 @@
 		       <&clk_frag>, "target:0=",<&cam0_clk>,
 		       <&cam_node>, "clocks:0=",<&cam0_clk>,
 		       <&cam_node>, "avdd-supply:0=",<&cam0_reg>;
-		vcm = <&vcm>, "status=okay",
-		      <&cam_node>,"lens-focus:0=", <&vcm>;
+		vcm = <&vcm_node>, "status=okay",
+		       <&cam_node>,"lens-focus:0=", <&vcm_node>;
 	};
 };
 

--- a/arch/arm/boot/dts/overlays/ov5647-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov5647-overlay.dts
@@ -77,7 +77,8 @@
 		       <&reg_frag>, "target:0=",<&cam0_reg>,
 		       <&clk_frag>, "target:0=",<&cam0_clk>,
 		       <&cam_node>, "clocks:0=",<&cam0_clk>,
-		       <&cam_node>, "avdd-supply:0=",<&cam0_reg>;
+		       <&cam_node>, "avdd-supply:0=",<&cam0_reg>,
+		       <&vcm_node>, "VANA-supply:0=",<&cam0_reg>;
 		vcm = <&vcm_node>, "status=okay",
 		       <&cam_node>,"lens-focus:0=", <&vcm_node>;
 	};


### PR DESCRIPTION
When the cam0 parameter is used, the vcm should be updated to refer to
the cam0 regulator.

See: https://github.com/raspberrypi/linux/issues/5722

Also use a more common name for the vcm label.
