### PR TITLE
Allow disabling FIFOs on PL011 UART

### DIFF
--- a/Documentation/devicetree/bindings/serial/pl011.yaml
+++ b/Documentation/devicetree/bindings/serial/pl011.yaml
@@ -106,6 +106,12 @@ properties:
       CTS-induced TX lockup.
     type: boolean
 
+  disable-fifos:
+    description:
+      Disable FIFOs (character mode) that is, the FIFOs become 1-byte-deep
+      holding registers.
+    type: boolean
+
 required:
   - compatible
   - reg

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4542,7 +4542,7 @@ Params: <None>
 
 
 Name:   uart0
-Info:   Change the pin usage of uart0
+Info:   Change the pin usage and parameters of uart0
 Load:   dtoverlay=uart0,<param>=<val>
 Params: txd0_pin                GPIO pin for TXD0 (14, 32 or 36 - default 14)
 
@@ -4550,6 +4550,7 @@ Params: txd0_pin                GPIO pin for TXD0 (14, 32 or 36 - default 14)
 
         pin_func                Alternative pin function - 4(Alt0) for 14&15,
                                 7(Alt3) for 32&33, 6(Alt2) for 36&37
+        disable_fifos           Disable FIFOs (character mode)
 
 
 Name:   uart0-pi5

--- a/arch/arm/boot/dts/overlays/uart0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart0-overlay.dts
@@ -6,7 +6,7 @@
 
 	fragment@0 {
 		target = <&uart0>;
-		__overlay__ {
+		frag0: __overlay__ {
 			pinctrl-names = "default";
 			pinctrl-0 = <&uart0_pins>;
 			status = "okay";
@@ -28,5 +28,6 @@
 		txd0_pin = <&uart0_pins>,"brcm,pins:0";
 		rxd0_pin = <&uart0_pins>,"brcm,pins:4";
 		pin_func = <&uart0_pins>,"brcm,function:0";
+		disable_fifos = <&frag0>,"disable-fifos?";
 	};
 };

--- a/drivers/tty/serial/amba-pl011.c
+++ b/drivers/tty/serial/amba-pl011.c
@@ -2824,9 +2824,14 @@ static int pl011_probe(struct amba_device *dev, const struct amba_id *id)
 	    dev_info(&dev->dev, "cts_event_workaround enabled\n");
 	}
 
+	if (of_property_read_bool(dev->dev.of_node, "disable-fifos")) {
+		uap->fifosize = 1;
+		dev_info(&dev->dev, "FIFOs disabled (character mode)\n");
+	} else
+		uap->fifosize = vendor->get_fifosize(dev);
+
 	uap->reg_offset = vendor->reg_offset;
 	uap->vendor = vendor;
-	uap->fifosize = vendor->get_fifosize(dev);
 	uap->port.iotype = vendor->access_32b ? UPIO_MEM32 : UPIO_MEM;
 	uap->port.irq = dev->irq[0];
 	uap->port.ops = &amba_pl011_pops;
@@ -2933,8 +2938,13 @@ static int sbsa_uart_probe(struct platform_device *pdev)
 #endif
 		uap->vendor = &vendor_sbsa;
 
+	if (of_property_read_bool(pdev->dev.of_node, "disable-fifos")) {
+		uap->fifosize = 1;
+		dev_info(&pdev->dev, "FIFOs disabled (character mode)\n");
+	} else
+		uap->fifosize = 32;
+
 	uap->reg_offset	= uap->vendor->reg_offset;
-	uap->fifosize	= 32;
 	uap->port.iotype = uap->vendor->access_32b ? UPIO_MEM32 : UPIO_MEM;
 	uap->port.ops	= &sbsa_uart_pops;
 	uap->fixed_baud = baudrate;
@@ -3020,9 +3030,14 @@ static int pl011_axi_probe(struct platform_device *pdev)
 	of_property_read_u32(pdev->dev.of_node, "arm,primecell-periphid",
 			     &periphid);
 
+	if (of_property_read_bool(pdev->dev.of_node, "disable-fifos")) {
+		uap->fifosize = 1;
+		dev_info(&pdev->dev, "FIFOs disabled (character mode)\n");
+	} else
+		uap->fifosize = (AMBA_REV_BITS(periphid) < 3) ? 16 : 32;
+
 	uap->reg_offset = vendor->reg_offset;
 	uap->vendor = vendor;
-	uap->fifosize = (AMBA_REV_BITS(periphid) < 3) ? 16 : 32;
 	uap->port.iotype = vendor->access_32b ? UPIO_MEM32 : UPIO_MEM;
 	uap->port.irq = irq;
 	uap->port.ops = &amba_pl011_pops;


### PR DESCRIPTION
The BCM2835 PL011 implementation assumes that Rx/Tx FIFOs should be always enabled. Although this is desirable for most of the time, there are rare occasions when FIFOs introduce unwanted delay on the line. The delay is unnoticeable for the common UART use cases but it can lead to communication failures in UART-based protocols expecting fast responses, such as eBUS.

The solution is to add a new `disable-fifos` property to Pi DTBs and use the presence of that property to forcefully set FIFOs size to 1, and prevent FIFOs from being enabled in the PL011 driver.

Example issues that might be originating from the delay introduced by FIFO buffering:

- https://forums.raspberrypi.com/viewtopic.php?t=170945&p=1095466
- john30/ebusd#91

Tested with **ebusd** on Raspberry Pi Zero W v1.1. I was able to communicate with eBUS's participants after adding `dtoverlay=uart0,disable_fifos` to `config.txt`. If it's not appropriate to keep this flag in the "uart0" overlay, a dedicated overlay for the flag can be created instead.

## Results on logic analyzer

For a simple test I tied TX and RX pins together, and I ran a simple program written in C in which I'm writing a single character, reading it back, and then writing and reading it again. This way I can test if there are any delays in both write and read queues.

![FIFO is enabled](https://github.com/raspberrypi/linux/assets/16398666/240efe04-2b03-460d-960c-f560624895ac)

The first screenshot shows that when **FIFOs are enabled**, the gap between consecutive write/read/write operations is roughly **13 milliseconds**.

![FIFO is disabled](https://github.com/raspberrypi/linux/assets/16398666/d3acb990-224c-42f6-bc7e-84298d23f5ce)

The same test repeated when **FIFOs are disabled** shows that the gap is now only **30 microseconds**. This is 430 times smaller than when FIFOs were enabled.

The code I used for testing:

```c
#include <stdio.h>
#include <fcntl.h>
#include <termios.h>
#include <unistd.h>

int main() {
    int port = open("/dev/ttyAMA0", O_RDWR);

    if (port < 0) {
        printf("Cannot open port\n");
        return -1;
    }

    struct termios tty;

    tty.c_cflag &= ~(PARENB | CSTOPB | CRTSCTS);
    tty.c_cflag |= CREAD | CLOCAL | CS8;

    tty.c_lflag &= ~(ICANON | ECHO | ECHOE | ECHONL | ISIG);

    tty.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR 
            | ICRNL | IXON | IXOFF | IXANY);

    tty.c_oflag &= ~(OPOST | ONLCR);

    tty.c_cc[VTIME] = 10;
    tty.c_cc[VMIN] = 0;

    cfsetispeed(&tty, B2400);

    if (tcsetattr(port, TCSANOW, &tty) != 0) {
        printf("Cannot write attributes\n");
        close(port);

        return -1;
    }

    char read_buffer[1];
    unsigned char msg[] = { 'a' };
    int read_chars;

    write(port, msg, 1);
    read_chars = read(port, read_buffer, 1);

    write(port, msg, 1);
    read(port, read_buffer, 1);

    close(port);

    printf("Read: %d\n", read_chars);

    return 0;
}
```