### PR TITLE
overlays: qca7000: Use a LEVEL_HIGH interrupt

### DIFF
--- a/arch/arm/boot/dts/overlays/qca7000-overlay.dts
+++ b/arch/arm/boot/dts/overlays/qca7000-overlay.dts
@@ -29,7 +29,7 @@
 				pinctrl-names = "default";
 				pinctrl-0 = <&eth1_pins>;
 				interrupt-parent = <&gpio>;
-				interrupts = <23 0x1>; /* rising edge */
+				interrupts = <23 4>; // IRQ_TYPE_LEVEL_HIGH
 				spi-max-frequency = <12000000>;
 				status = "okay";
 			};


### PR DESCRIPTION
The QCA7000 interrupt should be level-triggered.

See: https://github.com/raspberrypi/linux/issues/5766