### PR TITLE
overlays: Add overlay for the Pineboards Hat Ai!

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -196,6 +196,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	pifi-dac-zero.dtbo \
 	pifi-mini-210.dtbo \
 	piglow.dtbo \
+	pineboards-hat-ai.dtbo \
 	piscreen.dtbo \
 	piscreen2r.dtbo \
 	pisound.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3618,6 +3618,12 @@ Load:   dtoverlay=piglow
 Params: <None>
 
 
+Name:   pineboards-hat-ai
+Info:   Pineboards Hat Ai! overlay for the Google Coral Edge TPU
+Load:   dtoverlay=pineboards-hat-ai
+Params: <None>
+
+
 Name:   piscreen
 Info:   PiScreen display by OzzMaker.com
 Load:   dtoverlay=piscreen,<param>=<val>

--- a/arch/arm/boot/dts/overlays/pineboards-hat-ai-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pineboards-hat-ai-overlay.dts
@@ -1,0 +1,18 @@
+/*
+ * Device Tree overlay for Pineboards Hat Ai!.
+ * Compatible with the Google Coral Edge TPU (Single and Dual Edge).
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2712";
+
+	fragment@0 {
+		target = <&pcie1>;
+		__overlay__ {
+			msi-parent = <&pcie1>;
+		};
+	};
+};


### PR DESCRIPTION
This overlay simplifies the configuration of the Coral Edge TPU (Single and Dual Edge) on the Pi 5.

On top of the msi-parent change the Gasket driver does need the 4K page kernel right now (/boot/firmware/config.txt -> kernel=kernel8.img)