### PR TITLE
dtoverlays: Fixup pendown gpio polarity for ads7846 users

### DIFF
--- a/arch/arm/boot/dts/overlays/ads7846-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ads7846-overlay.dts
@@ -57,7 +57,7 @@
 				spi-max-frequency = <2000000>;
 				interrupts = <255 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
-				pendown-gpio = <&gpio 255 0>;
+				pendown-gpio = <&gpio 255 1>;
 
 				/* driver defaults */
 				ti,x-min = /bits/ 16 <0>;

--- a/arch/arm/boot/dts/overlays/hy28a-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hy28a-overlay.dts
@@ -73,7 +73,7 @@
 				spi-max-frequency = <2000000>;
 				interrupts = <17 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
-				pendown-gpio = <&gpio 17 0>;
+				pendown-gpio = <&gpio 17 1>;
 				ti,x-plate-ohms = /bits/ 16 <100>;
 				ti,pressure-max = /bits/ 16 <255>;
 			};

--- a/arch/arm/boot/dts/overlays/hy28b-2017-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hy28b-2017-overlay.dts
@@ -132,7 +132,7 @@
 				spi-max-frequency = <2000000>;
 				interrupts = <17 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
-				pendown-gpio = <&gpio 17 0>;
+				pendown-gpio = <&gpio 17 1>;
 				ti,x-plate-ohms = /bits/ 16 <100>;
 				ti,pressure-max = /bits/ 16 <255>;
 			};

--- a/arch/arm/boot/dts/overlays/hy28b-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hy28b-overlay.dts
@@ -128,7 +128,7 @@
 				spi-max-frequency = <2000000>;
 				interrupts = <17 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
-				pendown-gpio = <&gpio 17 0>;
+				pendown-gpio = <&gpio 17 1>;
 				ti,x-plate-ohms = /bits/ 16 <100>;
 				ti,pressure-max = /bits/ 16 <255>;
 			};

--- a/arch/arm/boot/dts/overlays/mz61581-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mz61581-overlay.dts
@@ -99,7 +99,7 @@
 				spi-max-frequency = <2000000>;
 				interrupts = <4 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
-				pendown-gpio = <&gpio 4 0>;
+				pendown-gpio = <&gpio 4 1>;
 
 				ti,x-plate-ohms = /bits/ 16 <60>;
 				ti,pressure-max = /bits/ 16 <255>;

--- a/arch/arm/boot/dts/overlays/piscreen-overlay.dts
+++ b/arch/arm/boot/dts/overlays/piscreen-overlay.dts
@@ -87,7 +87,7 @@
 				spi-max-frequency = <2000000>;
 				interrupts = <17 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
-				pendown-gpio = <&gpio 17 0>;
+				pendown-gpio = <&gpio 17 GPIO_ACTIVE_LOW>;
 				ti,swap-xy;
 				ti,x-plate-ohms = /bits/ 16 <100>;
 				ti,pressure-max = /bits/ 16 <255>;

--- a/arch/arm/boot/dts/overlays/piscreen2r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/piscreen2r-overlay.dts
@@ -88,7 +88,7 @@
 				spi-max-frequency = <2000000>;
 				interrupts = <17 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
-				pendown-gpio = <&gpio 17 0>;
+				pendown-gpio = <&gpio 17 1>;
 				ti,swap-xy;
 				ti,x-plate-ohms = /bits/ 16 <100>;
 				ti,pressure-max = /bits/ 16 <255>;

--- a/arch/arm/boot/dts/overlays/tinylcd35-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tinylcd35-overlay.dts
@@ -121,7 +121,7 @@
 				spi-max-frequency = <2000000>;
 				interrupts = <5 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
-				pendown-gpio = <&gpio 5 0>;
+				pendown-gpio = <&gpio 5 1>;
 				ti,x-plate-ohms = /bits/ 16 <100>;
 				ti,pressure-max = /bits/ 16 <255>;
 			};


### PR DESCRIPTION
The driver has been converted to use gpiod, which will normalise polarity based on DT.

The piscreen overlay (and others) incorrectly defines the pendown GPIO as being ACTIVE_HIGH (0), althought triggering on the high-low edge for pen down. It therefore tries reading the pen position when not being touched, and stops when it is touched.

Tested with piscreen and ads7846 overlays. Also fixed on others where the interrupt says high->low but the polarity was ACTIVE_HIGH.

https://github.com/raspberrypi/bookworm-feedback/issues/88