### PR TITLE
input: goodix: Support output-only reset lines

### DIFF
--- a/drivers/input/touchscreen/goodix.c
+++ b/drivers/input/touchscreen/goodix.c
@@ -1060,6 +1060,8 @@ retry_get_irq_gpio:
 
 	/* Get the reset line GPIO pin number */
 	gpiod = devm_gpiod_get_optional(dev, GOODIX_GPIO_RST_NAME, ts->gpiod_rst_flags);
+	if (IS_ERR(gpiod))
+		gpiod = devm_gpiod_get_optional(dev, GOODIX_GPIO_RST_NAME, GPIOD_OUT_LOW);
 	if (IS_ERR(gpiod)) {
 		error = PTR_ERR(gpiod);
 		if (error != -EPROBE_DEFER)


### PR DESCRIPTION
Although the motivation behind initialising the reset GPIO as an input is sound, it prevents the driver from being used with an output-only GPIO controller. Fall back to trying to create it as an output.

See: https://forums.raspberrypi.com/viewtopic.php?t=361103