### PR TITLE
media/v4l2_m2m: In buffered mode run jobs if either port is streaming

### DIFF
--- a/drivers/media/v4l2-core/v4l2-mem2mem.c
+++ b/drivers/media/v4l2-core/v4l2-mem2mem.c
@@ -301,8 +301,9 @@ static void __v4l2_m2m_try_queue(struct v4l2_m2m_dev *m2m_dev,
 
 	dprintk("Trying to schedule a job for m2m_ctx: %p\n", m2m_ctx);
 
-	if (!m2m_ctx->out_q_ctx.q.streaming ||
-	    (!m2m_ctx->cap_q_ctx.q.streaming && !m2m_ctx->ignore_cap_streaming)) {
+	if ((!m2m_ctx->out_q_ctx.q.streaming ||
+	     (!m2m_ctx->cap_q_ctx.q.streaming && !m2m_ctx->ignore_cap_streaming)) &&
+		 !(m2m_ctx->out_q_ctx.buffered && m2m_ctx->out_q_ctx.q.streaming)) {
 		if (!m2m_ctx->ignore_cap_streaming)
 			dprintk("Streaming needs to be on for both queues\n");
 		else


### PR DESCRIPTION
In order to get the intended behaviour of the stateful video decoder API where only the OUTPUT queue needs to be enabled and fed buffers in order to get the SOURCE_CHANGED event that configures the CAPTURE queue, we want the device to run should either queue be streaming.

@6by9 This patch didn't merge cleanly in the port from 6.7 to 6.8. I've tried to fix it up, and it does compile, but before merging I wanted to check:
1. if it looks OK to you, and
2. if it is still needed - it seems odd that this old patch hasn't gone upstream when so much else has.