### PR TITLE
dwc_otg: Avoid the use of align_buf for short packets

### DIFF
--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
@@ -1339,8 +1339,10 @@ static void assign_and_init_hc(dwc_otg_hcd_t * hcd, dwc_otg_qh_t * qh)
 			 * buffer.
 			 */
 			wLength = ((uint16_t *)urb->setup_packet)[3];
+			#if 0
 			if (hc->ep_is_in && wLength < 4)
 				ptr = hc->xfer_buff;
+			#endif
 
 			hc->data_pid_start = qtd->data_toggle;
 			break;


### PR DESCRIPTION
Recent kernels (from 6.5) fail to boot on Pi0-3.

This has been tracked down to the call to:
ret = usb_get_std_status(hdev, USB_RECIP_DEVICE, 0, &hubstatus);

returning garbage in hubstatus (it gets the uninitialised contents of a kmalloc buffer that is not overwritten as expected).

As we don't have strong evidence that this code path has ever worked, and it is causing a clear problem currently, lets disable it to allow wider use of newer kernels.