### PR TITLE
vc4/hvs: Fix lbm size calculation for yuv

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -733,7 +733,7 @@ static unsigned int vc4_lbm_channel_size(const struct drm_plane_state *state,
 	if (!components)
 		return 0;
 
-	if (state->alpha != DRM_BLEND_ALPHA_OPAQUE)
+	if (state->alpha != DRM_BLEND_ALPHA_OPAQUE && info->has_alpha)
 		components -= 1;
 
 	words = width * wpc * components;


### PR DESCRIPTION
The code was reducing the number of components by one when we were not blending with alpha. But that only makes sense if the components include alpha.

For YUV, we were reducing the number of components for Y from one to zero which resulted in no lbm space being allocated.

Fixes: https://github.com/raspberrypi/linux/issues/5912