### PR TITLE
Add specific clk-producer/-consumer overlays for Hifiberry DACplus

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -88,6 +88,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	hifiberry-amp3.dtbo \
 	hifiberry-amp4pro.dtbo \
 	hifiberry-dac.dtbo \
+	hifiberry-dac8x.dtbo \
 	hifiberry-dacplus.dtbo \
 	hifiberry-dacplusadc.dtbo \
 	hifiberry-dacplusadcpro.dtbo \

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -90,6 +90,8 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	hifiberry-dac.dtbo \
 	hifiberry-dac8x.dtbo \
 	hifiberry-dacplus.dtbo \
+	hifiberry-dacplus-pro.dtbo \
+	hifiberry-dacplus-std.dtbo \
 	hifiberry-dacplusadc.dtbo \
 	hifiberry-dacplusadcpro.dtbo \
 	hifiberry-dacplusdsp.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1772,6 +1772,12 @@ Load:   dtoverlay=hifiberry-dac
 Params: <None>
 
 
+Name:   hifiberry-dac8x
+Info:   Configures the HifiBerry DAC8X audio cards (only on PI5)
+Load:   dtoverlay=hifiberry-dac8x
+Params: <None>
+
+
 Name:   hifiberry-dacplus
 Info:   Configures the HifiBerry DAC+ audio card
 Load:   dtoverlay=hifiberry-dacplus,<param>=<val>

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1801,6 +1801,48 @@ Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
                                 are switched off at all times.
 
 
+Name:   hifiberry-dacplus-pro
+Info:   Configures the HifiBerry DAC+ PRO audio card (onboard clocks)
+Load:   dtoverlay=hifiberry-dacplus-pro,<param>=<val>
+Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
+                                Digital volume control. Enable with
+                                "dtoverlay=hifiberry-dacplus,24db_digital_gain"
+                                (The default behaviour is that the Digital
+                                volume control is limited to a maximum of
+                                0dB. ie. it can attenuate but not provide
+                                gain. For most users, this will be desired
+                                as it will prevent clipping. By appending
+                                the 24dB_digital_gain parameter, the Digital
+                                volume control will allow up to 24dB of
+                                gain. If this parameter is enabled, it is the
+                                responsibility of the user to ensure that
+                                the Digital volume control is set to a value
+                                that does not result in clipping/distortion!)
+        leds_off                If set to 'true' the onboard indicator LEDs
+                                are switched off at all times.
+
+
+Name:   hifiberry-dacplus-std
+Info:   Configures the HifiBerry DAC+ standard audio card (no onboard clocks)
+Load:   dtoverlay=hifiberry-dacplus-std,<param>=<val>
+Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
+                                Digital volume control. Enable with
+                                "dtoverlay=hifiberry-dacplus,24db_digital_gain"
+                                (The default behaviour is that the Digital
+                                volume control is limited to a maximum of
+                                0dB. ie. it can attenuate but not provide
+                                gain. For most users, this will be desired
+                                as it will prevent clipping. By appending
+                                the 24dB_digital_gain parameter, the Digital
+                                volume control will allow up to 24dB of
+                                gain. If this parameter is enabled, it is the
+                                responsibility of the user to ensure that
+                                the Digital volume control is set to a value
+                                that does not result in clipping/distortion!)
+        leds_off                If set to 'true' the onboard indicator LEDs
+                                are switched off at all times.
+
+
 Name:   hifiberry-dacplusadc
 Info:   Configures the HifiBerry DAC+ADC audio card
 Load:   dtoverlay=hifiberry-dacplusadc,<param>=<val>

--- a/arch/arm/boot/dts/overlays/hifiberry-dac8x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dac8x-overlay.dts
@@ -1,0 +1,50 @@
+// Definitions for HiFiBerry DAC8x
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2712";
+
+	fragment@0 {
+		target = <&gpio>;
+		__overlay__ {
+			rp1_i2s0_dac8x: rp1_i2s0_dac8x {
+				function = "i2s0";
+				pins = "gpio18", "gpio19", "gpio21",
+				       "gpio23", "gpio25", "gpio27";
+				bias-disable;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2s_clk_producer>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&rp1_i2s0_dac8x>;
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			pcm5102a-codec {
+				#sound-dai-cells = <0>;
+				compatible = "ti,pcm5102a";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&sound>;
+		__overlay__ {
+			compatible = "hifiberry,hifiberry-dac8x";
+			i2s-controller = <&i2s_clk_producer>;
+			status = "okay";
+		};
+	};
+
+};

--- a/arch/arm/boot/dts/overlays/hifiberry-dacplus-pro-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dacplus-pro-overlay.dts
@@ -1,0 +1,64 @@
+// Definitions for HiFiBerry DAC+ PRO, with onboard clocks
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			dacpro_osc: dacpro_osc {
+				compatible = "hifiberry,dacpro-clk";
+				#clock-cells = <0>;
+			};
+		};
+	};
+
+	frag1: fragment@1 {
+		target = <&i2s_clk_consumer>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			pcm5122@4d {
+				#sound-dai-cells = <0>;
+				compatible = "ti,pcm5122";
+				reg = <0x4d>;
+				clocks = <&dacpro_osc>;
+				AVDD-supply = <&vdd_3v3_reg>;
+				DVDD-supply = <&vdd_3v3_reg>;
+				CPVDD-supply = <&vdd_3v3_reg>;
+				status = "okay";
+			};
+			hpamp: hpamp@60 {
+				compatible = "ti,tpa6130a2";
+				reg = <0x60>;
+				status = "disabled";
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&sound>;
+		hifiberry_dacplus: __overlay__ {
+			compatible = "hifiberry,hifiberry-dacplus";
+			i2s-controller = <&i2s_clk_consumer>;
+			status = "okay";
+		};
+	};
+
+	__overrides__ {
+		24db_digital_gain =
+			<&hifiberry_dacplus>,"hifiberry,24db_digital_gain?";
+		leds_off = <&hifiberry_dacplus>,"hifiberry-dacplus,leds_off?";
+	};
+};

--- a/arch/arm/boot/dts/overlays/hifiberry-dacplus-std-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dacplus-std-overlay.dts
@@ -1,0 +1,65 @@
+// Definitions for HiFiBerry DAC+ Standard w/o onboard clocks
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			dacpro_osc: dacpro_osc {
+				compatible = "hifiberry,dacpro-clk";
+				#clock-cells = <0>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2s_clk_producer>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			pcm5122@4d {
+				#sound-dai-cells = <0>;
+				compatible = "ti,pcm5122";
+				reg = <0x4d>;
+				clocks = <&dacpro_osc>;
+				AVDD-supply = <&vdd_3v3_reg>;
+				DVDD-supply = <&vdd_3v3_reg>;
+				CPVDD-supply = <&vdd_3v3_reg>;
+				status = "okay";
+			};
+			hpamp: hpamp@60 {
+				compatible = "ti,tpa6130a2";
+				reg = <0x60>;
+				status = "disabled";
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&sound>;
+		hifiberry_dacplus: __overlay__ {
+			compatible = "hifiberry,hifiberry-dacplus";
+			i2s-controller = <&i2s_clk_producer>;
+			hifiberry-dacplus,slave;
+			status = "okay";
+		};
+	};
+
+	__overrides__ {
+		24db_digital_gain =
+			<&hifiberry_dacplus>,"hifiberry,24db_digital_gain?";
+		leds_off = <&hifiberry_dacplus>,"hifiberry-dacplus,leds_off?";
+	};
+};

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -48,6 +48,10 @@
 		bcm2712;
 	};
 
+	hifiberry-dac8x {
+		bcm2712;
+	};
+
 	highperi {
 		bcm2711;
 	};

--- a/sound/soc/bcm/Kconfig
+++ b/sound/soc/bcm/Kconfig
@@ -40,11 +40,12 @@ config SND_BCM2708_SOC_GOOGLEVOICEHAT_SOUNDCARD
           Say Y or M if you want to add support for voiceHAT soundcard.
 
 config SND_BCM2708_SOC_HIFIBERRY_DAC
-        tristate "Support for HifiBerry DAC"
+        tristate "Support for HifiBerry DAC and DAC8X"
         select SND_SOC_PCM5102A
         select SND_RPI_SIMPLE_SOUNDCARD
         help
-         Say Y or M if you want to add support for HifiBerry DAC.
+         Say Y or M if you want to add support for HifiBerry DAC and DAC8X.
+         Note: DAC8X only works on PI5
 
 config SND_BCM2708_SOC_HIFIBERRY_DACPLUS
         tristate "Support for HifiBerry DAC+"

--- a/sound/soc/bcm/rpi-simple-soundcard.c
+++ b/sound/soc/bcm/rpi-simple-soundcard.c
@@ -316,6 +316,37 @@ static struct snd_rpi_simple_drvdata drvdata_hifiberry_dac = {
 	.dai       = snd_hifiberry_dac_dai,
 };
 
+static int hifiberry_dac8x_init(struct snd_soc_pcm_runtime *rtd)
+{
+	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+
+	/* override the defaults to reflect 4 x PCM5102A on the card
+	 * and limit the sample rate to 192ksps
+	 */
+	codec_dai->driver->playback.channels_max = 8;
+	codec_dai->driver->playback.rates = SNDRV_PCM_RATE_8000_192000;
+
+	return 0;
+}
+
+static struct snd_soc_dai_link snd_hifiberry_dac8x_dai[] = {
+	{
+		.name           = "HifiBerry DAC8x",
+		.stream_name    = "HifiBerry DAC8x HiFi",
+		.dai_fmt        = SND_SOC_DAIFMT_I2S |
+					SND_SOC_DAIFMT_NB_NF |
+					SND_SOC_DAIFMT_CBS_CFS,
+		.init           = hifiberry_dac8x_init,
+		SND_SOC_DAILINK_REG(hifiberry_dac),
+	},
+};
+
+static struct snd_rpi_simple_drvdata drvdata_hifiberry_dac8x = {
+	.card_name = "snd_rpi_hifiberry_dac8x",
+	.dai       = snd_hifiberry_dac8x_dai,
+	.fixed_bclk_ratio = 64,
+};
+
 SND_SOC_DAILINK_DEFS(dionaudio_kiwi,
 	DAILINK_COMP_ARRAY(COMP_EMPTY()),
 	DAILINK_COMP_ARRAY(COMP_CODEC("pcm1794a-codec", "pcm1794a-hifi")),
@@ -417,6 +448,8 @@ static const struct of_device_id snd_rpi_simple_of_match[] = {
 		.data = (void *) &drvdata_hifiberry_amp3 },
 	{ .compatible = "hifiberry,hifiberry-dac",
 		.data = (void *) &drvdata_hifiberry_dac },
+	{ .compatible = "hifiberry,hifiberry-dac8x",
+		.data = (void *) &drvdata_hifiberry_dac8x },
 	{ .compatible = "dionaudio,dionaudio-kiwi",
 		.data = (void *) &drvdata_dionaudio_kiwi },
 	{ .compatible = "rpi,rpi-dac", &drvdata_rpi_dac},


### PR DESCRIPTION
With this fix we use dedicated overlays for the STD and PRO boards loading the needed I2S module without probing inside the driver causing potential fail. The former easy switching during driver-init is not easily supported by PI5 architecture.
The former hifiberry-dacplus overlay is kept for compatibility.

These changes will be reflected also in the hat_map definitions using only STD and PRO overlays.