### PR TITLE
ASoC: Fix 16bit sample support for Hifiberry DACplusADC

### DIFF
--- a/sound/soc/bcm/hifiberry_dacplusadc.c
+++ b/sound/soc/bcm/hifiberry_dacplusadc.c
@@ -229,12 +229,10 @@ static int snd_rpi_hifiberry_dacplusadc_hw_params(
 	int ret = 0;
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	int channels = params_channels(params);
-	int width = 32;
+	int width = snd_pcm_format_width(params_format(params));
 
 	if (snd_rpi_hifiberry_is_dacpro) {
 		struct snd_soc_component *component = asoc_rtd_to_codec(rtd, 0)->component;
-
-		width = snd_pcm_format_physical_width(params_format(params));
 
 		snd_rpi_hifiberry_dacplusadc_set_sclk(component,
 			params_rate(params));


### PR DESCRIPTION
Same issue as #5919.
'width' needs to be set independent of clocking mode.