### PR TITLE
Add Pi 5 workaround for w1-gpio

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -308,7 +308,9 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	vga666.dtbo \
 	vl805.dtbo \
 	w1-gpio.dtbo \
+	w1-gpio-pi5.dtbo \
 	w1-gpio-pullup.dtbo \
+	w1-gpio-pullup-pi5.dtbo \
 	w5500.dtbo \
 	watterott-display.dtbo \
 	waveshare-can-fd-hat-mode-a.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5044,6 +5044,10 @@ Params: gpiopin                 GPIO for I/O (default "4")
         pullup                  Now enabled by default (ignored)
 
 
+Name:   w1-gpio-pi5
+Info:   See w1-gpio (this is the Pi 5 version)
+
+
 Name:   w1-gpio-pullup
 Info:   Configures the w1-gpio Onewire interface module.
         Use this overlay if you *do* need a GPIO to drive an external pullup.
@@ -5051,6 +5055,10 @@ Load:   dtoverlay=w1-gpio-pullup,<param>=<val>
 Params: gpiopin                 GPIO for I/O (default "4")
         extpullup               GPIO for external pullup (default "5")
         pullup                  Now enabled by default (ignored)
+
+
+Name:   w1-gpio-pullup-pi5
+Info:   See w1-gpio-pullup (this is the Pi 5 version)
 
 
 Name:   w5500

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -460,4 +460,25 @@
 	vl805 {
 		bcm2711;
 	};
+
+	w1-gpio {
+		bcm2835;
+		bcm2711;
+		bcm2712 = "w1-gpio-pi5";
+	};
+
+	w1-gpio-pi5 {
+		bcm2712;
+	};
+
+	w1-gpio-pullup {
+		bcm2835;
+		bcm2711;
+		bcm2712 = "w1-gpio-pullup-pi5";
+	};
+
+	w1-gpio-pullup-pi5 {
+		bcm2712;
+	};
+
 };

--- a/arch/arm/boot/dts/overlays/w1-gpio-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/w1-gpio-pi5-overlay.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+#include "w1-gpio-overlay.dts"
+
+/ {
+	compatible = "brcm,bcm2712";
+
+	fragment@2 {
+		target = <&w1>;
+		__overlay__ {
+			raspberrypi,delay-needs-poll;
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/w1-gpio-pullup-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/w1-gpio-pullup-pi5-overlay.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+#include "w1-gpio-pullup-overlay.dts"
+
+/ {
+	compatible = "brcm,bcm2712";
+
+	fragment@2 {
+		target = <&w1>;
+		__overlay__ {
+			raspberrypi,delay-needs-poll;
+		};
+	};
+};

--- a/drivers/w1/masters/w1-gpio.c
+++ b/drivers/w1/masters/w1-gpio.c
@@ -90,6 +90,9 @@ static int w1_gpio_probe(struct platform_device *pdev)
 		if (of_property_present(np, "linux,open-drain"))
 			gflags = GPIOD_OUT_LOW;
 
+		if (of_property_present(np, "raspberrypi,delay-needs-poll"))
+			master->delay_needs_poll = true;
+
 		pdev->dev.platform_data = pdata;
 	}
 	pdata = dev_get_platdata(dev);

--- a/drivers/w1/w1_io.c
+++ b/drivers/w1/w1_io.c
@@ -6,6 +6,7 @@
 #include <asm/io.h>
 
 #include <linux/delay.h>
+#include <linux/ktime.h>
 #include <linux/moduleparam.h>
 #include <linux/module.h>
 
@@ -36,9 +37,21 @@ static u8 w1_crc8_table[] = {
 	116, 42, 200, 150, 21, 75, 169, 247, 182, 232, 10, 84, 215, 137, 107, 53
 };
 
-static void w1_delay(unsigned long tm)
+static void w1_delay(struct w1_master *dev, unsigned long tm)
 {
-	udelay(tm * w1_delay_parm);
+	ktime_t start, delta;
+
+	if (!dev->bus_master->delay_needs_poll) {
+		udelay(tm * w1_delay_parm);
+		return;
+	}
+
+	start = ktime_get();
+	delta = ktime_add(start, ns_to_ktime(1000 * tm * w1_delay_parm));
+	do {
+		dev->bus_master->read_bit(dev->bus_master->data);
+		udelay(1);
+	} while (ktime_before(ktime_get(), delta));
 }
 
 static void w1_write_bit(struct w1_master *dev, int bit);
@@ -77,14 +90,14 @@ static void w1_write_bit(struct w1_master *dev, int bit)
 
 	if (bit) {
 		dev->bus_master->write_bit(dev->bus_master->data, 0);
-		w1_delay(6);
+		w1_delay(dev, 6);
 		dev->bus_master->write_bit(dev->bus_master->data, 1);
-		w1_delay(64);
+		w1_delay(dev, 64);
 	} else {
 		dev->bus_master->write_bit(dev->bus_master->data, 0);
-		w1_delay(60);
+		w1_delay(dev, 60);
 		dev->bus_master->write_bit(dev->bus_master->data, 1);
-		w1_delay(10);
+		w1_delay(dev, 10);
 	}
 
 	if(w1_disable_irqs) local_irq_restore(flags);
@@ -164,14 +177,14 @@ static u8 w1_read_bit(struct w1_master *dev)
 	/* sample timing is critical here */
 	local_irq_save(flags);
 	dev->bus_master->write_bit(dev->bus_master->data, 0);
-	w1_delay(6);
+	w1_delay(dev, 6);
 	dev->bus_master->write_bit(dev->bus_master->data, 1);
-	w1_delay(9);
+	w1_delay(dev, 9);
 
 	result = dev->bus_master->read_bit(dev->bus_master->data);
 	local_irq_restore(flags);
 
-	w1_delay(55);
+	w1_delay(dev, 55);
 
 	return result & 0x1;
 }
@@ -333,16 +346,16 @@ int w1_reset_bus(struct w1_master *dev)
 		 * cpu for such a short amount of time AND get it back in
 		 * the maximum amount of time.
 		 */
-		w1_delay(500);
+		w1_delay(dev, 500);
 		dev->bus_master->write_bit(dev->bus_master->data, 1);
-		w1_delay(70);
+		w1_delay(dev, 70);
 
 		result = dev->bus_master->read_bit(dev->bus_master->data) & 0x1;
 		/* minimum 70 (above) + 430 = 500 us
 		 * There aren't any timing requirements between a reset and
 		 * the following transactions.  Sleeping is safe here.
 		 */
-		/* w1_delay(430); min required time */
+		/* w1_delay(dev, 430); min required time */
 		msleep(1);
 	}
 

--- a/include/linux/w1.h
+++ b/include/linux/w1.h
@@ -121,6 +121,9 @@ typedef void (*w1_slave_found_callback)(struct w1_master *, u64);
  * @dev_id: Optional device id string, which w1 slaves could use for
  * creating names, which then give a connection to the w1 master
  *
+ * @delay_needs_poll: work around jitter introduced with GPIO controllers
+ * accessed over PCIe (RP1)
+ *
  * Note: read_bit and write_bit are very low level functions and should only
  * be used with hardware that doesn't really support 1-wire operations,
  * like a parallel/serial port.
@@ -155,6 +158,8 @@ struct w1_bus_master {
 		u8, w1_slave_found_callback);
 
 	char		*dev_id;
+
+	bool		delay_needs_poll;
 };
 
 /**


### PR DESCRIPTION
Slightly less hacky - parse that we want read-polling out of devicetree, so it's used only where needed.