### PR TITLE
drm/rp1: depends on, instead of select, MFD_RP1

### DIFF
--- a/drivers/gpu/drm/rp1/rp1-dpi/Kconfig
+++ b/drivers/gpu/drm/rp1/rp1-dpi/Kconfig
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 config DRM_RP1_DPI
 	tristate "DRM Support for RP1 DPI"
-	depends on DRM
-	select MFD_RP1
+	depends on DRM && MFD_RP1
 	select DRM_GEM_DMA_HELPER
 	select DRM_KMS_HELPER
 	select DRM_VRAM_HELPER

--- a/drivers/gpu/drm/rp1/rp1-dsi/Kconfig
+++ b/drivers/gpu/drm/rp1/rp1-dsi/Kconfig
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 config DRM_RP1_DSI
 	tristate "DRM Support for RP1 DSI"
-	depends on DRM
-	select MFD_RP1
+	depends on DRM && MFD_RP1
 	select DRM_GEM_DMA_HELPER
 	select DRM_KMS_HELPER
 	select DRM_MIPI_DSI

--- a/drivers/gpu/drm/rp1/rp1-vec/Kconfig
+++ b/drivers/gpu/drm/rp1/rp1-vec/Kconfig
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 config DRM_RP1_VEC
 	tristate "DRM Support for RP1 VEC"
-	depends on DRM
-	select MFD_RP1
+	depends on DRM && MFD_RP1
 	select DRM_GEM_DMA_HELPER
 	select DRM_KMS_HELPER
 	select DRM_VRAM_HELPER


### PR DESCRIPTION
According to kconfig-language.txt [1], select should be used only for "non-visible symbols ... and for symbols with no dependencies". Since MFD_RP1 both is visible and has a dependency, "select" should not be used and "depends on" should be used instead.

In particular, this fixes the build of this kernel tree on NixOS, where its kernel config system will try to answer 'M' to as many config as possible.

[1] https://www.kernel.org/doc/html/latest/kbuild/kconfig-language.html