### PR TITLE
i2c: designware: Make the SDA hold time half LCNT

### DIFF
--- a/arch/arm/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm/boot/dts/broadcom/rp1.dtsi
@@ -307,7 +307,6 @@
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
 			i2c-scl-rising-time-ns = <65>;
 			i2c-scl-falling-time-ns = <100>;
-			i2c-sda-hold-time-ns = <300>;
 			status = "disabled";
 		};
 
@@ -318,7 +317,6 @@
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
 			i2c-scl-rising-time-ns = <65>;
 			i2c-scl-falling-time-ns = <100>;
-			i2c-sda-hold-time-ns = <300>;
 			status = "disabled";
 		};
 
@@ -329,7 +327,6 @@
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
 			i2c-scl-rising-time-ns = <65>;
 			i2c-scl-falling-time-ns = <100>;
-			i2c-sda-hold-time-ns = <300>;
 			status = "disabled";
 		};
 
@@ -340,7 +337,6 @@
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
 			i2c-scl-rising-time-ns = <65>;
 			i2c-scl-falling-time-ns = <100>;
-			i2c-sda-hold-time-ns = <300>;
 			status = "disabled";
 		};
 
@@ -351,7 +347,6 @@
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
 			i2c-scl-rising-time-ns = <65>;
 			i2c-scl-falling-time-ns = <100>;
-			i2c-sda-hold-time-ns = <300>;
 			status = "disabled";
 		};
 
@@ -362,7 +357,6 @@
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
 			i2c-scl-rising-time-ns = <65>;
 			i2c-scl-falling-time-ns = <100>;
-			i2c-sda-hold-time-ns = <300>;
 			status = "disabled";
 		};
 
@@ -373,7 +367,6 @@
 			clocks = <&rp1_clocks RP1_CLK_SYS>;
 			i2c-scl-rising-time-ns = <65>;
 			i2c-scl-falling-time-ns = <100>;
-			i2c-sda-hold-time-ns = <300>;
 			status = "disabled";
 		};
 

--- a/drivers/i2c/busses/i2c-designware-master.c
+++ b/drivers/i2c/busses/i2c-designware-master.c
@@ -194,6 +194,9 @@ static int i2c_dw_set_timings_master(struct dw_i2c_dev *dev)
 			dev->hs_hcnt, dev->hs_lcnt);
 	}
 
+	if (!dev->sda_hold_time)
+		dev->sda_hold_time = lcnt / 2;
+
 	ret = i2c_dw_set_sda_hold(dev);
 	if (ret)
 		return ret;


### PR DESCRIPTION
Here's another attempt at improving the Pi 5 I2C compatibility and reliability. The observation from small LCD displays discussed in #6056 is that something causes the ACK to be released early. Comparing the traces to Pi 4 showed that the ACK signal starts much earlier on Pi 5 - it's roughly halfway through the SCL low on Pi 4. Increasing the SDA hold time to half the SCL low cycle count gives the same appearance on Pi 5 and seems to fix the issue.

The new logic is dependent on there not being an explicit override from Device Tree, so the second part of this PR is a reversion of the commit that added the sda-hold-time-ns values.