### PR TITLE
arm: dt: bcm2712: Reduce DDC frequency to 97.5kHz from 200kHz.

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712.dtsi
@@ -442,7 +442,7 @@
 			reg = <0x7d508200 0x58>;
 			interrupt-parent = <&bsc_irq>;
 			interrupts = <1>;
-			clock-frequency = <200000>;
+			clock-frequency = <97500>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -453,7 +453,7 @@
 			reg = <0x7d508280 0x58>;
 			interrupt-parent = <&bsc_irq>;
 			interrupts = <2>;
-			clock-frequency = <200000>;
+			clock-frequency = <97500>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";


### PR DESCRIPTION
The I2C spec says the DDC link should run at 100kHz or less, however Pi5/BCM2712 had been configured for 200kHz.
Reduce it to comply with the spec, and match Pi4.