### PR TITLE
Improve Pi 5 I2C bus timing

### DIFF
--- a/arch/arm/boot/dts/rp1.dtsi
+++ b/arch/arm/boot/dts/rp1.dtsi
@@ -305,6 +305,12 @@
 			compatible = "snps,designware-i2c";
 			interrupts = <RP1_INT_I2C0 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+			snps,ss_hcnt = <978>;
+			snps,ss_lcnt = <990>;
+			snps,fs_hcnt = <200>;
+			snps,fs_lcnt = <268>;
+			snps,fp_hcnt = <60>;
+			snps,fp_lcnt = <107>;
 			status = "disabled";
 		};
 
@@ -313,6 +319,12 @@
 			compatible = "snps,designware-i2c";
 			interrupts = <RP1_INT_I2C1 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+			snps,ss_hcnt = <978>;
+			snps,ss_lcnt = <990>;
+			snps,fs_hcnt = <200>;
+			snps,fs_lcnt = <268>;
+			snps,fp_hcnt = <60>;
+			snps,fp_lcnt = <107>;
 			status = "disabled";
 		};
 
@@ -321,6 +333,12 @@
 			compatible = "snps,designware-i2c";
 			interrupts = <RP1_INT_I2C2 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+			snps,ss_hcnt = <978>;
+			snps,ss_lcnt = <990>;
+			snps,fs_hcnt = <200>;
+			snps,fs_lcnt = <268>;
+			snps,fp_hcnt = <60>;
+			snps,fp_lcnt = <107>;
 			status = "disabled";
 		};
 
@@ -329,6 +347,12 @@
 			compatible = "snps,designware-i2c";
 			interrupts = <RP1_INT_I2C3 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+			snps,ss_hcnt = <978>;
+			snps,ss_lcnt = <990>;
+			snps,fs_hcnt = <200>;
+			snps,fs_lcnt = <268>;
+			snps,fp_hcnt = <60>;
+			snps,fp_lcnt = <107>;
 			status = "disabled";
 		};
 
@@ -337,6 +361,12 @@
 			compatible = "snps,designware-i2c";
 			interrupts = <RP1_INT_I2C4 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+			snps,ss_hcnt = <978>;
+			snps,ss_lcnt = <990>;
+			snps,fs_hcnt = <200>;
+			snps,fs_lcnt = <268>;
+			snps,fp_hcnt = <60>;
+			snps,fp_lcnt = <107>;
 			status = "disabled";
 		};
 
@@ -345,6 +375,12 @@
 			compatible = "snps,designware-i2c";
 			interrupts = <RP1_INT_I2C5 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+			snps,ss_hcnt = <978>;
+			snps,ss_lcnt = <990>;
+			snps,fs_hcnt = <200>;
+			snps,fs_lcnt = <268>;
+			snps,fp_hcnt = <60>;
+			snps,fp_lcnt = <107>;
 			status = "disabled";
 		};
 
@@ -353,6 +389,12 @@
 			compatible = "snps,designware-i2c";
 			interrupts = <RP1_INT_I2C6 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+			snps,ss_hcnt = <978>;
+			snps,ss_lcnt = <990>;
+			snps,fs_hcnt = <200>;
+			snps,fs_lcnt = <268>;
+			snps,fp_hcnt = <60>;
+			snps,fp_lcnt = <107>;
 			status = "disabled";
 		};
 

--- a/drivers/i2c/busses/i2c-designware-platdrv.c
+++ b/drivers/i2c/busses/i2c-designware-platdrv.c
@@ -132,9 +132,18 @@ static int mscc_twi_set_sda_hold_time(struct dw_i2c_dev *dev)
 	return 0;
 }
 
+static void dw_i2c_read_of_cnt(struct device_node *np, const char *name, u16 *pval)
+{
+	u32 val;
+
+	if (!of_property_read_u32(np, name, &val))
+		*pval = (u16)val;
+}
+
 static int dw_i2c_of_configure(struct platform_device *pdev)
 {
 	struct dw_i2c_dev *dev = platform_get_drvdata(pdev);
+	struct device_node *np = pdev->dev.of_node;
 
 	switch (dev->flags & MODEL_MASK) {
 	case MODEL_MSCC_OCELOT:
@@ -145,6 +154,15 @@ static int dw_i2c_of_configure(struct platform_device *pdev)
 	default:
 		break;
 	}
+
+	dw_i2c_read_of_cnt(np, "snps,ss_hcnt", &dev->ss_hcnt);
+	dw_i2c_read_of_cnt(np, "snps,ss_lcnt", &dev->ss_lcnt);
+	dw_i2c_read_of_cnt(np, "snps,fs_hcnt", &dev->fs_hcnt);
+	dw_i2c_read_of_cnt(np, "snps,fs_lcnt", &dev->fs_lcnt);
+	dw_i2c_read_of_cnt(np, "snps,fp_hcnt", &dev->fp_hcnt);
+	dw_i2c_read_of_cnt(np, "snps,fp_lcnt", &dev->fp_lcnt);
+	dw_i2c_read_of_cnt(np, "snps,hs_hcnt", &dev->hs_hcnt);
+	dw_i2c_read_of_cnt(np, "snps,hs_lcnt", &dev->hs_lcnt);
 
 	return 0;
 }


### PR DESCRIPTION
It has been observed that the Pi 5 I2C buses don't reach the expected speeds. That is down to the absence of accurate bus timings, with the defaults being pessimistic. Add a way of configuring bus-speed specific timings via Device Tree, and a set of tuned values that should give accurate 100kHz, 400kHz and 1MHz speeds.

See: https://github.com/raspberrypi/linux/issues/5792