### PR TITLE
dts: bcm2712, rpi1: add definitions for multi channel I2S module

### DIFF
--- a/arch/arm/boot/dts/bcm2712-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2712-rpi.dtsi
@@ -168,6 +168,7 @@ i2c5: &rp1_i2c5 { };
 i2c6: &rp1_i2c6 { };
 i2s:  &rp1_i2s0 { };
 i2s_clk_producer: &rp1_i2s0 { };
+i2s_clk_producer_mc8: &rp1_i2s0 { };
 i2s_clk_consumer: &rp1_i2s1 { };
 pwm0: &rp1_pwm0 { };
 pwm1: &rp1_pwm1 { };
@@ -227,6 +228,12 @@ i2c_arm: &i2c1 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&rp1_i2s0_18_21>;
 };
+
+&i2s_clk_producer_mc8 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rp1_i2s0_18_27>;
+};
+
 
 &i2s_clk_consumer {
 	pinctrl-names = "default";

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -88,6 +88,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	hifiberry-amp3.dtbo \
 	hifiberry-amp4pro.dtbo \
 	hifiberry-dac.dtbo \
+	hifiberry-dac8x.dtbo \
 	hifiberry-dacplus.dtbo \
 	hifiberry-dacplusadc.dtbo \
 	hifiberry-dacplusadcpro.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1772,6 +1772,12 @@ Load:   dtoverlay=hifiberry-dac
 Params: <None>
 
 
+Name:   hifiberry-dac8x
+Info:   Configures the HifiBerry DAC8X audio cards (only on PI5)
+Load:   dtoverlay=hifiberry-dac8x
+Params: <None>
+
+
 Name:   hifiberry-dacplus
 Info:   Configures the HifiBerry DAC+ audio card
 Load:   dtoverlay=hifiberry-dacplus,<param>=<val>

--- a/arch/arm/boot/dts/overlays/hifiberry-dac8x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dac8x-overlay.dts
@@ -1,0 +1,34 @@
+// Definitions for HiFiBerry DAC8x
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2s_clk_producer_mc8>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			pcm5102a-codec {
+				#sound-dai-cells = <0>;
+				compatible = "ti,pcm5102a";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&sound>;
+		__overlay__ {
+			compatible = "hifiberry,hifiberry-dac8x";
+			i2s-controller = <&i2s_clk_producer_mc8>;
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm/boot/dts/rp1.dtsi
+++ b/arch/arm/boot/dts/rp1.dtsi
@@ -648,6 +648,13 @@
 				bias-disable;
 			};
 
+			rp1_i2s0_18_27: rp1_i2s0_18_27 {
+				function = "i2s0";
+				pins = "gpio18", "gpio19", "gpio20", "gpio21", "gpio22",
+				       "gpio23", "gpio24", "gpio25", "gpio26", "gpio27";
+				bias-disable;
+			};
+
 			rp1_i2s1_18_21: rp1_i2s1_18_21 {
 				function = "i2s1";
 				pins = "gpio18", "gpio19", "gpio20", "gpio21";


### PR DESCRIPTION
Defines the pin functions for use in clk producer mode for I2S0 module using GPIOs 18..27 to enable 4 data lanes input and 4 lanes output.
The pin definitions enable all 4 stereo channels for input and output. In the DT overlay just use <&i2s_clk_producer_mc8> instead of <&i2s_clk_producer>.
The multi channel capability is necessary for our new DAC8X which I'll submit in a separate request.