### PR TITLE
Update PiTFT overlays for compatibility and consistency

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3526,6 +3526,10 @@ Params: speed                   Display SPI bus speed
 
         debug                   Debug output level {0-7}
 
+        drm                     Force the use of the mi0283qt DRM driver (by
+                                default the ili9340 framebuffer driver will
+                                be used in preference if available)
+
 
 Name:   pitft28-capacitive
 Info:   Adafruit PiTFT 2.8" capacitive touch screen
@@ -3537,6 +3541,10 @@ Params: speed                   Display SPI bus speed
         fps                     Delay between frame updates
 
         debug                   Debug output level {0-7}
+
+        drm                     Force the use of the mi0283qt DRM driver (by
+                                default the ili9340 framebuffer driver will
+                                be used in preference if available)
 
         touch-sizex             Touchscreen size x (default 240)
 
@@ -3564,6 +3572,12 @@ Params: speed                   Display SPI bus speed
                                 default the ili9340 framebuffer driver will
                                 be used in preference if available)
 
+        touch-invx              Touchscreen inverted x axis
+
+        touch-invy              Touchscreen inverted y axis
+
+        touch-swapxy            Touchscreen swapped x y axis
+
 
 Name:   pitft35-resistive
 Info:   Adafruit PiTFT 3.5" resistive touch screen
@@ -3579,6 +3593,12 @@ Params: speed                   Display SPI bus speed
         drm                     Force the use of the hx8357d DRM driver (by
                                 default the fb_hx8357d framebuffer driver will
                                 be used in preference if available)
+
+        touch-invx              Touchscreen inverted x axis
+
+        touch-invy              Touchscreen inverted y axis
+
+        touch-swapxy            Touchscreen swapped x y axis
 
 
 Name:   pps-gpio

--- a/arch/arm/boot/dts/overlays/pitft22-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pitft22-overlay.dts
@@ -7,63 +7,65 @@
 /plugin/;
 
 / {
-        compatible = "brcm,bcm2835";
+	compatible = "brcm,bcm2835";
 
-        fragment@0 {
-                target = <&spidev0>;
-                __overlay__ {
-                        status = "disabled";
-                };
+	fragment@0 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
         };
 
-        fragment@1 {
-                target = <&spidev1>;
-                __overlay__ {
-                        status = "disabled";
-                };
-        };
+	fragment@1 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
 
-        fragment@2 {
-                target = <&gpio>;
-                __overlay__ {
-                        pitft_pins: pitft_pins {
-                                brcm,pins = <25>;
-                                brcm,function = <1>; /* out */
-                                brcm,pull = <0>; /* none */
-                        };
-                };
-        };
+	fragment@2 {
+		target = <&gpio>;
+		__overlay__ {
+			pitft_pins: pitft_pins {
+				brcm,pins = <25>;
+				brcm,function = <1>; /* out */
+				brcm,pull = <0>; /* none */
+			};
+		};
+	};
 
-        fragment@3 {
-                target = <&spi0>;
-                __overlay__ {
-                        /* needed to avoid dtc warning */
-                        #address-cells = <1>;
-                        #size-cells = <0>;
-                        status = "okay";
+	fragment@3 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
 
-                        pitft: pitft@0{
-                                compatible = "ilitek,ili9340";
-                                reg = <0>;
-                                pinctrl-names = "default";
-                                pinctrl-0 = <&pitft_pins>;
+			pitft: pitft@0{
+				compatible = "ilitek,ili9340";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&pitft_pins>;
 
-                                spi-max-frequency = <32000000>;
-                                rotate = <90>;
-                                fps = <25>;
-                                bgr;
-                                buswidth = <8>;
-                                dc-gpios = <&gpio 25 0>;
-                                debug = <0>;
-                        };
+				spi-max-frequency = <32000000>;
+				rotate = <90>;
+				fps = <25>;
+				bgr;
+				buswidth = <8>;
+				dc-gpios = <&gpio 25 0>;
+				debug = <0>;
+			};
 
-                };
-        };
+		};
+	};
 
-        __overrides__ {
-                speed =   <&pitft>,"spi-max-frequency:0";
-                rotate =  <&pitft>,"rotate:0";
-                fps =     <&pitft>,"fps:0";
-                debug =   <&pitft>,"debug:0";
-        };
+	__overrides__ {
+		speed =   <&pitft>,"spi-max-frequency:0";
+		rotate =  <&pitft>,"rotate:0", /* fbtft */
+				<&pitft>,"rotation:0"; /* drm */
+		fps =     <&pitft>,"fps:0";
+		debug =   <&pitft>,"debug:0";
+		drm =     <&pitft>,"compatible=adafruit,yx240qv29";
+	};
 };

--- a/arch/arm/boot/dts/overlays/pitft28-capacitive-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pitft28-capacitive-overlay.dts
@@ -7,14 +7,14 @@
 /plugin/;
 
 / {
-        compatible = "brcm,bcm2835";
+	compatible = "brcm,bcm2835";
 
-        fragment@0 {
-                target = <&spi0>;
-                __overlay__ {
-                        status = "okay";
-                };
-        };
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
 
 	fragment@1 {
 		target = <&spidev0>;
@@ -23,69 +23,71 @@
 		};
 	};
 
-        fragment@2 {
-                target = <&gpio>;
-                __overlay__ {
-                        pitft_pins: pitft_pins {
-                                brcm,pins = <24 25>;
-                                brcm,function = <0 1>; /* in out */
-                                brcm,pull = <2 0>; /* pullup none */
-                        };
-                };
-        };
+	fragment@2 {
+		target = <&gpio>;
+		__overlay__ {
+			pitft_pins: pitft_pins {
+				brcm,pins = <24 25>;
+				brcm,function = <0 1>; /* in out */
+				brcm,pull = <2 0>; /* pullup none */
+			};
+		};
+	};
 
-        fragment@3 {
-                target = <&spi0>;
-                __overlay__ {
-                        /* needed to avoid dtc warning */
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+	fragment@3 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-                        pitft: pitft@0{
-                                compatible = "ilitek,ili9340";
-                                reg = <0>;
-                                pinctrl-names = "default";
-                                pinctrl-0 = <&pitft_pins>;
+			pitft: pitft@0{
+				compatible = "ilitek,ili9340";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&pitft_pins>;
 
-                                spi-max-frequency = <32000000>;
-                                rotate = <90>;
-                                fps = <25>;
-                                bgr;
-                                buswidth = <8>;
-                                dc-gpios = <&gpio 25 0>;
-                                debug = <0>;
-                        };
-                };
-        };
+				spi-max-frequency = <32000000>;
+				rotate = <90>;
+				fps = <25>;
+				bgr;
+				buswidth = <8>;
+				dc-gpios = <&gpio 25 0>;
+				debug = <0>;
+			};
+		};
+	};
 
-        fragment@4 {
-                target = <&i2c1>;
-                __overlay__ {
-                        /* needed to avoid dtc warning */
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+	fragment@4 {
+		target = <&i2c1>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-                        ft6236: ft6236@38 {
-                                compatible = "focaltech,ft6236";
-                                reg = <0x38>;
+			ft6236: ft6236@38 {
+				compatible = "focaltech,ft6236";
+				reg = <0x38>;
 
-                                interrupt-parent = <&gpio>;
-                                interrupts = <24 2>;
-                                touchscreen-size-x = <240>;
-                                touchscreen-size-y = <320>;
-                        };
-                };
-        };
+				interrupt-parent = <&gpio>;
+				interrupts = <24 2>;
+				touchscreen-size-x = <240>;
+				touchscreen-size-y = <320>;
+			};
+		};
+	};
 
-        __overrides__ {
-                speed =   <&pitft>,"spi-max-frequency:0";
-                rotate =  <&pitft>,"rotate:0";
-                fps =     <&pitft>,"fps:0";
-                debug =   <&pitft>,"debug:0";
-                touch-sizex = <&ft6236>,"touchscreen-size-x?";
-                touch-sizey = <&ft6236>,"touchscreen-size-y?";
-                touch-invx  = <&ft6236>,"touchscreen-inverted-x?";
-                touch-invy  = <&ft6236>,"touchscreen-inverted-y?";
-                touch-swapxy = <&ft6236>,"touchscreen-swapped-x-y?";
-        };
+	__overrides__ {
+		speed =   <&pitft>,"spi-max-frequency:0";
+		rotate =  <&pitft>,"rotate:0", /* fbtft */
+				<&pitft>,"rotation:0"; /* drm */
+		fps =     <&pitft>,"fps:0";
+		debug =   <&pitft>,"debug:0";
+		drm =     <&pitft>,"compatible=adafruit,yx240qv29";
+		touch-sizex = <&ft6236>,"touchscreen-size-x:0";
+		touch-sizey = <&ft6236>,"touchscreen-size-y:0";
+		touch-invx  = <&ft6236>,"touchscreen-inverted-x?";
+		touch-invy  = <&ft6236>,"touchscreen-inverted-y?";
+		touch-swapxy = <&ft6236>,"touchscreen-swapped-x-y?";
+	};
 };

--- a/arch/arm/boot/dts/overlays/pitft28-resistive-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pitft28-resistive-overlay.dts
@@ -49,7 +49,7 @@
 			#size-cells = <0>;
 
 			pitft: pitft@0{
-				compatible = "ilitek,ili9340", "multi-inno,mi0283qt";
+				compatible = "ilitek,ili9340";
 				reg = <0>;
 				pinctrl-names = "default";
 				pinctrl-0 = <&pitft_pins>;
@@ -64,6 +64,9 @@
 			};
 
 			pitft_ts@1 {
+				/* needed to avoid dtc warning */
+				#address-cells = <1>;
+				#interrupt-cells = <1>;
 				compatible = "st,stmpe610";
 				reg = <1>;
 
@@ -72,7 +75,7 @@
 				interrupt-parent = <&gpio>;
 				interrupt-controller;
 
-				stmpe_touchscreen {
+				stmpe_touchscreen: stmpe_touchscreen {
 					compatible = "st,stmpe-ts";
 					st,sample-time = <4>;
 					st,mod-12b = <1>;
@@ -115,6 +118,9 @@
 			  <&pitft>,"rotation:0"; /* drm */
 		fps =     <&pitft>,"fps:0";
 		debug =   <&pitft>,"debug:0";
-		drm =     <&pitft>,"compatible=multi-inno,mi0283qt";
+		drm =     <&pitft>,"compatible=adafruit,yx240qv29";
+		touch-invx  = <&stmpe_touchscreen>,"touchscreen-inverted-x?";
+		touch-invy  = <&stmpe_touchscreen>,"touchscreen-inverted-y?";
+		touch-swapxy = <&stmpe_touchscreen>,"touchscreen-swapped-x-y?";
 	};
 };

--- a/arch/arm/boot/dts/overlays/pitft35-resistive-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pitft35-resistive-overlay.dts
@@ -49,7 +49,7 @@
 			#size-cells = <0>;
 
 			pitft: pitft@0{
-				compatible = "himax,hx8357d", "adafruit,yx350hv15";
+				compatible = "himax,hx8357d";
 				reg = <0>;
 				pinctrl-names = "default";
 				pinctrl-0 = <&pitft_pins>;
@@ -64,6 +64,9 @@
 			};
 
 			pitft_ts@1 {
+				/* needed to avoid dtc warning */
+				#address-cells = <1>;
+				#interrupt-cells = <1>;
 				compatible = "st,stmpe610";
 				reg = <1>;
 
@@ -72,7 +75,7 @@
 				interrupt-parent = <&gpio>;
 				interrupt-controller;
 
-				stmpe_touchscreen {
+				stmpe_touchscreen: stmpe_touchscreen {
 					compatible = "st,stmpe-ts";
 					st,sample-time = <4>;
 					st,mod-12b = <1>;
@@ -117,5 +120,8 @@
 		debug =   <&pitft>,"debug:0";
 		drm =     <&pitft>,"compatible=adafruit,yx350hv15",
 			  <&pitft>,"backlight:0=",<&backlight>;
+		touch-invx  = <&stmpe_touchscreen>,"touchscreen-inverted-x?";
+		touch-invy  = <&stmpe_touchscreen>,"touchscreen-inverted-y?";
+		touch-swapxy = <&stmpe_touchscreen>,"touchscreen-swapped-x-y?";
 	};
 };


### PR DESCRIPTION
This PR includes the following changes:

- Touch parameters now exposed on resistive touchscreens (2.8 and 3.5)
- DRM parameter added for pitft22 and pitft28-capacitive overlays like in resistive overlays
- "multi-inno,mi0283qt" changed to "adafruit,yx240qv29" because the rotations in that driver are consistent with the fbtft driver.

cc: @ladyada

Tested with the corresponding hardware on a Raspberry Pi 5.