### PR TITLE
drm/vc4: vec: Add the margin properties to the connector

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_vec.c
+++ b/drivers/gpu/drm/vc4/vc4_vec.c
@@ -584,6 +584,8 @@ static int vc4_vec_connector_init(struct drm_device *dev, struct vc4_vec *vec)
 
 	drm_object_attach_property(&connector->base, prop, legacy_default_mode);
 
+	drm_connector_attach_tv_margin_properties(connector);
+
 	drm_connector_attach_encoder(connector, &vec->encoder.base);
 
 	return 0;


### PR DESCRIPTION
All the handling for the properties was present, but they were never attached to the connector to allow userspace to change them.

Add them to the connector.