### PR TITLE
overlays: Sets i2s_clk_producer as default for Hifiberry DACplusADC

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1773,7 +1773,7 @@ Params: <None>
 
 
 Name:   hifiberry-dac8x
-Info:   Configures the HifiBerry DAC8X audio cards (only on PI5)
+Info:   Configures the HifiBerry DAC8X audio cards (only on Pi5)
 Load:   dtoverlay=hifiberry-dac8x
 Params: <None>
 
@@ -1860,8 +1860,6 @@ Params: 24db_digital_gain       Allow gain to be applied via the PCM512x codec
                                 responsibility of the user to ensure that
                                 the Digital volume control is set to a value
                                 that does not result in clipping/distortion!)
-        slave                   Force DAC+ADC into slave mode, using Pi as
-                                master for bit clock and frame clock.
         leds_off                If set to 'true' the onboard indicator LEDs
                                 are switched off at all times.
 

--- a/arch/arm/boot/dts/overlays/hifiberry-dacplusadc-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dacplusadc-overlay.dts
@@ -1,4 +1,4 @@
-// Definitions for HiFiBerry DAC+ADC
+// Definitions for HiFiBerry DAC+ADC, no onboard clocks
 /dts-v1/;
 /plugin/;
 
@@ -15,8 +15,8 @@
 		};
 	};
 
-	frag1: fragment@1 {
-		target = <&i2s_clk_consumer>;
+	fragment@1 {
+		target = <&i2s_clk_producer>;
 		__overlay__ {
 			status = "okay";
 		};
@@ -58,7 +58,8 @@
 		target = <&sound>;
 		hifiberry_dacplusadc: __overlay__ {
 			compatible = "hifiberry,hifiberry-dacplusadc";
-			i2s-controller = <&i2s_clk_consumer>;
+			i2s-controller = <&i2s_clk_producer>;
+			hifiberry-dacplusadc,slave;
 			status = "okay";
 		};
 	};
@@ -66,9 +67,6 @@
 	__overrides__ {
 		24db_digital_gain =
 			<&hifiberry_dacplusadc>,"hifiberry,24db_digital_gain?";
-		slave = <&hifiberry_dacplusadc>,"hifiberry-dacplusadc,slave?",
-			<&frag1>,"target:0=",<&i2s_clk_producer>,
-			<&hifiberry_dacplusadc>,"i2s-controller:0=",<&i2s_clk_producer>;
 		leds_off = <&hifiberry_dacplusadc>,"hifiberry-dacplusadc,leds_off?";
 	};
 };


### PR DESCRIPTION
As we have never released a (standard) DACplusADC board with onboard clocks, we can simply use a fixed setup avoiding incompatibilities with Pi5 during driver init. Setting 'hifiberry-dacplusadc,slave' in the overlays disables the failing clock probing mechanism.

README fixes:
1) Removes 'slave' parameter description which is still supported but not needed. 
2) PI5 -> Pi5 @ DAC8X description