### PR TITLE
imx477: make trigger-mode more configurable

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -862,6 +862,10 @@ Params: cam0-arducam-64mp       Select Arducam64MP for camera on port 0
         cam1-ov7251             Select OV7251 for camera on port 1
         cam1-ov9281             Select OV9281 for camera on port 1
         cam1-imx290-clk-freq    Set clock frequency for an IMX290 on port 1
+        cam0-sync-source        Set camera on port 0 as vsync source
+        cam0-sync-sink          Set camera on port 0 as vsync sink
+        cam1-sync-source        Set camera on port 1 as vsync source
+        cam1-sync-sink          Set camera on port 1 as vsync sink
 
         cam0                    Connect the mux to CAM0 port (default is CAM1)
 
@@ -923,6 +927,14 @@ Params: cam0-arducam-64mp       Select Arducam64MP for camera on port 0
         cam3-ov7251             Select OV7251 for camera on port 3
         cam3-ov9281             Select OV9281 for camera on port 3
         cam3-imx290-clk-freq    Set clock frequency for an IMX290 on port 3
+        cam0-sync-source        Set camera on port 0 as vsync source
+        cam0-sync-sink          Set camera on port 0 as vsync sink
+        cam1-sync-source        Set camera on port 1 as vsync source
+        cam1-sync-sink          Set camera on port 1 as vsync sink
+        cam2-sync-source        Set camera on port 2 as vsync source
+        cam2-sync-sink          Set camera on port 2 as vsync sink
+        cam3-sync-source        Set camera on port 3 as vsync source
+        cam3-sync-sink          Set camera on port 3 as vsync sink
 
         cam0                    Connect the mux to CAM0 port (default is CAM1)
 
@@ -2630,6 +2642,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
         always-on               Leave the regulator powered up, to stop the
                                 camera clamping I/Os such as XVS to 0V.
+        sync-source             Configure as vsync source
+        sync-sink               Configure as vsync sink
 
 
 Name:   imx462
@@ -2670,6 +2684,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
         always-on               Leave the regulator powered up, to stop the
                                 camera clamping I/Os such as XVS to 0V.
+        sync-source             Configure as vsync source
+        sync-sink               Configure as vsync sink
 
 
 Name:   imx519

--- a/arch/arm/boot/dts/overlays/camera-mux-2port-overlay.dts
+++ b/arch/arm/boot/dts/overlays/camera-mux-2port-overlay.dts
@@ -536,5 +536,10 @@
 
 		cam0 = <&i2c_frag>, "target:0=",<&i2c_csi_dsi0>,
 		       <&csi_frag>, "target:0=",<&csi0>;
+
+		cam0-sync-source = <&imx477_0>, "trigger-mode:0=1";
+		cam0-sync-sink = <&imx477_0>, "trigger-mode:0=2";
+		cam1-sync-source = <&imx477_1>, "trigger-mode:0=1";
+		cam1-sync-sink = <&imx477_1>, "trigger-mode:0=2";
 	};
 };

--- a/arch/arm/boot/dts/overlays/camera-mux-4port-overlay.dts
+++ b/arch/arm/boot/dts/overlays/camera-mux-4port-overlay.dts
@@ -939,5 +939,14 @@
 
 		cam0 = <&i2c_frag>, "target:0=",<&i2c_csi_dsi0>,
 		       <&csi_frag>, "target:0=",<&csi0>;
+
+		cam0-sync-source = <&imx477_0>, "trigger-mode:0=1";
+		cam0-sync-sink = <&imx477_0>, "trigger-mode:0=2";
+		cam1-sync-source = <&imx477_1>, "trigger-mode:0=1";
+		cam1-sync-sink = <&imx477_1>, "trigger-mode:0=2";
+		cam2-sync-source = <&imx477_2>, "trigger-mode:0=1";
+		cam2-sync-sink = <&imx477_2>, "trigger-mode:0=2";
+		cam3-sync-source = <&imx477_3>, "trigger-mode:0=1";
+		cam3-sync-sink = <&imx477_3>, "trigger-mode:0=2";
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx378-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx378-overlay.dts
@@ -8,3 +8,10 @@
 &cam_node {
 	compatible = "sony,imx378";
 };
+
+/{
+	__overrides__ {
+		sync-sink = <&cam_node>,"trigger-mode:0=2";
+		sync-source = <&cam_node>,"trigger-mode:0=1";
+	};
+};

--- a/arch/arm/boot/dts/overlays/imx477-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx477-overlay.dts
@@ -8,3 +8,10 @@
 &cam_node {
 	compatible = "sony,imx477";
 };
+
+/{
+	__overrides__ {
+		sync-sink = <&cam_node>,"trigger-mode:0=2";
+		sync-source = <&cam_node>,"trigger-mode:0=1";
+	};
+};

--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -1124,6 +1124,9 @@ struct imx477 {
 	/* Current mode */
 	const struct imx477_mode *mode;
 
+	/* Trigger mode */
+	int trigger_mode_of;
+
 	/*
 	 * Mutex for serialized access:
 	 * Protect sensor module set pad format and start/stop streaming safely.
@@ -1711,7 +1714,7 @@ static int imx477_start_streaming(struct imx477 *imx477)
 	struct i2c_client *client = v4l2_get_subdevdata(&imx477->sd);
 	const struct imx477_reg_list *reg_list;
 	const struct imx477_reg_list *extra_regs;
-	int ret;
+	int ret, tm;
 
 	if (!imx477->common_regs_written) {
 		ret = imx477_write_regs(imx477, mode_common_regs,
@@ -1748,14 +1751,15 @@ static int imx477_start_streaming(struct imx477 *imx477)
 		return ret;
 
 	/* Set vsync trigger mode: 0=standalone, 1=source, 2=sink */
+	tm = (imx477->trigger_mode_of >= 0) ? imx477->trigger_mode_of : trigger_mode;
 	imx477_write_reg(imx477, IMX477_REG_MC_MODE,
-			 IMX477_REG_VALUE_08BIT, (trigger_mode > 0) ? 1 : 0);
+			 IMX477_REG_VALUE_08BIT, (tm > 0) ? 1 : 0);
 	imx477_write_reg(imx477, IMX477_REG_MS_SEL,
-			 IMX477_REG_VALUE_08BIT, (trigger_mode <= 1) ? 1 : 0);
+			 IMX477_REG_VALUE_08BIT, (tm <= 1) ? 1 : 0);
 	imx477_write_reg(imx477, IMX477_REG_XVS_IO_CTRL,
-			 IMX477_REG_VALUE_08BIT, (trigger_mode == 1) ? 1 : 0);
+			 IMX477_REG_VALUE_08BIT, (tm == 1) ? 1 : 0);
 	imx477_write_reg(imx477, IMX477_REG_EXTOUT_EN,
-			 IMX477_REG_VALUE_08BIT, (trigger_mode == 1) ? 1 : 0);
+			 IMX477_REG_VALUE_08BIT, (tm == 1) ? 1 : 0);
 
 	/* set stream on register */
 	return imx477_write_reg(imx477, IMX477_REG_MODE_SELECT,
@@ -2187,6 +2191,7 @@ static int imx477_probe(struct i2c_client *client)
 	struct imx477 *imx477;
 	const struct of_device_id *match;
 	int ret;
+	u32 tm_of;
 
 	imx477 = devm_kzalloc(&client->dev, sizeof(*imx477), GFP_KERNEL);
 	if (!imx477)
@@ -2203,6 +2208,10 @@ static int imx477_probe(struct i2c_client *client)
 	/* Check the hardware configuration in device tree */
 	if (imx477_check_hwcfg(dev))
 		return -EINVAL;
+
+	/* Default the trigger mode from OF to -1, which means invalid */
+	ret = of_property_read_u32(dev->of_node, "trigger-mode", &tm_of);
+	imx477->trigger_mode_of = (ret == 0) ? tm_of : -1;
 
 	/* Get system clock (xclk) */
 	imx477->xclk = devm_clk_get(dev, NULL);


### PR DESCRIPTION
Currently there's no good way to have two imx477 cameras and configure them so that one is vsync source and the other vsync sink, since the configuration is done as a module parameter affecting both instances.

In our case we have a Raspberry Pi5 with two HQ cameras connected (imx477 based), and we want to use the XVS pins to allow them to capture in synchronously. With these changes we can now use the dtoverlays to configure the function of the XVS pin individually.