### PR TITLE
overlays: Add pcie-32bit-dma-pi5-overlay to enable 32bit DMA on the Pi 5's external PCIe interface

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -182,6 +182,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	pca953x.dtbo \
 	pcf857x.dtbo \
 	pcie-32bit-dma.dtbo \
+	pcie-32bit-dma-pi5.dtbo \
 	pibell.dtbo \
 	pifacedigital.dtbo \
 	pifi-40.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3382,6 +3382,12 @@ Load:   dtoverlay=pcie-32bit-dma
 Params: <None>
 
 
+Name:   pcie-32bit-dma-pi5
+Info:   Force PCIe config to support 32bit DMA addresses at the expense of
+        having to bounce buffers (on the Pi 5).
+Load:   dtoverlay=pcie-32bit-dma-pi5
+Params: <None>
+
 [ The pcf2127-rtc overlay has been deleted. See i2c-rtc. ]
 
 

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -185,6 +185,11 @@
 
 	pcie-32bit-dma {
 		bcm2711;
+		bcm2712 = "pcie-32bit-dma-pi5";
+	};
+
+	pcie-32bit-dma-pi5 {
+		bcm2712;
 	};
 
 	pi3-act-led {

--- a/arch/arm/boot/dts/overlays/pcie-32bit-dma-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pcie-32bit-dma-pi5-overlay.dts
@@ -1,0 +1,26 @@
+/*
+ * pcie-32bit-dma-pi5-overlay.dts
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2712";
+
+	fragment@0 {
+		target = <&pcie1>;
+		__overlay__ {
+			/*
+			 * The size of the range is rounded up to a power of 2,
+			 * so the range ends up being 0-4GB, and the MSI vector
+			 * gets pushed beyond 4GB.
+			 */
+			#address-cells = <3>;
+			#size-cells = <2>;
+			dma-ranges = <0x02000000 0x0 0x00000000 0x0 0x00000000
+				      0x0 0x80000000>;
+		};
+	};
+
+};


### PR DESCRIPTION
The pcie-32bit-dma dts overlay is only compatible with CM4 and does not work for the Pi 5 and its external PCIe interface.
This PR adds a new overlay "pcie-32bit-dma-pi5-overlay" with a fix based on #4216 and #4870. 

In this case, the target component is _pcie1_, and the _dma-ranges_ attribute changes from:
`dma-ranges = <0x03000000 0x10 0x00000000
				      0x00 0x00000000
				      0x10 0x00000000>;`
to:
`dma-ranges = <0x03000000 0x0 0x00000000 0x0 0x00000000
				      0x0 0x80000000>;`
in order to ensure that the DMA addressing space is 32bits, at the expense of having to bounce buffers.

I've confirmed that this functions correctly on a Raspberry Pi 5 connected to Pineberry Pi's "Hat AI!", to which I plugged in a MikroTik R11e-5HnD (Atheros AR9580) wireless card.

Issue Link: #5896 

Thanks:
- @vianpl 
- @6by9 
- @geerlingguy
- Network Architectures and Protocols Group - Instituto de Telecomunicações (Aveiro, Portugal)