### PR TITLE
overlays: ADS1115: allow specification of the i2c bus

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -489,6 +489,16 @@ Params: addr                    I2C bus address of device. Set based on how the
         cha_gain                Set the gain of the Programmable Gain
                                 Amplifier for this channel. (Default 1 sets the
                                 full scale of the channel to 4.096 Volts)
+        i2c0                    Choose the I2C0 bus on GPIOs 0&1
+        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c3                    Choose the I2C3 bus (configure with the i2c3
+                                overlay - BCM2711 only)
+        i2c4                    Choose the I2C4 bus (configure with the i2c4
+                                overlay - BCM2711 only)
+        i2c5                    Choose the I2C5 bus (configure with the i2c5
+                                overlay - BCM2711 only)
+        i2c6                    Choose the I2C6 bus (configure with the i2c6
+                                overlay - BCM2711 only)
 
         Channel parameters can be set for each enabled channel.
         A maximum of 4 channels can be enabled (letters a thru d).

--- a/arch/arm/boot/dts/overlays/ads1115-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ads1115-overlay.dts
@@ -9,7 +9,63 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c_arm>;
+		target = <&ads1115>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			channel_a: channel_a {
+				reg = <4>;
+				ti,gain = <1>;
+				ti,datarate = <7>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&ads1115>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			channel_b: channel_b {
+				reg = <5>;
+				ti,gain = <1>;
+				ti,datarate = <7>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&ads1115>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			channel_c: channel_c {
+				reg = <6>;
+				ti,gain = <1>;
+				ti,datarate = <7>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&ads1115>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			channel_d: channel_d {
+				reg = <7>;
+				ti,gain = <1>;
+				ti,datarate = <7>;
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&i2cbus>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -25,79 +81,55 @@
 		};
 	};
 
-	fragment@1 {
-		target = <&ads1115>;
-		__dormant__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			channel_a: channel_a {
-				reg = <4>;
-				ti,gain = <1>;
-				ti,datarate = <7>;
-			};
+	frag100: fragment@100 {
+		target = <&i2c1>;
+		i2cbus: __overlay__ {
+			status = "okay";
 		};
 	};
 
-	fragment@2 {
-		target = <&ads1115>;
+	fragment@101 {
+		target = <&i2c0if>;
 		__dormant__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			channel_b: channel_b {
-				reg = <5>;
-				ti,gain = <1>;
-				ti,datarate = <7>;
-			};
+			status = "okay";
 		};
 	};
 
-	fragment@3 {
-		target = <&ads1115>;
+	fragment@102 {
+		target = <&i2c0mux>;
 		__dormant__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			channel_c: channel_c {
-				reg = <6>;
-				ti,gain = <1>;
-				ti,datarate = <7>;
-			};
-		};
-	};
-
-	fragment@4 {
-		target = <&ads1115>;
-		__dormant__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			channel_d: channel_d {
-				reg = <7>;
-				ti,gain = <1>;
-				ti,datarate = <7>;
-			};
+			status = "okay";
 		};
 	};
 
 	__overrides__ {
 		addr =            <&ads1115>,"reg:0";
-		cha_enable =      <0>,"=1";
+		cha_enable =      <0>,"=0";
 		cha_cfg =         <&channel_a>,"reg:0";
 		cha_gain =        <&channel_a>,"ti,gain:0";
 		cha_datarate =    <&channel_a>,"ti,datarate:0";
-		chb_enable =      <0>,"=2";
+		chb_enable =      <0>,"=1";
 		chb_cfg =         <&channel_b>,"reg:0";
 		chb_gain =        <&channel_b>,"ti,gain:0";
 		chb_datarate =    <&channel_b>,"ti,datarate:0";
-		chc_enable =      <0>,"=3";
+		chc_enable =      <0>,"=2";
 		chc_cfg =         <&channel_c>,"reg:0";
 		chc_gain =        <&channel_c>,"ti,gain:0";
 		chc_datarate =    <&channel_c>,"ti,datarate:0";
-		chd_enable =      <0>,"=4";
+		chd_enable =      <0>,"=3";
 		chd_cfg =         <&channel_d>,"reg:0";
 		chd_gain =        <&channel_d>,"ti,gain:0";
 		chd_datarate =    <&channel_d>,"ti,datarate:0";
+		i2c0 = <&frag100>, "target:0=",<&i2c0>;
+		i2c_csi_dsi = <&frag100>, "target:0=",<&i2c_csi_dsi>,
+			      <0>,"+101+102";
+		i2c3 = <&frag100>, "target?=0",
+		       <&frag100>, "target-path=i2c3";
+		i2c4 = <&frag100>, "target?=0",
+		       <&frag100>, "target-path=i2c4";
+		i2c5 = <&frag100>, "target?=0",
+		       <&frag100>, "target-path=i2c5";
+		i2c6 = <&frag100>, "target?=0",
+		       <&frag100>, "target-path=i2c6";
 	};
 };


### PR DESCRIPTION
This is a minor modification to #5755 that reorders the fragments to avoid the effects of some fragments getting dropped.