### PR TITLE
dts: overlay: ov5647: Specify clock-noncontinuous on CSI endpoint

### DIFF
--- a/arch/arm/boot/dts/overlays/camera-mux-2port-overlay.dts
+++ b/arch/arm/boot/dts/overlays/camera-mux-2port-overlay.dts
@@ -453,6 +453,7 @@
 			      <&imx708_0>,"lens-focus:0=", <&imx708_0_vcm>;
 		cam0-ov5647 = <&mux_in0>, "remote-endpoint:0=",<&ov5647_0_ep>,
 			      <&ov5647_0_ep>, "remote-endpoint:0=",<&mux_in0>,
+			      <&mux_in0>, "clock-noncontinuous?",
 			      <&ov5647_0>, "status=okay";
 		cam0-ov7251 = <&mux_in0>, "remote-endpoint:0=",<&ov7251_0_ep>,
 			      <&ov7251_0_ep>, "remote-endpoint:0=",<&mux_in0>,
@@ -505,6 +506,7 @@
 			      <&imx708_1>,"lens-focus:0=", <&imx708_1_vcm>;
 		cam1-ov5647 = <&mux_in1>, "remote-endpoint:0=",<&ov5647_1_ep>,
 			      <&ov5647_1_ep>, "remote-endpoint:0=",<&mux_in1>,
+			      <&mux_in1>, "clock-noncontinuous?",
 			      <&ov5647_1>, "status=okay";
 		cam1-ov7251 = <&mux_in1>, "remote-endpoint:0=",<&ov7251_1_ep>,
 			      <&ov7251_1_ep>, "remote-endpoint:0=",<&mux_in1>,

--- a/arch/arm/boot/dts/overlays/camera-mux-4port-overlay.dts
+++ b/arch/arm/boot/dts/overlays/camera-mux-4port-overlay.dts
@@ -748,6 +748,7 @@
 			      <&imx708_0>,"lens-focus:0=", <&imx708_0_vcm>;
 		cam0-ov5647 = <&mux_in0>, "remote-endpoint:0=",<&ov5647_0_ep>,
 			      <&ov5647_0_ep>, "remote-endpoint:0=",<&mux_in0>,
+			      <&mux_in0>, "clock-noncontinuous?",
 			      <&ov5647_0>, "status=okay";
 		cam0-ov7251 = <&mux_in0>, "remote-endpoint:0=",<&ov7251_0_ep>,
 			      <&ov7251_0_ep>, "remote-endpoint:0=",<&mux_in0>,
@@ -800,6 +801,7 @@
 			      <&imx708_1>,"lens-focus:0=", <&imx708_1_vcm>;
 		cam1-ov5647 = <&mux_in1>, "remote-endpoint:0=",<&ov5647_1_ep>,
 			      <&ov5647_1_ep>, "remote-endpoint:0=",<&mux_in1>,
+			      <&mux_in1>, "clock-noncontinuous?",
 			      <&ov5647_1>, "status=okay";
 		cam1-ov7251 = <&mux_in1>, "remote-endpoint:0=",<&ov7251_1_ep>,
 			      <&ov7251_1_ep>, "remote-endpoint:0=",<&mux_in1>,
@@ -852,6 +854,7 @@
 			      <&imx708_2>,"lens-focus:0=", <&imx708_2_vcm>;
 		cam2-ov5647 = <&mux_in2>, "remote-endpoint:0=",<&ov5647_2_ep>,
 			      <&ov5647_2_ep>, "remote-endpoint:0=",<&mux_in2>,
+			      <&mux_in2>, "clock-noncontinuous?",
 			      <&ov5647_2>, "status=okay";
 		cam2-ov7251 = <&mux_in2>, "remote-endpoint:0=",<&ov7251_2_ep>,
 			      <&ov7251_2_ep>, "remote-endpoint:0=",<&mux_in2>,
@@ -904,6 +907,7 @@
 			      <&imx708_3>,"lens-focus:0=", <&imx708_3_vcm>;
 		cam3-ov5647 = <&mux_in3>, "remote-endpoint:0=",<&ov5647_3_ep>,
 			      <&ov5647_3_ep>, "remote-endpoint:0=",<&mux_in3>,
+			      <&mux_in3>, "clock-noncontinuous?",
 			      <&ov5647_3>, "status=okay";
 		cam3-ov7251 = <&mux_in3>, "remote-endpoint:0=",<&ov7251_3_ep>,
 			      <&ov7251_3_ep>, "remote-endpoint:0=",<&mux_in3>,

--- a/arch/arm/boot/dts/overlays/ov5647-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov5647-overlay.dts
@@ -34,6 +34,7 @@
 				csi_ep: endpoint {
 					remote-endpoint = <&cam_endpoint>;
 					data-lanes = <1 2>;
+					clock-noncontinuous;
 				};
 			};
 		};


### PR DESCRIPTION
I've encountered frontend timeouts with the ov5647 on a Raspberry PI 3+ when using a longer cable (~30cm-ish). None of the odd suggestions on the internet worked to fix that, but it suggests that the problem gets worse with longer cables. I did not test a short cable, however an imx477 works just fine with my setup.

After some trail-and-error I've stumbled across the fact, that the clock-noncontinuous parameter specified in the device tree was not honoured. Fixing this, and therefore enabling the non-continuous clock mode fixed the frontend timeouts in my setup.