### PR TITLE
ASoC: DACplus - fix 16bit sample support in clock consumer mode

### DIFF
--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -279,12 +279,10 @@ static int snd_rpi_hifiberry_dacplus_hw_params(
 	int ret = 0;
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	int channels = params_channels(params);
-	int width = 32;
+	int width = snd_pcm_format_physical_width(params_format(params));
 
 	if (snd_rpi_hifiberry_is_dacpro) {
 		struct snd_soc_component *component = asoc_rtd_to_codec(rtd, 0)->component;
-
-		width = snd_pcm_format_physical_width(params_format(params));
 
 		snd_rpi_hifiberry_dacplus_set_sclk(component,
 			params_rate(params));


### PR DESCRIPTION
The former code did not adjust the physical sample width when in clock consumer mode and has taken the fixed 32 bit default. This has caused the audio to be played at half its frequency due to the fixed bclk_ratio of 64.

Problem appears only on PI5 as on the former PIs the I2S module did simply run at fixed 64x rate. 