### PR TITLE
drm: rp1: rp1-dsi: Switch to PLL_SYS source for DPI when 8*lanes > bpp

### DIFF
--- a/arch/arm/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm/boot/dts/broadcom/rp1.dtsi
@@ -1111,13 +1111,14 @@
 
 			clocks = <&rp1_clocks RP1_CLK_MIPI0_CFG>,  // required, config bus clock
 				 <&rp1_clocks RP1_CLK_MIPI0_DPI>,  // required, pixel clock
-				 <&clksrc_mipi0_dsi_byteclk>,      // internal, parent for DPI divider
+				 <&rp1_clocks RP1_CLK_MIPI0_DSI_BYTECLOCK>, // required clock source
 				 <&clk_xosc>,                      // hardwired to DSI "refclk"
 				 <&rp1_clocks RP1_PLL_SYS>;        // alternative parent for divider
 			clock-names = "cfgclk", "dpiclk", "byteclk", "refclk", "pllsys";
 
 			assigned-clocks = <&rp1_clocks RP1_CLK_MIPI0_CFG>,
-					  <&rp1_clocks RP1_CLK_MIPI0_DPI>;
+					  <&rp1_clocks RP1_CLK_MIPI0_DPI>,
+					  <&rp1_clocks RP1_CLK_MIPI0_DSI_BYTECLOCK>;
 			assigned-clock-rates = <25000000>;
 		};
 
@@ -1132,13 +1133,14 @@
 
 			clocks = <&rp1_clocks RP1_CLK_MIPI1_CFG>,  // required, config bus clock
 				 <&rp1_clocks RP1_CLK_MIPI1_DPI>,  // required, pixel clock
-				 <&clksrc_mipi1_dsi_byteclk>,      // internal, parent for DPI divider
+				 <&rp1_clocks RP1_CLK_MIPI1_DSI_BYTECLOCK>, // required clock source
 				 <&clk_xosc>,                      // hardwired to DSI "refclk"
 				 <&rp1_clocks RP1_PLL_SYS>;        // alternative parent for divider
 			clock-names = "cfgclk", "dpiclk", "byteclk", "refclk", "pllsys";
 
 			assigned-clocks = <&rp1_clocks RP1_CLK_MIPI1_CFG>,
-					  <&rp1_clocks RP1_CLK_MIPI1_DPI>;
+					  <&rp1_clocks RP1_CLK_MIPI1_DPI>,
+					  <&rp1_clocks RP1_CLK_MIPI1_DSI_BYTECLOCK>;
 			assigned-clock-rates = <25000000>;
 		};
 
@@ -1215,24 +1217,6 @@
 		#clock-cells = <0>;
 		clock-output-names = "core";
 		clock-frequency = <50000000>;
-	};
-	clksrc_mipi0_dsi_byteclk: clksrc_mipi0_dsi_byteclk {
-		// This clock is synthesized by MIPI0 D-PHY, when DSI is running.
-		// Its frequency is not known a priori (until a panel driver attaches)
-		// so assign a made-up frequency of 72kHz so it can be divided for DPI.
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "clksrc_mipi0_dsi_byteclk";
-		clock-frequency = <72000>;
-	};
-	clksrc_mipi1_dsi_byteclk: clksrc_mipi1_dsi_byteclk {
-		// This clock is synthesized by MIPI1 D-PHY, when DSI is running.
-		// Its frequency is not known a priori (until a panel driver attaches)
-		// so assign a made-up frequency of 72kHz so it can be divided for DPI.
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "clksrc_mipi1_dsi_byteclk";
-		clock-frequency = <72000>;
 	};
 	/* GPIO derived clock sources. Each GPIO with a GPCLK function
 	 * can drive its output from the respective GPCLK

--- a/arch/arm/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm/boot/dts/broadcom/rp1.dtsi
@@ -1111,14 +1111,14 @@
 
 			clocks = <&rp1_clocks RP1_CLK_MIPI0_CFG>,  // required, config bus clock
 				 <&rp1_clocks RP1_CLK_MIPI0_DPI>,  // required, pixel clock
-				 <&clksrc_mipi0_dsi_byteclk>,    // internal, parent for divide
-				 <&clk_xosc>;                    // hardwired to DSI "refclk"
-			clock-names = "cfgclk", "dpiclk", "byteclk", "refclk";
+				 <&clksrc_mipi0_dsi_byteclk>,      // internal, parent for DPI divider
+				 <&clk_xosc>,                      // hardwired to DSI "refclk"
+				 <&rp1_clocks RP1_PLL_SYS>;        // alternative parent for divider
+			clock-names = "cfgclk", "dpiclk", "byteclk", "refclk", "pllsys";
 
 			assigned-clocks = <&rp1_clocks RP1_CLK_MIPI0_CFG>,
 					  <&rp1_clocks RP1_CLK_MIPI0_DPI>;
 			assigned-clock-rates = <25000000>;
-			assigned-clock-parents = <0>, <&clksrc_mipi0_dsi_byteclk>;
 		};
 
 		rp1_dsi1: dsi@128000 {
@@ -1132,14 +1132,14 @@
 
 			clocks = <&rp1_clocks RP1_CLK_MIPI1_CFG>,  // required, config bus clock
 				 <&rp1_clocks RP1_CLK_MIPI1_DPI>,  // required, pixel clock
-				 <&clksrc_mipi1_dsi_byteclk>,    // internal, parent for divide
-				 <&clk_xosc>;                    // hardwired to DSI "refclk"
-			clock-names = "cfgclk", "dpiclk", "byteclk", "refclk";
+				 <&clksrc_mipi1_dsi_byteclk>,      // internal, parent for DPI divider
+				 <&clk_xosc>,                      // hardwired to DSI "refclk"
+				 <&rp1_clocks RP1_PLL_SYS>;        // alternative parent for divider
+			clock-names = "cfgclk", "dpiclk", "byteclk", "refclk", "pllsys";
 
 			assigned-clocks = <&rp1_clocks RP1_CLK_MIPI1_CFG>,
 					  <&rp1_clocks RP1_CLK_MIPI1_DPI>;
 			assigned-clock-rates = <25000000>;
-			assigned-clock-parents = <0>, <&clksrc_mipi1_dsi_byteclk>;
 		};
 
 		/* VEC and DPI both need to control PLL_VIDEO and cannot work together;   */
@@ -1219,20 +1219,20 @@
 	clksrc_mipi0_dsi_byteclk: clksrc_mipi0_dsi_byteclk {
 		// This clock is synthesized by MIPI0 D-PHY, when DSI is running.
 		// Its frequency is not known a priori (until a panel driver attaches)
-		// so assign a made-up frequency of 72MHz so it can be divided for DPI.
+		// so assign a made-up frequency of 72kHz so it can be divided for DPI.
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-output-names = "clksrc_mipi0_dsi_byteclk";
-		clock-frequency = <72000000>;
+		clock-frequency = <72000>;
 	};
 	clksrc_mipi1_dsi_byteclk: clksrc_mipi1_dsi_byteclk {
 		// This clock is synthesized by MIPI1 D-PHY, when DSI is running.
 		// Its frequency is not known a priori (until a panel driver attaches)
-		// so assign a made-up frequency of 72MHz so it can be divided for DPI.
+		// so assign a made-up frequency of 72kHz so it can be divided for DPI.
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-output-names = "clksrc_mipi1_dsi_byteclk";
-		clock-frequency = <72000000>;
+		clock-frequency = <72000>;
 	};
 	/* GPIO derived clock sources. Each GPIO with a GPCLK function
 	 * can drive its output from the respective GPCLK

--- a/drivers/clk/clk-rp1.c
+++ b/drivers/clk/clk-rp1.c
@@ -394,6 +394,11 @@ struct rp1_clock {
 	unsigned long cached_rate;
 };
 
+struct rp1_varsrc {
+	struct clk_hw hw;
+	struct rp1_clockman *clockman;
+	unsigned long rate;
+};
 
 struct rp1_clk_change {
 	struct clk_hw *hw;
@@ -1414,6 +1419,34 @@ static void rp1_clk_debug_init(struct clk_hw *hw, struct dentry *dentry)
 	rp1_debugfs_regset(clockman, 0, regs, i, dentry);
 }
 
+static int rp1_varsrc_set_rate(struct clk_hw *hw,
+			       unsigned long rate, unsigned long parent_rate)
+{
+	struct rp1_varsrc *varsrc = container_of(hw, struct rp1_varsrc, hw);
+
+	/*
+	 * "varsrc" exists purely to let clock dividers know the frequency
+	 * of an externally-managed clock source (such as MIPI DSI byte-clock)
+	 * which may change at run-time as a side-effect of some other driver.
+	 */
+	varsrc->rate = rate;
+	return 0;
+}
+
+static unsigned long rp1_varsrc_recalc_rate(struct clk_hw *hw,
+					    unsigned long parent_rate)
+{
+	struct rp1_varsrc *varsrc = container_of(hw, struct rp1_varsrc, hw);
+
+	return varsrc->rate;
+}
+
+static long rp1_varsrc_round_rate(struct clk_hw *hw, unsigned long rate,
+				  unsigned long *parent_rate)
+{
+	return rate;
+}
+
 static const struct clk_ops rp1_pll_core_ops = {
 	.is_prepared = rp1_pll_core_is_on,
 	.prepare = rp1_pll_core_on,
@@ -1462,6 +1495,12 @@ static const struct clk_ops rp1_clk_ops = {
 	.set_rate = rp1_clock_set_rate,
 	.determine_rate = rp1_clock_determine_rate,
 	.debug_init = rp1_clk_debug_init,
+};
+
+static const struct clk_ops rp1_varsrc_ops = {
+	.set_rate = rp1_varsrc_set_rate,
+	.recalc_rate = rp1_varsrc_recalc_rate,
+	.round_rate = rp1_varsrc_round_rate,
 };
 
 static bool rp1_clk_is_claimed(const char *name);
@@ -1647,6 +1686,35 @@ static struct clk_hw *rp1_register_clock(struct rp1_clockman *clockman,
 	return &clock->hw;
 }
 
+static struct clk_hw *rp1_register_varsrc(struct rp1_clockman *clockman,
+					  const void *data)
+{
+	const char *name = *(char const * const *)data;
+	struct rp1_varsrc *clock;
+	struct clk_init_data init;
+	int ret;
+
+	memset(&init, 0, sizeof(init));
+	init.parent_names = &ref_clock;
+	init.num_parents = 1;
+	init.name = name;
+	init.flags = CLK_IGNORE_UNUSED;
+	init.ops = &rp1_varsrc_ops;
+
+	clock = devm_kzalloc(clockman->dev, sizeof(*clock), GFP_KERNEL);
+	if (!clock)
+		return NULL;
+
+	clock->clockman = clockman;
+	clock->hw.init = &init;
+
+	ret = devm_clk_hw_register(clockman->dev, &clock->hw);
+	if (ret)
+		return ERR_PTR(ret);
+
+	return &clock->hw;
+}
+
 struct rp1_clk_desc {
 	struct clk_hw *(*clk_register)(struct rp1_clockman *clockman,
 				       const void *data);
@@ -1675,6 +1743,8 @@ struct rp1_clk_desc {
 #define REGISTER_CLK(...)	_REGISTER(&rp1_register_clock,		\
 					  &(struct rp1_clock_data)	\
 					  {__VA_ARGS__})
+
+#define REGISTER_VARSRC(n)	_REGISTER(&rp1_register_varsrc,	&(const char *){n})
 
 static const struct rp1_clk_desc clk_desc_array[] = {
 	[RP1_PLL_SYS_CORE] = REGISTER_PLL_CORE(
@@ -2318,6 +2388,9 @@ static const struct rp1_clk_desc clk_desc_array[] = {
 				.max_freq = 200 * MHz,
 				.fc0_src = FC_NUM(3, 6),
 				),
+
+	[RP1_CLK_MIPI0_DSI_BYTECLOCK] = REGISTER_VARSRC("clksrc_mipi0_dsi_byteclk"),
+	[RP1_CLK_MIPI1_DSI_BYTECLOCK] = REGISTER_VARSRC("clksrc_mipi1_dsi_byteclk"),
 };
 
 static bool rp1_clk_claimed[ARRAY_SIZE(clk_desc_array)];

--- a/drivers/gpu/drm/rp1/rp1-dsi/rp1_dsi.c
+++ b/drivers/gpu/drm/rp1/rp1-dsi/rp1_dsi.c
@@ -54,6 +54,7 @@ static void rp1_dsi_bridge_pre_enable(struct drm_bridge *bridge,
 	struct rp1_dsi *dsi = bridge_to_rp1_dsi(bridge);
 
 	rp1dsi_dsi_setup(dsi, &dsi->pipe.crtc.state->adjusted_mode);
+	dsi->dsi_running = true;
 }
 
 static void rp1_dsi_bridge_enable(struct drm_bridge *bridge,
@@ -443,7 +444,7 @@ static int rp1dsi_platform_probe(struct platform_device *pdev)
 	/* Hardware resources */
 	for (i = 0; i < RP1DSI_NUM_CLOCKS; i++) {
 		static const char * const myclocknames[RP1DSI_NUM_CLOCKS] = {
-			"cfgclk", "dpiclk", "byteclk", "refclk"
+			"cfgclk", "dpiclk", "byteclk", "refclk", "pllsys"
 		};
 		dsi->clocks[i] = devm_clk_get(dev, myclocknames[i]);
 		if (IS_ERR(dsi->clocks[i])) {

--- a/drivers/gpu/drm/rp1/rp1-dsi/rp1_dsi.h
+++ b/drivers/gpu/drm/rp1/rp1-dsi/rp1_dsi.h
@@ -30,7 +30,8 @@
 #define RP1DSI_CLOCK_DPI     1
 #define RP1DSI_CLOCK_BYTE    2
 #define RP1DSI_CLOCK_REF     3
-#define RP1DSI_NUM_CLOCKS    4
+#define RP1DSI_CLOCK_PLLSYS  4
+#define RP1DSI_NUM_CLOCKS    5
 
 /* ---------------------------------------------------------------------- */
 

--- a/drivers/gpu/drm/rp1/rp1-dsi/rp1_dsi_dsi.c
+++ b/drivers/gpu/drm/rp1/rp1-dsi/rp1_dsi_dsi.c
@@ -7,6 +7,7 @@
 
 #include <linux/delay.h>
 #include <linux/errno.h>
+#include <linux/math64.h>
 #include <linux/platform_device.h>
 #include <linux/rp1_platform.h>
 #include "drm/drm_print.h"
@@ -1111,7 +1112,7 @@ static void dphy_transaction(struct rp1_dsi *dsi, uint8_t test_code, uint8_t tes
 	DSI_WRITE(DSI_PHY_TST_CTRL0, DPHY_CTRL0_PHY_TESTCLK_BITS);
 }
 
-static uint8_t dphy_get_div(u32 refclk_khz, u32 vco_freq_khz, u32 *ptr_m, u32 *ptr_n)
+static u64 dphy_get_div(u32 refclk, u64 vco_freq, u32 *ptr_m, u32 *ptr_n)
 {
 	/*
 	 * See pg 77-78 of dphy databook
@@ -1124,19 +1125,23 @@ static uint8_t dphy_get_div(u32 refclk_khz, u32 vco_freq_khz, u32 *ptr_m, u32 *p
 	 * In practice, given a 50MHz reference clock, it can produce any
 	 * multiple of 10MHz, 11.1111MHz, 12.5MHz, 14.286MHz or 16.667MHz
 	 * with < 1% error for all frequencies above 495MHz.
+	 *
+	 * vco_freq should be set to the lane bit rate (not the MIPI clock
+	 * which is half of this). These frequencies are now measured in Hz.
+	 * They should fit within u32, but u64 is needed for calculations.
 	 */
 
-	static const u32 REF_DIVN_MAX = 40000u;
-	static const u32 REF_DIVN_MIN =  5000u;
-	u32 best_n, best_m, best_err = 0x7fffffff;
-	unsigned int n;
+	static const u32 REF_DIVN_MAX = 40000000;
+	static const u32 REF_DIVN_MIN =  5000000;
+	u32 n, best_n, best_m;
+	u64 best_err = vco_freq;
 
-	for (n = 1 + refclk_khz / REF_DIVN_MAX; n * REF_DIVN_MIN <= refclk_khz && n < 100; ++n) {
-		u32 half_m = (n * vco_freq_khz + refclk_khz) / (2 * refclk_khz);
+	for (n = 1 + refclk / REF_DIVN_MAX; n * REF_DIVN_MIN <= refclk && n < 100; ++n) {
+		u32 half_m = DIV_U64_ROUND_CLOSEST(n * vco_freq, 2 * refclk);
 
 		if (half_m < 150) {
-			u32 f = (2 * half_m * refclk_khz) / n;
-			u32 err = (f > vco_freq_khz) ? f - vco_freq_khz : vco_freq_khz - f;
+			u64 f = div_u64(mul_u32_u32(2 * half_m, refclk), n);
+			u64 err = (f > vco_freq) ? f - vco_freq : vco_freq - f;
 
 			if (err < best_err) {
 				best_n = n;
@@ -1148,12 +1153,12 @@ static uint8_t dphy_get_div(u32 refclk_khz, u32 vco_freq_khz, u32 *ptr_m, u32 *p
 		}
 	}
 
-	if (64 * best_err < vco_freq_khz) { /* tolerate small error */
-		*ptr_n = best_n;
-		*ptr_m = best_m;
-		return 1;
-	}
-	return 0;
+	if (64 * best_err >= vco_freq)
+		return 0;
+
+	*ptr_n = best_n;
+	*ptr_m = best_m;
+	return div_u64(mul_u32_u32(best_m, refclk), best_n);
 }
 
 struct hsfreq_range {
@@ -1226,13 +1231,14 @@ static void dphy_set_hsfreqrange(struct rp1_dsi *dsi, u32 freq_mhz)
 			 hsfreq_table[i].hsfreqrange << 1);
 }
 
-static void dphy_configure_pll(struct rp1_dsi *dsi, u32 refclk_khz, u32 vco_freq_khz)
+static u32 dphy_configure_pll(struct rp1_dsi *dsi, u32 refclk, u32 vco_freq)
 {
 	u32 m = 0;
 	u32 n = 0;
+	u32 actual_vco_freq = dphy_get_div(refclk, vco_freq, &m, &n);
 
-	if (dphy_get_div(refclk_khz, vco_freq_khz, &m, &n)) {
-		dphy_set_hsfreqrange(dsi, vco_freq_khz / 1000);
+	if (actual_vco_freq) {
+		dphy_set_hsfreqrange(dsi, actual_vco_freq / 1000000);
 		/* Program m,n from registers */
 		dphy_transaction(dsi, DPHY_PLL_DIV_CTRL_OFFSET, 0x30);
 		/* N (program N-1) */
@@ -1242,18 +1248,21 @@ static void dphy_configure_pll(struct rp1_dsi *dsi, u32 refclk_khz, u32 vco_freq
 		/* M[4:0] (program M-1) */
 		dphy_transaction(dsi, DPHY_PLL_LOOP_DIV_OFFSET, ((m - 1) & 0x1F));
 		drm_dbg_driver(dsi->drm,
-			       "DPHY: vco freq want %dkHz got %dkHz = %d * (%dkHz / %d), hsfreqrange = 0x%02x\r\n",
-			       vco_freq_khz, refclk_khz * m / n, m, refclk_khz,
-			       n, hsfreq_table[dsi->hsfreq_index].hsfreqrange);
+			       "DPHY: vco freq want %uHz got %uHz = %d * (%uHz / %d), hsfreqrange = 0x%02x\n",
+			       vco_freq, actual_vco_freq, m, refclk, n,
+			       hsfreq_table[dsi->hsfreq_index].hsfreqrange);
 	} else {
-		drm_info(dsi->drm,
-			 "rp1dsi: Error configuring DPHY PLL! %dkHz = %d * (%dkHz / %d)\r\n",
-			 vco_freq_khz, m, refclk_khz, n);
+		drm_warn(dsi->drm,
+			 "rp1dsi: Error configuring DPHY PLL %uHz\n", vco_freq);
 	}
+
+	return actual_vco_freq;
 }
 
-static void dphy_init_khz(struct rp1_dsi *dsi, u32 ref_freq, u32 vco_freq)
+static u32 dphy_init(struct rp1_dsi *dsi, u32 ref_freq, u32 vco_freq)
 {
+	u32 actual_vco_freq;
+
 	/* Reset the PHY */
 	DSI_WRITE(DSI_PHYRSTZ, 0);
 	DSI_WRITE(DSI_PHY_TST_CTRL0, DPHY_CTRL0_PHY_TESTCLK_BITS);
@@ -1263,13 +1272,15 @@ static void dphy_init_khz(struct rp1_dsi *dsi, u32 ref_freq, u32 vco_freq)
 	DSI_WRITE(DSI_PHY_TST_CTRL0, DPHY_CTRL0_PHY_TESTCLK_BITS);
 	udelay(1);
 	/* Since we are in DSI (not CSI2) mode here, start the PLL */
-	dphy_configure_pll(dsi, ref_freq, vco_freq);
+	actual_vco_freq = dphy_configure_pll(dsi, ref_freq, vco_freq);
 	udelay(1);
 	/* Unreset */
 	DSI_WRITE(DSI_PHYRSTZ, DSI_PHYRSTZ_SHUTDOWNZ_BITS);
 	udelay(1);
 	DSI_WRITE(DSI_PHYRSTZ, (DSI_PHYRSTZ_SHUTDOWNZ_BITS | DSI_PHYRSTZ_RSTZ_BITS));
 	udelay(1); /* so we can see PLL coming up? */
+
+	return actual_vco_freq;
 }
 
 void rp1dsi_mipicfg_setup(struct rp1_dsi *dsi)
@@ -1290,23 +1301,25 @@ static unsigned long rp1dsi_refclk_freq(struct rp1_dsi *dsi)
 	return u;
 }
 
-static void rp1dsi_dpiclk_start(struct rp1_dsi *dsi, unsigned int bpp, unsigned int lanes)
+static void rp1dsi_dpiclk_start(struct rp1_dsi *dsi, u32 byte_clock,
+				unsigned int bpp, unsigned int lanes)
 {
-	unsigned long u;
+	if (!dsi->clocks[RP1DSI_CLOCK_DPI])
+		return;
 
-	if (dsi->clocks[RP1DSI_CLOCK_DPI]) {
-		u = (dsi->clocks[RP1DSI_CLOCK_BYTE]) ?
-				clk_get_rate(dsi->clocks[RP1DSI_CLOCK_BYTE]) : 0;
-		drm_info(dsi->drm,
-			 "rp1dsi: Nominal byte clock %lu; scale by %u/%u",
-			 u, 4 * lanes, (bpp >> 1));
-		if (u < 1 || u >= (1ul << 28))
-			u = 72000000ul; /* default DUMMY frequency for byteclock */
+	if (bpp >= 8 * lanes && dsi->clocks[RP1DSI_CLOCK_BYTE] &&
+	    !clk_set_parent(dsi->clocks[RP1DSI_CLOCK_DPI], dsi->clocks[RP1DSI_CLOCK_BYTE]))
+		byte_clock = clk_get_rate(dsi->clocks[RP1DSI_CLOCK_BYTE]); /* dummy/nominal rate */
+	else if (dsi->clocks[RP1DSI_CLOCK_PLLSYS])
+		clk_set_parent(dsi->clocks[RP1DSI_CLOCK_DPI], dsi->clocks[RP1DSI_CLOCK_PLLSYS]);
 
-		clk_set_parent(dsi->clocks[RP1DSI_CLOCK_DPI], dsi->clocks[RP1DSI_CLOCK_BYTE]);
-		clk_set_rate(dsi->clocks[RP1DSI_CLOCK_DPI], (4 * lanes * u) / (bpp >> 1));
-		clk_prepare_enable(dsi->clocks[RP1DSI_CLOCK_DPI]);
-	}
+	clk_set_rate(dsi->clocks[RP1DSI_CLOCK_DPI], (4 * lanes * byte_clock) / (bpp >> 1));
+	clk_prepare_enable(dsi->clocks[RP1DSI_CLOCK_DPI]);
+	drm_dbg_driver(dsi->drm,
+		       "rp1dsi: Nominal Byte clock %u DPI clock %lu (parent rate %lu)",
+		       byte_clock,
+		       clk_get_rate(dsi->clocks[RP1DSI_CLOCK_DPI]),
+		       clk_get_rate(clk_get_parent(dsi->clocks[RP1DSI_CLOCK_DPI])));
 }
 
 static void rp1dsi_dpiclk_stop(struct rp1_dsi *dsi)
@@ -1336,18 +1349,21 @@ static u32 get_colorcode(enum mipi_dsi_pixel_format fmt)
 	return 0x005;
 }
 
-/* Maximum frequency for LP escape clock (20MHz), and some magic numbers */
-#define RP1DSI_ESC_CLK_KHZ      20000
+/* Frequency limits for DPI, HS and LP clocks, and some magic numbers */
+#define RP1DSI_DPI_MAX_KHZ     200000
+#define RP1DSI_BYTE_CLK_MIN  10000000
+#define RP1DSI_BYTE_CLK_MAX 187500000
+#define RP1DSI_ESC_CLK_MAX   20000000
 #define RP1DSI_TO_CLK_DIV           5
-#define RP1DSI_HSTX_TO_MIN      0x200
 #define RP1DSI_LPRX_TO_VAL      0x400
 #define RP1DSI_BTA_TO_VAL       0xd00
 
 void rp1dsi_dsi_setup(struct rp1_dsi *dsi, struct drm_display_mode const *mode)
 {
 	u32 timeout, mask, vid_mode_cfg;
-	int lane_kbps;
 	unsigned int bpp = mipi_dsi_pixel_format_to_bpp(dsi->display_format);
+	u32 byte_clock = clamp((bpp * 125 * min(mode->clock, RP1DSI_DPI_MAX_KHZ)) / dsi->lanes,
+			       RP1DSI_BYTE_CLK_MIN, RP1DSI_BYTE_CLK_MAX);
 
 	DSI_WRITE(DSI_PHY_IF_CFG, dsi->lanes - 1);
 	DSI_WRITE(DSI_DPI_CFG_POL, 0);
@@ -1370,14 +1386,12 @@ void rp1dsi_dsi_setup(struct rp1_dsi *dsi, struct drm_display_mode const *mode)
 
 	/* Set timeouts and clock dividers */
 	DSI_WRITE(DSI_TO_CNT_CFG,
-		  (max((bpp * mode->htotal) / (7 * RP1DSI_TO_CLK_DIV * dsi->lanes),
-		       RP1DSI_HSTX_TO_MIN) << 16) |
+		  (((bpp * mode->htotal) / (7 * RP1DSI_TO_CLK_DIV * dsi->lanes)) << 16) |
 		  RP1DSI_LPRX_TO_VAL);
 	DSI_WRITE(DSI_BTA_TO_CNT, RP1DSI_BTA_TO_VAL);
-	lane_kbps = (bpp *  mode->clock) / dsi->lanes;
 	DSI_WRITE(DSI_CLKMGR_CFG,
 		  (RP1DSI_TO_CLK_DIV << 8) |
-		  max(2, lane_kbps / (8 * RP1DSI_ESC_CLK_KHZ) + 1));
+		  max(2u, 1u + byte_clock / RP1DSI_ESC_CLK_MAX));
 
 	/* Configure video timings */
 	DSI_WRITE(DSI_VID_PKT_SIZE, mode->hdisplay);
@@ -1394,7 +1408,7 @@ void rp1dsi_dsi_setup(struct rp1_dsi *dsi, struct drm_display_mode const *mode)
 	DSI_WRITE(DSI_VID_VACTIVE_LINES, mode->vdisplay);
 
 	/* Init PHY */
-	dphy_init_khz(dsi, rp1dsi_refclk_freq(dsi) / 1000, lane_kbps);
+	byte_clock = dphy_init(dsi, rp1dsi_refclk_freq(dsi), 8 * byte_clock) >> 3;
 
 	DSI_WRITE(DSI_PHY_TMR_LPCLK_CFG,
 		  (hsfreq_table[dsi->hsfreq_index].clk_lp2hs << DSI_PHY_TMR_LP2HS_LSB) |
@@ -1418,7 +1432,7 @@ void rp1dsi_dsi_setup(struct rp1_dsi *dsi, struct drm_display_mode const *mode)
 	DSI_WRITE(DSI_PWR_UP, 0x1);		/* power up */
 
 	/* Now it should be safe to start the external DPI clock divider */
-	rp1dsi_dpiclk_start(dsi, bpp, dsi->lanes);
+	rp1dsi_dpiclk_start(dsi, byte_clock, bpp, dsi->lanes);
 
 	/* Wait for all lane(s) to be in Stopstate */
 	mask = (1 << 4);

--- a/include/dt-bindings/clock/rp1.h
+++ b/include/dt-bindings/clock/rp1.h
@@ -54,3 +54,7 @@
 /* Extra PLL output channels - RP1B0 only */
 #define RP1_PLL_VIDEO_PRI_PH		43
 #define RP1_PLL_AUDIO_TERN		44
+
+/* MIPI clocks managed by the DSI driver */
+#define RP1_CLK_MIPI0_DSI_BYTECLOCK	45
+#define RP1_CLK_MIPI1_DSI_BYTECLOCK	46


### PR DESCRIPTION
Draft which partially addresses #6125.

This sets up the DPI clock as accurately as it can to match the DSI rate; without altering HS/LP transitions or messing with the mode timings.

If 4-lane panels are as fussy as the bridge chip in our (1-lane) 7" display, there is a risk of horizontal jitter, due to irregular line intervals at most pixel-clock rates.

Not yet successfully tested with any real 4-lane panel.