### PR TITLE
iommu/bcm2712: don't allow building as module

### DIFF
--- a/drivers/iommu/Kconfig
+++ b/drivers/iommu/Kconfig
@@ -507,7 +507,7 @@ config SPRD_IOMMU
 	  Say Y here if you want to use the multimedia devices listed above.
 
 config BCM2712_IOMMU
-       tristate "BCM2712 IOMMU driver"
+       bool "BCM2712 IOMMU driver"
        depends on ARM64 && ARCH_BCM
        select IOMMU_API
        help


### PR DESCRIPTION
Since bcm2712-iommu{,-cache}.c doesn't have usual module descriptors such as `MODULE_LICENSE`, configuring this as 'M' fails the build with `ERROR: modpost: missing MODULE_LICENSE() in <...>/bcm2712-iommu.o`. Since it seems like the code is not intended to be built as a module anyway (it registers the driver with `builtin_platform_driver()`), don't allow building this code as a module.