### PR TITLE
Fix UVC gadget support on 32-bit systems

### DIFF
--- a/drivers/usb/gadget/function/uvc_configfs.c
+++ b/drivers/usb/gadget/function/uvc_configfs.c
@@ -92,10 +92,10 @@ static int __uvcg_iter_item_entries(const char *page, size_t len,
 
 	while (pg - page < len) {
 		i = 0;
-		while (i < sizeof(buf) && (pg - page < len) &&
+		while (i < bufsize && (pg - page < len) &&
 		       *pg != '\0' && *pg != '\n')
 			buf[i++] = *pg++;
-		if (i == sizeof(buf)) {
+		if (i == bufsize) {
 			ret = -EINVAL;
 			goto out_free_buf;
 		}


### PR DESCRIPTION
Note that this is clearly a common upstream problem, not specific to Raspberry Pi. I will work with mainline kernel to get this upstreamed (when I figure out how to do so :)), which will take quite some time.

Given that currently UVC gadget support is completely broken on 6.6 32-bit kernel, I believe that this is valuable for the community to be included into Raspberry Pi kernels sooner than doing it in the roundabout way through upstream.

The problem description follows:

Commit 0df28607c5cb4fe60bba591e9858a8f7ba39aa4a introduced a helper function to parse commonly occurring strings containing lists of numbers. Original functions used `buf` buffer on stack, and queried its size using `sizeof(buf)` to avoid overrun. The newly intruduced function, however, used a dynamically sized heap-allocated buffer, but wasn't updated to use this new buffer size instead of just sizeof.

Therefore, parsing now can only read items of size 3 max on 32-bit systems, and of size 7 on 64-bit ones. Some UVC fields do need numbers with more digits, e.g. `dwFrameInteval` needs at least 5-6, so it fails to be written into, thus completely breaking UVC gadget support on 32 bit systems.