### PR TITLE
DTS: overlays: fix Pi 5 midi-over-UART

### DIFF
--- a/arch/arm/boot/dts/overlays/midi-uart0-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart0-pi5-overlay.dts
@@ -5,10 +5,10 @@
 
 /*
  * Fake a higher clock rate to get a larger divisor, and thereby a lower
- * baudrate. The real clock is 100MHz, which we scale so that requesting
+ * baudrate. The real clock is 50MHz, which we scale so that requesting
  * 38.4kHz results in an actual 31.25kHz.
  *
- *   100000000*38400/31250 = 122880000
+ *   50000000*38400/31250 = 61440000
  */
 
 /{
@@ -21,7 +21,7 @@
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-output-names = "uart0_pclk";
-				clock-frequency = <122880000>;
+				clock-frequency = <61440000>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/midi-uart1-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart1-pi5-overlay.dts
@@ -5,10 +5,10 @@
 
 /*
  * Fake a higher clock rate to get a larger divisor, and thereby a lower
- * baudrate. The real clock is 100MHz, which we scale so that requesting
+ * baudrate. The real clock is 50MHz, which we scale so that requesting
  * 38.4kHz results in an actual 31.25kHz.
  *
- *   100000000*38400/31250 = 122880000
+ *   50000000*38400/31250 = 61440000
  */
 
 /{
@@ -21,7 +21,7 @@
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-output-names = "uart1_pclk";
-				clock-frequency = <122880000>;
+				clock-frequency = <61440000>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/midi-uart2-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart2-pi5-overlay.dts
@@ -5,10 +5,10 @@
 
 /*
  * Fake a higher clock rate to get a larger divisor, and thereby a lower
- * baudrate. The real clock is 100MHz, which we scale so that requesting
+ * baudrate. The real clock is 50MHz, which we scale so that requesting
  * 38.4kHz results in an actual 31.25kHz.
  *
- *   100000000*38400/31250 = 122880000
+ *   50000000*38400/31250 = 61440000
  */
 
 /{
@@ -21,7 +21,7 @@
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-output-names = "uart2_pclk";
-				clock-frequency = <122880000>;
+				clock-frequency = <61440000>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/midi-uart3-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart3-pi5-overlay.dts
@@ -5,10 +5,10 @@
 
 /*
  * Fake a higher clock rate to get a larger divisor, and thereby a lower
- * baudrate. The real clock is 100MHz, which we scale so that requesting
+ * baudrate. The real clock is 50MHz, which we scale so that requesting
  * 38.4kHz results in an actual 31.25kHz.
  *
- *   100000000*38400/31250 = 122880000
+ *   50000000*38400/31250 = 61440000
  */
 
 /{
@@ -21,7 +21,7 @@
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-output-names = "uart3_pclk";
-				clock-frequency = <122880000>;
+				clock-frequency = <61440000>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/midi-uart4-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/midi-uart4-pi5-overlay.dts
@@ -5,10 +5,10 @@
 
 /*
  * Fake a higher clock rate to get a larger divisor, and thereby a lower
- * baudrate. The real clock is 100MHz, which we scale so that requesting
+ * baudrate. The real clock is 50MHz, which we scale so that requesting
  * 38.4kHz results in an actual 31.25kHz.
  *
- *   100000000*38400/31250 = 122880000
+ *   50000000*38400/31250 = 61440000
  */
 
 /{
@@ -21,7 +21,7 @@
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-output-names = "uart4_pclk";
-				clock-frequency = <122880000>;
+				clock-frequency = <61440000>;
 			};
 		};
 	};


### PR DESCRIPTION
The UART source clock is 50MHz not 100MHz, so fix the fake-clock used to munge the baudrate.

See https://forums.raspberrypi.com/viewtopic.php?p=2212755