### PR TITLE
media: i2c: imx296: Updated register setting to fix Fast Trigger

### DIFF
--- a/drivers/media/i2c/imx296.c
+++ b/drivers/media/i2c/imx296.c
@@ -472,7 +472,7 @@ static const struct {
 	{ IMX296_REG_8BIT(0x30a4), 0x5f },
 	{ IMX296_REG_8BIT(0x30a8), 0x91 },
 	{ IMX296_REG_8BIT(0x30ac), 0x28 },
-	{ IMX296_REG_8BIT(0x30af), 0x09 },
+	{ IMX296_REG_8BIT(0x30af), 0x0b },
 	{ IMX296_REG_8BIT(0x30df), 0x00 },
 	{ IMX296_REG_8BIT(0x3165), 0x00 },
 	{ IMX296_REG_8BIT(0x3169), 0x10 },


### PR DESCRIPTION
In Fast Trigger mode (external shutter control), FE packet was not sent at end of frame. Sony recommend this specific change, which fixes the issue.

The Sony registers also differ from the open source driver in a few other places (not reflected in this initial commit); pending further testing, I may add those later...