### PR TITLE
drivers: staging: bcm2835-isp: Respect caller's stride value

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
@@ -1050,8 +1050,10 @@ static int bcm2835_isp_node_try_fmt(struct file *file, void *priv,
 		f->fmt.pix.quantization = V4L2_MAP_QUANTIZATION_DEFAULT(is_rgb, f->fmt.pix.colorspace,
 									f->fmt.pix.ycbcr_enc);
 
-		f->fmt.pix.bytesperline = get_bytesperline(f->fmt.pix.width,
-							   fmt);
+		/* Respect any stride value (suitably aligned) that was requested. */
+		f->fmt.pix.bytesperline = max(get_bytesperline(f->fmt.pix.width, fmt),
+					      ALIGN(f->fmt.pix.bytesperline,
+						    fmt->bytesperline_align));
 		f->fmt.pix.field = V4L2_FIELD_NONE;
 		f->fmt.pix.sizeimage =
 			get_sizeimage(f->fmt.pix.bytesperline, f->fmt.pix.width,


### PR DESCRIPTION
The stride value reported for output image buffers should be at least as large as any value that was passed in by the caller (subject to correct alignment for the pixel format). If the value is zero (meaning no value was passed), or is too small, the minimum acceptable value will be substituted.