### PR TITLE
drm: rp1: dpi: Add support for MEDIA_BUS_FMT_RGB565_1X24_CPADHI

### DIFF
--- a/drivers/gpu/drm/rp1/rp1-dpi/rp1_dpi_hw.c
+++ b/drivers/gpu/drm/rp1/rp1-dpi/rp1_dpi_hw.c
@@ -319,8 +319,14 @@ static u32 set_output_format(u32 bus_format, u32 *shift, u32 *imask, u32 *rgbsz)
 		*shift |= OSHIFT_RGB(29, 19, 9);
 		return OMASK_RGB(0x3fc, 0x3fc, 0x3fc);
 
+	case MEDIA_BUS_FMT_RGB565_1X24_CPADHI:
+		/* This should match Raspberry Pi legacy "mode 3" */
+		*shift |= OSHIFT_RGB(26, 17, 6);
+		*rgbsz &= DPI_DMA_RGBSZ_BPP_MASK;
+		return OMASK_RGB(0x3e0, 0x3f0, 0x3e0);
+
 	default:
-		/* RGB666_1x24_CPADHI, BGR666_1X24_CPADHI and "RGB565_666" formats */
+		/* RGB666_1x24_CPADHI, BGR666_1X24_CPADHI and "mode 4" formats */
 		*shift |= OSHIFT_RGB(27, 17, 7);
 		*rgbsz &= DPI_DMA_RGBSZ_BPP_MASK;
 		return OMASK_RGB(0x3f0, 0x3f0, 0x3f0);


### PR DESCRIPTION
This new format corresponds to the Raspberry Pi legacy DPI mode 3. This should enable it to work on Raspberry Pi 5.

I suppose I should test it before merging!

XXX we still don't have a way to get DPI mode 4. RGB666_1X24_CPADHI will put the bits in the right places, a named pinctrl is defined for Raspberry Pi 5 / RP1, but no pinctrl is defined for earlier Raspberry Pi models.