### PR TITLE
ASoC: bcm: Use power-of-2 bclk_ratios

### DIFF
--- a/sound/soc/bcm/allo-boss-dac.c
+++ b/sound/soc/bcm/allo-boss-dac.c
@@ -278,6 +278,9 @@ static int snd_allo_boss_hw_params(
 	struct snd_soc_component *component = asoc_rtd_to_codec(rtd, 0)->component;
 	struct snd_soc_card *card = rtd->card;
 
+	/* Using powers of 2 allows for an integer clock divisor */
+	width = width <= 16 ? 16 : 32;
+
 	/* Mute before changing sample rate */
 	snd_allo_boss_gpio_mute(card);
 

--- a/sound/soc/bcm/dionaudio_loco.c
+++ b/sound/soc/bcm/dionaudio_loco.c
@@ -34,6 +34,9 @@ static int snd_rpi_dionaudio_loco_hw_params(
 	unsigned int sample_bits =
 		snd_pcm_format_width(params_format(params));
 
+	/* Using powers of 2 allows for an integer clock divisor */
+	sample_bits = sample_bits <= 16 ? 16 : 32;
+
 	return snd_soc_dai_set_bclk_ratio(cpu_dai, sample_bits * 2);
 }
 

--- a/sound/soc/bcm/hifiberry_dacplus.c
+++ b/sound/soc/bcm/hifiberry_dacplus.c
@@ -297,6 +297,9 @@ static int snd_rpi_hifiberry_dacplus_hw_params(
 	int channels = params_channels(params);
 	int width = snd_pcm_format_width(params_format(params));
 
+	/* Using powers of 2 allows for an integer clock divisor */
+	width = width <= 16 ? 16 : 32;
+
 	if (snd_rpi_hifiberry_is_dacpro) {
 		struct snd_soc_component *component = asoc_rtd_to_codec(rtd, 0)->component;
 

--- a/sound/soc/bcm/hifiberry_dacplusadc.c
+++ b/sound/soc/bcm/hifiberry_dacplusadc.c
@@ -231,6 +231,9 @@ static int snd_rpi_hifiberry_dacplusadc_hw_params(
 	int channels = params_channels(params);
 	int width = snd_pcm_format_width(params_format(params));
 
+	/* Using powers of 2 allows for an integer clock divisor */
+	width = width <= 16 ? 16 : 32;
+
 	if (snd_rpi_hifiberry_is_dacpro) {
 		struct snd_soc_component *component = asoc_rtd_to_codec(rtd, 0)->component;
 

--- a/sound/soc/bcm/hifiberry_dacplusadcpro.c
+++ b/sound/soc/bcm/hifiberry_dacplusadcpro.c
@@ -389,6 +389,9 @@ static int snd_rpi_hifiberry_dacplusadcpro_hw_params(
 	struct snd_soc_dai_driver *drv = dai->driver;
 	const struct snd_soc_dai_ops *ops = drv->ops;
 
+	/* Using powers of 2 allows for an integer clock divisor */
+	width = width <= 16 ? 16 : 32;
+
 	if (snd_rpi_hifiberry_is_dacpro) {
 		snd_rpi_hifiberry_dacplusadcpro_set_sclk(dac,
 			params_rate(params));

--- a/sound/soc/bcm/i-sabre-q2m.c
+++ b/sound/soc/bcm/i-sabre-q2m.c
@@ -53,8 +53,9 @@ static int snd_rpi_i_sabre_q2m_hw_params(
 	struct snd_soc_dai         *cpu_dai = asoc_rtd_to_cpu(rtd, 0);
 	int bclk_ratio;
 
-	bclk_ratio = snd_pcm_format_width(
-			params_format(params)) * params_channels(params);
+	/* Using powers of 2 allows for an integer clock divisor */
+	bclk_ratio = (snd_pcm_format_width(params_format(params)) <= 16 ? 16 : 32) *
+				 params_channels(params);
 	return snd_soc_dai_set_bclk_ratio(cpu_dai, bclk_ratio);
 }
 

--- a/sound/soc/bcm/rpi-cirrus.c
+++ b/sound/soc/bcm/rpi-cirrus.c
@@ -708,6 +708,9 @@ static int rpi_cirrus_hw_params(struct snd_pcm_substream *substream,
 	unsigned int rate = params_rate(params);
 	unsigned int clk_freq = calc_sysclk(rate);
 
+	/* Using powers of 2 allows for an integer clock divisor */
+	width = width <= 16 ? 16 : 32;
+
 	mutex_lock(&priv->lock);
 
 	dev_dbg(card->dev, "hw_params: setting rate to %d\n", rate);

--- a/sound/soc/bcm/rpi-simple-soundcard.c
+++ b/sound/soc/bcm/rpi-simple-soundcard.c
@@ -134,10 +134,13 @@ static int snd_rpi_simple_hw_params(struct snd_pcm_substream *substream,
 		return 0; // BCLK is configured in .init
 
 	/* The simple drivers just set the bclk_ratio to sample_bits * 2 so
-	 * hard-code this for now. More complex drivers could just replace
+	 * hard-code this for now, but sticking to powers of 2 to allow for
+	 * integer clock divisors. More complex drivers could just replace
 	 * the hw_params routine.
 	 */
 	sample_bits = snd_pcm_format_width(params_format(params));
+	sample_bits = sample_bits <= 16 ? 16 : 32;
+
 	return snd_soc_dai_set_bclk_ratio(cpu_dai, sample_bits * 2);
 }
 


### PR DESCRIPTION
The soundcard drivers originally used snd_pcm_format_physical_width, but a later commit changed that to snd_pcm_format_width because the in-memory sample storage width should not be a factor in determining the bclk_ratio. However, the physical width rounds the sample bits up to the nearest power of 2, which makes it easier to find integer clock divisors.

Restore the old behaviour, but with an implementation that makes it clear what is going on.

See: https://github.com/raspberrypi/linux/issues/6104