### PR TITLE
Fix hysteresis support in gov_step_wise.c

### DIFF
--- a/drivers/thermal/gov_step_wise.c
+++ b/drivers/thermal/gov_step_wise.c
@@ -98,15 +98,9 @@ static void thermal_zone_trip_update(struct thermal_zone_device *tz, int trip_id
 		trace_thermal_zone_trip(tz, trip_id, trip.type);
 	}
 
-	hyst_temp = trip_temp = trip.temperature;
+	trip_temp = trip.temperature;
+	hyst_temp = trip_temp - trip.hysteresis;
 	trip_type = trip.type;
-
-	if (trip.hysteresis)
-		hyst_temp = trip_temp - trip.hysteresis;
-	else
-		dev_info_once(&tz->device,
-			"Zero hysteresis value for Trip%d[type=%d]\n",
-			trip_id, trip_type);
 
 	dev_dbg(&tz->device,
 		"Trip%d[type=%d,temp=%d,hyst=%d]:trend=%d,throttle=%d\n",

--- a/drivers/thermal/gov_step_wise.c
+++ b/drivers/thermal/gov_step_wise.c
@@ -99,11 +99,14 @@ static void thermal_zone_trip_update(struct thermal_zone_device *tz, int trip_id
 	}
 
 	hyst_temp = trip_temp = trip.temperature;
-	if (tz->ops->get_trip_hyst) {
-		tz->ops->get_trip_hyst(tz, trip_id, &hyst_temp);
-		hyst_temp = trip_temp - hyst_temp;
-	}
 	trip_type = trip.type;
+
+	if (trip.hysteresis)
+		hyst_temp = trip_temp - trip.hysteresis;
+	else
+		dev_info_once(&tz->device,
+			"Zero hysteresis value for Trip%d[type=%d]\n",
+			trip_id, trip_type);
 
 	dev_dbg(&tz->device,
 		"Trip%d[type=%d,temp=%d,hyst=%d]:trend=%d,throttle=%d\n",


### PR DESCRIPTION
Directly get hyst value instead of going through an optional and, now, unimplemented function.

Fixes https://github.com/raspberrypi/linux/issues/5726
(Note that there are more drivers with this problem. But this PR fixes it for stand Pi fans.)