### PR TITLE
ARM: dts: pi400: Force stdout-path to serial0

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-400.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-400.dts
@@ -43,6 +43,12 @@
 // =============================================
 // Downstream rpi- changes
 
+/ {
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+};
+
 &audio_pins {
 	brcm,pins = <>;
 	brcm,function = <>;


### PR DESCRIPTION
The upstream Pi DTS files select serial1 for stdout-path, but because of the way the downstream kernel numbers UARTS, serial0 is required in the downstream DTS. Using the wrong value breaks U-boot.

In the 6.6 kernel the downstream Pi 400 DTS was made closer to upstream, inheriting most of its content from the Pi 4B DTS, but because of the order of inclusion it lost the override for stdout-path. Restore that override.

See: https://github.com/raspberrypi/firmware/issues/1875