### PR TITLE
Fixes for pcie-brcmstb on 6.8

### DIFF
--- a/drivers/pci/controller/pcie-brcmstb.c
+++ b/drivers/pci/controller/pcie-brcmstb.c
@@ -1357,10 +1357,15 @@ static int brcm_pcie_setup(struct brcm_pcie *pcie)
  */
 static void brcm_extend_rbus_timeout(struct brcm_pcie *pcie)
 {
-	/* TIMEOUT register is two registers before RGR1_SW_INIT_1 */
-	const unsigned int REG_OFFSET = PCIE_RGR1_SW_INIT_1(pcie) - 8;
+	unsigned int REG_OFFSET;
 	u32 timeout_us = 4000000; /* 4 seconds, our setting for L1SS */
 
+	/* BCM2712 doesn't have an RGR bridge */
+	if (pcie->type == BCM2712)
+		return;
+
+	/* TIMEOUT register is two registers before RGR1_SW_INIT_1 */
+	REG_OFFSET = PCIE_RGR1_SW_INIT_1(pcie) - 8;
 	/* Each unit in timeout register is 1/216,000,000 seconds */
 	writel(216 * timeout_us, pcie->base + REG_OFFSET);
 }


### PR DESCRIPTION
Not entirely sure how we want this to look in the history - I assume once the downstream reversions are all squashed together, we go back to having one mega-commit for pcie-brcmstb.