### PR TITLE
ASoC: Add multichannel HiFiBerry DAC8X

### DIFF
--- a/arch/arm/boot/dts/bcm2712-rpi.dtsi
+++ b/arch/arm/boot/dts/bcm2712-rpi.dtsi
@@ -168,6 +168,7 @@ i2c5: &rp1_i2c5 { };
 i2c6: &rp1_i2c6 { };
 i2s:  &rp1_i2s0 { };
 i2s_clk_producer: &rp1_i2s0 { };
+i2s_clk_producer_mc8: &rp1_i2s0 { };
 i2s_clk_consumer: &rp1_i2s1 { };
 pwm0: &rp1_pwm0 { };
 pwm1: &rp1_pwm1 { };
@@ -227,6 +228,12 @@ i2c_arm: &i2c1 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&rp1_i2s0_18_21>;
 };
+
+&i2s_clk_producer_mc8 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rp1_i2s0_18_27>;
+};
+
 
 &i2s_clk_consumer {
 	pinctrl-names = "default";

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -88,6 +88,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	hifiberry-amp3.dtbo \
 	hifiberry-amp4pro.dtbo \
 	hifiberry-dac.dtbo \
+	hifiberry-dac8x.dtbo \
 	hifiberry-dacplus.dtbo \
 	hifiberry-dacplusadc.dtbo \
 	hifiberry-dacplusadcpro.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1772,6 +1772,12 @@ Load:   dtoverlay=hifiberry-dac
 Params: <None>
 
 
+Name:   hifiberry-dac8x
+Info:   Configures the HifiBerry DAC8X audio cards (only on PI5)
+Load:   dtoverlay=hifiberry-dac8x
+Params: <None>
+
+
 Name:   hifiberry-dacplus
 Info:   Configures the HifiBerry DAC+ audio card
 Load:   dtoverlay=hifiberry-dacplus,<param>=<val>

--- a/arch/arm/boot/dts/overlays/hifiberry-dac8x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dac8x-overlay.dts
@@ -1,0 +1,34 @@
+// Definitions for HiFiBerry DAC8x
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2s_clk_producer_mc8>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			pcm5102a-codec {
+				#sound-dai-cells = <0>;
+				compatible = "ti,pcm5102a";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&sound>;
+		__overlay__ {
+			compatible = "hifiberry,hifiberry-dac8x";
+			i2s-controller = <&i2s_clk_producer_mc8>;
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm/boot/dts/rp1.dtsi
+++ b/arch/arm/boot/dts/rp1.dtsi
@@ -648,6 +648,13 @@
 				bias-disable;
 			};
 
+			rp1_i2s0_18_27: rp1_i2s0_18_27 {
+				function = "i2s0";
+				pins = "gpio18", "gpio19", "gpio20", "gpio21", "gpio22",
+				       "gpio23", "gpio24", "gpio25", "gpio26", "gpio27";
+				bias-disable;
+			};
+
 			rp1_i2s1_18_21: rp1_i2s1_18_21 {
 				function = "i2s1";
 				pins = "gpio18", "gpio19", "gpio20", "gpio21";

--- a/sound/soc/bcm/Kconfig
+++ b/sound/soc/bcm/Kconfig
@@ -40,11 +40,12 @@ config SND_BCM2708_SOC_GOOGLEVOICEHAT_SOUNDCARD
           Say Y or M if you want to add support for voiceHAT soundcard.
 
 config SND_BCM2708_SOC_HIFIBERRY_DAC
-        tristate "Support for HifiBerry DAC"
+        tristate "Support for HifiBerry DAC and DAC8X"
         select SND_SOC_PCM5102A
         select SND_RPI_SIMPLE_SOUNDCARD
         help
-         Say Y or M if you want to add support for HifiBerry DAC.
+         Say Y or M if you want to add support for HifiBerry DAC and DAC8X.
+         Note: DAC8X only works on PI5
 
 config SND_BCM2708_SOC_HIFIBERRY_DACPLUS
         tristate "Support for HifiBerry DAC+"

--- a/sound/soc/bcm/rpi-simple-soundcard.c
+++ b/sound/soc/bcm/rpi-simple-soundcard.c
@@ -316,6 +316,37 @@ static struct snd_rpi_simple_drvdata drvdata_hifiberry_dac = {
 	.dai       = snd_hifiberry_dac_dai,
 };
 
+static int hifiberry_dac8x_init(struct snd_soc_pcm_runtime *rtd)
+{
+	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+
+	/* override the defaults to reflect 4 x PCM5102A on the card
+	 * and limit the sample rate to 192ksps
+	 */
+	codec_dai->driver->playback.channels_max = 8;
+	codec_dai->driver->playback.rates = SNDRV_PCM_RATE_8000_192000;
+
+	return 0;
+}
+
+static struct snd_soc_dai_link snd_hifiberry_dac8x_dai[] = {
+	{
+		.name           = "HifiBerry DAC8x",
+		.stream_name    = "HifiBerry DAC8x HiFi",
+		.dai_fmt        = SND_SOC_DAIFMT_I2S |
+					SND_SOC_DAIFMT_NB_NF |
+					SND_SOC_DAIFMT_CBS_CFS,
+		.init           = hifiberry_dac8x_init,
+		SND_SOC_DAILINK_REG(hifiberry_dac),
+	},
+};
+
+static struct snd_rpi_simple_drvdata drvdata_hifiberry_dac8x = {
+	.card_name = "snd_rpi_hifiberry_dac8x",
+	.dai       = snd_hifiberry_dac8x_dai,
+	.fixed_bclk_ratio = 64,
+};
+
 SND_SOC_DAILINK_DEFS(dionaudio_kiwi,
 	DAILINK_COMP_ARRAY(COMP_EMPTY()),
 	DAILINK_COMP_ARRAY(COMP_CODEC("pcm1794a-codec", "pcm1794a-hifi")),
@@ -417,6 +448,8 @@ static const struct of_device_id snd_rpi_simple_of_match[] = {
 		.data = (void *) &drvdata_hifiberry_amp3 },
 	{ .compatible = "hifiberry,hifiberry-dac",
 		.data = (void *) &drvdata_hifiberry_dac },
+	{ .compatible = "hifiberry,hifiberry-dac8x",
+		.data = (void *) &drvdata_hifiberry_dac8x },
 	{ .compatible = "dionaudio,dionaudio-kiwi",
 		.data = (void *) &drvdata_dionaudio_kiwi },
 	{ .compatible = "rpi,rpi-dac", &drvdata_rpi_dac},


### PR DESCRIPTION
Combines all necessary changes:
Defines the settings for the 8 channel version of the standard DAC by overwriting the number of channels in the DAI defs.
It will run in 8ch mode only on a PI5 as it requires the designware I2S0 module.

Necessary changes are the 'mc8' definitions in the RP1 and bcm2712 DT setting.

Seems, one can't pass the checks with separate PRs.
@pelwell Please let me know in case I need to split it though. Or any other thought on the changes. Thanks, Joerg