### PR TITLE
6.6 VEC fixups

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_vec.c
+++ b/drivers/gpu/drm/vc4/vc4_vec.c
@@ -404,10 +404,6 @@ static void vc4_vec_connector_reset(struct drm_connector *connector)
 {
 	drm_atomic_helper_connector_reset(connector);
 	drm_atomic_helper_connector_tv_reset(connector);
-
-	/* preserve TV standard */
-	if (connector->state)
-		connector->state->tv.mode = vc4_vec_get_default_mode(connector);
 }
 
 static int

--- a/drivers/gpu/drm/vc4/vc4_vec.c
+++ b/drivers/gpu/drm/vc4/vc4_vec.c
@@ -757,18 +757,6 @@ static int vc4_vec_encoder_atomic_check(struct drm_encoder *encoder,
 		if ((mode->crtc_vtotal - mode->crtc_vsync_end) < 4)
 			return -EINVAL;
 
-		if ((mode->flags & DRM_MODE_FLAG_INTERLACE) &&
-		    (mode->vdisplay % 2 != 0 ||
-		     mode->vsync_start % 2 != 1 ||
-		     mode->vsync_end % 2 != 1 ||
-		     mode->vtotal % 2 != 1))
-			return -EINVAL;
-
-		/* progressive mode is hard-wired to 262 total lines */
-		if (!(mode->flags & DRM_MODE_FLAG_INTERLACE) &&
-		    mode->crtc_vtotal != 262)
-			return -EINVAL;
-
 		break;
 
 	/* PAL/SECAM */
@@ -786,18 +774,6 @@ static int vc4_vec_encoder_atomic_check(struct drm_encoder *encoder,
 			return -EINVAL;
 
 		if ((mode->crtc_vtotal - mode->crtc_vsync_end) < 2)
-			return -EINVAL;
-
-		if ((mode->flags & DRM_MODE_FLAG_INTERLACE) &&
-		    (mode->vdisplay % 2 != 0 ||
-		     mode->vsync_start % 2 != 0 ||
-		     mode->vsync_end % 2 != 0 ||
-		     mode->vtotal % 2 != 1))
-			return -EINVAL;
-
-		/* progressive mode is hard-wired to 312 total lines */
-		if (!(mode->flags & DRM_MODE_FLAG_INTERLACE) &&
-		    mode->crtc_vtotal != 312)
 			return -EINVAL;
 
 		break;

--- a/drivers/gpu/drm/vc4/vc4_vec.c
+++ b/drivers/gpu/drm/vc4/vc4_vec.c
@@ -370,7 +370,9 @@ static const struct drm_prop_enum_list legacy_tv_mode_names[] = {
 enum drm_connector_tv_mode
 vc4_vec_get_default_mode(struct drm_connector *connector)
 {
-	if (vc4_vec_tv_norm) {
+	if (connector->cmdline_mode.tv_mode_specified) {
+		return connector->cmdline_mode.tv_mode;
+	} else if (vc4_vec_tv_norm) {
 		int ret;
 
 		ret = drm_get_tv_mode_from_name(vc4_vec_tv_norm, strlen(vc4_vec_tv_norm));


### PR DESCRIPTION
Fixes up the downstream VEC patches so that the VEC works on 6.6. Also needed on 6.7.
See #5894