### PR TITLE
ASoC: dwc: Permit sample rates up to 384kHz

### DIFF
--- a/sound/soc/dwc/dwc-i2s.c
+++ b/sound/soc/dwc/dwc-i2s.c
@@ -667,7 +667,7 @@ static int dw_configure_dai_by_dt(struct dw_i2s_dev *dev,
 	if (WARN_ON(idx >= ARRAY_SIZE(bus_widths)))
 		return -EINVAL;
 
-	ret = dw_configure_dai(dev, dw_i2s_dai, SNDRV_PCM_RATE_8000_192000);
+	ret = dw_configure_dai(dev, dw_i2s_dai, SNDRV_PCM_RATE_8000_384000);
 	if (ret < 0)
 		return ret;
 


### PR DESCRIPTION
The BCM2835 I2S block advertises clock rates up to 384kHz, and there's no reason why RP1's DWC I2S block shouldn't do the same.

See: https://github.com/raspberrypi/linux/issues/5748