### PR TITLE
ARM: dts: bcm2712-rpi-5-b: Add eth_ledx parameters

### DIFF
--- a/arch/arm/boot/dts/bcm2712-rpi-5-b.dts
+++ b/arch/arm/boot/dts/bcm2712-rpi-5-b.dts
@@ -830,6 +830,8 @@ spi10_cs_pins: &spi10_cs_gpio1 {};
 		act_led_trigger = <&act_led>, "linux,default-trigger";
 		pwr_led_activelow = <&pwr_led>, "gpios:8";
 		pwr_led_trigger = <&pwr_led>, "linux,default-trigger";
+		eth_led0 = <&phy1>,"led-modes:0";
+		eth_led1 = <&phy1>,"led-modes:4";
 		drm_fb0_rp1_dsi0 = <&aliases>, "drm-fb0=",&dsi0;
 		drm_fb0_rp1_dsi1 = <&aliases>, "drm-fb0=",&dsi1;
 		drm_fb0_rp1_dpi = <&aliases>, "drm-fb0=",&dpi;

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -207,7 +207,7 @@ Params:
                                 0 means never downshift (default 2). Pi3B+ only.
 
         eth_led0                Set mode of LED0 - amber on Pi3B+ (default "1"),
-                                green on Pi4 (default "0").
+                                green on Pi4/5 (default "0").
                                 The legal values are:
 
                                 Pi3B+
@@ -217,7 +217,7 @@ Params:
                                 4=link100/1000/activity  5=link10/1000/activity
                                 6=link10/100/activity    14=off    15=on
 
-                                Pi4
+                                Pi4/5
 
                                 0=Speed/Activity         1=Speed
                                 2=Flash activity         3=FDX
@@ -226,7 +226,7 @@ Params:
                                 8=Link                   9=Activity
 
         eth_led1                Set mode of LED1 - green on Pi3B+ (default "6"),
-                                amber on Pi4 (default "8"). See eth_led0 for
+                                amber on Pi4/5 (default "8"). See eth_led0 for
                                 legal values.
 
         eth_max_speed           Set the maximum speed a link is allowed


### PR DESCRIPTION
Include the dtparams controlling the Ethernet jack LEDs, as used on other Pis.

See: https://github.com/raspberrypi/linux/issues/5825