### PR TITLE
drivers: media: cfe: Increase default size of embedded buffer

### DIFF
--- a/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
@@ -93,7 +93,7 @@ MODULE_PARM_DESC(verbose_debug, "verbose debugging messages");
 #define MIN_WIDTH 16
 #define MIN_HEIGHT 16
 /* Default size of the embedded buffer */
-#define DEFAULT_EMBEDDED_SIZE 8192
+#define DEFAULT_EMBEDDED_SIZE 16384
 
 const struct v4l2_mbus_framefmt cfe_default_format = {
 	.width = 640,
@@ -107,7 +107,7 @@ const struct v4l2_mbus_framefmt cfe_default_format = {
 };
 
 const struct v4l2_mbus_framefmt cfe_default_meta_format = {
-	.width = 8192,
+	.width = DEFAULT_EMBEDDED_SIZE,
 	.height = 1,
 	.code = MEDIA_BUS_FMT_SENSOR_DATA,
 	.field = V4L2_FIELD_NONE,


### PR DESCRIPTION
Increase the size of the default embedded buffer to 16k. This is done to match what is advertised by the IMX219 driver and workaround a problem where the embedded stream is not actually used. Without full streams API support, the media pipeline validation will fail in these circumstances.