### PR TITLE
brcmfmac: Fix 802.1x

### DIFF
--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
@@ -2493,7 +2493,7 @@ brcmf_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
 				brcmf_dbg(INFO, "using PSK offload\n");
 				profile->use_fwsup = BRCMF_PROFILE_FWSUP_PSK;
 			}
-		} else {
+		} else if (profile->use_fwsup != BRCMF_PROFILE_FWSUP_1X) {
 			profile->use_fwsup = BRCMF_PROFILE_FWSUP_NONE;
 		}
 


### PR DESCRIPTION
Commit 7d239fbf9d4 broke 802.1X authentication by setting profile->use_fwsup = NONE whenever PSK is not used. However 802.1X does not use PSK and requires profile->use_fwsup set to 1X, or brcmf_cfg80211_set_pmk() fails. Fix this by checking that profile->use_fwsup is not already set to 1X and avoid setting it to NONE in that case.

Fixes: 7d239fbf9d4 (brcmfmac: Fix interoperating DPP and other encryption network access)
Fixes: https://github.com/raspberrypi/linux/issues/5964