### PR TITLE
overlays: i2c-rtc: pcf8563 supports wakeup-source

### DIFF
--- a/arch/arm/boot/dts/overlays/i2c-rtc-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-rtc-common.dtsi
@@ -348,6 +348,7 @@
 				<&ds3231>,"wakeup-source?",
 				<&mcp7940x>,"wakeup-source?",
 				<&mcp7941x>,"wakeup-source?",
-				<&m41t62>,"wakeup-source?";
+				<&m41t62>,"wakeup-source?",
+				<&pcf8563>,"wakeup-source?";
 	};
 };


### PR DESCRIPTION
PCF8563 has alarm functionality, so allow it to accept the wakeup-source parameter.

See: https://github.com/raspberrypi/linux/issues/6030