### PR TITLE
drm/vc4: Enable bg_fill if there are no planes enabled

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hvs.c
+++ b/drivers/gpu/drm/vc4/vc4_hvs.c
@@ -1406,7 +1406,7 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 	struct drm_plane *plane;
 	struct vc4_plane_state *vc4_plane_state;
 	bool debug_dump_regs = false;
-	bool enable_bg_fill = false;
+	bool enable_bg_fill = true;
 	u32 __iomem *dlist_start, *dlist_next;
 	unsigned long irqflags;
 	unsigned int zpos = 0;


### PR DESCRIPTION
The default was to have enable_bg_fill disabled and the first plane set it if it wasn't opaque and covering the whole screen. However that meant that if no planes were enabled, then the background fill wasn't enabled, and would give a striped output from the uninitialised output buffer.

Initialise it to enabled to avoid this.