### PR TITLE
Harmonizing the improvement on backup-switchover-mode overlay value definitions

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2184,7 +2184,13 @@ Params: abx80x                  Select one of the ABx80x family:
                                 source
 
         backup-switchover-mode  Backup power supply switch mode. Must be 0 for
-                                off or 1 for Vdd < VBackup (RV3028, RV3032)
+                                "Switchover disabled", 1 for "Direct Switching"
+                                (if Vdd < VBackup), 2 for "Standby
+                                Mode" (if Vdd < Vbackup,
+                                does not draw current) or 3 for
+                                "Level Switching" (if Vdd < Vbackup
+                                and Vdd < Vddsw and Vbackup > Vddsw)
+                                (RV3028, RV3032)
 
         i2c_gpio_sda            GPIO used for I2C data (default "23")
 


### PR DESCRIPTION
On the followup of https://github.com/raspberrypi/linux/pull/5884, I missed a second duplicate definition. Now, harmonized the entire document

Signed-off-by: Tiago Freire <41837236+tiagofreire-pt@users.noreply.github.com>