### PR TITLE
ASoC: dwc: Remove check in set_bclk_ratio handling

### DIFF
--- a/sound/soc/dwc/dwc-i2s.c
+++ b/sound/soc/dwc/dwc-i2s.c
@@ -427,11 +427,8 @@ static int dw_i2s_set_bclk_ratio(struct snd_soc_dai *cpu_dai,
 				 unsigned int ratio)
 {
 	struct dw_i2s_dev *dev = snd_soc_dai_get_drvdata(cpu_dai);
-	struct i2s_clk_config_data *config = &dev->config;
 
 	dev_dbg(dev->dev, "%s(%d)\n", __func__, ratio);
-	if (ratio < config->data_width * 2)
-		return -EINVAL;
 
 	switch (ratio) {
 	case 32:


### PR DESCRIPTION
A check added to dw_i2s_set_bclk_ratio that the data format is consistent with the ratio seems reasonable but breaks when the ratio is changed before the format. Remove the check - it is unnecessary.

See: https://github.com/raspberrypi/linux/issues/5724
Fixes: 9c6694c24f26 ("ASOC: dwc: Fix 16-bit audio handling")