### PR TITLE
dtoverlays: Correct width/height on Waveshare 2.8" panel

### DIFF
--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
@@ -77,8 +77,8 @@
 
 	__overrides__ {
 		2_8_inch = <&panel>, "compatible=waveshare,2.8inch-panel",
-				   <&touch>, "touchscreen-size-x:0=640",
-				   <&touch>, "touchscreen-size-y:0=480",
+				   <&touch>, "touchscreen-size-x:0=480",
+				   <&touch>, "touchscreen-size-y:0=640",
 				   <&touch>, "touchscreen-inverted-y?",
 				   <&touch>, "touchscreen-swapped-x-y?";
 		3_4_inch = <&panel>, "compatible=waveshare,3.4inch-panel",


### PR DESCRIPTION
Width and height were swapped, so touch didn't work over the whole panel.