### PR TITLE
overlays: hat_map: Add all Hifiberry cards

### DIFF
--- a/arch/arm/boot/dts/overlays/hat_map.dts
+++ b/arch/arm/boot/dts/overlays/hat_map.dts
@@ -1,6 +1,81 @@
 /dts-v1/;
 
 / {
+	hifiberry-amp100-1 {
+		uuid = [ 5eb863b8 12f9 41ad 978f 4cee1b3eca62 ];
+		overlay = "hifiberry-amp100";
+	};
+
+	hifiberry-amp100-2 {
+		uuid = [ b1a57dbe 8b52 447f 939e 1baf72157d79 ];
+		overlay = "hifiberry-amp100";
+	};
+
+	hifiberry-amp4pro {
+		uuid = [ 3619722a c92d 4092 95bd 493a2903e933 ];
+		overlay = "hifiberry-amp4pro";
+	};
+
+	hifiberry-amp4 {
+		uuid = [ fcb6ec42 a182 419d a314 7eeae416f608 ];
+		overlay = "hifiberry-dacplus-std";
+	};
+
+	hifiberry-dac2proadc {
+		uuid = [ 30660215 dbb2 4c57 953f 099370b63e2e ];
+		overlay = "hifiberry-dacplusadcpro";
+	};
+
+	hifiberry-dac2hd {
+		uuid = [ 482ad277 5586 480c 88e7 85ae89c4e501 ];
+		overlay = "hifiberry-dacplushd";
+	};
+
+	hifiberry-dac2pro {
+		uuid = [ ebf9cfc4 6d77 4880 89fd 353690467dfc ];
+		overlay = "hifiberry-dacplus-pro";
+	};
+
+	hifiberry-dac8x {
+		uuid = [ f65985f9 5354 4457 ae3b 3da39ba2cf6d ];
+		overlay = "hifiberry-dac8x";
+	};
+
+	hifiberry-dacplus-amp2-1 {
+		uuid = [ 81cac43d 27c6 4a1e a0b2 c70b4e608ab6 ];
+		overlay = "hifiberry-dacplus-std";
+	};
+
+	hifiberry-dacplus-amp2-2 {
+		uuid = [ ef586afc 2efa 47a0 be2e 95a7d952fe98 ];
+		overlay = "hifiberry-dacplus-std";
+	};
+
+	hifiberry-digiplus-pro {
+		uuid = [ 2154f80b 0f92 45e4 96db c1643ec2b46b ];
+		overlay = "hifiberry-digi-pro";
+	};
+
+	hifiberry-dacplusadcpro {
+		uuid = [ 36e3d3da 1ed9 468b aea3 cd165f6820f0 ];
+		overlay = "hifiberry-dacplusadcpro";
+	};
+
+	hifiberry-digi2pro {
+		uuid = [ 5af941bb 4dcf 4eac 82a8 e36e84fcabef ];
+		overlay = "hifiberry-digi-pro";
+	};
+
+	hifiberry-digi2standard {
+		uuid = [ 7c980a0e 9d15 40af 9f40 bddfbd3aee8c ];
+		overlay = "hifiberry-digi";
+	};
+
+	hifiberry-dsp2x4 {
+		uuid = [ 8f287583 429d 4206 a751 862264bbda63 ];
+		overlay = "hifiberry-dacplus-dsp";
+	};
+
 	iqaudio-pi-codecplus {
 		uuid = [ dc1c9594 c1ab 4c6c acda a88dc59a3c5b ];
 		overlay = "iqaudio-codec";


### PR DESCRIPTION
Adds all available Hifberry cards' UUIDs to the hat_map file.