### PR TITLE
Set PCIe QOS chicken bits for 2712D0

### DIFF
--- a/drivers/pci/controller/pcie-brcmstb.c
+++ b/drivers/pci/controller/pcie-brcmstb.c
@@ -199,6 +199,9 @@
 #define  VDM_PRIORITY_TO_QOS_MAP_MASK			0xf
 
 #define PCIE_MISC_AXI_INTF_CTRL 0x416C
+#define  AXI_EN_RCLK_QOS_ARRAY_FIX			BIT(13)
+#define  AXI_EN_QOS_UPDATE_TIMING_FIX			BIT(12)
+#define  AXI_DIS_QOS_GATING_IN_MASTER			BIT(11)
 #define  AXI_REQFIFO_EN_QOS_PROPAGATION			BIT(7)
 #define  AXI_BRIDGE_LOW_LATENCY_MODE			BIT(6)
 #define  AXI_MASTER_MAX_OUTSTANDING_REQUESTS_MASK	0x3f
@@ -558,9 +561,11 @@ static void brcm_pcie_set_tc_qos(struct brcm_pcie *pcie)
 	if (pcie->type != BCM2712)
 		return;
 
-	/* XXX: BCM2712C0 is broken, disable the forwarding search */
+	/* Disable broken QOS forwarding search. Set chicken bits for 2712D0 */
 	reg = readl(pcie->base + PCIE_MISC_AXI_INTF_CTRL);
 	reg &= ~AXI_REQFIFO_EN_QOS_PROPAGATION;
+	reg |= AXI_EN_RCLK_QOS_ARRAY_FIX | AXI_EN_QOS_UPDATE_TIMING_FIX |
+		AXI_DIS_QOS_GATING_IN_MASTER;
 	writel(reg, pcie->base + PCIE_MISC_AXI_INTF_CTRL);
 
 	/* Disable VDM reception by default - QoS map defaults to 0 */


### PR DESCRIPTION
Fairly conservative small change which just sets the three top bits, which should make D0 behave the same as C1.

Still using high QOS values with almost no spread, and ignoring QOS forwarding which seems still to be broken (while it no longer always gives a QOS of zero, it doesn't prevent glitches when real-time and non-real-time traffic share the link and any traffic has QOS below the ARM cores'; regardless of AXI burst clobbering).

Not currently setting the "emergency QOS OR" field of either chip revision: I'm hoping it won't be necessary.

This is a draft PR pending extended testing; it also needs testing on 2712C1 to verify my assertion that these bits are harmlessly ignored  (if not, we'll have to do different things for the different revisions).