### PR TITLE
ARM: dts: bcm2712: Add the missing L1/L2/L3 cache information

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712.dtsi
@@ -750,12 +750,22 @@
 		#size-cells = <0>;
 		enable-method = "brcm,bcm2836-smp"; // for ARM 32-bit
 
+		/* Source for d/i cache-line-size, cache-sets, cache-size
+		 * https://developer.arm.com/documentation/100798/0401
+		 * /L1-memory-system/About-the-L1-memory-system?lang=en
+		 */
 		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a76";
 			reg = <0x000>;
 			enable-method = "psci";
-			next-level-cache = <&l2_cache>;
+			d-cache-size = <0x10000>;
+			d-cache-line-size = <64>;
+			d-cache-sets = <256>; // 64KiB(size)/64(line-size)=1024ways/4-way set
+			i-cache-size = <0x10000>;
+			i-cache-line-size = <64>;
+			i-cache-sets = <256>; // 64KiB(size)/64(line-size)=1024ways/4-way set
+			next-level-cache = <&l2_cache_l0>;
 		};
 
 		cpu1: cpu@1 {
@@ -763,7 +773,13 @@
 			compatible = "arm,cortex-a76";
 			reg = <0x100>;
 			enable-method = "psci";
-			next-level-cache = <&l2_cache>;
+			d-cache-size = <0x10000>;
+			d-cache-line-size = <64>;
+			d-cache-sets = <256>; // 64KiB(size)/64(line-size)=1024ways/4-way set
+			i-cache-size = <0x10000>;
+			i-cache-line-size = <64>;
+			i-cache-sets = <256>; // 64KiB(size)/64(line-size)=1024ways/4-way set
+			next-level-cache = <&l2_cache_l1>;
 		};
 
 		cpu2: cpu@2 {
@@ -771,7 +787,13 @@
 			compatible = "arm,cortex-a76";
 			reg = <0x200>;
 			enable-method = "psci";
-			next-level-cache = <&l2_cache>;
+			d-cache-size = <0x10000>;
+			d-cache-line-size = <64>;
+			d-cache-sets = <256>; // 64KiB(size)/64(line-size)=1024ways/4-way set
+			i-cache-size = <0x10000>;
+			i-cache-line-size = <64>;
+			i-cache-sets = <256>; // 64KiB(size)/64(line-size)=1024ways/4-way set
+			next-level-cache = <&l2_cache_l2>;
 		};
 
 		cpu3: cpu@3 {
@@ -779,16 +801,73 @@
 			compatible = "arm,cortex-a76";
 			reg = <0x300>;
 			enable-method = "psci";
-			next-level-cache = <&l2_cache>;
+			d-cache-size = <0x10000>;
+			d-cache-line-size = <64>;
+			d-cache-sets = <256>; // 64KiB(size)/64(line-size)=1024ways/4-way set
+			i-cache-size = <0x10000>;
+			i-cache-line-size = <64>;
+			i-cache-sets = <256>; // 64KiB(size)/64(line-size)=1024ways/4-way set
+			next-level-cache = <&l2_cache_l3>;
 		};
 
-		l2_cache: l2-cache {
+		/* Source for cache-line-size and cache-sets:
+		 * https://developer.arm.com/documentation/100798/0401
+		 * /L2-memory-system/About-the-L2-memory-system?lang=en
+		 * and for cache-size:
+		 * https://www.raspberrypi.com/documentation/computers
+		 * /processors.html#bcm2712
+		 */
+		l2_cache_l0: l2-cache-l0 {
 			compatible = "cache";
+			cache-size = <0x80000>;
+			cache-line-size = <128>;
+			cache-sets = <1024>; // 512KiB(size)/64(line-size)=8192ways/8-way set
+			cache-level = <2>;
+			cache-unified;
 			next-level-cache = <&l3_cache>;
 		};
 
+		l2_cache_l1: l2-cache-l1 {
+			compatible = "cache";
+			cache-size = <0x80000>;
+			cache-line-size = <128>;
+			cache-sets = <1024>; // 512KiB(size)/64(line-size)=8192ways/8-way set
+			cache-level = <2>;
+			cache-unified;
+			next-level-cache = <&l3_cache>;
+		};
+
+		l2_cache_l2: l2-cache-l2 {
+			compatible = "cache";
+			cache-size = <0x80000>;
+			cache-line-size = <128>;
+			cache-sets = <1024>; // 512KiB(size)/64(line-size)=8192ways/8-way set
+			cache-level = <2>;
+			cache-unified;
+			next-level-cache = <&l3_cache>;
+		};
+
+		l2_cache_l3: l2-cache-l3 {
+			compatible = "cache";
+			cache-size = <0x80000>;
+			cache-line-size = <128>;
+			cache-sets = <1024>; // 512KiB(size)/64(line-size)=8192ways/8-way set
+			cache-level = <2>;
+			cache-unified;
+			next-level-cache = <&l3_cache>;
+		};
+
+		/* Source for cache-line-size and cache-sets:
+		 * https://developer.arm.com/documentation/100453/0401/L3-cache?lang=en
+		 * Source for cache-size:
+		 * https://www.raspberrypi.com/documentation/computers/processors.html#bcm2712
+		 */
 		l3_cache: l3-cache {
 			compatible = "cache";
+			cache-size = <0x200000>;
+			cache-line-size = <64>;
+			cache-sets = <2048>; // 2MiB(size)/64(line-size)=32768ways/16-way set
+			cache-level = <3>;
 		};
 	};
 


### PR DESCRIPTION
This provides the missing cache information for bcm2712

lscpu now reports:

Caches (sum of all):
  L1d:                    256 KiB (4 instances)
  L1i:                    256 KiB (4 instances)
  L2:                     2 MiB (4 instances)
  L3:                     2 MiB (1 instance)