### PR TITLE
dtoverlays: Add option for cam0 to camera-mux-Nport overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -823,6 +823,8 @@ Params: cam0-arducam-64mp       Select Arducam64MP for camera on port 0
         cam1-ov9281             Select OV9281 for camera on port 1
         cam1-imx290-clk-freq    Set clock frequency for an IMX290 on port 1
 
+        cam0                    Connect the mux to CAM0 port (default is CAM1)
+
 
 Name:   camera-mux-4port
 Info:   Configures a 4 port camera multiplexer
@@ -877,6 +879,8 @@ Params: cam0-arducam-64mp       Select Arducam64MP for camera on port 0
         cam3-ov7251             Select OV7251 for camera on port 3
         cam3-ov9281             Select OV9281 for camera on port 3
         cam3-imx290-clk-freq    Set clock frequency for an IMX290 on port 3
+
+        cam0                    Connect the mux to CAM0 port (default is CAM1)
 
 
 Name:   cap1106

--- a/arch/arm/boot/dts/overlays/camera-mux-2port-overlay.dts
+++ b/arch/arm/boot/dts/overlays/camera-mux-2port-overlay.dts
@@ -77,7 +77,7 @@
 	};
 
 	/* Mux define */
-	fragment@200 {
+	i2c_frag: fragment@200 {
 		target = <&i2c_csi_dsi>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -294,7 +294,7 @@
 		};
 	};
 
-	fragment@201 {
+	csi_frag: fragment@201 {
 		target = <&csi1>;
 		__overlay__ {
 			status = "okay";
@@ -501,5 +501,8 @@
 				       <&imx290_0>,"clock-frequency:0";
 		cam1-imx290-clk-freq = <&clk_imx290>,"clock-frequency:0",
 				       <&imx290_1>,"clock-frequency:0";
+
+		cam0 = <&i2c_frag>, "target:0=",<&i2c_csi_dsi0>,
+		       <&csi_frag>, "target:0=",<&csi0>;
 	};
 };

--- a/arch/arm/boot/dts/overlays/camera-mux-4port-overlay.dts
+++ b/arch/arm/boot/dts/overlays/camera-mux-4port-overlay.dts
@@ -135,7 +135,7 @@
 	};
 
 	/* Mux define */
-	fragment@200 {
+	i2c_frag: fragment@200 {
 		target = <&i2c_csi_dsi>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -552,7 +552,7 @@
 		};
 	};
 
-	fragment@201 {
+	csi_frag: fragment@201 {
 		target = <&csi1>;
 		__overlay__ {
 			status = "okay";
@@ -872,5 +872,8 @@
 				       <&imx290_2>,"clock-frequency:0";
 		cam3-imx290-clk-freq = <&clk_imx290>,"clock-frequency:0",
 				       <&imx290_3>,"clock-frequency:0";
+
+		cam0 = <&i2c_frag>, "target:0=",<&i2c_csi_dsi0>,
+		       <&csi_frag>, "target:0=",<&csi0>;
 	};
 };


### PR DESCRIPTION
Seeing as the mux can be connected to either CAM/DISP1 or CAM/DISP0 on a Pi5, add a cam0 override to allow configuration of which is used. Default (as with all camera overlays) is CAM/DISP1.

The overlay does NOT update the camera regulator used by all the sensors as doing so would be a nightmare. The Arducam mulitplexer boards these overlays are initially supporting seem to tie the regulator GPIO for all the sensors high anyway.
If it was viewed as necessary, then creating an additional regulator that listed cam[01]_reg as the parent should work.