### PR TITLE
vc4/hdmi: Ignore hotplug interrupt with force_hotplug

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -2910,7 +2910,7 @@ static irqreturn_t vc4_hdmi_hpd_irq_thread(int irq, void *priv)
 	struct drm_connector *connector = &vc4_hdmi->connector;
 	struct drm_device *dev = connector->dev;
 
-	if (dev && dev->registered)
+	if (dev && dev->registered && !force_hotplug)
 		drm_connector_helper_hpd_irq_event(connector);
 
 	return IRQ_HANDLED;


### PR DESCRIPTION
The intention of the vc4.force_hotplug setting is to ignore hotplug completely.

It can be used when a display switching AV inputs, or going into stanbdby or changing a KVM switch
toggles hotplug and some side effect of that is unwanted.

It turns out while vc4.force_hotplug currently makes hotplug always read as asserted, that isn't enough to stop drm doing lots of stuff, including re-reading the edid.

An example of what drm does with a hotplug deasert/assert and vc4.force_hotplug=1 currently is:

https://paste.debian.net/hidden/dc07434b/

That is unwanted. Lets ignore the hotplug interrupt completely so drm is blissfully unaware of the hotplug change.