### PR TITLE
Unicam FS/FE timing GPIO

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm270x-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm270x-rpi.dtsi
@@ -97,6 +97,19 @@
 		drm_fb0_vc4 = <&aliases>, "drm-fb0=",&vc4;
 		drm_fb1_vc4 = <&aliases>, "drm-fb1=",&vc4;
 		drm_fb2_vc4 = <&aliases>, "drm-fb2=",&vc4;
+
+		cam1_sync = <&csi1>, "sync-gpios:0=", <&gpio>,
+			    <&csi1>, "sync-gpios:4",
+			    <&csi1>, "sync-gpios:8=0", <GPIO_ACTIVE_HIGH>;
+		cam1_sync_inverted = <&csi1>, "sync-gpios:0=", <&gpio>,
+			    <&csi1>, "sync-gpios:4",
+			    <&csi1>, "sync-gpios:8=0", <GPIO_ACTIVE_LOW>;
+		cam0_sync = <&csi0>, "sync-gpios:0=", <&gpio>,
+			    <&csi0>, "sync-gpios:4",
+			    <&csi0>, "sync-gpios:8=0", <GPIO_ACTIVE_HIGH>;
+		cam0_sync_inverted = <&csi0>, "sync-gpios:0=", <&gpio>,
+			    <&csi0>, "sync-gpios:4",
+			    <&csi0>, "sync-gpios:8=0", <GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -170,6 +170,18 @@ Params:
                                 Default of GPIO expander 5 on CM4, but override
                                 switches to normal GPIO.
 
+        cam0_sync               Enable a GPIO to reflect frame sync from CSI0,
+                                going high on frame start, and low on frame end.
+
+        cam0_sync_inverted      Enable a GPIO to reflect frame sync from CSI0
+                                going low on frame start, and high on frame end.
+
+        cam1_sync               Enable a GPIO to reflect frame sync from CSI1,
+                                going high on frame start, and low on frame end.
+
+        cam1_sync_inverted      Enable a GPIO to reflect frame sync from CSI1
+                                going low on frame start, and high on frame end.
+
         cooling_fan             Enables the Pi 5 cooling fan (enabled
                                 automatically by the firmware)
 


### PR DESCRIPTION
Replicates the firmware option to enable a GPIO to follow CSI frame start/end timings.

https://forums.raspberrypi.com/viewtopic.php?t=368437