### PR TITLE
ASoC: Add multichannel HiFiBerry DAC8X [V2]

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -88,6 +88,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	hifiberry-amp3.dtbo \
 	hifiberry-amp4pro.dtbo \
 	hifiberry-dac.dtbo \
+	hifiberry-dac8x.dtbo \
 	hifiberry-dacplus.dtbo \
 	hifiberry-dacplusadc.dtbo \
 	hifiberry-dacplusadcpro.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1772,6 +1772,12 @@ Load:   dtoverlay=hifiberry-dac
 Params: <None>
 
 
+Name:   hifiberry-dac8x
+Info:   Configures the HifiBerry DAC8X audio cards (only on PI5)
+Load:   dtoverlay=hifiberry-dac8x
+Params: <None>
+
+
 Name:   hifiberry-dacplus
 Info:   Configures the HifiBerry DAC+ audio card
 Load:   dtoverlay=hifiberry-dacplus,<param>=<val>

--- a/arch/arm/boot/dts/overlays/hifiberry-dac8x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dac8x-overlay.dts
@@ -1,0 +1,50 @@
+// Definitions for HiFiBerry DAC8x
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2712";
+
+	fragment@0 {
+		target = <&gpio>;
+		__overlay__ {
+			rp1_i2s0_dac8x: rp1_i2s0_dac8x {
+				function = "i2s0";
+				pins = "gpio18", "gpio19", "gpio21",
+				       "gpio23", "gpio25", "gpio27";
+				bias-disable;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2s_clk_producer>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&rp1_i2s0_dac8x>;
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			pcm5102a-codec {
+				#sound-dai-cells = <0>;
+				compatible = "ti,pcm5102a";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&sound>;
+		__overlay__ {
+			compatible = "hifiberry,hifiberry-dac8x";
+			i2s-controller = <&i2s_clk_producer>;
+			status = "okay";
+		};
+	};
+
+};

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -48,6 +48,10 @@
 		bcm2712;
 	};
 
+	hifiberry-dac8x {
+		bcm2712;
+	};
+
 	highperi {
 		bcm2711;
 	};

--- a/sound/soc/bcm/Kconfig
+++ b/sound/soc/bcm/Kconfig
@@ -40,11 +40,12 @@ config SND_BCM2708_SOC_GOOGLEVOICEHAT_SOUNDCARD
           Say Y or M if you want to add support for voiceHAT soundcard.
 
 config SND_BCM2708_SOC_HIFIBERRY_DAC
-        tristate "Support for HifiBerry DAC"
+        tristate "Support for HifiBerry DAC and DAC8X"
         select SND_SOC_PCM5102A
         select SND_RPI_SIMPLE_SOUNDCARD
         help
-         Say Y or M if you want to add support for HifiBerry DAC.
+         Say Y or M if you want to add support for HifiBerry DAC and DAC8X.
+         Note: DAC8X only works on PI5
 
 config SND_BCM2708_SOC_HIFIBERRY_DACPLUS
         tristate "Support for HifiBerry DAC+"

--- a/sound/soc/bcm/rpi-simple-soundcard.c
+++ b/sound/soc/bcm/rpi-simple-soundcard.c
@@ -316,6 +316,37 @@ static struct snd_rpi_simple_drvdata drvdata_hifiberry_dac = {
 	.dai       = snd_hifiberry_dac_dai,
 };
 
+static int hifiberry_dac8x_init(struct snd_soc_pcm_runtime *rtd)
+{
+	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+
+	/* override the defaults to reflect 4 x PCM5102A on the card
+	 * and limit the sample rate to 192ksps
+	 */
+	codec_dai->driver->playback.channels_max = 8;
+	codec_dai->driver->playback.rates = SNDRV_PCM_RATE_8000_192000;
+
+	return 0;
+}
+
+static struct snd_soc_dai_link snd_hifiberry_dac8x_dai[] = {
+	{
+		.name           = "HifiBerry DAC8x",
+		.stream_name    = "HifiBerry DAC8x HiFi",
+		.dai_fmt        = SND_SOC_DAIFMT_I2S |
+					SND_SOC_DAIFMT_NB_NF |
+					SND_SOC_DAIFMT_CBS_CFS,
+		.init           = hifiberry_dac8x_init,
+		SND_SOC_DAILINK_REG(hifiberry_dac),
+	},
+};
+
+static struct snd_rpi_simple_drvdata drvdata_hifiberry_dac8x = {
+	.card_name = "snd_rpi_hifiberry_dac8x",
+	.dai       = snd_hifiberry_dac8x_dai,
+	.fixed_bclk_ratio = 64,
+};
+
 SND_SOC_DAILINK_DEFS(dionaudio_kiwi,
 	DAILINK_COMP_ARRAY(COMP_EMPTY()),
 	DAILINK_COMP_ARRAY(COMP_CODEC("pcm1794a-codec", "pcm1794a-hifi")),
@@ -417,6 +448,8 @@ static const struct of_device_id snd_rpi_simple_of_match[] = {
 		.data = (void *) &drvdata_hifiberry_amp3 },
 	{ .compatible = "hifiberry,hifiberry-dac",
 		.data = (void *) &drvdata_hifiberry_dac },
+	{ .compatible = "hifiberry,hifiberry-dac8x",
+		.data = (void *) &drvdata_hifiberry_dac8x },
 	{ .compatible = "dionaudio,dionaudio-kiwi",
 		.data = (void *) &drvdata_dionaudio_kiwi },
 	{ .compatible = "rpi,rpi-dac", &drvdata_rpi_dac},


### PR DESCRIPTION
Additions and changes for the 8 channel version of the standard PCM5102 DAC by setting the number of channels
in the DAI definitions.
It will run in 8ch mode only on a PI5 as it requires the designware I2S0 module.

The necessary output lanes I2S0_DO[0..3] are claimed from within the DT overlay.
