### PR TITLE
ARM: dts: bcm2712: Move /soc/sound to bcm2712-rpi

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -158,6 +158,10 @@ pciex4: &pcie2 { };
 		reg = <0x7d510700 0x20>;
 		chardev-name = "gpiomem4";
 	};
+
+	sound: sound {
+		status = "disabled";
+	};
 };
 
 i2c0: &rp1_i2c0 { };

--- a/arch/arm/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712.dtsi
@@ -720,9 +720,6 @@
 			dma-names = "audio-rx";
 			status = "disabled";
 		};
-
-		sound: sound {
-		};
 	};
 
 	arm-pmu {


### PR DESCRIPTION
The /soc/sound node is not a feature of the bcm2712 hardware, rather a Raspberry Pi convention of where to declare soundcards. Move it to bcm2712-rpi.dtsi accordingly, at the same time marking it as disabled so that runtime overlay application causes the soundcard device to be created.

See: https://forums.raspberrypi.com/viewtopic.php?t=367530