### PR TITLE
dtoverlays: rotate override needs to update "rotation" for drm mode

### DIFF
--- a/arch/arm/boot/dts/overlays/piscreen-overlay.dts
+++ b/arch/arm/boot/dts/overlays/piscreen-overlay.dts
@@ -96,7 +96,8 @@
 	};
 	__overrides__ {
 		speed =		<&piscreen>,"spi-max-frequency:0";
-		rotate =	<&piscreen>,"rotate:0";
+		rotate =	<&piscreen>,"rotate:0",
+				<&piscreen>,"rotation:0";
 		fps =		<&piscreen>,"fps:0";
 		debug =		<&piscreen>,"debug:0";
 		xohms =		<&piscreen_ts>,"ti,x-plate-ohms;0";


### PR DESCRIPTION
Whilst the fbtft driver uses the DT property "rotate" to set the display rotation, the tinydrm ili9486 driver uses "rotation". The overlay was only updating "rotate" from the override, so add in "rotation".

https://github.com/raspberrypi/bookworm-feedback/issues/88#issuecomment-1968093993