### PR TITLE
ARM: pl011: Add rs485 to the RP1 support

### DIFF
--- a/drivers/tty/serial/amba-pl011.c
+++ b/drivers/tty/serial/amba-pl011.c
@@ -3026,6 +3026,8 @@ static int pl011_axi_probe(struct platform_device *pdev)
 	uap->port.iotype = vendor->access_32b ? UPIO_MEM32 : UPIO_MEM;
 	uap->port.irq = irq;
 	uap->port.ops = &amba_pl011_pops;
+	uap->port.rs485_config = pl011_rs485_config;
+	uap->port.rs485_supported = pl011_rs485_supported;
 
 	snprintf(uap->type, sizeof(uap->type), "PL011 AXI");
 


### PR DESCRIPTION
pl011_axi_probe, added for RP1 support, lacks the rs485 additions that appeared during its development.

Suggested in https://forums.raspberrypi.com/viewtopic.php?p=2182033#p2182033.