### PR TITLE
dts: rp1: add SNPS quirk to USB3 host controllers

### DIFF
--- a/arch/arm/boot/dts/rp1.dtsi
+++ b/arch/arm/boot/dts/rp1.dtsi
@@ -1017,6 +1017,7 @@
 			usb3-lpm-capable;
 			snps,axi-pipe-limit = /bits/ 8 <8>;
 			snps,dis_rxdet_inp3_quirk;
+			snps,parkmode-disable-ss-quirk;
 			snps,tx-max-burst-prd = <8>;
 			snps,tx-thr-num-pkt-prd = <2>;
 			interrupts = <RP1_INT_USBHOST0_0 IRQ_TYPE_EDGE_RISING>;
@@ -1030,6 +1031,7 @@
 			usb3-lpm-capable;
 			snps,axi-pipe-limit = /bits/ 8 <8>;
 			snps,dis_rxdet_inp3_quirk;
+			snps,parkmode-disable-ss-quirk;
 			snps,tx-max-burst-prd = <8>;
 			snps,tx-thr-num-pkt-prd = <2>;
 			interrupts = <RP1_INT_USBHOST1_0 IRQ_TYPE_EDGE_RISING>;


### PR DESCRIPTION
Searching for the "controller died" messages turned up the introduction of this quirk on the linux-usb mailing list.

Let's give it a go here...

See #5753