### PR TITLE
drivers: sdhci-brcmstb: work around mystery CQE CMD_IDLE_TIMER trampling

### DIFF
--- a/drivers/mmc/host/sdhci-brcmstb.c
+++ b/drivers/mmc/host/sdhci-brcmstb.c
@@ -338,6 +338,7 @@ static void sdhci_brcmstb_dumpregs(struct mmc_host *mmc)
 static void sdhci_brcmstb_cqe_enable(struct mmc_host *mmc)
 {
 	struct sdhci_host *host = mmc_priv(mmc);
+	struct cqhci_host *cq_host = mmc->cqe_private;
 	u32 reg;
 
 	reg = sdhci_readl(host, SDHCI_PRESENT_STATE);
@@ -347,6 +348,9 @@ static void sdhci_brcmstb_cqe_enable(struct mmc_host *mmc)
 	}
 
 	sdhci_cqe_enable(mmc);
+
+	/* Reset CMD13 polling timer back to eMMC specification default */
+	cqhci_writel(cq_host, 0x00011000, CQHCI_SSC1);
 }
 
 static const struct cqhci_host_ops sdhci_brcmstb_cqhci_ops = {


### PR DESCRIPTION
For unknown reasons the controller seems to reset the idle polling timer interval on CQE enable/disable to 8 clocks which is extremely short.

Just use the reset value in the eMMC spec (4096 clock periods which at 200MHz is ~20uS).