### PR TITLE
dts: bcm2712: cm5: Add antenna controls

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -344,7 +344,7 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 
 /* SDIO1 is used to drive the eMMC/SD card */
 &sdio1 {
-	pinctrl-0 = <&emmc_cmddat_pulls>, <&emmc_ds_pull>, <&emmc_aon_cd_pins>;
+	pinctrl-0 = <&emmc_cmddat_pulls>, <&emmc_ds_pull>;
 	pinctrl-names = "default";
 	vqmmc-supply = <&sd_io_1v8_reg>;
 	vmmc-supply = <&sd_vcc_reg>;
@@ -359,10 +359,6 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 };
 
 &pinctrl_aon {
-	emmc_aon_cd_pins: emmc_aon_cd_pins {
-		function = "sd_card_g";
-		pins = "aon_gpio5";
-		bias-pull-up;
 	};
 
 	/* Slight hack - only one PWM pin (status LED) is usable */

--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -359,6 +359,9 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 };
 
 &pinctrl_aon {
+	ant_pins: ant_pins {
+		function = "gpio";
+		pins = "aon_gpio5", "aon_gpio6";
 	};
 
 	/* Slight hack - only one PWM pin (status LED) is usable */
@@ -461,7 +464,7 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 
 /* SDIO2 drives the WLAN interface */
 &sdio2 {
-	pinctrl-0 = <&sdio2_30_pins>;
+	pinctrl-0 = <&sdio2_30_pins>, <&ant_pins>;
 	pinctrl-names = "default";
 	bus-width = <4>;
 	vmmc-supply = <&wl_on_reg>;

--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -670,6 +670,22 @@ spi10_cs_pins: &spi10_cs_gpio1 {};
 		output-high;
 		line-name = "RP1 RUN pin";
 	};
+
+	ant1: ant1-hog {
+		gpio-hog;
+		gpios = <5 GPIO_ACTIVE_HIGH>;
+		/* internal antenna enabled */
+		output-high;
+		line-name = "ant1";
+	};
+
+	ant2: ant2-hog {
+		gpio-hog;
+		gpios = <6 GPIO_ACTIVE_HIGH>;
+		/* external antenna disabled */
+		output-low;
+		line-name = "ant2";
+	};
 };
 
 &rp1_gpio {
@@ -839,6 +855,19 @@ spi10_cs_pins: &spi10_cs_gpio1 {};
 		drm_fb2_rp1_dsi1 = <&aliases>, "drm-fb2=",&dsi1;
 		drm_fb2_rp1_dpi = <&aliases>, "drm-fb2=",&dpi;
 		drm_fb2_vc4 = <&aliases>, "drm-fb2=",&vc4;
+
+		ant1 =  <&ant1>,"output-high?=on",
+			<&ant1>, "output-low?=off",
+			<&ant2>, "output-high?=off",
+			<&ant2>, "output-low?=on";
+		ant2 =  <&ant1>,"output-high?=off",
+			<&ant1>, "output-low?=on",
+			<&ant2>, "output-high?=on",
+			<&ant2>, "output-low?=off";
+		noant = <&ant1>,"output-high?=off",
+			<&ant1>, "output-low?=on",
+			<&ant2>, "output-high?=off",
+			<&ant2>, "output-low?=on";
 
 		fan_temp0 = <&cpu_tepid>,"temperature:0";
 		fan_temp1 = <&cpu_warm>,"temperature:0";

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -130,11 +130,11 @@ Name:   <The base DTB>
 Info:   Configures the base Raspberry Pi hardware
 Load:   <loaded automatically>
 Params:
-        ant1                    Select antenna 1 (default). CM4 only.
+        ant1                    Select antenna 1 (default). CM4/5 only.
 
-        ant2                    Select antenna 2. CM4 only.
+        ant2                    Select antenna 2. CM4/5 only.
 
-        noant                   Disable both antennas. CM4 only.
+        noant                   Disable both antennas. CM4/5 only.
 
         audio                   Set to "on" to enable the onboard ALSA audio
                                 interface (default "off")


### PR DESCRIPTION
Use the same ant1/ant2/noant controls as CM4.