### PR TITLE
Add support for adt7410 (module and overlay)

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2148,10 +2148,14 @@ Name:   i2c-sensor
 Info:   Adds support for a number of I2C barometric pressure, temperature,
         light level and chemical sensors on i2c_arm
 Load:   dtoverlay=i2c-sensor,<param>=<val>
-Params: addr                    Set the address for the BH1750, BME280, BME680,
-                                BMP280, BMP380, CCS811, DS1621, HDC100X, JC42,
-                                LM75, MCP980x, MPU6050, MPU9250, MS5637, MS5803,
-                                MS5805, MS5837, MS8607, SHT3x or TMP102
+Params: addr                    Set the address for the ADT7410, BH1750, BME280,
+                                BME680, BMP280, BMP380, CCS811, DS1621, HDC100X,
+                                JC42, LM75, MCP980x, MPU6050, MPU9250, MS5637,
+                                MS5803, MS5805, MS5837, MS8607, SHT3x or TMP102
+
+        adt7410                 Select the Analog Devices ADT7410 and ADT7420
+                                temperature sensors
+                                Valid address 0x48-0x4b, default 0x48
 
         aht10                   Select the Aosong AHT10 temperature and humidity
                                 sensor

--- a/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
@@ -508,6 +508,21 @@
 		};
 	};
 
+	fragment@34 {
+		target = <&i2cbus>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adt7410: adt7410@48 {
+				compatible = "adi,adt7410", "adi,adt7420";
+				reg = <0x48>;
+				status = "okay";
+			};
+		};
+	};
+
 	__overrides__ {
 		bme280 = <0>,"+0";
 		bmp085 = <0>,"+1";
@@ -543,6 +558,7 @@
 		mpu9250 = <0>,"+29";
 		bno055 = <0>,"+31";
 		sht4x = <0>,"+32";
+		adt7410 = <0>,"+34";
 
 		addr =	<&bme280>,"reg:0", <&bmp280>,"reg:0", <&tmp102>,"reg:0",
 			<&lm75>,"reg:0", <&hdc100x>,"reg:0", <&sht3x>,"reg:0",
@@ -552,7 +568,7 @@
 			<&ms5837>,"reg:0", <&ms8607>,"reg:0",
 			<&mpu6050>,"reg:0", <&mpu9250>,"reg:0",
 			<&bno055>,"reg:0", <&sht4x>,"reg:0",
-			<&bmp380>,"reg:0";
+			<&bmp380>,"reg:0", <&adt7410>,"reg:0";
 		int_pin = <&max30102>, "interrupts:0",
 			<&mpu6050>, "interrupts:0",
 			<&mpu9250>, "interrupts:0";


### PR DESCRIPTION
The Analog Devices ADT7410 is a high precision temperature sensor with growing popularity. This PR seeks to add the module and overlay.