### PR TITLE
DTS: rp1: fix setting xHCI TX burst fifo thresholds

### DIFF
--- a/arch/arm/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm/boot/dts/broadcom/rp1.dtsi
@@ -1077,8 +1077,8 @@
 			snps,parkmode-disable-ss-quirk;
 			snps,parkmode-disable-hs-quirk;
 			snps,parkmode-disable-fsls-quirk;
-			snps,tx-max-burst-prd = <8>;
-			snps,tx-thr-num-pkt-prd = <2>;
+			snps,tx-max-burst = /bits/ 8 <8>;
+			snps,tx-thr-num-pkt = /bits/ 8 <2>;
 			interrupts = <RP1_INT_USBHOST0_0 IRQ_TYPE_EDGE_RISING>;
 			status = "disabled";
 		};
@@ -1093,8 +1093,8 @@
 			snps,parkmode-disable-ss-quirk;
 			snps,parkmode-disable-hs-quirk;
 			snps,parkmode-disable-fsls-quirk;
-			snps,tx-max-burst-prd = <8>;
-			snps,tx-thr-num-pkt-prd = <2>;
+			snps,tx-max-burst = /bits/ 8 <8>;
+			snps,tx-thr-num-pkt = /bits/ 8 <2>;
 			interrupts = <RP1_INT_USBHOST1_0 IRQ_TYPE_EDGE_RISING>;
 			status = "disabled";
 		};


### PR DESCRIPTION
See https://github.com/raspberrypi/firmware/issues/1877

Morgan's law bites again: I didn't check that the register value stuck after testing manually...