### PR TITLE
dtoverlays: Add a disconnect_on_idle override to i2c-mux

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2042,6 +2042,9 @@ Params: pca9542                 Select the NXP PCA9542 device
         i2c6                    Choose the I2C6 bus (configure with the i2c6
                                 overlay - BCM2711 only)
 
+        disconnect_on_idle      Force the mux to disconnect all child buses
+                                after every transaction.
+
 
 [ The i2c-mux-pca9548a overlay has been deleted. See i2c-mux. ]
 

--- a/arch/arm/boot/dts/overlays/i2c-mux-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-mux-overlay.dts
@@ -3,6 +3,8 @@
 /dts-v1/;
 /plugin/;
 
+#include <dt-bindings/mux/mux.h>
+
 /{
 	compatible = "brcm,bcm2835";
 
@@ -169,5 +171,9 @@
 		       <&frag100>, "target-path=i2c5";
 		i2c6 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c6";
+		disconnect_on_idle =
+			<&pca9542>,"idle-state:0=", <MUX_IDLE_DISCONNECT>,
+			<&pca9545>,"idle-state:0=", <MUX_IDLE_DISCONNECT>,
+			<&pca9548>,"idle-state:0=", <MUX_IDLE_DISCONNECT>;
 	};
 };


### PR DESCRIPTION
When running multiple muxes, in order to be able to reuse the same address on child buses of different muxes you have to disconnect the mux after every transaction.

Add an override to select that option.

See #6039 