### PR TITLE
Update the 3B LED support

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b.dts
@@ -168,17 +168,6 @@
 	};
 };
 
-&soc {
-	virtgpio: virtgpio {
-		compatible = "brcm,bcm2835-virtgpio";
-		gpio-controller;
-		#gpio-cells = <2>;
-		firmware = <&firmware>;
-		status = "okay";
-	};
-
-};
-
 &firmware {
 	expgpio: expgpio {
 		compatible = "raspberrypi,firmware-gpio";
@@ -192,6 +181,13 @@
 				  "CAM_GPIO0",
 				  "CAM_GPIO1",
 				  "PWR_LOW_N";
+		status = "okay";
+	};
+
+	virtgpio: virtgpio {
+		compatible = "brcm,bcm2835-virtgpio";
+		gpio-controller;
+		#gpio-cells = <2>;
 		status = "okay";
 	};
 };

--- a/drivers/gpio/gpio-bcm-virt.c
+++ b/drivers/gpio/gpio-bcm-virt.c
@@ -85,13 +85,14 @@ static int brcmvirt_gpio_probe(struct platform_device *pdev)
 	struct brcmvirt_gpio *ucb;
 	u32 gpiovirtbuf;
 
-	fw_node = of_parse_phandle(np, "firmware", 0);
+	fw_node = of_get_parent(np);
 	if (!fw_node) {
 		dev_err(dev, "Missing firmware node\n");
 		return -ENOENT;
 	}
 
-	fw = rpi_firmware_get(fw_node);
+	fw = devm_rpi_firmware_get(&pdev->dev, fw_node);
+	of_node_put(fw_node);
 	if (!fw)
 		return -EPROBE_DEFER;
 
@@ -145,10 +146,10 @@ static int brcmvirt_gpio_probe(struct platform_device *pdev)
 		}
 		ucb->bus_addr = 0;
 	}
+	ucb->gc.parent = dev;
 	ucb->gc.label = MODULE_NAME;
 	ucb->gc.owner = THIS_MODULE;
-	//ucb->gc.dev = dev;
-	ucb->gc.base = 100;
+	ucb->gc.base = -1;
 	ucb->gc.ngpio = NUM_GPIO;
 
 	ucb->gc.direction_input = brcmvirt_gpio_dir_in;


### PR DESCRIPTION
As reported in https://forums.raspberrypi.com/viewtopic.php?p=2171315#p2171315, the Pi 3B LEDs were broken in rpi-6.6.y. This is because the downstream brcmvirt-gpio driver (used to optimise the activity LED handling) needed some work to make it 6.6-compatible. It's also been brought slightly more up to date in general.

