### PR TITLE
drm/vc4: Fix atomic_async_check to call the right mode_set function

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -2205,11 +2205,15 @@ static int vc4_plane_atomic_async_check(struct drm_plane *plane,
 {
 	struct drm_plane_state *new_plane_state = drm_atomic_get_new_plane_state(state,
 										 plane);
+	struct vc4_dev *vc4 = to_vc4_dev(plane->dev);
 	struct vc4_plane_state *old_vc4_state, *new_vc4_state;
 	int ret;
 	u32 i;
 
-	ret = vc4_plane_mode_set(plane, new_plane_state);
+	if (vc4->gen >= VC4_GEN_6)
+		ret = vc6_plane_mode_set(plane, new_plane_state);
+	else
+		ret = vc4_plane_mode_set(plane, new_plane_state);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
vc4_plane_atomic_async_check was always calling vc4_plane_mode_set to validate and generate the dlist for the check. If async_check decided it had to fall back to a sync commit, then this GEN4/5 dlist could get used on GEN6.

Call either vc4_plane_mode_set or vc6_plane_mode_set as appropriate.

Fixes: 1ab1fbbb7e76 ("drm/vc4: hvs: Support BCM2712 HVS")