### PR TITLE
drivers/pinctrl/bcm/Kconfig: Fix BCM2712 help

### DIFF
--- a/drivers/pinctrl/bcm/Kconfig
+++ b/drivers/pinctrl/bcm/Kconfig
@@ -10,7 +10,7 @@ config PINCTRL_BCM2712
 	select PINCONF
 	select GENERIC_PINCONF
 	help
-	   Say Y here to enable the Broadcom BCM2835 GPIO driver.
+	   Say Y here to enable the Broadcom BCM2712 PINCONF driver.
 
 config PINCTRL_BCM281XX
 	bool "Broadcom BCM281xx pinctrl driver"


### PR DESCRIPTION
While working on the kernel as part of the efforts for support [Raspberry Pi 5 in Yocto/OpenEmbedded layer meta-raspberrypi](https://github.com/agherzan/meta-raspberrypi/pull/1237/commits/1386acc25af1a5a7ab033e51fe69ece7be824530), I noticed a mismatch in the driver name and the help message in Kconfig. This GitHub pull request contains a commit to replace "Broadcom BCM2835 GPIO" with "Broadcom BCM2712 PINCONF" and fix the help message. 