### PR TITLE
overlays: Force IRQ pins to inputs

### DIFF
--- a/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
@@ -307,6 +307,8 @@
 				maxim,ir-led-current-microamp  = <7000>;
 				interrupt-parent = <&gpio>;
 				interrupts = <4 2>;
+				pinctrl-0 = <&int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -436,6 +438,8 @@
 				reg = <0x68>;
 				interrupt-parent = <&gpio>;
 				interrupts = <4 2>;
+				pinctrl-0 = <&int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -453,6 +457,8 @@
 				reg = <0x68>;
 				interrupt-parent = <&gpio>;
 				interrupts = <4 2>;
+				pinctrl-0 = <&int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -523,6 +529,17 @@
 		};
 	};
 
+	fragment@99 {
+		target = <&gpio>;
+		__dormant__ {
+			int_pins: int_pins@4 {
+					brcm,pins = <4>;
+					brcm,function = <0>; /* in */
+					brcm,pull = <0>; /* none */
+			};
+		};
+	};
+
 	__overrides__ {
 		bme280 = <0>,"+0";
 		bmp085 = <0>,"+1";
@@ -545,7 +562,7 @@
 		sgp30 = <0>,"+16";
 		ccs811 = <0>, "+17";
 		bh1750 = <0>, "+18";
-		max30102 = <0>,"+19";
+		max30102 = <0>,"+19+99";
 		aht10 = <0>,"+20";
 		mcp980x = <0>,"+21";
 		jc42 = <0>,"+22";
@@ -554,8 +571,8 @@
 		ms5805 = <0>,"+25";
 		ms5837 = <0>,"+26";
 		ms8607 = <0>,"+27";
-		mpu6050 = <0>,"+28";
-		mpu9250 = <0>,"+29";
+		mpu6050 = <0>,"+28+99";
+		mpu9250 = <0>,"+29+99";
 		bno055 = <0>,"+31";
 		sht4x = <0>,"+32";
 		adt7410 = <0>,"+34";
@@ -569,7 +586,9 @@
 			<&mpu6050>,"reg:0", <&mpu9250>,"reg:0",
 			<&bno055>,"reg:0", <&sht4x>,"reg:0",
 			<&bmp380>,"reg:0", <&adt7410>,"reg:0";
-		int_pin = <&max30102>, "interrupts:0",
+		int_pin = <&int_pins>, "brcm,pins:0",
+			<&int_pins>, "reg:0",
+			<&max30102>, "interrupts:0",
 			<&mpu6050>, "interrupts:0",
 			<&mpu9250>, "interrupts:0";
 		no_timeout = <&jc42>, "smbus-timeout-disable?";

--- a/arch/arm/boot/dts/overlays/sc16is750-i2c-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is750-i2c-overlay.dts
@@ -17,6 +17,8 @@
 				clocks = <&sc16is750_clk>;
 				interrupt-parent = <&gpio>;
 				interrupts = <24 2>; /* IRQ_TYPE_EDGE_FALLING */
+				pinctrl-0 = <&int_pins>;
+				pinctrl-names = "default";
 				gpio-controller;
 				#gpio-cells = <2>;
 				i2c-max-frequency = <400000>;
@@ -35,8 +37,20 @@
 		};
 	};
 
+	fragment@2 {
+		target = <&gpio>;
+		__overlay__ {
+			int_pins: int_pins@18 {
+					brcm,pins = <24>;
+					brcm,function = <0>; /* in */
+					brcm,pull = <0>; /* none */
+			};
+		};
+	};
+
 	__overrides__ {
-		int_pin = <&sc16is750>,"interrupts:0";
+		int_pin = <&sc16is750>,"interrupts:0", <&int_pins>,"brcm,pins:0",
+			  <&int_pins>,"reg:0";
 		addr = <&sc16is750>,"reg:0", <&sc16is750_clk>,"name";
 		xtal = <&sc16is750_clk>,"clock-frequency:0";
 	};

--- a/arch/arm/boot/dts/overlays/sc16is752-i2c-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is752-i2c-overlay.dts
@@ -17,6 +17,8 @@
 				clocks = <&sc16is752_clk>;
 				interrupt-parent = <&gpio>;
 				interrupts = <24 2>; /* IRQ_TYPE_EDGE_FALLING */
+				pinctrl-0 = <&int_pins>;
+				pinctrl-names = "default";
 				gpio-controller;
 				#gpio-cells = <2>;
 				i2c-max-frequency = <400000>;
@@ -35,8 +37,20 @@
 		};
 	};
 
+	fragment@2 {
+		target = <&gpio>;
+		__overlay__ {
+			int_pins: int_pins@18 {
+					brcm,pins = <24>;
+					brcm,function = <0>; /* in */
+					brcm,pull = <0>; /* none */
+			};
+		};
+	};
+
 	__overrides__ {
-		int_pin = <&sc16is752>,"interrupts:0";
+		int_pin = <&sc16is752>,"interrupts:0", <&int_pins>,"brcm,pins:0",
+			  <&int_pins>,"reg:0";
 		addr = <&sc16is752>,"reg:0",<&sc16is752_clk>,"name";
 		xtal = <&sc16is752_clk>,"clock-frequency:0";
 	};

--- a/arch/arm/boot/dts/overlays/sc16is752-spi0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is752-spi0-overlay.dts
@@ -17,6 +17,8 @@
 				clocks = <&sc16is752_clk>;
 				interrupt-parent = <&gpio>;
 				interrupts = <24 2>; /* IRQ_TYPE_EDGE_FALLING */
+				pinctrl-0 = <&int_pins>;
+				pinctrl-names = "default";
 				gpio-controller;
 				#gpio-cells = <2>;
 				spi-max-frequency = <4000000>;
@@ -42,8 +44,20 @@
 		};
 	};
 
+	fragment@3 {
+		target = <&gpio>;
+		__overlay__ {
+			int_pins: int_pins@18 {
+					brcm,pins = <24>;
+					brcm,function = <0>; /* in */
+					brcm,pull = <0>; /* none */
+			};
+		};
+	};
+
 	__overrides__ {
-		int_pin = <&sc16is752>,"interrupts:0";
+		int_pin = <&sc16is752>,"interrupts:0", <&int_pins>,"brcm,pins:0",
+			  <&int_pins>,"reg:0";
 		xtal = <&sc16is752_clk>,"clock-frequency:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/sc16is752-spi1-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is752-spi1-overlay.dts
@@ -16,6 +16,12 @@
 				brcm,pins = <18>;
 				brcm,function = <1>; /* output */
 			};
+
+			int_pins: int_pins@18 {
+					brcm,pins = <24>;
+					brcm,function = <0>; /* in */
+					brcm,pull = <0>; /* none */
+			};
 		};
 	};
 
@@ -25,7 +31,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&spi1_pins &spi1_cs_pins>;
+			pinctrl-0 = <&spi1_pins &spi1_cs_pins &int_pins>;
 			cs-gpios = <&gpio 18 1>;
 			status = "okay";
 
@@ -35,6 +41,8 @@
 				clocks = <&sc16is752_clk>;
 				interrupt-parent = <&gpio>;
 				interrupts = <24 2>; /* IRQ_TYPE_EDGE_FALLING */
+				pinctrl-0 = <&int_pins>;
+				pinctrl-names = "default";
 				gpio-controller;
 				#gpio-cells = <2>;
 				spi-max-frequency = <4000000>;
@@ -61,7 +69,8 @@
 	};
 
 	__overrides__ {
-		int_pin = <&sc16is752>,"interrupts:0";
+		int_pin = <&sc16is752>,"interrupts:0", <&int_pins>,"brcm,pins:0",
+			  <&int_pins>,"reg:0";
 		xtal = <&sc16is752_clk>,"clock-frequency:0";
 	};
 };


### PR DESCRIPTION
Requesting a GPIO as an interrupt source does not automatically make it an input (or even a GPIO pin). Add the necessary pinctrl nodes to the overlays that don't already do this.

See: https://github.com/raspberrypi/linux/issues/6106