### PR TITLE
ARM: dts: Set all RPi PWM clocks to 50MHz

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2711.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2711.dtsi
@@ -277,7 +277,7 @@
 			reg = <0x7e20c800 0x28>;
 			clocks = <&clocks BCM2835_CLOCK_PWM>;
 			assigned-clocks = <&clocks BCM2835_CLOCK_PWM>;
-			assigned-clock-rates = <10000000>;
+			assigned-clock-rates = <50000000>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};

--- a/arch/arm/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712.dtsi
@@ -345,7 +345,7 @@
 		pwm0: pwm@7d00c000 {
 			compatible = "brcm,bcm2835-pwm";
 			reg = <0x7d00c000 0x28>;
-			assigned-clock-rates = <10000000>;
+			assigned-clock-rates = <50000000>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
@@ -353,7 +353,7 @@
 		pwm1: pwm@7d00c800 {
 			compatible = "brcm,bcm2835-pwm";
 			reg = <0x7d00c800 0x28>;
-			assigned-clock-rates = <10000000>;
+			assigned-clock-rates = <50000000>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};

--- a/arch/arm/boot/dts/broadcom/bcm283x.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm283x.dtsi
@@ -415,7 +415,7 @@
 			reg = <0x7e20c000 0x28>;
 			clocks = <&clocks BCM2835_CLOCK_PWM>;
 			assigned-clocks = <&clocks BCM2835_CLOCK_PWM>;
-			assigned-clock-rates = <10000000>;
+			assigned-clock-rates = <50000000>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};

--- a/arch/arm/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm/boot/dts/broadcom/rp1.dtsi
@@ -383,7 +383,7 @@
 			#pwm-cells = <3>;
 			clocks = <&rp1_clocks RP1_CLK_PWM0>;
 			assigned-clocks = <&rp1_clocks RP1_CLK_PWM0>;
-			assigned-clock-rates = <6144000>;
+			assigned-clock-rates = <50000000>;
 			status = "disabled";
 		};
 
@@ -393,7 +393,7 @@
 			#pwm-cells = <3>;
 			clocks = <&rp1_clocks RP1_CLK_PWM1>;
 			assigned-clocks = <&rp1_clocks RP1_CLK_PWM1>;
-			assigned-clock-rates = <6144000>;
+			assigned-clock-rates = <50000000>;
 			status = "disabled";
 		};
 

--- a/arch/arm/boot/dts/overlays/pwm-2chan-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pwm-2chan-overlay.dts
@@ -34,7 +34,6 @@ N.B.:
 		frag1: __overlay__ {
 			pinctrl-names = "default";
 			pinctrl-0 = <&pwm_pins>;
-			assigned-clock-rates = <100000000>;
 			status = "okay";
 		};
 	};

--- a/arch/arm/boot/dts/overlays/pwm-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pwm-overlay.dts
@@ -32,7 +32,6 @@ N.B.:
 		frag1: __overlay__ {
 			pinctrl-names = "default";
 			pinctrl-0 = <&pwm_pins>;
-			assigned-clock-rates = <100000000>;
 			status = "okay";
 		};
 	};

--- a/arch/arm/boot/dts/overlays/pwm1-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pwm1-overlay.dts
@@ -42,7 +42,6 @@
 		target = <&pwm1>;
 		pwm: __overlay__ {
 			status = "okay";
-			assigned-clock-rates = <100000000>;
 			pinctrl-names = "default";
 			pinctrl-0 = <&pins>;
 		};


### PR DESCRIPTION
With the RP1 PWM configured to use the 50MHz oscillator clock source, requesting a 100MHz clock will fail. Set the RP1 PWM clock rate to 50MHz, do the same to other Pi PWM blocks, and remove the default clock override in the PWM overlays. However, an explicit "clock=..." parameter is still supported.