### PR TITLE
module: Avoid ABI changes when debug info is disabled

### DIFF
--- a/include/linux/module.h
+++ b/include/linux/module.h
@@ -507,7 +507,7 @@ struct module {
 	unsigned int num_bpf_raw_events;
 	struct bpf_raw_event_map *bpf_raw_events;
 #endif
-#ifdef CONFIG_DEBUG_INFO_BTF_MODULES
+#if 1
 	unsigned int btf_data_size;
 	void *btf_data;
 #endif


### PR DESCRIPTION
CI builds are done with debug info disabled, but this removes some members from struct module.  This causes builds to fail if there is an ABI reference for the current ABI.

Define these members unconditionally, so that there is no ABI change.