### PR TITLE
dts: bcm2712: Add blpubkey nvram node

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-5-b.dts
@@ -744,6 +744,7 @@ spi10_cs_pins: &spi10_cs_gpio1 {};
 / {
 	aliases: aliases {
 		blconfig = &blconfig;
+		blpubkey = &blpubkey;
 		bluetooth = &bluetooth;
 		console = &uart10;
 		ethernet0 = &rp1_eth;

--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -745,6 +745,7 @@ spi10_cs_pins: &spi10_cs_gpio1 {};
 / {
 	aliases: aliases {
 		blconfig = &blconfig;
+		blpubkey = &blpubkey;
 		bluetooth = &bluetooth;
 		console = &uart10;
 		ethernet0 = &rp1_eth;

--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -102,12 +102,24 @@ pciex4: &pcie2 { };
 
 &rmem {
 	/*
-	 * RPi4's co-processor will copy the board's bootloader configuration
+	 * RPi5's co-processor will copy the board's bootloader configuration
 	 * into memory for the OS to consume. It'll also update this node with
 	 * its placement information.
 	 */
 	blconfig: nvram@0 {
 		compatible = "raspberrypi,bootloader-config", "nvmem-rmem";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0x0 0x0 0x0>;
+		no-map;
+		status = "disabled";
+	};
+	/*
+	 * RPi5 will copy the binary public key blob (if present) from the bootloader
+	 * into memory for use by the OS.
+	 */
+	blpubkey: nvram@1 {
+		compatible = "raspberrypi,bootloader-public-key", "nvmem-rmem";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		reg = <0x0 0x0 0x0>;


### PR DESCRIPTION
The RPi5 firmware also supports exporting the customer public key stored in flash via device-tree. Define the node so that the firmware can populate it.