### PR TITLE
HACK: drm/vc4: Disable overrun interrupts

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -867,7 +867,7 @@ static void vc4_crtc_handle_page_flip(struct vc4_crtc *vc4_crtc)
 		 * the CRTC and encoder already reconfigured, leading to
 		 * underruns. This can be seen when reconfiguring the CRTC.
 		 */
-		if (vc4->gen < VC4_GEN_6)
+		if (0 && vc4->gen < VC4_GEN_6)
 			vc4_hvs_unmask_underrun(hvs, chan);
 	}
 	spin_unlock(&vc4_crtc->irq_lock);

--- a/drivers/gpu/drm/vc4/vc4_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_kms.c
@@ -397,7 +397,7 @@ static void vc4_atomic_commit_tail(struct drm_atomic_state *state)
 	if (WARN_ON(IS_ERR(new_hvs_state)))
 		return;
 
-	if (vc4->gen < VC4_GEN_6) {
+	if (0 && vc4->gen < VC4_GEN_6) {
 		struct drm_crtc_state *new_crtc_state;
 		struct drm_crtc *crtc;
 		int i;


### PR DESCRIPTION
For testing hypothesis that the lockup of not clearing stale dlist allocs is down to a read-modify-write race between DSPEISLUR and DSPEIEOF.