### PR TITLE
media: rp1: cfe: Actually use the number of lanes configured

### DIFF
--- a/drivers/media/platform/raspberrypi/rp1_cfe/csi2.h
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/csi2.h
@@ -57,7 +57,6 @@ struct csi2_device {
 
 	enum v4l2_mbus_type bus_type;
 	unsigned int bus_flags;
-	u32 active_data_lanes;
 	bool multipacket_line;
 	unsigned int num_lines[CSI2_NUM_CHANNELS];
 

--- a/drivers/media/platform/raspberrypi/rp1_cfe/dphy.c
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/dphy.c
@@ -149,7 +149,7 @@ static void dphy_init(struct dphy_data *dphy)
 
 void dphy_start(struct dphy_data *dphy)
 {
-	dw_csi2_host_write(dphy, N_LANES, (dphy->num_lanes - 1));
+	dw_csi2_host_write(dphy, N_LANES, (dphy->active_lanes - 1));
 	dphy_init(dphy);
 	dw_csi2_host_write(dphy, RESETN, 0xffffffff);
 	usleep_range(10, 50);

--- a/drivers/media/platform/raspberrypi/rp1_cfe/dphy.h
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/dphy.h
@@ -16,7 +16,8 @@ struct dphy_data {
 	void __iomem *base;
 
 	u32 dphy_rate;
-	u32 num_lanes;
+	u32 max_lanes;
+	u32 active_lanes;
 };
 
 void dphy_probe(struct dphy_data *dphy);


### PR DESCRIPTION
The driver was calling get_mbus_config to ask the sensor subdev how many CSI2 data lanes it wished to use and with what other properties, but then failed to pass that to the DPHY configuration.

https://forums.raspberrypi.com/viewtopic.php?t=359412