### PR TITLE
ARM: dts: bcm2712-rpi-5-b: Allow RTC to be disabled

### DIFF
--- a/arch/arm/boot/dts/bcm2712-rpi-5-b.dts
+++ b/arch/arm/boot/dts/bcm2712-rpi-5-b.dts
@@ -819,6 +819,7 @@ spi10_cs_pins: &spi10_cs_gpio1 {};
 		pciex1_tperst_clk_ms = <&pciex1>, "brcm,tperst-clk-ms:0";
 		pcie_tperst_clk_ms = <&pciex1>, "brcm,tperst-clk-ms:0";
 		random = <&random>, "status";
+		rtc = <&rpi_rtc>, "status";
 		rtc_bbat_vchg = <&rpi_rtc>, "trickle-charge-microvolt:0";
 		spi = <&spi0>, "status";
 		suspend = <&pwr_key>, "linux,code:0=205";

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -307,6 +307,9 @@ Params:
         random                  Set to "on" to enable the hardware random
                                 number generator (default "on")
 
+        rtc                     Set to "off" to disable the onboard Real Time
+                                Clock (2712 only, default "on")
+
         rtc_bbat_vchg           Set the RTC backup battery charging voltage in
                                 microvolts. If set to 0 or not specified, the
                                 trickle charger is disabled.


### PR DESCRIPTION
Add a dtparam "rtc", so that "dtparam=rtc=off" can be used to disable the Pi 5's onboard RTC.

See: https://forums.raspberrypi.com/viewtopic.php?t=361813