### PR TITLE
ASoC: DACplusADCPro - fix 16bit sample support in clock consumer mode

### DIFF
--- a/sound/soc/bcm/hifiberry_dacplusadcpro.c
+++ b/sound/soc/bcm/hifiberry_dacplusadcpro.c
@@ -383,15 +383,13 @@ static int snd_rpi_hifiberry_dacplusadcpro_hw_params(
 	int ret = 0;
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	int channels = params_channels(params);
-	int width = 32;
+	int width = snd_pcm_format_physical_width(params_format(params));
 	struct snd_soc_component *dac = asoc_rtd_to_codec(rtd, 0)->component;
 	struct snd_soc_dai *dai = asoc_rtd_to_codec(rtd, 0);
 	struct snd_soc_dai_driver *drv = dai->driver;
 	const struct snd_soc_dai_ops *ops = drv->ops;
 
 	if (snd_rpi_hifiberry_is_dacpro) {
-		width = snd_pcm_format_physical_width(params_format(params));
-
 		snd_rpi_hifiberry_dacplusadcpro_set_sclk(dac,
 			params_rate(params));
 


### PR DESCRIPTION
The former code did not adjust the physical sample width when in clock consumer mode and has taken the fixed 32 bit default. This has caused the audio to be played at half its frequency due to the fixed bclk_ratio of 64.

Problem appears only on PI5 as on the former PIs the I2S module did simply run at fixed 64x rate.

Same fix as https://github.com/raspberrypi/linux/pull/5917