### PR TITLE
firmware/psci: Pass given partition number through

### DIFF
--- a/arch/arm/boot/dts/bcm2712-rpi-5-b.dts
+++ b/arch/arm/boot/dts/bcm2712-rpi-5-b.dts
@@ -428,7 +428,7 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 
 / {
 	chosen: chosen {
-		bootargs = "coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe snd_bcm2835.enable_compat_alsa=0 snd_bcm2835.enable_hdmi=1";
+		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe snd_bcm2835.enable_compat_alsa=0 snd_bcm2835.enable_hdmi=1";
 		stdout-path = "serial10:115200n8";
 	};
 

--- a/drivers/firmware/psci/psci.c
+++ b/drivers/firmware/psci/psci.c
@@ -314,7 +314,14 @@ static int psci_sys_reset(struct notifier_block *nb, unsigned long action,
 		 * reset_type[30:0] = 0 (SYSTEM_WARM_RESET)
 		 * cookie = 0 (ignored by the implementation)
 		 */
-		invoke_psci_fn(PSCI_FN_NATIVE(1_1, SYSTEM_RESET2), 0, 0, 0);
+		// Allow extra arguments separated by spaces after
+		// the partition number.
+		unsigned long val;
+		u8 partition = 0;
+
+		if (data && sscanf(data, "%lu", &val) == 1 && val < 63)
+			partition = val;
+		invoke_psci_fn(PSCI_FN_NATIVE(1_1, SYSTEM_RESET2), 0, partition, 0);
 	} else {
 		invoke_psci_fn(PSCI_0_2_FN_SYSTEM_RESET, 0, 0, 0);
 	}


### PR DESCRIPTION
Pi 5 uses BL31 as its armstub file, so the reset goes via PSCI. Parse any "reboot" parameter as a partition number to reboot into.

This code path is only used if reboot mode has been set to warm or soft, so the second patch enables warm reboot mode.
