### PR TITLE
dmaengine: dw-axi-dmac: Fix a non-atomic update

### DIFF
--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
@@ -465,8 +465,6 @@ static void axi_chan_block_xfer_start(struct axi_dma_chan *chan,
 		return;
 	}
 
-	axi_dma_enable(chan->chip);
-
 	config.dst_multblk_type = DWAXIDMAC_MBLK_TYPE_LL;
 	config.src_multblk_type = DWAXIDMAC_MBLK_TYPE_LL;
 	config.tt_fc = DWAXIDMAC_TT_FC_MEM_TO_MEM_DMAC;


### PR DESCRIPTION
dw_axi_dma_interrupt disables interrupts for the duration of the channel handling. It does so by clearing a bit in the DMA_CFG register - an action that involves a read-modify-write. That in itself would be safe because there will be no further interrupts, hence no reentrancy, were it the only bit of code accessing that register.

The only neighbour of INT_EN is DMAC_EN - the main enable for the block. That's not the sort of thing you would expect to be modified during the normal course of operation, but bizarrely it is set at the start of the transfer of every block, in axi_chan_block_xfer_star, by a call to axi_dma_enable. This can lead to INT_EN being accidentally cleared, which causes all DMA transfers to time out.

One might think that the enabling was being delayed until the first transfer, but the probe function calls axi_dma_resume which in turn calls axi_dma_enable, so that isn't the case.

Fix the atomicity problem by removing the spurious call to axi_dma_enable.

See: #6020, #5858, #5865