### PR TITLE
nvmem: raspberrypi: Add nvmem driver for reading customer OTP

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi.dtsi
@@ -19,8 +19,25 @@
 		hdmi = <&hdmi>,"status";
 		i2c2_iknowwhatimdoing = <&i2c2>,"status";
 		i2c2_baudrate = <&i2c2>,"clock-frequency:0";
+		nvmem_cust_rw = <&nvmem_cust>,"rw?";
 		sd = <&sdhost>,"status";
 		sd_poll_once = <&sdhost>,"non-removable?";
+	};
+};
+
+&soc {
+	nvmem_otp: nvmem_otp {
+		compatible = "raspberrypi,rpi-otp";
+		firmware = <&firmware>;
+		reg = <0 192>;
+		status = "okay";
+	};
+
+	nvmem_cust: nvmem_cust {
+		compatible = "raspberrypi,rpi-otp";
+		firmware = <&firmware>;
+		reg = <1 8>;
+		status = "okay";
 	};
 };
 

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
@@ -10,6 +10,8 @@
 		eee = <&chosen>,"bootargs{on='',off='genet.eee=N'}";
 		hdmi = <&hdmi0>,"status",
 		       <&hdmi1>,"status";
+		nvmem_cust_rw = <&nvmem_cust>,"rw?";
+		nvmem_priv_rw = <&nvmem_priv>,"rw?";
 		pcie = <&pcie0>,"status";
 		sd = <&emmc2>,"status";
 
@@ -88,6 +90,27 @@
 	/* Add the physical <-> DMA mapping for the I/O space */
 	dma-ranges = <0xc0000000  0x0 0x00000000  0x40000000>,
 		     <0x7c000000  0x0 0xfc000000  0x03800000>;
+
+	nvmem_otp: nvmem_otp {
+		compatible = "raspberrypi,rpi-otp";
+		firmware = <&firmware>;
+		reg = <0 166>;
+		status = "okay";
+	};
+
+	nvmem_cust: nvmem_cust {
+		compatible = "raspberrypi,rpi-otp";
+		firmware = <&firmware>;
+		reg = <1 8>;
+		status = "okay";
+	};
+
+	nvmem_priv: nvmem_priv {
+		compatible = "raspberrypi,rpi-otp";
+		firmware = <&firmware>;
+		reg = <3 8>;
+		status = "okay";
+	};
 };
 
 &scb {

--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -45,6 +45,34 @@
 		trickle-charge-microvolt = <0>;
 	};
 
+	nvmem_otp: nvmem_otp {
+		compatible = "raspberrypi,rpi-otp";
+		firmware = <&firmware>;
+		reg = <0 192>;
+		status = "okay";
+	};
+
+	nvmem_cust: nvmem_cust {
+		compatible = "raspberrypi,rpi-otp";
+		firmware = <&firmware>;
+		reg = <1 8>;
+		status = "okay";
+	};
+
+	nvmem_mac: nvmem_mac {
+		compatible = "raspberrypi,rpi-otp";
+		firmware = <&firmware>;
+		reg = <2 6>;
+		status = "okay";
+	};
+
+	nvmem_priv: nvmem_priv {
+		compatible = "raspberrypi,rpi-otp";
+		firmware = <&firmware>;
+		reg = <3 16>;
+		status = "okay";
+	};
+
 	/* Define these notional regulators for use by overlays, etc. */
 	vdd_3v3_reg: fixedregulator_3v3 {
 		compatible = "regulator-fixed";
@@ -67,6 +95,10 @@
 	__overrides__ {
 		arm_freq;
 		axiperf = <&axiperf>,"status";
+
+		nvmem_cust_rw = <&nvmem_cust>,"rw?";
+		nvmem_priv_rw = <&nvmem_priv>,"rw?";
+		nvmem_mac_rw = <&nvmem_mac>,"rw?";
 	};
 };
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -300,6 +300,12 @@ Params:
 
         nvme                    Alias for "pciex1" (2712 only)
 
+        nvmem_cust_rw           Allow read/write access to customer otp
+
+        nvmem_mac_rw            Allow read/write access to mac addresses otp
+
+        nvmem_priv_rw           Allow read/write access to customer private otp
+
         pcie                    Set to "off" to disable the PCIe interface
                                 (default "on")
                                 (2711 only, but not applicable on CM4S)

--- a/drivers/nvmem/Kconfig
+++ b/drivers/nvmem/Kconfig
@@ -39,6 +39,18 @@ config NVMEM_APPLE_EFUSES
 	  This driver can also be built as a module. If so, the module will
 	  be called nvmem-apple-efuses.
 
+config NVMEM_RASPBERRYPI_OTP
+	tristate "Raspberry Pi OTP support"
+	depends on (ARCH_BCM && RASPBERRYPI_FIRMWARE) || COMPILE_TEST
+	default ARCH_BCM && RASPBERRYPI_FIRMWARE
+	help
+	  Say y here to enable support for accessing OTP on Raspberry Pi boards.
+	  These are used to store non-volatile information such as serial number,
+	  board revision and customer stored data.
+
+	  This driver can also be built as a module. If so, the module will
+	  be called nvmem-raspberrypi-otp.
+
 config NVMEM_BCM_OCOTP
 	tristate "Broadcom On-Chip OTP Controller support"
 	depends on ARCH_BCM_IPROC || COMPILE_TEST

--- a/drivers/nvmem/Makefile
+++ b/drivers/nvmem/Makefile
@@ -10,6 +10,8 @@ obj-y				+= layouts/
 # Devices
 obj-$(CONFIG_NVMEM_APPLE_EFUSES)	+= nvmem-apple-efuses.o
 nvmem-apple-efuses-y 			:= apple-efuses.o
+obj-$(CONFIG_NVMEM_RASPBERRYPI_OTP)	+= nvmem-raspberrypi-otp.o
+nvmem-raspberrypi-otp-y			:= raspberrypi-otp.o
 obj-$(CONFIG_NVMEM_BCM_OCOTP)		+= nvmem-bcm-ocotp.o
 nvmem-bcm-ocotp-y			:= bcm-ocotp.o
 obj-$(CONFIG_NVMEM_BRCM_NVRAM)		+= nvmem_brcm_nvram.o

--- a/drivers/nvmem/raspberrypi-otp.c
+++ b/drivers/nvmem/raspberrypi-otp.c
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+/**
+ * raspberrypi-otp.c
+ *
+ * nvmem driver using firmware mailbox to access otp
+ *
+ * Copyright (c) 2024, Raspberry Pi Ltd.
+ */
+
+#include <linux/nvmem-provider.h>
+#include <soc/bcm2835/raspberrypi-firmware.h>
+
+struct rpi_otp_priv {
+	struct rpi_firmware *fw;
+	u32 block;
+};
+
+#define MAX_ROWS 192
+
+#define RPI_FIRMWARE_GET_USER_OTP 0x00030024
+#define RPI_FIRMWARE_SET_USER_OTP 0x00038024
+
+static int rpi_otp_read(void *context, unsigned int offset, void *val,
+			     size_t bytes)
+{
+	struct rpi_otp_priv *priv = context;
+	int words = bytes / sizeof(u32);
+	int index = offset / sizeof(u32);
+	u32 data[3 + MAX_ROWS] = {priv->block, index, words};
+	int err = 0;
+
+	if (words > MAX_ROWS)
+		return -EINVAL;
+
+	err = rpi_firmware_property(priv->fw, RPI_FIRMWARE_GET_USER_OTP,
+				    &data, sizeof(data));
+	if (err == 0)
+		memcpy(val, data + 3, bytes);
+	else
+		memset(val, 0xee, bytes);
+	return err;
+}
+
+static int rpi_otp_write(void *context, unsigned int offset, void *val,
+			     size_t bytes)
+{
+	struct rpi_otp_priv *priv = context;
+	int words = bytes / sizeof(u32);
+	int index = offset / sizeof(u32);
+	u32 data[3 + MAX_ROWS] = {priv->block, index, words};
+
+	if (bytes > MAX_ROWS * sizeof(u32))
+		return -EINVAL;
+
+	memcpy(data + 3, val, bytes);
+	return rpi_firmware_property(priv->fw, RPI_FIRMWARE_SET_USER_OTP,
+				    &data, sizeof(data));
+}
+
+static int rpi_otp_probe(struct platform_device *pdev)
+{
+	struct rpi_otp_priv *priv;
+	struct nvmem_config config = {
+		.dev = &pdev->dev,
+		.reg_read = rpi_otp_read,
+		.reg_write = rpi_otp_write,
+		.stride = sizeof(u32),
+		.word_size = sizeof(u32),
+		.type = NVMEM_TYPE_OTP,
+		.root_only = true,
+	};
+	struct device *dev = &pdev->dev;
+	struct device_node *np = dev->of_node;
+	struct device_node *fw_node;
+	struct rpi_firmware *fw;
+	u32 reg[2];
+	const char *pname;
+
+	if (of_property_read_u32_array(np, "reg", reg, ARRAY_SIZE(reg))) {
+		dev_err(dev, "Failed to parse \"reg\" property\n");
+		return -EINVAL;
+	}
+
+	pname = of_get_property(np, "name", NULL);
+	if (!pname) {
+		dev_err(dev, "Failed to parse \"name\" property\n");
+		return -ENOENT;
+	}
+
+	config.name = pname;
+	config.size = reg[1] * sizeof(u32);
+	config.read_only = !of_property_read_bool(np, "rw");
+
+	fw_node = of_parse_phandle(np, "firmware", 0);
+	if (!fw_node) {
+		dev_err(dev, "Missing firmware node\n");
+		return -ENOENT;
+	}
+
+	fw = rpi_firmware_get(fw_node);
+	if (!fw)
+		return -EPROBE_DEFER;
+
+	priv = devm_kzalloc(config.dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv)
+		return -ENOMEM;
+
+	priv->fw = fw;
+	priv->block = reg[0];
+	config.priv = priv;
+
+	return PTR_ERR_OR_ZERO(devm_nvmem_register(config.dev, &config));
+}
+
+static const struct of_device_id rpi_otp_of_match[] = {
+	{ .compatible = "raspberrypi,rpi-otp", },
+	{}
+};
+
+MODULE_DEVICE_TABLE(of, rpi_otp_of_match);
+
+static struct platform_driver rpi_otp_driver = {
+	.driver = {
+		.name = "rpi_otp",
+		.of_match_table = rpi_otp_of_match,
+	},
+	.probe = rpi_otp_probe,
+};
+
+module_platform_driver(rpi_otp_driver);
+
+MODULE_AUTHOR("Dom Cobley <popcornmix@gmail.com>");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
This supports reading and writing OTP using the firmware mailbox interface.

It needs supporting firmware to run.