### PR TITLE
Improvement on backup-switchover-mode overlay value definitions

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2108,9 +2108,9 @@ Params: abx80x                  Select one of the ABx80x family:
         backup-switchover-mode  Backup power supply switch mode. Must be 0 for
                                 "Switchover disabled", 1 for "Direct Switching" 
                                 (switchover when Vdd < VBackup), 2 for "Standby
-                                 Mode" (go into standby when Vdd < Vbackup, 
-                                does not draw current) or 3 (recommended) for 
-                                "Level Switching" (switchover when Vdd < Vbackup 
+                                Mode" (go into standby when Vdd < Vbackup,
+                                does not draw current) or 3 (recommended) for
+                                "Level Switching" (switchover when Vdd < Vbackup
                                 and Vdd < Vddsw and Vbackup > Vddsw)
                                 (RV3028, RV3032)
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2107,10 +2107,10 @@ Params: abx80x                  Select one of the ABx80x family:
 
         backup-switchover-mode  Backup power supply switch mode. Must be 0 for
                                 "Switchover disabled", 1 for "Direct Switching"
-                                (switchover if Vdd < VBackup), 2 for "Standby
-                                Mode" (standby if Vdd < Vbackup,
+                                (if Vdd < VBackup), 2 for "Standby
+                                Mode" (if Vdd < Vbackup,
                                 does not draw current) or 3 for
-                                "Level Switching" (switchover if Vdd < Vbackup
+                                "Level Switching" (if Vdd < Vbackup
                                 and Vdd < Vddsw and Vbackup > Vddsw)
                                 (RV3028, RV3032)
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2106,7 +2106,7 @@ Params: abx80x                  Select one of the ABx80x family:
                                 source
 
         backup-switchover-mode  Backup power supply switch mode. Must be 0 for
-                                "Switchover disabled", 1 for "Direct Switching" 
+                                "Switchover disabled", 1 for "Direct Switching"
                                 (switchover when Vdd < VBackup), 2 for "Standby
                                 Mode" (go into standby when Vdd < Vbackup,
                                 does not draw current) or 3 (recommended) for

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2107,10 +2107,10 @@ Params: abx80x                  Select one of the ABx80x family:
 
         backup-switchover-mode  Backup power supply switch mode. Must be 0 for
                                 "Switchover disabled", 1 for "Direct Switching"
-                                (switchover when Vdd < VBackup), 2 for "Standby
-                                Mode" (go into standby when Vdd < Vbackup,
-                                does not draw current) or 3 (recommended) for
-                                "Level Switching" (switchover when Vdd < Vbackup
+                                (switchover if Vdd < VBackup), 2 for "Standby
+                                Mode" (standby if Vdd < Vbackup,
+                                does not draw current) or 3 for
+                                "Level Switching" (switchover if Vdd < Vbackup
                                 and Vdd < Vddsw and Vbackup > Vddsw)
                                 (RV3028, RV3032)
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2106,7 +2106,13 @@ Params: abx80x                  Select one of the ABx80x family:
                                 source
 
         backup-switchover-mode  Backup power supply switch mode. Must be 0 for
-                                off or 1 for Vdd < VBackup (RV3028, RV3032)
+                                "Switchover disabled", 1 for "Direct Switching" 
+                                (switchover when Vdd < VBackup), 2 for "Standby
+                                 Mode" (go into standby when Vdd < Vbackup, 
+                                does not draw current) or 3 (recommended) for 
+                                "Level Switching" (switchover when Vdd < Vbackup 
+                                and Vdd < Vddsw and Vbackup > Vddsw)
+                                (RV3028, RV3032)
 
 
 Name:   i2c-rtc-gpio


### PR DESCRIPTION
For the RV3028 RTC, the definitions for its `backup-switchover-mode` overlay were not intelligible neither complete/exhaustive. Accordingly to the https://github.com/raspberrypi/linux/issues/2912#issuecomment-477670051, these ones here proposed should be correct. The purpose is to allow the users to know the 4 different values for the switchover functionality of this RTC backup battery functionality.

`/boot/config.txt` should be as a configuration example, for RV3028, on a Uputronics GPS Extension HAT:
```
dtparam=i2c_arm=on
dtoverlay=i2c-rtc,rv3028,backup-switchover-mode=3
dtoverlay=pps-gpio,gpiopin=18
init_uart_baud=115200
```

From my tests (`sudo rmmod rtc_rv3028 && sudo i2cget -y 1 0x52 0x37`):

`Default from factory`: `0x10`
`Mode 0`: `0x10`
`Mode 1`: `0x14`
`Mode 2`: `0x18`
`Mode 3`: `0x1c`

`Mode 3`: `0x1c` is consistent with the manufacturer configuration script: http://store.uputronics.com/files/configure-rv3028.sh