### PR TITLE
support_4inch_DSI_LCD_C-Resolved_11.9inch_touch_orientation_error

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5011,6 +5011,7 @@ Load:   dtoverlay=vc4-kms-dsi-waveshare-panel,<param>=<val>
 Params: 2_8_inch                2.8" 480x640
         3_4_inch                3.4" 800x800 round
         4_0_inch                4.0" 480x800
+        4_0_inchC               4.0" 720x720
         7_0_inchC               7.0" C 1024x600
         7_9_inch                7.9" 400x1280
         8_0_inch                8.0" 1280x800

--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
@@ -108,8 +108,6 @@
 				   <&touch>, "touchscreen-inverted-x?",
 				   <&touch>, "touchscreen-swapped-x-y?";
 		11_9_inch = <&panel>, "compatible=waveshare,11.9inch-panel",
-				   <&touch>, "touchscreen-size-x:0=320",
-				   <&touch>, "touchscreen-size-y:0=1480",
 				   <&touch>, "touchscreen-inverted-x?",
 				   <&touch>, "touchscreen-swapped-x-y?";
 		4_0_inchC = <&panel>, "compatible=waveshare,4inch-panel",

--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
@@ -112,6 +112,9 @@
 				   <&touch>, "touchscreen-size-y:0=1480",
 				   <&touch>, "touchscreen-inverted-x?",
 				   <&touch>, "touchscreen-swapped-x-y?";
+		4_0_inchC = <&panel>, "compatible=waveshare,4inch-panel",
+				   <&touch>, "touchscreen-size-x:0=720",
+				   <&touch>, "touchscreen-size-y:0=720";
 		i2c1 = <&i2c_frag>, "target:0=",<&i2c1>,
 		       <0>, "-3-4+5";
 		disable_touch = <&touch>, "status=disabled";

--- a/drivers/gpu/drm/panel/panel-waveshare-dsi.c
+++ b/drivers/gpu/drm/panel/panel-waveshare-dsi.c
@@ -138,6 +138,18 @@ static const struct drm_display_mode ws_panel_11_9_mode = {
 	.vtotal = 1480 + 60 + 60 + 60,
 };
 
+static const struct drm_display_mode ws_panel_4_mode = {
+	.clock = 50000,
+	.hdisplay = 720,
+	.hsync_start = 720 + 32,
+	.hsync_end = 720 + 32 + 200,
+	.htotal = 720 + 32 + 200 + 120,
+	.vdisplay = 720,
+	.vsync_start = 720 + 8,
+	.vsync_end = 720 + 8 + 4,
+	.vtotal = 720 + 8 + 4 + 16,
+};
+
 static struct ws_panel *panel_to_ts(struct drm_panel *panel)
 {
 	return container_of(panel, struct ws_panel, base);
@@ -398,6 +410,9 @@ static const struct of_device_id ws_panel_of_ids[] = {
 	}, {
 		.compatible = "waveshare,11.9inch-panel",
 		.data = &ws_panel_11_9_mode,
+	}, {
+		.compatible = "waveshare,4inch-panel",
+		.data = &ws_panel_4_mode,
 	}, {
 		/* sentinel */
 	}


### PR DESCRIPTION
The content of PR
1.support waveshare 4inch DSI LCD (C)
2.Resolved waveshare 11.9inch touch orientation error
