### PR TITLE
drm/vc4: Drop planes that have 0 destination size

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -1114,7 +1114,7 @@ static int vc4_plane_mode_set(struct drm_plane *plane,
 	width = vc4_state->src_w[0] >> 16;
 	height = vc4_state->src_h[0] >> 16;
 
-	if (!width || !height) {
+	if (!width || !height || !vc4_state->crtc_w || !vc4_state->crtc_h) {
 		/* 0 source size probably means the plane is offscreen */
 		vc4_state->dlist_initialized = 1;
 		return 0;
@@ -1641,8 +1641,10 @@ static int vc6_plane_mode_set(struct drm_plane *plane,
 	width = vc4_state->src_w[0] >> 16;
 	height = vc4_state->src_h[0] >> 16;
 
-	if (!width || !height) {
-		/* 0 source size probably means the plane is offscreen */
+	if (!width || !height || !vc4_state->crtc_w || !vc4_state->crtc_h) {
+		/* 0 source size probably means the plane is offscreen.
+		 * 0 destination size is a redundant plane.
+		 */
 		vc4_state->dlist_initialized = 1;
 		return 0;
 	}
@@ -2018,7 +2020,8 @@ int vc4_plane_atomic_check(struct drm_plane *plane,
 	if (ret)
 		return ret;
 
-	if (!vc4_state->src_w[0] || !vc4_state->src_h[0])
+	if (!vc4_state->src_w[0] || !vc4_state->src_h[0] ||
+	    !vc4_state->crtc_w || !vc4_state->crtc_h)
 		return 0;
 
 	ret = vc4_plane_allocate_lbm(new_plane_state);


### PR DESCRIPTION
There is no point in trying to create a dlist entry for planes that have a 0 crtc size, and it can also cause grief in the vc6 dlist generation as it takes width-1 and height-1, causing wrap around.
Drop these planes.