### PR TITLE
Squashed commit of the following:

### DIFF
--- a/arch/arm/boot/dts/overlays/imx296-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx296-overlay.dts
@@ -97,8 +97,9 @@
 		cam0 = <&i2c_frag>, "target:0=",<&i2c_csi_dsi0>,
 		       <&csi_frag>, "target:0=",<&csi0>,
 		       <&clk_frag>, "target:0=",<&cam0_clk>,
+		       <&reg_frag>, "target:0=",<&cam0_reg>,
 		       <&imx296>, "clocks:0=",<&cam0_clk>,
-		       <&imx296>, "VANA-supply:0=",<&cam0_reg>;
+		       <&imx296>, "avdd-supply:0=",<&cam0_reg>;
 		clock-frequency = <&clk_over>, "clock-frequency:0";
 	};
 };

--- a/drivers/media/i2c/imx296.c
+++ b/drivers/media/i2c/imx296.c
@@ -1031,7 +1031,6 @@ static int imx296_identify_model(struct imx296 *sensor)
 			"failed to get sensor out of standby (%d)\n", ret);
 		return ret;
 	}
-	usleep_range(2000, 5000);
 
 	usleep_range(2000, 5000);
 

--- a/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
@@ -983,7 +983,7 @@ static void cfe_buffer_queue(struct vb2_buffer *vb)
 	spin_unlock_irqrestore(&cfe->state_lock, flags);
 }
 
-static u64 sensor_link_frequency(struct cfe_device *cfe)
+static u64 sensor_link_rate(struct cfe_device *cfe)
 {
 	struct v4l2_mbus_framefmt *source_fmt;
 	struct v4l2_subdev_state *state;
@@ -1028,11 +1028,11 @@ static u64 sensor_link_frequency(struct cfe_device *cfe)
 
 	/* x2 for DDR. */
 	link_freq *= 2;
-	cfe_info("Using a link frequency of %lld Hz\n", link_freq);
+	cfe_info("Using a link rate of %lld Mbps\n", link_freq / (1000 * 1000));
 	return link_freq;
 
 err:
-	cfe_err("Unable to determine sensor link frequency, using 999 MHz\n");
+	cfe_err("Unable to determine sensor link rate, using 999 Mbps\n");
 	return 999 * 1000000UL;
 }
 
@@ -1104,7 +1104,7 @@ static int cfe_start_streaming(struct vb2_queue *vq, unsigned int count)
 	}
 
 	cfe_dbg("Configuring CSI-2 block\n");
-	cfe->csi2.dphy.dphy_freq = sensor_link_frequency(cfe) / 1000000UL;
+	cfe->csi2.dphy.dphy_rate = sensor_link_rate(cfe) / 1000000UL;
 	csi2_open_rx(&cfe->csi2);
 
 	cfe_dbg("Starting sensor streaming\n");

--- a/drivers/media/platform/raspberrypi/rp1_cfe/dphy.c
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/dphy.c
@@ -96,7 +96,7 @@ static uint8_t dphy_transaction(struct dphy_data *dphy, u8 test_code,
 	return get_tstdout(dphy);
 }
 
-static void dphy_set_hsfreqrange(struct dphy_data *dphy, uint32_t freq_mhz)
+static void dphy_set_hsfreqrange(struct dphy_data *dphy, uint32_t mbps)
 {
 	/* See Table 5-1 on page 65 of dphy databook */
 	static const u16 hsfreqrange_table[][2] = {
@@ -116,11 +116,11 @@ static void dphy_set_hsfreqrange(struct dphy_data *dphy, uint32_t freq_mhz)
 	};
 	unsigned int i;
 
-	if (freq_mhz < 80 || freq_mhz > 1500)
-		dphy_err("DPHY: Frequency %u MHz out of range\n", freq_mhz);
+	if (mbps < 80 || mbps > 1500)
+		dphy_err("DPHY: Datarate %u Mbps out of range\n", mbps);
 
 	for (i = 0; i < ARRAY_SIZE(hsfreqrange_table) - 1; i++) {
-		if (freq_mhz <= hsfreqrange_table[i][0])
+		if (mbps <= hsfreqrange_table[i][0])
 			break;
 	}
 
@@ -139,7 +139,7 @@ static void dphy_init(struct dphy_data *dphy)
 	set_tstclr(dphy, 0);
 	usleep_range(15, 20);
 
-	dphy_set_hsfreqrange(dphy, dphy->dphy_freq);
+	dphy_set_hsfreqrange(dphy, dphy->dphy_rate);
 
 	usleep_range(5, 10);
 	dw_csi2_host_write(dphy, PHY_SHUTDOWNZ, 1);

--- a/drivers/media/platform/raspberrypi/rp1_cfe/dphy.h
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/dphy.h
@@ -15,7 +15,7 @@ struct dphy_data {
 
 	void __iomem *base;
 
-	u32 dphy_freq;
+	u32 dphy_rate;
 	u32 num_lanes;
 };
 


### PR DESCRIPTION
commit 6137fb168c08bd8c41c8421bf26f09ed29479f08
Author: Naushir Patuck <naush@raspberrypi.com>
Date:   Wed Nov 15 08:25:11 2023 +0000

    overlays: imx296: Fix cam port override for regulators

    The override was missing/incorrect for the regulator labels.

    Signed-off-by: Naushir Patuck <naush@raspberrypi.com>

commit 65407c54fb4119e528b70b329448269657e0941e
Author: Naushir Patuck <naush@raspberrypi.com>
Date:   Wed Nov 8 10:05:05 2023 +0000

    drivers: media: cfe: Don't confuse MHz and Mbps

    The driver was interchaning these units when talking about link rate.
    Fix this to avoid confusion. Apart from the logging message change,
    there is no function change in this commit.

    Signed-off-by: Naushir Patuck <naush@raspberrypi.com>

commit a054d44b23e3619e4fa2d09139e76fd8cf3f8c7b
Author: Nick Hollinghurst <nick.hollinghurst@raspberrypi.com>
Date:   Tue Nov 14 16:03:54 2023 +0000

    Revert "media: i2c: imx296: Add 2ms delay after releasing standby"

    This reverts commit ecbc04aa0c2e7c8879764c9d2c769ecc74fd9093
    which duplicated 5fb3b300557d6a6902e7321f42fdabb8c09eef54

    Signed-off-by: Nick Hollinghurst <nick.hollinghurst@raspberrypi.com>