### PR TITLE
drivers: mmc: add SD support for Command Queueing

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-5-b.dts
@@ -819,6 +819,7 @@ spi10_cs_pins: &spi10_cs_gpio1 {};
 		random = <&random>, "status";
 		rtc = <&rpi_rtc>, "status";
 		rtc_bbat_vchg = <&rpi_rtc>, "trickle-charge-microvolt:0";
+		sd_cqe = <&sdio1>, "supports-cqe?";
 		spi = <&spi0>, "status";
 		suspend = <&pwr_key>, "linux,code:0=205";
 		uart0 = <&uart0>, "status";

--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -355,6 +355,7 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 	mmc-hs200-1_8v;
 	mmc-hs400-1_8v;
 	broken-cd;
+	supports-cqe;
 	status = "okay";
 };
 

--- a/arch/arm/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712.dtsi
@@ -1214,7 +1214,7 @@
 		clk_emmc2: clk_emmc2 {
 			#clock-cells = <0>;
 			compatible = "fixed-clock";
-			clock-frequency = <54000000>;
+			clock-frequency = <200000000>;
 			clock-output-names = "emmc2-clock";
 		};
 	};

--- a/arch/arm/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712.dtsi
@@ -1119,7 +1119,6 @@
 			clocks = <&clk_emmc2>;
 			sdhci-caps-mask = <0x0000C000 0x0>;
 			sdhci-caps = <0x0 0x0>;
-			supports-cqe;
 			mmc-ddr-3_3v;
 		};
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -344,6 +344,10 @@ Params:
                                 non-lite SKU of CM4).
                                 (default "on")
 
+        sd_cqe                  Use to enable Command Queueing on the SD
+                                interface for faster Class A2 card performance
+                                (Pi 5 only, default "off")
+
         sd_overclock            Clock (in MHz) to use when the MMC framework
                                 requests 50MHz
 

--- a/drivers/mmc/core/block.c
+++ b/drivers/mmc/core/block.c
@@ -886,7 +886,10 @@ static int mmc_blk_part_switch_pre(struct mmc_card *card,
 
 	if ((part_type & mask) == mask) {
 		if (card->ext_csd.cmdq_en) {
-			ret = mmc_cmdq_disable(card);
+			if (mmc_card_sd(card))
+				ret = mmc_sd_cmdq_disable(card);
+			else
+				ret = mmc_cmdq_disable(card);
 			if (ret)
 				return ret;
 		}
@@ -904,8 +907,12 @@ static int mmc_blk_part_switch_post(struct mmc_card *card,
 
 	if ((part_type & mask) == mask) {
 		mmc_retune_unpause(card->host);
-		if (card->reenable_cmdq && !card->ext_csd.cmdq_en)
-			ret = mmc_cmdq_enable(card);
+		if (card->reenable_cmdq && !card->ext_csd.cmdq_en) {
+			if (mmc_card_sd(card))
+				ret = mmc_sd_cmdq_enable(card);
+			else
+				ret = mmc_cmdq_enable(card);
+		}
 	}
 
 	return ret;
@@ -1101,7 +1108,10 @@ static void mmc_blk_issue_drv_op(struct mmc_queue *mq, struct request *req)
 	switch (mq_rq->drv_op) {
 	case MMC_DRV_OP_IOCTL:
 		if (card->ext_csd.cmdq_en) {
-			ret = mmc_cmdq_disable(card);
+			if (mmc_card_sd(card))
+				ret = mmc_sd_cmdq_disable(card);
+			else
+				ret = mmc_cmdq_disable(card);
 			if (ret)
 				break;
 		}
@@ -1119,8 +1129,12 @@ static void mmc_blk_issue_drv_op(struct mmc_queue *mq, struct request *req)
 		/* Always switch back to main area after RPMB access */
 		if (rpmb_ioctl)
 			mmc_blk_part_switch(card, 0);
-		else if (card->reenable_cmdq && !card->ext_csd.cmdq_en)
-			mmc_cmdq_enable(card);
+		else if (card->reenable_cmdq && !card->ext_csd.cmdq_en) {
+			if (mmc_card_sd(card))
+				mmc_sd_cmdq_enable(card);
+			else
+				mmc_cmdq_enable(card);
+		}
 		break;
 	case MMC_DRV_OP_BOOT_WP:
 		ret = mmc_switch(card, EXT_CSD_CMD_SET_NORMAL, EXT_CSD_BOOT_WP,

--- a/drivers/mmc/core/bus.c
+++ b/drivers/mmc/core/bus.c
@@ -264,6 +264,8 @@ static void mmc_release_card(struct device *dev)
 
 	sdio_free_common_cis(card);
 
+	kfree(card->ext_reg_buf);
+
 	kfree(card->info);
 
 	kfree(card);

--- a/drivers/mmc/core/core.c
+++ b/drivers/mmc/core/core.c
@@ -556,7 +556,11 @@ int mmc_cqe_recovery(struct mmc_host *host)
 	mmc_poll_for_busy(host->card, MMC_CQE_RECOVERY_TIMEOUT, true, MMC_BUSY_IO);
 
 	memset(&cmd, 0, sizeof(cmd));
-	cmd.opcode       = MMC_CMDQ_TASK_MGMT;
+	if (mmc_card_sd(host->card))
+		cmd.opcode = SD_CMDQ_TASK_MGMT;
+	else
+		cmd.opcode = MMC_CMDQ_TASK_MGMT;
+
 	cmd.arg          = 1; /* Discard entire queue */
 	cmd.flags        = MMC_RSP_R1B | MMC_CMD_AC;
 	cmd.flags       &= ~MMC_RSP_CRC; /* Ignore CRC */

--- a/drivers/mmc/core/core.c
+++ b/drivers/mmc/core/core.c
@@ -455,6 +455,7 @@ int mmc_cqe_start_req(struct mmc_host *host, struct mmc_request *mrq)
 		goto out_err;
 
 	trace_mmc_request_start(host, mrq);
+	led_trigger_event(host->led, LED_FULL);
 
 	return 0;
 

--- a/drivers/mmc/core/sd.c
+++ b/drivers/mmc/core/sd.c
@@ -1025,9 +1025,8 @@ int sd_write_ext_reg(struct mmc_card *card, u8 fno, u8 page, u16 offset,
 	struct scatterlist sg;
 	u8 *reg_buf;
 
-	reg_buf = kzalloc(512, GFP_KERNEL);
-	if (!reg_buf)
-		return -ENOMEM;
+	reg_buf = card->ext_reg_buf;
+	memset(reg_buf, 0, 512);
 
 	mrq.cmd = &cmd;
 	mrq.data = &data;
@@ -1058,8 +1057,6 @@ int sd_write_ext_reg(struct mmc_card *card, u8 fno, u8 page, u16 offset,
 
 	mmc_set_data_timeout(&data, card);
 	mmc_wait_for_req(host, &mrq);
-
-	kfree(reg_buf);
 
 	/*
 	 * Note that, the SD card is allowed to signal busy on DAT0 up to 1s
@@ -1101,9 +1098,7 @@ static int sd_parse_ext_reg_power(struct mmc_card *card, u8 fno, u8 page,
 	int err;
 	u8 *reg_buf;
 
-	reg_buf = kzalloc(512, GFP_KERNEL);
-	if (!reg_buf)
-		return -ENOMEM;
+	reg_buf = card->ext_reg_buf;
 
 	/* Read the extension register for power management function. */
 	err = sd_read_ext_reg(card, fno, page, offset, 512, reg_buf);
@@ -1133,7 +1128,6 @@ static int sd_parse_ext_reg_power(struct mmc_card *card, u8 fno, u8 page,
 	card->ext_power.offset = offset;
 
 out:
-	kfree(reg_buf);
 	return err;
 }
 
@@ -1143,9 +1137,7 @@ static int sd_parse_ext_reg_perf(struct mmc_card *card, u8 fno, u8 page,
 	int err;
 	u8 *reg_buf;
 
-	reg_buf = kzalloc(512, GFP_KERNEL);
-	if (!reg_buf)
-		return -ENOMEM;
+	reg_buf = card->ext_reg_buf;
 
 	err = sd_read_ext_reg(card, fno, page, offset, 512, reg_buf);
 	if (err) {
@@ -1188,7 +1180,6 @@ static int sd_parse_ext_reg_perf(struct mmc_card *card, u8 fno, u8 page,
 	card->ext_perf.offset = offset;
 
 out:
-	kfree(reg_buf);
 	return err;
 }
 
@@ -1259,6 +1250,12 @@ static int sd_read_ext_regs(struct mmc_card *card)
 	if (!gen_info_buf)
 		return -ENOMEM;
 
+	card->ext_reg_buf = kzalloc(512, GFP_KERNEL);
+	if (!card->ext_reg_buf) {
+		err = -ENOMEM;
+		goto out;
+	}
+
 	/*
 	 * Read 512 bytes of general info, which is found at function number 0,
 	 * at page 0 and with no offset.
@@ -1325,9 +1322,7 @@ static int sd_flush_cache(struct mmc_host *host)
 	if (!sd_cache_enabled(host))
 		return 0;
 
-	reg_buf = kzalloc(512, GFP_KERNEL);
-	if (!reg_buf)
-		return -ENOMEM;
+	reg_buf = card->ext_reg_buf;
 
 	/*
 	 * Set Flush Cache at bit 0 in the performance enhancement register at
@@ -1363,20 +1358,14 @@ static int sd_flush_cache(struct mmc_host *host)
 	if (reg_buf[0] & BIT(0))
 		err = -ETIMEDOUT;
 out:
-	kfree(reg_buf);
 	return err;
 }
 
 static int sd_enable_cache(struct mmc_card *card)
 {
-	u8 *reg_buf;
 	int err;
 
 	card->ext_perf.feature_enabled &= ~SD_EXT_PERF_CACHE;
-
-	reg_buf = kzalloc(512, GFP_KERNEL);
-	if (!reg_buf)
-		return -ENOMEM;
 
 	/*
 	 * Set Cache Enable at bit 0 in the performance enhancement register at
@@ -1396,7 +1385,6 @@ static int sd_enable_cache(struct mmc_card *card)
 		card->ext_perf.feature_enabled |= SD_EXT_PERF_CACHE;
 
 out:
-	kfree(reg_buf);
 	return err;
 }
 

--- a/drivers/mmc/core/sd_ops.c
+++ b/drivers/mmc/core/sd_ops.c
@@ -365,3 +365,40 @@ int mmc_app_sd_status(struct mmc_card *card, void *ssr)
 
 	return 0;
 }
+
+int sd_write_ext_reg(struct mmc_card *card, u8 fno, u8 page, u16 offset,
+		     u8 reg_data);
+
+static int mmc_sd_cmdq_switch(struct mmc_card *card, bool enable)
+{
+	int err;
+	u8 reg = 0;
+	/*
+	 * SD offers two command queueing modes - sequential (in-order) and
+	 * voluntary (out-of-order). Apps Class A2 performance is only
+	 * guaranteed for voluntary CQ (bit 1 = 0), so use that in preference
+	 * to sequential.
+	 */
+	if (enable)
+		reg = BIT(0);
+
+	/* Performance enhancement register byte 262 controls command queueing */
+	err = sd_write_ext_reg(card, card->ext_perf.fno, card->ext_perf.page,
+			       card->ext_perf.offset + 262, reg);
+	if (!err)
+		card->ext_csd.cmdq_en = enable;
+
+	return err;
+}
+
+int mmc_sd_cmdq_enable(struct mmc_card *card)
+{
+	return mmc_sd_cmdq_switch(card, true);
+}
+EXPORT_SYMBOL_GPL(mmc_sd_cmdq_enable);
+
+int mmc_sd_cmdq_disable(struct mmc_card *card)
+{
+	return mmc_sd_cmdq_switch(card, false);
+}
+EXPORT_SYMBOL_GPL(mmc_sd_cmdq_disable);

--- a/drivers/mmc/core/sd_ops.h
+++ b/drivers/mmc/core/sd_ops.h
@@ -21,6 +21,8 @@ int mmc_send_relative_addr(struct mmc_host *host, unsigned int *rca);
 int mmc_app_send_scr(struct mmc_card *card);
 int mmc_app_sd_status(struct mmc_card *card, void *ssr);
 int mmc_app_cmd(struct mmc_host *host, struct mmc_card *card);
+int mmc_sd_cmdq_enable(struct mmc_card *card);
+int mmc_sd_cmdq_disable(struct mmc_card *card);
 
 #endif
 

--- a/drivers/mmc/host/sdhci-brcmstb.c
+++ b/drivers/mmc/host/sdhci-brcmstb.c
@@ -41,6 +41,9 @@
 #define  SDIO_CFG_SD_PIN_SEL_SD			BIT(1)
 #define  SDIO_CFG_SD_PIN_SEL_MMC		BIT(0)
 
+#define SDIO_CFG_CQ_CAPABILITY			0x4c
+#define  SDIO_CFG_CQ_CAPABILITY_FMUL_SHIFT	12
+
 #define SDIO_CFG_MAX_50MHZ_MODE			0x1ac
 #define  SDIO_CFG_MAX_50MHZ_MODE_STRAP_OVERRIDE	BIT(31)
 #define  SDIO_CFG_MAX_50MHZ_MODE_ENABLE		BIT(0)
@@ -201,7 +204,7 @@ static void sdhci_brcmstb_cfginit_2712(struct sdhci_host *host)
 	u32 uhs_mask = (MMC_CAP_UHS_SDR50 | MMC_CAP_UHS_SDR104);
 	u32 hsemmc_mask = (MMC_CAP2_HS200_1_8V_SDR | MMC_CAP2_HS200_1_2V_SDR |
 			   MMC_CAP2_HS400_1_8V | MMC_CAP2_HS400_1_2V);
-	u32 reg;
+	u32 reg, base_clk_mhz;
 
 	/*
 	* If we support a speed that requires tuning,
@@ -222,6 +225,11 @@ static void sdhci_brcmstb_cfginit_2712(struct sdhci_host *host)
 		reg |= SDIO_CFG_CTRL_SDCD_N_TEST_EN;
 		writel(reg, brcmstb_priv->cfg_regs + SDIO_CFG_CTRL);
 	}
+
+	/* Guesstimate the timer frequency (controller base clock) */
+	base_clk_mhz = max_t(u32, clk_get_rate(pltfm_host->clk) / (1000 * 1000), 1);
+	reg = (3 << SDIO_CFG_CQ_CAPABILITY_FMUL_SHIFT) | base_clk_mhz;
+	writel(reg, brcmstb_priv->cfg_regs + SDIO_CFG_CQ_CAPABILITY);
 }
 
 static int bcm2712_init_sd_express(struct sdhci_host *host, struct mmc_ios *ios)
@@ -493,6 +501,8 @@ static int sdhci_brcmstb_probe(struct platform_device *pdev)
 		return PTR_ERR(host);
 
 	pltfm_host = sdhci_priv(host);
+	pltfm_host->clk = clk;
+
 	priv = sdhci_pltfm_priv(pltfm_host);
 	if (device_property_read_bool(&pdev->dev, "supports-cqe")) {
 		priv->flags |= BRCMSTB_PRIV_FLAGS_HAS_CQE;
@@ -623,7 +633,6 @@ add_host:
 	if (res)
 		goto err;
 
-	pltfm_host->clk = clk;
 	return res;
 
 err:

--- a/include/linux/mmc/card.h
+++ b/include/linux/mmc/card.h
@@ -320,6 +320,7 @@ struct mmc_card {
 	struct sd_switch_caps	sw_caps;	/* switch (CMD6) caps */
 	struct sd_ext_reg	ext_power;	/* SD extension reg for PM */
 	struct sd_ext_reg	ext_perf;	/* SD extension reg for PERF */
+	u8			*ext_reg_buf;	/* 512 byte block for extension register R/W */
 
 	unsigned int		sdio_funcs;	/* number of SDIO functions */
 	atomic_t		sdio_funcs_probed; /* number of probed SDIO funcs */

--- a/include/linux/mmc/sd.h
+++ b/include/linux/mmc/sd.h
@@ -29,6 +29,9 @@
 #define SD_APP_OP_COND           41   /* bcr  [31:0] OCR         R3  */
 #define SD_APP_SEND_SCR          51   /* adtc                    R1  */
 
+  /* class 1 */
+#define SD_CMDQ_TASK_MGMT        43   /* ac   See below          R1b */
+
   /* class 11 */
 #define SD_READ_EXTR_SINGLE      48   /* adtc [31:0]             R1  */
 #define SD_WRITE_EXTR_SINGLE     49   /* adtc [31:0]             R1  */
@@ -58,6 +61,15 @@
  *	[31:12] Reserved (0)
  *	[11:8] Host Voltage Supply Flags
  *	[7:0] Check Pattern (0xAA)
+ */
+
+/*
+ * SD_CMDQ_TASK_MGMT argument format:
+ *
+ * [31:21] Reserved (0)
+ * [20:16] Task ID
+ * [15:4] Reserved (0)
+ * [3:0] Operation - 0x1 = abort all tasks, 0x2 = abort Task ID
  */
 
 /*


### PR DESCRIPTION
Application class A2 cards require CQ to be enabled to realise their stated performance figures. Add support to enable/disable card CQ via the Performance Enhancement extension register, and cater for the slight differences in command set versus eMMC.

--

Tested using a 64GB Sandisk Extreme U3 class A2 card. Typical performance uplift is ~2.5x for random 4k read, and 4x for random 4k write. There are sporadic instances of errors (usually command timeouts) that result in the queue being flushed, but I've not been able to identify a pattern/set of commands that cause it.

Please don't merge immediately. I want a testing thread on the forums to flush out anything that's going to be fatal to your root filesystem first...