### PR TITLE
drm: vc4: Free the dlist alloc immediately if it never hit the hw

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -696,6 +696,7 @@ struct vc4_hvs_dlist_allocation {
 	struct drm_mm_node mm_node;
 	unsigned int channel;
 	u8 target_frame_count;
+	bool dlist_programmed;
 };
 
 struct vc4_crtc_state {


### PR DESCRIPTION
atomic_check creates a state, and allocates the dlist memory for it such that atomic_flush can not fail.

On destroy that dlist allocation was being put in the stale list, even though it had never been programmed into the hardware, therefore doing lots of atomic_checks could consume all the dlist memory and fail.

If the dlist has never been programmed into the hardware, then free it immediately.