### PR TITLE
ARM: dts: bcm2712-rpi: Add i2c<n>_pins labels

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -202,26 +202,30 @@ uart4_pins: &rp1_uart4_12_13 {};
 uart4_ctsrts_pins: &rp1_uart4_ctsrts_14_15 {};
 uart4: &rp1_uart4 { };
 
+i2c0_pins: &rp1_i2c0_0_1 {};
 i2c_vc: &i2c0 {      // This is pins 27,28 on the header (not MIPI)
-	pinctrl-0 = <&rp1_i2c0_0_1>;
+	pinctrl-0 = <&i2c0_pins>;
 	pinctrl-names = "default";
 	clock-frequency = <100000>;
 };
 
+i2c1_pins: &rp1_i2c1_2_3 {};
 i2c_arm: &i2c1 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&rp1_i2c1_2_3>;
+	pinctrl-0 = <&i2c1_pins>;
 	clock-frequency = <100000>;
 };
 
+i2c2_pins: &rp1_i2c2_4_5 {};
 &i2c2 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&rp1_i2c2_4_5>;
+	pinctrl-0 = <&i2c2_pins>;
 };
 
+i2c3_pins: &rp1_i2c3_6_7 {};
 &i2c3 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&rp1_i2c3_6_7>;
+	pinctrl-0 = <&i2c3_pins>;
 };
 
 &i2s_clk_producer {


### PR DESCRIPTION
Older Pi SoCs have friendly labels on the i2c pin nodes, e.g. i2c0_pins, but they are absent from the BCM2712 dtsi files, even though UARTs and SPI interfaces have them. Fix that omission.

See: https://forums.raspberrypi.com/viewtopic.php?p=2199599#p2199599