### PR TITLE
Add IQaudio CodecZero to hat_map.dts

### DIFF
--- a/arch/arm/boot/dts/overlays/hat_map.dts
+++ b/arch/arm/boot/dts/overlays/hat_map.dts
@@ -6,6 +6,11 @@
 		overlay = "iqaudio-codec";
 	};
 
+	iqaudio-pi-codeczero {
+		uuid = [ e15c739c 877d 4e29 ab36 4dc73c21127c ];
+		overlay = "iqaudio-codec";
+	};
+
 	pisound {
 		uuid = [ a7ee5d28 da03 41f5 bbd7 20438a4bec5d ];
 		overlay = "pisound";


### PR DESCRIPTION
Fixes https://github.com/raspberrypi/Pi-Codec/issues/9

Verified on a freshly-written Raspberry Pi OS card, both before and after installing updates.