### PR TITLE
Add GPCLK support on RP1

### DIFF
--- a/arch/arm/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm/boot/dts/broadcom/rp1.dtsi
@@ -865,6 +865,36 @@
 				bias-disable;
 			};
 
+			rp1_gpclksrc0_gpio4: rp1_gpclksrc0_gpio4 {
+				function = "gpclk0";
+				pins = "gpio4";
+				bias-disable;
+			};
+
+			rp1_gpclksrc0_gpio20: rp1_gpclksrc0_gpio20 {
+				function = "gpclk0";
+				pins = "gpio20";
+				bias-disable;
+			};
+
+			rp1_gpclksrc1_gpio5: rp1_gpclksrc1_gpio5 {
+				function = "gpclk1";
+				pins = "gpio5";
+				bias-disable;
+			};
+
+			rp1_gpclksrc1_gpio18: rp1_gpclksrc1_gpio18 {
+				function = "gpclk1";
+				pins = "gpio18";
+				bias-disable;
+			};
+
+			rp1_gpclksrc1_gpio21: rp1_gpclksrc1_gpio21 {
+				function = "gpclk1";
+				pins = "gpio21";
+				bias-disable;
+			};
+
 			rp1_pwm1_gpio45: rp1_pwm1_gpio45 {
 				function = "pwm1";
 				pins = "gpio45";
@@ -1209,6 +1239,66 @@
 		#clock-cells = <0>;
 		clock-output-names = "clksrc_mipi1_dsi_byteclk";
 		clock-frequency = <72000000>;
+	};
+	/* GPIO derived clock sources. Each GPIO with a GPCLK function
+	 * can drive its output from the respective GPCLK
+	 * generator, and provide a clock source to other internal
+	 * dividers. Add dummy sources here so that they can be overridden
+	 * with overlays.
+	 */
+	clksrc_gp0: clksrc_gp0 {
+		status = "disabled";
+		compatible = "fixed-factor-clock";
+		#clock-cells = <0>;
+		clock-div = <1>;
+		clock-mult = <1>;
+		clocks = <&rp1_clocks RP1_CLK_GP0>;
+		clock-output-names = "clksrc_gp0";
+	};
+	clksrc_gp1: clksrc_gp1 {
+		status = "disabled";
+		compatible = "fixed-factor-clock";
+		#clock-cells = <0>;
+		clock-div = <1>;
+		clock-mult = <1>;
+		clocks = <&rp1_clocks RP1_CLK_GP1>;
+		clock-output-names = "clksrc_gp1";
+	};
+	clksrc_gp2: clksrc_gp2 {
+		status = "disabled";
+		compatible = "fixed-factor-clock";
+		clock-div = <1>;
+		clock-mult = <1>;
+		#clock-cells = <0>;
+		clocks = <&rp1_clocks RP1_CLK_GP2>;
+		clock-output-names = "clksrc_gp2";
+	};
+	clksrc_gp3: clksrc_gp3 {
+		status = "disabled";
+		compatible = "fixed-factor-clock";
+		clock-div = <1>;
+		clock-mult = <1>;
+		#clock-cells = <0>;
+		clocks = <&rp1_clocks RP1_CLK_GP3>;
+		clock-output-names = "clksrc_gp3";
+	};
+	clksrc_gp4: clksrc_gp4 {
+		status = "disabled";
+		compatible = "fixed-factor-clock";
+		#clock-cells = <0>;
+		clock-div = <1>;
+		clock-mult = <1>;
+		clocks = <&rp1_clocks RP1_CLK_GP4>;
+		clock-output-names = "clksrc_gp4";
+	};
+	clksrc_gp5: clksrc_gp5 {
+		status = "disabled";
+		compatible = "fixed-factor-clock";
+		#clock-cells = <0>;
+		clock-div = <1>;
+		clock-mult = <1>;
+		clocks = <&rp1_clocks RP1_CLK_GP5>;
+		clock-output-names = "clksrc_gp5";
 	};
 };
 

--- a/drivers/clk/clk-rp1.c
+++ b/drivers/clk/clk-rp1.c
@@ -361,6 +361,7 @@ struct rp1_clock_data {
 	u32 div_frac_reg;
 	u32 sel_reg;
 	u32 div_int_max;
+	unsigned long max_freq;
 	u32 fc0_src;
 };
 
@@ -1211,7 +1212,15 @@ static void rp1_clock_choose_div_and_prate(struct clk_hw *hw,
 	/* Recalculate to account for rounding errors */
 	tmp = (u64)*prate << CLK_DIV_FRAC_BITS;
 	tmp = div_u64(tmp, div);
-	*calc_rate = tmp;
+	/*
+	 * Prevent overclocks - if all parent choices result in
+	 * a downstream clock in excess of the maximum, then the
+	 * call to set the clock will fail.
+	 */
+	if (tmp > clock->data->max_freq)
+		*calc_rate = 0;
+	else
+		*calc_rate = tmp;
 }
 
 static int rp1_clock_determine_rate(struct clk_hw *hw,
@@ -1672,6 +1681,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_SYS_DIV_INT,
 				.sel_reg = CLK_SYS_SEL,
 				.div_int_max = DIV_INT_24BIT_MAX,
+				.max_freq = 200 * MHz,
 				.fc0_src = FC_NUM(0, 4),
 				.clk_src_mask = 0x3,
 				),
@@ -1685,6 +1695,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_SLOW_SYS_DIV_INT,
 				.sel_reg = CLK_SLOW_SYS_SEL,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 50 * MHz,
 				.fc0_src = FC_NUM(1, 4),
 				.clk_src_mask = 0x1,
 				),
@@ -1706,6 +1717,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_UART_DIV_INT,
 				.sel_reg = CLK_UART_SEL,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 100 * MHz,
 				.fc0_src = FC_NUM(6, 7),
 				),
 
@@ -1726,6 +1738,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_ETH_DIV_INT,
 				.sel_reg = CLK_ETH_SEL,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 125 * MHz,
 				.fc0_src = FC_NUM(4, 6),
 				),
 
@@ -1747,6 +1760,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_frac_reg = CLK_PWM0_DIV_FRAC,
 				.sel_reg = CLK_PWM0_SEL,
 				.div_int_max = DIV_INT_16BIT_MAX,
+				.max_freq = 76800 * KHz,
 				.fc0_src = FC_NUM(0, 5),
 				),
 
@@ -1768,6 +1782,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_frac_reg = CLK_PWM1_DIV_FRAC,
 				.sel_reg = CLK_PWM1_SEL,
 				.div_int_max = DIV_INT_16BIT_MAX,
+				.max_freq = 76800 * KHz,
 				.fc0_src = FC_NUM(1, 5),
 				),
 
@@ -1790,6 +1805,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_AUDIO_IN_DIV_INT,
 				.sel_reg = CLK_AUDIO_IN_SEL,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 76800 * KHz,
 				.fc0_src = FC_NUM(2, 5),
 				),
 
@@ -1811,6 +1827,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_AUDIO_OUT_DIV_INT,
 				.sel_reg = CLK_AUDIO_OUT_SEL,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 153600 * KHz,
 				.fc0_src = FC_NUM(3, 5),
 				),
 
@@ -1831,6 +1848,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_I2S_DIV_INT,
 				.sel_reg = CLK_I2S_SEL,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 50 * MHz,
 				.fc0_src = FC_NUM(4, 4),
 				),
 
@@ -1843,6 +1861,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_MIPI0_CFG_DIV_INT,
 				.sel_reg = CLK_MIPI0_CFG_SEL,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 50 * MHz,
 				.fc0_src = FC_NUM(4, 5),
 				),
 
@@ -1856,6 +1875,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.sel_reg = CLK_MIPI1_CFG_SEL,
 				.clk_src_mask = 1,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 50 * MHz,
 				.fc0_src = FC_NUM(5, 6),
 				),
 
@@ -1875,6 +1895,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_ETH_TSU_DIV_INT,
 				.sel_reg = CLK_ETH_TSU_SEL,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 50 * MHz,
 				.fc0_src = FC_NUM(5, 7),
 				),
 
@@ -1894,6 +1915,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_ADC_DIV_INT,
 				.sel_reg = CLK_ADC_SEL,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 50 * MHz,
 				.fc0_src = FC_NUM(5, 5),
 				),
 
@@ -1906,6 +1928,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_SDIO_TIMER_DIV_INT,
 				.sel_reg = CLK_SDIO_TIMER_SEL,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 50 * MHz,
 				.fc0_src = FC_NUM(3, 4),
 				),
 
@@ -1918,6 +1941,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_int_reg = CLK_SDIO_ALT_SRC_DIV_INT,
 				.sel_reg = CLK_SDIO_ALT_SRC_SEL,
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 200 * MHz,
 				.fc0_src = FC_NUM(5, 4),
 				),
 
@@ -1947,6 +1971,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_frac_reg = CLK_GP0_DIV_FRAC,
 				.sel_reg = CLK_GP0_SEL,
 				.div_int_max = DIV_INT_16BIT_MAX,
+				.max_freq = 100 * MHz,
 				.fc0_src = FC_NUM(0, 1),
 				),
 
@@ -1976,6 +2001,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_frac_reg = CLK_GP1_DIV_FRAC,
 				.sel_reg = CLK_GP1_SEL,
 				.div_int_max = DIV_INT_16BIT_MAX,
+				.max_freq = 100 * MHz,
 				.fc0_src = FC_NUM(1, 1),
 				),
 
@@ -2005,6 +2031,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_frac_reg = CLK_GP2_DIV_FRAC,
 				.sel_reg = CLK_GP2_SEL,
 				.div_int_max = DIV_INT_16BIT_MAX,
+				.max_freq = 100 * MHz,
 				.fc0_src = FC_NUM(2, 1),
 				),
 
@@ -2034,6 +2061,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_frac_reg = CLK_GP3_DIV_FRAC,
 				.sel_reg = CLK_GP3_SEL,
 				.div_int_max = DIV_INT_16BIT_MAX,
+				.max_freq = 100 * MHz,
 				.fc0_src = FC_NUM(3, 1),
 				),
 
@@ -2064,6 +2092,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_frac_reg = CLK_GP4_DIV_FRAC,
 				.sel_reg = CLK_GP4_SEL,
 				.div_int_max = DIV_INT_16BIT_MAX,
+				.max_freq = 100 * MHz,
 				.fc0_src = FC_NUM(4, 1),
 				),
 
@@ -2093,6 +2122,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.div_frac_reg = CLK_GP5_DIV_FRAC,
 				.sel_reg = CLK_GP5_SEL,
 				.div_int_max = DIV_INT_16BIT_MAX,
+				.max_freq = 100 * MHz,
 				.fc0_src = FC_NUM(5, 1),
 				),
 
@@ -2113,6 +2143,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.sel_reg = VIDEO_CLK_VEC_SEL,
 				.flags = CLK_SET_RATE_NO_REPARENT, /* Let VEC driver set parent */
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 108 * MHz,
 				.fc0_src = FC_NUM(0, 6),
 				),
 
@@ -2133,6 +2164,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.sel_reg = VIDEO_CLK_DPI_SEL,
 				.flags = CLK_SET_RATE_NO_REPARENT, /* Let DPI driver set parent */
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 200 * MHz,
 				.fc0_src = FC_NUM(1, 6),
 				),
 
@@ -2154,6 +2186,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.sel_reg = VIDEO_CLK_MIPI0_DPI_SEL,
 				.flags = CLK_SET_RATE_NO_REPARENT, /* Let DSI driver set parent */
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 200 * MHz,
 				.fc0_src = FC_NUM(2, 6),
 				),
 
@@ -2175,6 +2208,7 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.sel_reg = VIDEO_CLK_MIPI1_DPI_SEL,
 				.flags = CLK_SET_RATE_NO_REPARENT, /* Let DSI driver set parent */
 				.div_int_max = DIV_INT_8BIT_MAX,
+				.max_freq = 200 * MHz,
 				.fc0_src = FC_NUM(3, 6),
 				),
 };

--- a/drivers/clk/clk-rp1.c
+++ b/drivers/clk/clk-rp1.c
@@ -35,6 +35,7 @@
 #define PLL_AUDIO_FBDIV_FRAC		0x0c00c
 #define PLL_AUDIO_PRIM			0x0c010
 #define PLL_AUDIO_SEC			0x0c014
+#define PLL_AUDIO_TERN			0x0c018
 
 #define PLL_VIDEO_CS			0x10000
 #define PLL_VIDEO_PWR			0x10004
@@ -42,6 +43,8 @@
 #define PLL_VIDEO_FBDIV_FRAC		0x1000c
 #define PLL_VIDEO_PRIM			0x10010
 #define PLL_VIDEO_SEC			0x10014
+
+#define GPCLK_OE_CTRL			0x00000
 
 #define CLK_SYS_CTRL			0x00014
 #define CLK_SYS_DIV_INT			0x00018
@@ -245,7 +248,7 @@
 #define LOCK_TIMEOUT_NS			100000000
 #define FC_TIMEOUT_NS			100000000
 
-#define MAX_CLK_PARENTS	8
+#define MAX_CLK_PARENTS	16
 
 #define MEASURE_CLOCK_RATE
 const char * const fc0_ref_clk_name = "clk_slow_sys";
@@ -351,6 +354,7 @@ struct rp1_clock_data {
 	int num_std_parents;
 	int num_aux_parents;
 	unsigned long flags;
+	u32 oe_mask;
 	u32 clk_src_mask;
 	u32 ctrl_reg;
 	u32 div_int_reg;
@@ -1011,6 +1015,10 @@ static int rp1_clock_on(struct clk_hw *hw)
 	spin_lock(&clockman->regs_lock);
 	clockman_write(clockman, data->ctrl_reg,
 		       clockman_read(clockman, data->ctrl_reg) | CLK_CTRL_ENABLE);
+	/* If this is a GPCLK, turn on the output-enable */
+	if (data->oe_mask)
+		clockman_write(clockman, GPCLK_OE_CTRL,
+			       clockman_read(clockman, GPCLK_OE_CTRL) | data->oe_mask);
 	spin_unlock(&clockman->regs_lock);
 
 #ifdef MEASURE_CLOCK_RATE
@@ -1028,6 +1036,10 @@ static void rp1_clock_off(struct clk_hw *hw)
 	spin_lock(&clockman->regs_lock);
 	clockman_write(clockman, data->ctrl_reg,
 		       clockman_read(clockman, data->ctrl_reg) & ~CLK_CTRL_ENABLE);
+	/* If this is a GPCLK, turn off the output-enable */
+	if (data->oe_mask)
+		clockman_write(clockman, GPCLK_OE_CTRL,
+			       clockman_read(clockman, GPCLK_OE_CTRL) & ~data->oe_mask);
 	spin_unlock(&clockman->regs_lock);
 }
 
@@ -1614,6 +1626,15 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.fc0_src = FC_NUM(5, 1),
 				),
 
+	[RP1_PLL_VIDEO_PRI_PH] = REGISTER_PLL_PH(
+				.name = "pll_video_pri_ph",
+				.source_pll = "pll_video",
+				.ph_reg = PLL_VIDEO_PRIM,
+				.fixed_divider = 2,
+				.phase = RP1_PLL_PHASE_0,
+				.fc0_src = FC_NUM(4, 3),
+				),
+
 	[RP1_PLL_SYS_SEC] = REGISTER_PLL_DIV(
 				.name = "pll_sys_sec",
 				.source_pll = "pll_sys_core",
@@ -1633,6 +1654,13 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.source_pll = "pll_video_core",
 				.ctrl_reg = PLL_VIDEO_SEC,
 				.fc0_src = FC_NUM(5, 3),
+				),
+
+	[RP1_PLL_AUDIO_TERN] = REGISTER_PLL_DIV(
+				.name = "pll_audio_tern",
+				.source_pll = "pll_audio_core",
+				.ctrl_reg = PLL_AUDIO_TERN,
+				.fc0_src = FC_NUM(6, 2),
 				),
 
 	[RP1_CLK_SYS] = REGISTER_CLK(
@@ -1665,9 +1693,15 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.name = "clk_uart",
 				.parents = {"pll_sys_pri_ph",
 					    "pll_video",
-					    "xosc"},
+					    "xosc",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5"},
 				.num_std_parents = 0,
-				.num_aux_parents = 3,
+				.num_aux_parents = 9,
 				.ctrl_reg = CLK_UART_CTRL,
 				.div_int_reg = CLK_UART_DIV_INT,
 				.sel_reg = CLK_UART_SEL,
@@ -1677,9 +1711,17 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 
 	[RP1_CLK_ETH] = REGISTER_CLK(
 				.name = "clk_eth",
-				.parents = {"-"},
-				.num_std_parents = 1,
-				.num_aux_parents = 0,
+				.parents = {"pll_sys_sec",
+					    "pll_sys",
+					    "pll_video_sec",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5"},
+				.num_std_parents = 0,
+				.num_aux_parents = 9,
 				.ctrl_reg = CLK_ETH_CTRL,
 				.div_int_reg = CLK_ETH_DIV_INT,
 				.sel_reg = CLK_ETH_SEL,
@@ -1691,9 +1733,15 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.name = "clk_pwm0",
 				.parents = {"pll_audio_pri_ph",
 					    "pll_video_sec",
-					    "xosc"},
+					    "xosc",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5"},
 				.num_std_parents = 0,
-				.num_aux_parents = 3,
+				.num_aux_parents = 9,
 				.ctrl_reg = CLK_PWM0_CTRL,
 				.div_int_reg = CLK_PWM0_DIV_INT,
 				.div_frac_reg = CLK_PWM0_DIV_FRAC,
@@ -1706,9 +1754,15 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.name = "clk_pwm1",
 				.parents = {"pll_audio_pri_ph",
 					    "pll_video_sec",
-					    "xosc"},
+					    "xosc",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5"},
 				.num_std_parents = 0,
-				.num_aux_parents = 3,
+				.num_aux_parents = 9,
 				.ctrl_reg = CLK_PWM1_CTRL,
 				.div_int_reg = CLK_PWM1_DIV_INT,
 				.div_frac_reg = CLK_PWM1_DIV_FRAC,
@@ -1719,9 +1773,19 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 
 	[RP1_CLK_AUDIO_IN] = REGISTER_CLK(
 				.name = "clk_audio_in",
-				.parents = {"-"},
-				.num_std_parents = 1,
-				.num_aux_parents = 0,
+				.parents = {"pll_audio",
+					    "pll_audio_pri_ph",
+					    "pll_audio_sec",
+					    "pll_video_sec",
+					    "xosc",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5"},
+				.num_std_parents = 0,
+				.num_aux_parents = 11,
 				.ctrl_reg = CLK_AUDIO_IN_CTRL,
 				.div_int_reg = CLK_AUDIO_IN_DIV_INT,
 				.sel_reg = CLK_AUDIO_IN_SEL,
@@ -1731,9 +1795,18 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 
 	[RP1_CLK_AUDIO_OUT] = REGISTER_CLK(
 				.name = "clk_audio_out",
-				.parents = {"-"},
-				.num_std_parents = 1,
-				.num_aux_parents = 0,
+				.parents = {"pll_audio",
+					    "pll_audio_sec",
+					    "pll_video_sec",
+					    "xosc",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5"},
+				.num_std_parents = 0,
+				.num_aux_parents = 10,
 				.ctrl_reg = CLK_AUDIO_OUT_CTRL,
 				.div_int_reg = CLK_AUDIO_OUT_DIV_INT,
 				.sel_reg = CLK_AUDIO_OUT_SEL,
@@ -1745,9 +1818,15 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.name = "clk_i2s",
 				.parents = {"xosc",
 					    "pll_audio",
-					    "pll_audio_sec"},
+					    "pll_audio_sec",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5"},
 				.num_std_parents = 0,
-				.num_aux_parents = 3,
+				.num_aux_parents = 9,
 				.ctrl_reg = CLK_I2S_CTRL,
 				.div_int_reg = CLK_I2S_DIV_INT,
 				.sel_reg = CLK_I2S_SEL,
@@ -1782,9 +1861,16 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 
 	[RP1_CLK_ETH_TSU] = REGISTER_CLK(
 				.name = "clk_eth_tsu",
-				.parents = {"xosc"},
+				.parents = {"xosc",
+					    "pll_video_sec",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5"},
 				.num_std_parents = 0,
-				.num_aux_parents = 1,
+				.num_aux_parents = 8,
 				.ctrl_reg = CLK_ETH_TSU_CTRL,
 				.div_int_reg = CLK_ETH_TSU_DIV_INT,
 				.sel_reg = CLK_ETH_TSU_SEL,
@@ -1794,9 +1880,16 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 
 	[RP1_CLK_ADC] = REGISTER_CLK(
 				.name = "clk_adc",
-				.parents = {"xosc"},
+				.parents = {"xosc",
+					    "pll_audio_tern",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5"},
 				.num_std_parents = 0,
-				.num_aux_parents = 1,
+				.num_aux_parents = 8,
 				.ctrl_reg = CLK_ADC_CTRL,
 				.div_int_reg = CLK_ADC_DIV_INT,
 				.sel_reg = CLK_ADC_SEL,
@@ -1830,9 +1923,25 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 
 	[RP1_CLK_GP0] = REGISTER_CLK(
 				.name = "clk_gp0",
-				.parents = {"xosc"},
+				.parents = {"xosc",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5",
+					    "pll_sys",
+					    "pll_audio",
+					    "",
+					    "",
+					    "clk_i2s",
+					    "clk_adc",
+					    "",
+					    "",
+					    "",
+					    "clk_sys"},
 				.num_std_parents = 0,
-				.num_aux_parents = 1,
+				.num_aux_parents = 16,
+				.oe_mask = BIT(0),
 				.ctrl_reg = CLK_GP0_CTRL,
 				.div_int_reg = CLK_GP0_DIV_INT,
 				.div_frac_reg = CLK_GP0_DIV_FRAC,
@@ -1843,9 +1952,25 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 
 	[RP1_CLK_GP1] = REGISTER_CLK(
 				.name = "clk_gp1",
-				.parents = {"xosc"},
+				.parents = {"clk_sdio_timer",
+					    "clksrc_gp0",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5",
+					    "pll_sys_pri_ph",
+					    "pll_audio_pri_ph",
+					    "",
+					    "",
+					    "clk_adc",
+					    "clk_dpi",
+					    "clk_pwm0",
+					    "",
+					    "",
+					    ""},
 				.num_std_parents = 0,
-				.num_aux_parents = 1,
+				.num_aux_parents = 16,
+				.oe_mask = BIT(1),
 				.ctrl_reg = CLK_GP1_CTRL,
 				.div_int_reg = CLK_GP1_DIV_INT,
 				.div_frac_reg = CLK_GP1_DIV_FRAC,
@@ -1856,9 +1981,25 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 
 	[RP1_CLK_GP2] = REGISTER_CLK(
 				.name = "clk_gp2",
-				.parents = {"xosc"},
+				.parents = {"clk_sdio_alt_src",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "clksrc_gp5",
+					    "pll_sys_sec",
+					    "pll_audio_sec",
+					    "pll_video",
+					    "clk_audio_in",
+					    "clk_dpi",
+					    "clk_pwm0",
+					    "clk_pwm1",
+					    "clk_mipi0_dpi",
+					    "clk_mipi1_cfg",
+					    "clk_sys"},
 				.num_std_parents = 0,
-				.num_aux_parents = 1,
+				.num_aux_parents = 16,
+				.oe_mask = BIT(2),
 				.ctrl_reg = CLK_GP2_CTRL,
 				.div_int_reg = CLK_GP2_DIV_INT,
 				.div_frac_reg = CLK_GP2_DIV_FRAC,
@@ -1869,9 +2010,25 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 
 	[RP1_CLK_GP3] = REGISTER_CLK(
 				.name = "clk_gp3",
-				.parents = {"xosc"},
+				.parents = {"xosc",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp4",
+					    "clksrc_gp5",
+					    "",
+					    "",
+					    "pll_video_pri_ph",
+					    "clk_audio_out",
+					    "",
+					    "",
+					    "clk_mipi1_dpi",
+					    "",
+					    "",
+					    ""},
 				.num_std_parents = 0,
-				.num_aux_parents = 1,
+				.num_aux_parents = 16,
+				.oe_mask = BIT(3),
 				.ctrl_reg = CLK_GP3_CTRL,
 				.div_int_reg = CLK_GP3_DIV_INT,
 				.div_frac_reg = CLK_GP3_DIV_FRAC,
@@ -1882,9 +2039,26 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 
 	[RP1_CLK_GP4] = REGISTER_CLK(
 				.name = "clk_gp4",
-				.parents = {"xosc"},
+				.parents = {"xosc",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp5",
+					    "pll_audio_tern",
+					    "pll_video_sec",
+					    "",
+					    "",
+					    "",
+					    "clk_mipi0_cfg",
+					    "clk_uart",
+					    "",
+					    "",
+					    "clk_sys",
+					    },
 				.num_std_parents = 0,
-				.num_aux_parents = 1,
+				.num_aux_parents = 16,
+				.oe_mask = BIT(4),
 				.ctrl_reg = CLK_GP4_CTRL,
 				.div_int_reg = CLK_GP4_DIV_INT,
 				.div_frac_reg = CLK_GP4_DIV_FRAC,
@@ -1895,9 +2069,25 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 
 	[RP1_CLK_GP5] = REGISTER_CLK(
 				.name = "clk_gp5",
-				.parents = {"xosc"},
+				.parents = {"xosc",
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4",
+					    "pll_audio_tern",
+					    "pll_video_sec",
+					    "clk_eth_tsu",
+					    "",
+					    "clk_vec",
+					    "",
+					    "",
+					    "",
+					    "",
+					    ""},
 				.num_std_parents = 0,
-				.num_aux_parents = 1,
+				.num_aux_parents = 16,
+				.oe_mask = BIT(5),
 				.ctrl_reg = CLK_GP5_CTRL,
 				.div_int_reg = CLK_GP5_DIV_INT,
 				.div_frac_reg = CLK_GP5_DIV_FRAC,
@@ -1911,11 +2101,11 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.parents = {"pll_sys_pri_ph",
 					    "pll_video_sec",
 					    "pll_video",
-					    "clk_gp0",
-					    "clk_gp1",
-					    "clk_gp2",
-					    "clk_gp3",
-					    "clk_gp4"},
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4"},
 				.num_std_parents = 0,
 				.num_aux_parents = 8, /* XXX in fact there are more than 8 */
 				.ctrl_reg = VIDEO_CLK_VEC_CTRL,
@@ -1931,11 +2121,11 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.parents = {"pll_sys",
 					    "pll_video_sec",
 					    "pll_video",
-					    "clk_gp0",
-					    "clk_gp1",
-					    "clk_gp2",
-					    "clk_gp3",
-					    "clk_gp4"},
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3",
+					    "clksrc_gp4"},
 				.num_std_parents = 0,
 				.num_aux_parents = 8, /* XXX in fact there are more than 8 */
 				.ctrl_reg = VIDEO_CLK_DPI_CTRL,
@@ -1952,10 +2142,10 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 					    "pll_video_sec",
 					    "pll_video",
 					    "clksrc_mipi0_dsi_byteclk",
-					    "clk_gp0",
-					    "clk_gp1",
-					    "clk_gp2",
-					    "clk_gp3"},
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3"},
 				.num_std_parents = 0,
 				.num_aux_parents = 8, /* XXX in fact there are more than 8 */
 				.ctrl_reg = VIDEO_CLK_MIPI0_DPI_CTRL,
@@ -1973,10 +2163,10 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 					    "pll_video_sec",
 					    "pll_video",
 					    "clksrc_mipi1_dsi_byteclk",
-					    "clk_gp0",
-					    "clk_gp1",
-					    "clk_gp2",
-					    "clk_gp3"},
+					    "clksrc_gp0",
+					    "clksrc_gp1",
+					    "clksrc_gp2",
+					    "clksrc_gp3"},
 				.num_std_parents = 0,
 				.num_aux_parents = 8, /* XXX in fact there are more than 8 */
 				.ctrl_reg = VIDEO_CLK_MIPI1_DPI_CTRL,

--- a/include/dt-bindings/clock/rp1.h
+++ b/include/dt-bindings/clock/rp1.h
@@ -50,3 +50,7 @@
 #define RP1_CLK_DPI			40
 #define RP1_CLK_MIPI0_DPI		41
 #define RP1_CLK_MIPI1_DPI		42
+
+/* Extra PLL output channels - RP1B0 only */
+#define RP1_PLL_VIDEO_PRI_PH		43
+#define RP1_PLL_AUDIO_TERN		44


### PR DESCRIPTION
Prompted by https://forums.raspberrypi.com/viewtopic.php?t=365761&hilit=gpclk this lets users drive gpclks via overlays (and if suitably motivated, drive off-chip sources into peripherals).

I've noticed that clocks without the enable bit set (either by firmware or Linux) report a nonzero frequency - probably a bug, but I don't know where...