### PR TITLE
input: edt-ft5x06: Correct prefix length in snprintf

### DIFF
--- a/drivers/input/touchscreen/edt-ft5x06.c
+++ b/drivers/input/touchscreen/edt-ft5x06.c
@@ -966,7 +966,7 @@ static int edt_ft5x06_ts_identify(struct i2c_client *client,
 	char *model_name = tsdata->name;
 	char *fw_version = tsdata->fw_version;
 
-	snprintf(model_name, EDT_NAME_PREFIX_LEN, "%s ", dev_name(&client->dev));
+	snprintf(model_name, EDT_NAME_PREFIX_LEN + 1, "%s ", dev_name(&client->dev));
 	model_name += strlen(model_name);
 
 	/* see what we find if we assume it is a M06 *


### PR DESCRIPTION
snprintf takes the length of the array that we can print into, and has to fit the NULL terminator in there too.
Printing the prefix is generally "12-3456 " which is 8 desired characters (the length of EDT_NAME_PREFIX_LEN) and the NULL. The space is therefore being truncated to fit the NULL in.

Increase the length snprintf is allowed to use.