### PR TITLE
    Add support for generic i2c-mux base-nr property

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2026,6 +2026,9 @@ Params: pca9542                 Select the NXP PCA9542 device
 
         addr                    Change I2C address of the device (default 0x70)
 
+        base                    Set an explicit base value for the channel bus
+                                numbers
+
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
 
         i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45

--- a/arch/arm/boot/dts/overlays/i2c-mux-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-mux-overlay.dts
@@ -159,6 +159,10 @@
 			<&pca9545>,"reg:0",
 			<&pca9548>,"reg:0";
 
+		base =  <&pca9542>,"base-nr:0",
+			<&pca9545>,"base-nr:0",
+			<&pca9548>,"base-nr:0";
+
 		i2c0 = <&frag100>, "target:0=",<&i2c0>,
 			      <0>,"+101+102";
 		i2c_csi_dsi = <&frag100>, "target:0=",<&i2c_csi_dsi>,

--- a/drivers/i2c/i2c-mux.c
+++ b/drivers/i2c/i2c-mux.c
@@ -355,7 +355,12 @@ int i2c_mux_add_adapter(struct i2c_mux_core *muxc,
 	if (muxc->dev->of_node) {
 		struct device_node *dev_node = muxc->dev->of_node;
 		struct device_node *mux_node, *child = NULL;
+		u32 base_nr = 0;
 		u32 reg;
+
+		of_property_read_u32(dev_node, "base-nr", &base_nr);
+		if (!force_nr)
+			force_nr = base_nr;
 
 		if (muxc->arbitrator)
 			mux_node = of_get_child_by_name(dev_node, "i2c-arb");

--- a/drivers/i2c/i2c-mux.c
+++ b/drivers/i2c/i2c-mux.c
@@ -360,7 +360,7 @@ int i2c_mux_add_adapter(struct i2c_mux_core *muxc,
 
 		of_property_read_u32(dev_node, "base-nr", &base_nr);
 		if (!force_nr)
-			force_nr = base_nr;
+			force_nr = base_nr + chan_id;
 
 		if (muxc->arbitrator)
 			mux_node = of_get_child_by_name(dev_node, "i2c-arb");


### PR DESCRIPTION
It can be desirable to have a fixed, known base address for the channels of a mux. However, there is no easy way to do that from a DT overlay (aliases ought to work, but the overlay application logic can't perform the required string pasting to create "i2c<n>", and creating one alias per channel is tedious). To that end, create a `base-nr` DT property and a `base` parameter that allows the bus number for channel 0 to be specified, with the remaining channels allocated sequentially after it.
