### PR TITLE
dts: bcm2712: put usb under /axi not /soc

### DIFF
--- a/arch/arm/boot/dts/bcm2712.dtsi
+++ b/arch/arm/boot/dts/bcm2712.dtsi
@@ -133,19 +133,6 @@
 			status = "disabled";
 		};
 
-		usb: usb@7c480000 {
-			compatible = "brcm,bcm2835-usb";
-			reg = <0x7c480000 0x10000>;
-			interrupts = <GIC_SPI 73 IRQ_TYPE_LEVEL_HIGH>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			clocks = <&clk_usb>;
-			clock-names = "otg";
-			phys = <&usbphy>;
-			phy-names = "usb2-phy";
-			status = "disabled";
-		};
-
 		mop: mop@7c500000 {
 			compatible = "brcm,bcm2712-mop";
 			reg = <0x7c500000 0x20>;
@@ -1143,6 +1130,19 @@
 		syscon_piarbctl: syscon@400018 {
 			compatible = "brcm,syscon-piarbctl", "syscon", "simple-mfd";
 			reg = <0x10 0x00400018  0x0 0x18>;
+		};
+
+		usb: usb@480000 {
+			compatible = "brcm,bcm2835-usb";
+			reg = <0x10 0x00480000 0x0 0x10000>;
+			interrupts = <GIC_SPI 73 IRQ_TYPE_LEVEL_HIGH>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&clk_usb>;
+			clock-names = "otg";
+			phys = <&usbphy>;
+			phy-names = "usb2-phy";
+			status = "disabled";
 		};
 
 		rpivid: codec@800000 {


### PR DESCRIPTION
With dtoverlay=dwc2,dr_mode=host in /boot/firmware/config.txt, and the associated EEPROM firmware bump to turn the PHY on, I have a functional USB2 root port on the USB-C connector.

Still some rough edges if the port goes into suspend, which you get with a hub that has no occupied downstream ports.
- Frequent "mode mismatch interrupt" spam
- Disconnect interrupts aren't signalled.

