### PR TITLE
overlays: qca7000: Adjust URL & README info

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3844,7 +3844,7 @@ Params: clock                   PWM clock frequency (informational)
 
 
 Name:   qca7000
-Info:   in-tech's Evaluation Board for PLC Stamp micro
+Info:   Evaluation Board for PLC Stamp micro
         This uses spi0 and a separate GPIO interrupt to connect the QCA7000.
 Load:   dtoverlay=qca7000,<param>=<val>
 Params: int_pin                 GPIO pin for interrupt signal (default 23)
@@ -3853,7 +3853,7 @@ Params: int_pin                 GPIO pin for interrupt signal (default 23)
 
 
 Name:   qca7000-uart0
-Info:   in-tech's Evaluation Board for PLC Stamp micro (UART)
+Info:   Evaluation Board for PLC Stamp micro (UART)
         This uses uart0/ttyAMA0 over GPIOs 14 & 15 to connect the QCA7000.
         But it requires disabling of onboard Bluetooth on
         Pi 3B, 3B+, 3A+, 4B and Zero W.

--- a/arch/arm/boot/dts/overlays/qca7000-overlay.dts
+++ b/arch/arm/boot/dts/overlays/qca7000-overlay.dts
@@ -1,5 +1,5 @@
 // Overlay for the Qualcomm Atheros QCA7000 on PLC Stamp micro EVK
-// Visit: https://in-tech-smartcharging.com/products/evaluation-tools/plc-stamp-micro-2-evaluation-board for details
+// Visit: https://chargebyte.com/products/evaluation-tools/plc-stamp-micro-2-evaluation-board for details
 
 /dts-v1/;
 /plugin/;


### PR DESCRIPTION
in-tech smart charging is now called chargebyte. Our product name seems to be more stable than our company name, so drop them where it's possible.

https://chargebyte.com/articles/in-tech-smart-charging-wird-zu-chargebyte