### PR TITLE
drm: rp1: VEC and DPI drivers: Fix bug #5901

### DIFF
--- a/drivers/gpu/drm/rp1/rp1-dpi/rp1_dpi.h
+++ b/drivers/gpu/drm/rp1/rp1-dpi/rp1_dpi.h
@@ -28,8 +28,8 @@
 /* ---------------------------------------------------------------------- */
 
 struct rp1_dpi {
-	/* DRM and platform device pointers */
-	struct drm_device *drm;
+	/* DRM base and platform device pointer */
+	struct drm_device drm;
 	struct platform_device *pdev;
 
 	/* Framework and helper objects */

--- a/drivers/gpu/drm/rp1/rp1-dpi/rp1_dpi_hw.c
+++ b/drivers/gpu/drm/rp1/rp1-dpi/rp1_dpi_hw.c
@@ -451,7 +451,7 @@ void rp1dpi_hw_stop(struct rp1_dpi *dpi)
 	ctrl &= ~(DPI_DMA_CONTROL_ARM_MASK | DPI_DMA_CONTROL_AUTO_REPEAT_MASK);
 	rp1dpi_hw_write(dpi, DPI_DMA_CONTROL, ctrl);
 	if (!wait_for_completion_timeout(&dpi->finished, HZ / 10))
-		drm_err(dpi->drm, "%s: timed out waiting for idle\n", __func__);
+		drm_err(&dpi->drm, "%s: timed out waiting for idle\n", __func__);
 	rp1dpi_hw_write(dpi, DPI_DMA_IRQ_EN, 0);
 }
 
@@ -473,7 +473,7 @@ irqreturn_t rp1dpi_hw_isr(int irq, void *dev)
 		rp1dpi_hw_write(dpi, DPI_DMA_IRQ_FLAGS, u);
 		if (dpi) {
 			if (u & DPI_DMA_IRQ_FLAGS_UNDERFLOW_MASK)
-				drm_err_ratelimited(dpi->drm,
+				drm_err_ratelimited(&dpi->drm,
 						    "Underflow! (panics=0x%08x)\n",
 						    rp1dpi_hw_read(dpi, DPI_DMA_PANICS));
 			if (u & DPI_DMA_IRQ_FLAGS_DMA_READY_MASK)

--- a/drivers/gpu/drm/rp1/rp1-vec/rp1_vec.h
+++ b/drivers/gpu/drm/rp1/rp1-vec/rp1_vec.h
@@ -31,8 +31,8 @@
 /* ---------------------------------------------------------------------- */
 
 struct rp1_vec {
-	/* DRM and platform device pointers */
-	struct drm_device *drm;
+	/* DRM base and platform device pointer */
+	struct drm_device drm;
 	struct platform_device *pdev;
 
 	/* Framework and helper objects */

--- a/drivers/gpu/drm/rp1/rp1-vec/rp1_vec_hw.c
+++ b/drivers/gpu/drm/rp1/rp1-vec/rp1_vec_hw.c
@@ -480,7 +480,7 @@ void rp1vec_hw_stop(struct rp1_vec *vec)
 	reinit_completion(&vec->finished);
 	VEC_WRITE(VEC_CONTROL, 0);
 	if (!wait_for_completion_timeout(&vec->finished, HZ / 10))
-		drm_err(vec->drm, "%s: timed out waiting for idle\n", __func__);
+		drm_err(&vec->drm, "%s: timed out waiting for idle\n", __func__);
 	VEC_WRITE(VEC_IRQ_ENABLES, 0);
 }
 


### PR DESCRIPTION
Rework probe() to use devm_drm_dev_alloc(), embedding the DRM device in the DPI or VEC device as now seems to be recommended.

Change order of resource allocation and driver initialization. This prevents it trying to write to an unmapped register during clean-up, which previously could crash.