### PR TITLE
fixup! overlays: Force IRQ pins to inputs

### DIFF
--- a/arch/arm/boot/dts/overlays/sc16is752-spi1-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is752-spi1-overlay.dts
@@ -31,7 +31,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&spi1_pins &spi1_cs_pins &int_pins>;
+			pinctrl-0 = <&spi1_pins &spi1_cs_pins>;
 			cs-gpios = <&gpio 18 1>;
 			status = "okay";
 


### PR DESCRIPTION
The previous changes (only tested on I2C) added the pinctrl declaration to the spi1 variant twice, so it was guaranteed to clash with itself. Remove the double-accounting.