### PR TITLE
spi: bcm2835: Support spi0-0cs and SPI_NO_CS mode

### DIFF
--- a/drivers/spi/spi-bcm2835.c
+++ b/drivers/spi/spi-bcm2835.c
@@ -1222,6 +1222,7 @@ static int bcm2835_spi_setup(struct spi_device *spi)
 	struct bcm2835_spi *bs = spi_controller_get_devdata(ctlr);
 	struct bcm2835_spidev *slv = spi_get_ctldata(spi);
 	struct gpio_chip *chip;
+	int len;
 	int ret;
 	u32 cs;
 
@@ -1286,6 +1287,10 @@ static int bcm2835_spi_setup(struct spi_device *spi)
 		ret = -EINVAL;
 		goto err_cleanup;
 	}
+
+	/* Skip forced CS conversion if controller has an empty cs-gpios property */
+	if (of_find_property(ctlr->dev.of_node, "cs-gpios", &len) && len == 0)
+		return 0;
 
 	/*
 	 * Translate native CS to GPIO


### PR DESCRIPTION
The forced conversion of native CS lines into software CS lines is done whether or not the controller has been given any CS lines to use. This breaks the use of the spi0-0cs overlay to prevent SPI from claiming any CS lines, particularly with spidev which doesn't pass in the SPI_NO_CS flag at creation.

Use the presence of an empty cs-gpios property as an indication that no CS lines should be used, bypassing the native CS conversion code.

See: https://github.com/raspberrypi/linux/issues/5835