### PR TITLE
dw-axi-dmac-platform: Avoid trampling with zero length buffer

### DIFF
--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
@@ -916,7 +916,7 @@ dw_axi_dma_chan_prep_slave_sg(struct dma_chan *dchan, struct scatterlist *sgl,
 		mem = sg_dma_address(sg);
 		len = sg_dma_len(sg);
 		num_segments = DIV_ROUND_UP(sg_dma_len(sg), axi_block_len);
-		if (num_segments == 0)
+		if (!num_segments)
 			continue;
 
 		segment_len = DIV_ROUND_UP(sg_dma_len(sg), num_segments);

--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
@@ -916,6 +916,9 @@ dw_axi_dma_chan_prep_slave_sg(struct dma_chan *dchan, struct scatterlist *sgl,
 		mem = sg_dma_address(sg);
 		len = sg_dma_len(sg);
 		num_segments = DIV_ROUND_UP(sg_dma_len(sg), axi_block_len);
+		if (num_segments == 0)
+			continue;
+
 		segment_len = DIV_ROUND_UP(sg_dma_len(sg), num_segments);
 
 		do {


### PR DESCRIPTION
This code:
```
for_each_sg(sgl, sg, sg_len, i)
  num_sgs += DIV_ROUND_UP(sg_dma_len(sg), axi_block_len);
```
determines how many hw_desc are allocated.
If `sg_dma_len(sg)=0` we don't allocate for this sgl.

However in the next loop, we will increment loop
for this case, and loop gets higher than num_sgs
and we trample memory.