### PR TITLE
Allow IMX477 and IMX296 to be always on, to simplify multi-camera sync

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2514,6 +2514,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
         clock-frequency         Sets the clock frequency to match that used on
                                 the board, which should be one of 54000000
                                 (the default), 37125000 or 74250000.
+        always-on               Leave the regulator powered up, to stop the
+                                camera clamping I/Os such as XTRIG to 0V.
 
 
 Name:   imx327
@@ -2552,6 +2554,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 configuring the sensor (default on)
         cam0                    Adopt the default configuration for CAM0 on a
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
+        always-on               Leave the regulator powered up, to stop the
+                                camera clamping I/Os such as XVS to 0V.
 
 
 Name:   imx462
@@ -2590,6 +2594,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 configuring the sensor (default on)
         cam0                    Adopt the default configuration for CAM0 on a
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
+        always-on               Leave the regulator powered up, to stop the
+                                camera clamping I/Os such as XVS to 0V.
 
 
 Name:   imx519

--- a/arch/arm/boot/dts/overlays/imx296-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx296-overlay.dts
@@ -37,6 +37,13 @@
 		};
 	};
 
+	reg_alwayson_frag: fragment@99 {
+		target = <&cam1_reg>;
+		__dormant__ {
+			regulator-always-on;
+		};
+	};
+
 	i2c_frag: fragment@100 {
 		target = <&i2c_csi_dsi>;
 		__overlay__ {
@@ -98,8 +105,10 @@
 		       <&csi_frag>, "target:0=",<&csi0>,
 		       <&clk_frag>, "target:0=",<&cam0_clk>,
 		       <&reg_frag>, "target:0=",<&cam0_reg>,
+		       <&reg_alwayson_frag>, "target:0=",<&cam0_reg>,
 		       <&imx296>, "clocks:0=",<&cam0_clk>,
 		       <&imx296>, "avdd-supply:0=",<&cam0_reg>;
 		clock-frequency = <&clk_over>, "clock-frequency:0";
+		always-on = <0>, "+99";
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx477_378-overlay.dtsi
+++ b/arch/arm/boot/dts/overlays/imx477_378-overlay.dtsi
@@ -33,6 +33,13 @@
 		};
 	};
 
+	reg_alwayson_frag: fragment@99 {
+		target = <&cam1_reg>;
+		__dormant__ {
+			regulator-always-on;
+		};
+	};
+
 	i2c_frag: fragment@100 {
 		target = <&i2c_csi_dsi>;
 		__overlay__ {
@@ -69,8 +76,10 @@
 		       <&csi_frag>, "target:0=",<&csi0>,
 		       <&clk_frag>, "target:0=",<&cam0_clk>,
 		       <&reg_frag>, "target:0=",<&cam0_reg>,
+		       <&reg_alwayson_frag>, "target:0=",<&cam0_reg>,
 		       <&cam_node>, "clocks:0=",<&cam0_clk>,
 		       <&cam_node>, "VANA-supply:0=",<&cam0_reg>;
+		always-on = <0>, "+99";
 	};
 };
 

--- a/drivers/media/i2c/imx296.c
+++ b/drivers/media/i2c/imx296.c
@@ -650,10 +650,11 @@ static int imx296_stream_on(struct imx296 *sensor)
 	imx296_write(sensor, IMX296_CTRL00, 0, &ret);
 	usleep_range(2000, 5000);
 
-	if (trigger_mode == 1) {
-		imx296_write(sensor, IMX296_CTRL0B, IMX296_CTRL0B_TRIGEN, &ret);
-		imx296_write(sensor, IMX296_LOWLAGTRG,  IMX296_LOWLAGTRG_FAST, &ret);
-	}
+	/* external trigger mode: 0=normal, 1=triggered */
+	imx296_write(sensor, IMX296_CTRL0B,
+		     (trigger_mode == 1) ? IMX296_CTRL0B_TRIGEN : 0, &ret);
+	imx296_write(sensor, IMX296_LOWLAGTRG,
+		     (trigger_mode == 1) ? IMX296_LOWLAGTRG_FAST : 0, &ret);
 
 	imx296_write(sensor, IMX296_CTRL0A, 0, &ret);
 

--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -1742,25 +1742,20 @@ static int imx477_start_streaming(struct imx477 *imx477)
 	imx477_write_reg(imx477, 0x0b05, IMX477_REG_VALUE_08BIT, !!dpc_enable);
 	imx477_write_reg(imx477, 0x0b06, IMX477_REG_VALUE_08BIT, !!dpc_enable);
 
-	/* Set vsync trigger mode */
-	if (trigger_mode != 0) {
-		/* trigger_mode == 1 for source, 2 for sink */
-		const u32 val = (trigger_mode == 1) ? 1 : 0;
-
-		imx477_write_reg(imx477, IMX477_REG_MC_MODE,
-				 IMX477_REG_VALUE_08BIT, 1);
-		imx477_write_reg(imx477, IMX477_REG_MS_SEL,
-				 IMX477_REG_VALUE_08BIT, val);
-		imx477_write_reg(imx477, IMX477_REG_XVS_IO_CTRL,
-				 IMX477_REG_VALUE_08BIT, val);
-		imx477_write_reg(imx477, IMX477_REG_EXTOUT_EN,
-				 IMX477_REG_VALUE_08BIT, val);
-	}
-
 	/* Apply customized values from user */
 	ret =  __v4l2_ctrl_handler_setup(imx477->sd.ctrl_handler);
 	if (ret)
 		return ret;
+
+	/* Set vsync trigger mode: 0=standalone, 1=source, 2=sink */
+	imx477_write_reg(imx477, IMX477_REG_MC_MODE,
+			 IMX477_REG_VALUE_08BIT, (trigger_mode > 0) ? 1 : 0);
+	imx477_write_reg(imx477, IMX477_REG_MS_SEL,
+			 IMX477_REG_VALUE_08BIT, (trigger_mode <= 1) ? 1 : 0);
+	imx477_write_reg(imx477, IMX477_REG_XVS_IO_CTRL,
+			 IMX477_REG_VALUE_08BIT, (trigger_mode == 1) ? 1 : 0);
+	imx477_write_reg(imx477, IMX477_REG_EXTOUT_EN,
+			 IMX477_REG_VALUE_08BIT, (trigger_mode == 1) ? 1 : 0);
 
 	/* set stream on register */
 	return imx477_write_reg(imx477, IMX477_REG_MODE_SELECT,
@@ -1778,6 +1773,10 @@ static void imx477_stop_streaming(struct imx477 *imx477)
 			       IMX477_REG_VALUE_08BIT, IMX477_MODE_STANDBY);
 	if (ret)
 		dev_err(&client->dev, "%s failed to set stream\n", __func__);
+
+	/* Stop driving XVS out (there is still a weak pull-up) */
+	imx477_write_reg(imx477, IMX477_REG_EXTOUT_EN,
+			 IMX477_REG_VALUE_08BIT, 0);
 }
 
 static int imx477_set_stream(struct v4l2_subdev *sd, int enable)


### PR DESCRIPTION
The issue is that when the cameras are powered down, they clamp sync signals (XVS, XHS, XTRIG) to ground. As they are active-low, and not all the cameras start streaming at exactly the same time, it could result in spurious triggers.

A previous workaround involved low-impedance pull-ups so that all cameras would see a high quiescent level. This is potentially unsafe and does not scale to large multi-camera setups.

This change allows cameras to be brought up with XVS, XHS, XTRIG pins in a high-impedance state.