### PR TITLE
Add support for VEML6075 and HTS221 in i2c-sensor overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2281,10 +2281,13 @@ Params: addr                    Set the address for the ADT7410, BH1750, BME280,
         hdc100x                 Select the Texas Instruments HDC100x temp sensor
                                 Valid addresses 0x40-0x43, default 0x40
 
+        hts221                  Select the HTS221 temperature and humidity
+                                sensor
+
         htu21                   Select the HTU21 temperature and humidity sensor
 
-        int_pin                 Set the GPIO to use for interrupts (max30102,
-                                mpu6050 and mpu9250 only)
+        int_pin                 Set the GPIO to use for interrupts (hts221,
+                                max30102, mpu6050 and mpu9250 only)
 
         jc42                    Select any of the many JEDEC JC42.4-compliant
                                 temperature sensors, including:

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2370,6 +2370,9 @@ Params: addr                    Set the address for the ADT7410, BH1750, BME280,
         veml6070                Select the Vishay VEML6070 ultraviolet light
                                 sensor
 
+        veml6075                Select the Vishay VEML6075 UVA and UVB light
+                                sensor
+
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
 
         i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45

--- a/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
@@ -3,6 +3,7 @@
 /plugin/;
 
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
 
 / {
 	compatible = "brcm,bcm2835";
@@ -306,7 +307,7 @@
 				maxim,red-led-current-microamp = <7000>;
 				maxim,ir-led-current-microamp  = <7000>;
 				interrupt-parent = <&gpio>;
-				interrupts = <4 2>;
+				interrupts = <4 IRQ_TYPE_EDGE_FALLING>;
 			};
 		};
 	};
@@ -435,7 +436,7 @@
 				compatible = "invensense,mpu6050";
 				reg = <0x68>;
 				interrupt-parent = <&gpio>;
-				interrupts = <4 2>;
+				interrupts = <4 IRQ_TYPE_EDGE_FALLING>;
 			};
 		};
 	};
@@ -452,7 +453,7 @@
 				compatible = "invensense,mpu9250";
 				reg = <0x68>;
 				interrupt-parent = <&gpio>;
-				interrupts = <4 2>;
+				interrupts = <4 IRQ_TYPE_EDGE_FALLING>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
@@ -524,6 +524,23 @@
 		};
 	};
 
+	fragment@35 {
+		target = <&i2cbus>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			hts221: hts221@5f {
+				compatible = "st,hts221-humid", "st,hts221";
+				reg = <0x5f>;
+				interrupt-parent = <&gpio>;
+				interrupts = <4 IRQ_TYPE_EDGE_RISING>;
+			};
+		};
+	};
+
+
 	__overrides__ {
 		bme280 = <0>,"+0";
 		bmp085 = <0>,"+1";
@@ -560,6 +577,7 @@
 		bno055 = <0>,"+31";
 		sht4x = <0>,"+32";
 		adt7410 = <0>,"+34";
+		hts221 = <0>,"+35";
 
 		addr =	<&bme280>,"reg:0", <&bmp280>,"reg:0", <&tmp102>,"reg:0",
 			<&lm75>,"reg:0", <&hdc100x>,"reg:0", <&sht3x>,"reg:0",
@@ -572,7 +590,8 @@
 			<&bmp380>,"reg:0", <&adt7410>,"reg:0";
 		int_pin = <&max30102>, "interrupts:0",
 			<&mpu6050>, "interrupts:0",
-			<&mpu9250>, "interrupts:0";
+			<&mpu9250>, "interrupts:0",
+			<&hts221>, "interrupts:0";
 		no_timeout = <&jc42>, "smbus-timeout-disable?";
 		reset_pin = <&bno055>,"reset-gpios:4", <0>,"+30";
 	};

--- a/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
@@ -540,6 +540,21 @@
 		};
 	};
 
+	fragment@36 {
+		target = <&i2cbus>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			veml6075: veml6075@10 {
+				compatible = "vishay,veml6075";
+				reg = <0x10>;
+				status = "okay";
+			};
+		};
+	};
+
 
 	__overrides__ {
 		bme280 = <0>,"+0";
@@ -578,6 +593,7 @@
 		sht4x = <0>,"+32";
 		adt7410 = <0>,"+34";
 		hts221 = <0>,"+35";
+		veml6075 = <0>,"+36";
 
 		addr =	<&bme280>,"reg:0", <&bmp280>,"reg:0", <&tmp102>,"reg:0",
 			<&lm75>,"reg:0", <&hdc100x>,"reg:0", <&sht3x>,"reg:0",


### PR DESCRIPTION
The HTS221 humidity and temperature sensor is only supported inside the
rpi-sense v1 and v2 overlays, but there is still no support as a
standalone sensor. Moreover, its interrupt (data ready) is still not
supported. When at it, irq.h has been added to use interrupt trigger
definitions instead of hard coded numbers.

Support for the VEML6075 UVA and UVB light sensor has been added to the
kernel with v6.8. This device is supported by IIO and does not support
additional parameters like interrupts or different I2C addresses.