### PR TITLE
Completely disable dwc3 park mode 

### DIFF
--- a/Documentation/devicetree/bindings/usb/snps,dwc3.yaml
+++ b/Documentation/devicetree/bindings/usb/snps,dwc3.yaml
@@ -233,12 +233,17 @@ properties:
 
   snps,parkmode-disable-ss-quirk:
     description:
-      When set, all SuperSpeed bus instances in park mode are disabled.
+      When set, disable park mode for all Superspeed bus instances.
     type: boolean
 
   snps,parkmode-disable-hs-quirk:
     description:
-      When set, all HighSpeed bus instances in park mode are disabled.
+      When set, disable park mode for all Highspeed bus instances.
+    type: boolean
+
+  snps,parkmode-disable-fsls-quirk:
+    description:
+      When set, disable park mode for all Full/Lowspeed bus instances.
     type: boolean
 
   snps,dis_metastability_quirk:

--- a/arch/arm/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm/boot/dts/broadcom/rp1.dtsi
@@ -1060,6 +1060,8 @@
 			snps,axi-pipe-limit = /bits/ 8 <8>;
 			snps,dis_rxdet_inp3_quirk;
 			snps,parkmode-disable-ss-quirk;
+			snps,parkmode-disable-hs-quirk;
+			snps,parkmode-disable-fsls-quirk;
 			snps,tx-max-burst-prd = <8>;
 			snps,tx-thr-num-pkt-prd = <2>;
 			interrupts = <RP1_INT_USBHOST0_0 IRQ_TYPE_EDGE_RISING>;
@@ -1074,6 +1076,8 @@
 			snps,axi-pipe-limit = /bits/ 8 <8>;
 			snps,dis_rxdet_inp3_quirk;
 			snps,parkmode-disable-ss-quirk;
+			snps,parkmode-disable-hs-quirk;
+			snps,parkmode-disable-fsls-quirk;
 			snps,tx-max-burst-prd = <8>;
 			snps,tx-thr-num-pkt-prd = <2>;
 			interrupts = <RP1_INT_USBHOST1_0 IRQ_TYPE_EDGE_RISING>;

--- a/drivers/usb/dwc3/core.c
+++ b/drivers/usb/dwc3/core.c
@@ -1363,6 +1363,9 @@ static int dwc3_core_init(struct dwc3 *dwc)
 		if (dwc->parkmode_disable_hs_quirk)
 			reg |= DWC3_GUCTL1_PARKMODE_DISABLE_HS;
 
+		if (dwc->parkmode_disable_fsls_quirk)
+			reg |= DWC3_GUCTL1_PARKMODE_DISABLE_FSLS;
+
 		if (DWC3_VER_IS_WITHIN(DWC3, 290A, ANY) &&
 		    (dwc->maximum_speed == USB_SPEED_HIGH ||
 		     dwc->maximum_speed == USB_SPEED_FULL))
@@ -1659,6 +1662,8 @@ static void dwc3_get_properties(struct dwc3 *dwc)
 				"snps,parkmode-disable-ss-quirk");
 	dwc->parkmode_disable_hs_quirk = device_property_read_bool(dev,
 				"snps,parkmode-disable-hs-quirk");
+	dwc->parkmode_disable_fsls_quirk = device_property_read_bool(dev,
+				"snps,parkmode-disable-fsls-quirk");
 	dwc->gfladj_refclk_lpm_sel = device_property_read_bool(dev,
 				"snps,gfladj-refclk-lpm-sel-quirk");
 

--- a/drivers/usb/dwc3/core.h
+++ b/drivers/usb/dwc3/core.h
@@ -271,6 +271,7 @@
 #define DWC3_GUCTL1_DEV_L1_EXIT_BY_HW		BIT(24)
 #define DWC3_GUCTL1_PARKMODE_DISABLE_SS		BIT(17)
 #define DWC3_GUCTL1_PARKMODE_DISABLE_HS		BIT(16)
+#define DWC3_GUCTL1_PARKMODE_DISABLE_FSLS	BIT(15)
 #define DWC3_GUCTL1_RESUME_OPMODE_HS_HOST	BIT(10)
 
 /* Global Status Register */
@@ -1115,10 +1116,12 @@ struct dwc3_scratchpad_array {
  *			generation after resume from suspend.
  * @ulpi_ext_vbus_drv: Set to confiure the upli chip to drives CPEN pin
  *			VBUS with an external supply.
- * @parkmode_disable_ss_quirk: set if we need to disable all SuperSpeed
- *			instances in park mode.
- * @parkmode_disable_hs_quirk: set if we need to disable all HishSpeed
- *			instances in park mode.
+ * @parkmode_disable_ss_quirk: If set, disable park mode feature for all
+ *			Superspeed instances.
+ * @parkmode_disable_hs_quirk: If set, disable park mode feature for all
+ *			Highspeed instances.
+ * @parkmode_disable_fsls_quirk: If set, disable park mode feature for all
+ *			Full/Lowspeed instances.
  * @tx_de_emphasis_quirk: set if we enable Tx de-emphasis quirk
  * @tx_de_emphasis: Tx de-emphasis value
  *	0	- -6dB de-emphasis
@@ -1340,6 +1343,7 @@ struct dwc3 {
 	unsigned		ulpi_ext_vbus_drv:1;
 	unsigned		parkmode_disable_ss_quirk:1;
 	unsigned		parkmode_disable_hs_quirk:1;
+	unsigned		parkmode_disable_fsls_quirk:1;
 	unsigned		gfladj_refclk_lpm_sel:1;
 
 	unsigned		tx_de_emphasis_quirk:1;


### PR DESCRIPTION
A followup to #5753 we have further information from Synopsys and the recommendation is to just not use park mode at all. The feature optimises for the single-device case and ends up degrading many multi-device cases.