### PR TITLE
dts: bcm2712: cm5: Disable HS400

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -353,7 +353,6 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 	sd-uhs-ddr50;
 	sd-uhs-sdr104;
 	mmc-hs200-1_8v;
-	mmc-hs400-1_8v;
 	broken-cd;
 	supports-cqe;
 	status = "okay";


### PR DESCRIPTION
Disable HS400 support on CM5 until this is proved to be stable.