### PR TITLE
overlays: Add overlay for the Solomon SSD1327 OLED

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -263,6 +263,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	spi6-2cs.dtbo \
 	ssd1306.dtbo \
 	ssd1306-spi.dtbo \
+	ssd1327-spi.dtbo \
 	ssd1331-spi.dtbo \
 	ssd1351-spi.dtbo \
 	superaudioboard.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4459,6 +4459,14 @@ Params: speed                   SPI bus speed (default 10000000)
                                 (default=not set)
 
 
+Name:   ssd1327-spi
+Info:   Overlay for SSD1327 OLED via SPI using the DRM ssd130x driver.
+Load:   dtoverlay=ssd1327-spi,<param>=<val>
+Params: speed                   SPI bus speed (default 4500000)
+        dc_pin                  GPIO pin for D/C (default 24)
+        reset_pin               GPIO pin for RESET (default 25)
+
+
 Name:   ssd1331-spi
 Info:   Overlay for SSD1331 OLED via SPI using fbtft staging driver.
 Load:   dtoverlay=ssd1331-spi,<param>=<val>

--- a/arch/arm/boot/dts/overlays/ssd1327-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ssd1327-spi-overlay.dts
@@ -1,0 +1,70 @@
+/*
+ * Device Tree overlay for SSD1327 based SPI OLED display
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&gpio>;
+		__overlay__ {
+			ssd1327_pins: ssd1327_pins {
+				brcm,pins = <25 24>;
+				brcm,function = <1 1>;
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ssd1327: ssd1327@0{
+				compatible = "solomon,ssd1327";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&ssd1327_pins>;
+
+				spi-max-frequency = <4500000>;
+				reset-gpios = <&gpio 25 1>;
+				dc-gpios = <&gpio 24 0>;
+			};
+		};
+	};
+
+	__overrides__ {
+		speed     = <&ssd1327>,"spi-max-frequency:0";
+		dc_pin    = <&ssd1327>,"dc-gpios:4",
+			    <&ssd1327_pins>,"brcm,pins:4";
+		reset_pin = <&ssd1327>,"reset-gpios:4",
+			    <&ssd1327_pins>,"brcm,pins:0";
+	};
+};


### PR DESCRIPTION
The ssd130x driver now supports for the Solomon SSD132x controller family. Add a Device Tree Overlay for the SSD1327 OLED panel.