### PR TITLE
ASoC: adds support for Hifiberry AMP4Pro to the dacplus driver

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -86,6 +86,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	hifiberry-amp.dtbo \
 	hifiberry-amp100.dtbo \
 	hifiberry-amp3.dtbo \
+	hifiberry-amp4pro.dtbo \
 	hifiberry-dac.dtbo \
 	hifiberry-dacplus.dtbo \
 	hifiberry-dacplusadc.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1738,6 +1738,34 @@ Load:   dtoverlay=hifiberry-amp3
 Params: <None>
 
 
+Name:   hifiberry-amp4pro
+Info:   Configures the HifiBerry AMP4 Pro audio card
+Load:   dtoverlay=hifiberry-amp4pro,<param>=<val>
+Params: 24db_digital_gain       Allow gain to be applied via the TAS5756
+                                Digital volume control. Enable with
+                                "dtoverlay=hifiberry-amp4pro,24db_digital_gain"
+                                (The default behaviour is that the Digital
+                                volume control is limited to a maximum of
+                                0dB. ie. it can attenuate but not provide
+                                gain. For most users, this will be desired
+                                as it will prevent clipping. By appending
+                                the 24dB_digital_gain parameter, the Digital
+                                volume control will allow up to 24dB of
+                                gain. If this parameter is enabled, it is the
+                                responsibility of the user to ensure that
+                                the Digital volume control is set to a value
+                                that does not result in clipping/distortion!)
+        slave                   Force the amp into slave mode, using Pi as
+                                master for bit clock and frame clock.
+        leds_off                If set to 'true' the onboard indicator LEDs
+                                are switched off at all times.
+        auto_mute               If set to 'true' the amplifier is automatically
+                                muted when it is not playing.
+        mute_ext_ctl            The amplifier's HW mute control is enabled
+                                in ALSA mixer and set to <val>.
+                                Will be overwritten by ALSA user settings.
+
+
 Name:   hifiberry-dac
 Info:   Configures the HifiBerry DAC audio cards
 Load:   dtoverlay=hifiberry-dac

--- a/arch/arm/boot/dts/overlays/hifiberry-amp4pro-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-amp4pro-overlay.dts
@@ -1,0 +1,63 @@
+// Definitions for HiFiBerry AMP4PRO
+/dts-v1/;
+/plugin/;
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			dacpro_osc: dacpro_osc {
+				compatible = "hifiberry,dacpro-clk";
+				#clock-cells = <0>;
+			};
+		};
+	};
+
+	frag1: fragment@1 {
+		target = <&i2s_clk_consumer>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			tas5756@4d {
+				#sound-dai-cells = <0>;
+				compatible = "ti,tas5756";
+				reg = <0x4d>;
+				clocks = <&dacpro_osc>;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&sound>;
+		hifiberry_dacplus: __overlay__ {
+			compatible = "hifiberry,hifiberry-dacplus";
+			i2s-controller = <&i2s_clk_consumer>;
+			status = "okay";
+			mute-gpio = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	__overrides__ {
+		24db_digital_gain =
+			<&hifiberry_dacplus>,"hifiberry-amp4,24db_digital_gain?";
+		leds_off = <&hifiberry_dacplus>,"hifiberry-amp4,leds_off?";
+		mute_ext_ctl = <&hifiberry_dacplus>,"hifiberry-amp4,mute_ext_ctl:0";
+		auto_mute = <&hifiberry_dacplus>,"hifiberry-amp4,auto_mute?";
+		slave = <&hifiberry_dacplus>,"hifiberry-dacplus,slave?",
+			<&frag1>,"target:0=",<&i2s_clk_producer>,
+			<&hifiberry_dacplus>,"i2s-controller:0=",<&i2s_clk_producer>;
+	};
+};

--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -58,9 +58,20 @@ static bool leds_off;
 static bool auto_mute;
 static int mute_ext_ctl;
 static int mute_ext;
+static bool tas_device;
 static struct gpio_desc *snd_mute_gpio;
 static struct gpio_desc *snd_reset_gpio;
 static struct snd_soc_card snd_rpi_hifiberry_dacplus;
+
+static const u32 master_dai_rates[] = {
+	44100, 48000, 88200, 96000,
+	176400, 192000, 352800, 384000,
+};
+
+static const struct snd_pcm_hw_constraint_list constraints_master = {
+	.count = ARRAY_SIZE(master_dai_rates),
+	.list  = master_dai_rates,
+};
 
 static int snd_rpi_hifiberry_dacplus_mute_set(int mute)
 {
@@ -197,8 +208,13 @@ static int snd_rpi_hifiberry_dacplus_init(struct snd_soc_pcm_runtime *rtd)
 	if (snd_rpi_hifiberry_is_dacpro) {
 		struct snd_soc_dai_link *dai = rtd->dai_link;
 
-		dai->name = "HiFiBerry DAC+ Pro";
-		dai->stream_name = "HiFiBerry DAC+ Pro HiFi";
+		if (tas_device) {
+			dai->name = "HiFiBerry AMP4 Pro";
+			dai->stream_name = "HiFiBerry AMP4 Pro HiFi";
+		} else {
+			dai->name = "HiFiBerry DAC+ Pro";
+			dai->stream_name = "HiFiBerry DAC+ Pro HiFi";
+		}
 		dai->dai_fmt = SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF
 			| SND_SOC_DAIFMT_CBM_CFM;
 
@@ -305,6 +321,18 @@ static int snd_rpi_hifiberry_dacplus_startup(
 {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	struct snd_soc_component *component = asoc_rtd_to_codec(rtd, 0)->component;
+	int ret;
+
+	if (tas_device && !slave) {
+		ret = snd_pcm_hw_constraint_list(substream->runtime, 0,
+					  SNDRV_PCM_HW_PARAM_RATE,
+					  &constraints_master);
+		if (ret < 0) {
+			dev_err(rtd->card->dev,
+				"Cannot apply constraints for sample rates\n");
+			return ret;
+		}
+	}
 
 	if (auto_mute)
 		gpiod_set_value_cansleep(snd_mute_gpio, 0);
@@ -326,7 +354,7 @@ static void snd_rpi_hifiberry_dacplus_shutdown(
 }
 
 /* machine stream operations */
-static struct snd_soc_ops snd_rpi_hifiberry_dacplus_ops = {
+static const struct snd_soc_ops snd_rpi_hifiberry_dacplus_ops = {
 	.hw_params = snd_rpi_hifiberry_dacplus_hw_params,
 	.startup = snd_rpi_hifiberry_dacplus_startup,
 	.shutdown = snd_rpi_hifiberry_dacplus_shutdown,
@@ -396,6 +424,7 @@ static int snd_rpi_hifiberry_dacplus_probe(struct platform_device *pdev)
 	struct snd_soc_card *card = &snd_rpi_hifiberry_dacplus;
 	int len;
 	struct device_node *tpa_node;
+	struct device_node *tas_node;
 	struct property *tpa_prop;
 	struct of_changeset ocs;
 	struct property *pp;
@@ -431,6 +460,12 @@ static int snd_rpi_hifiberry_dacplus_probe(struct platform_device *pdev)
 			}
 		}
 	}
+
+	tas_node = of_find_compatible_node(NULL, NULL, "ti,tas5756");
+	if (tas_node) {
+		tas_device = true;
+		dev_info(&pdev->dev, "TAS5756 device found!\n");
+	};
 
 	snd_rpi_hifiberry_dacplus.dev = &pdev->dev;
 	if (pdev->dev.of_node) {


### PR DESCRIPTION
The AMP4 Pro is a I2S master mode capable amplifier with
providing all I2S clocks.
The card driver can be shared between TAS575x amplifiers
and the PCM512x DACs as they are SW compatible.
From a HW perspective though we need to limit the sample
rates to the standard audio rates to avoid running the
onboard clocks through the PLL. Using the PLL would require
even a different HW.
DAI/stream name are also set accordingly to allow the user
a convenient identification of the soundcard

Needs the pcm512x driver with TAS575x support (already in
upstream & raspberry kernels).