### PR TITLE
PCI: brcmstb: Enable CRS software visibility after linkup

### DIFF
--- a/drivers/pci/controller/pcie-brcmstb.c
+++ b/drivers/pci/controller/pcie-brcmstb.c
@@ -1385,7 +1385,7 @@ static int brcm_pcie_start_link(struct brcm_pcie *pcie)
 {
 	struct device *dev = pcie->dev;
 	void __iomem *base = pcie->base;
-	u16 nlw, cls, lnksta;
+	u16 nlw, cls, lnksta, tmp16;
 	bool ssc_good = false;
 	int ret, i;
 	u32 tmp;
@@ -1449,6 +1449,16 @@ static int brcm_pcie_start_link(struct brcm_pcie *pcie)
 		 pci_speed_string(pcie_link_speed[cls]), nlw,
 		 ssc_good ? "(SSC)" : "(!SSC)");
 
+	/*
+	 * RootCtl bits are reset by perst_n, which undoes pci_enable_crs()
+	 * called prior to pci_add_new_bus() during probe. Re-enable here.
+	 */
+	tmp16 = readw(base + BRCM_PCIE_CAP_REGS + PCI_EXP_RTCAP);
+	if (tmp16 & PCI_EXP_RTCAP_CRSVIS) {
+		tmp16 = readw(base + BRCM_PCIE_CAP_REGS + PCI_EXP_RTCTL);
+		u16p_replace_bits(&tmp16, 1, PCI_EXP_RTCTL_CRSSVE);
+		writew(tmp16, base + BRCM_PCIE_CAP_REGS + PCI_EXP_RTCTL);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
This fell out of the discussions around "why does the bootloader nvme probe behave differently to Linux" - as part of aligning the behaviours of both, we should make maximal use of the features offered by the RC.

The RC supports neither Device Readiness nor Function Readiness notifications, therefore we should use a combination of the 100ms grace period after link-up with CRS.

EPs are permitted to issue Retry statuses for up to 1 second, which if CRSSVE=0 will
a) completely stall the CPU until the Ubus/completion timeout is reached (<1s, but some tens of milliseconds)
b) cause the RC to return 0xffffffff for reads of the vendor ID register instead of 0xffff0001 which will cause probe failure instead of retrying up to the 1 second limit.

For some reason the associated root complex register bit is reset by perst_n, so enable it after link-up.