### PR TITLE
drivers: media: pisp_be: Remove extras field from pisp_be_config

### DIFF
--- a/drivers/media/platform/raspberrypi/pisp_be/pisp_be.c
+++ b/drivers/media/platform/raspberrypi/pisp_be/pisp_be.c
@@ -312,13 +312,10 @@ static void hw_queue_job(struct pispbe_dev *pispbe,
 	write_reg(pispbe, PISP_BE_GLOBAL_BAYER_ENABLE_OFFSET, hw_enables[0]);
 	write_reg(pispbe, PISP_BE_GLOBAL_RGB_ENABLE_OFFSET, hw_enables[1]);
 
-	/*
-	 * Everything else is as supplied by the user. XXX Buffer sizes not
-	 * checked!
-	 */
+	/* Everything else is as supplied by the user. */
 	begin =	offsetof(struct pisp_be_config, global.bayer_order) /
 								sizeof(u32);
-	end = offsetof(struct pisp_be_config, axi) / sizeof(u32);
+	end = sizeof(struct pisp_be_config) / sizeof(u32);
 	for (u = begin; u < end; u++) {
 		unsigned int val = ((u32 *)config)[u];
 

--- a/drivers/media/platform/raspberrypi/pisp_be/pisp_be_config.h
+++ b/drivers/media/platform/raspberrypi/pisp_be/pisp_be_config.h
@@ -398,15 +398,6 @@ struct pisp_be_hog_buffer_config {
 };
 
 struct pisp_be_config {
-	/* I/O configuration: */
-	struct pisp_be_input_buffer_config input_buffer;
-	struct pisp_be_tdn_input_buffer_config tdn_input_buffer;
-	struct pisp_be_stitch_input_buffer_config stitch_input_buffer;
-	struct pisp_be_tdn_output_buffer_config tdn_output_buffer;
-	struct pisp_be_stitch_output_buffer_config stitch_output_buffer;
-	struct pisp_be_output_buffer_config
-				output_buffer[PISP_BACK_END_NUM_OUTPUTS];
-	struct pisp_be_hog_buffer_config hog_buffer;
 	/* Processing configuration: */
 	struct pisp_be_global_config global;
 	struct pisp_image_format_config input_format;
@@ -446,18 +437,6 @@ struct pisp_be_config {
 	struct pisp_be_output_format_config
 				output_format[PISP_BACK_END_NUM_OUTPUTS];
 	struct pisp_be_hog_config hog;
-	struct pisp_be_axi_config axi;
-	/* Non-register fields: */
-	struct pisp_be_lsc_extra lsc_extra;
-	struct pisp_be_cac_extra cac_extra;
-	struct pisp_be_downscale_extra
-				downscale_extra[PISP_BACK_END_NUM_OUTPUTS];
-	struct pisp_be_resample_extra resample_extra[PISP_BACK_END_NUM_OUTPUTS];
-	struct pisp_be_crop_config crop;
-	struct pisp_image_format_config hog_format;
-	u32 dirty_flags_bayer; /* these use pisp_be_bayer_enable */
-	u32 dirty_flags_rgb; /* use pisp_be_rgb_enable */
-	u32 dirty_flags_extra; /* these use pisp_be_dirty_t */
 };
 
 /*
@@ -525,9 +504,9 @@ struct pisp_tile {
 static_assert(sizeof(struct pisp_tile) == 160);
 
 struct pisp_be_tiles_config {
-	struct pisp_be_config config;
 	struct pisp_tile tiles[PISP_BACK_END_NUM_TILES];
 	int num_tiles;
+	struct pisp_be_config config;
 };
 
 #endif /* _PISP_BE_CONFIG_H_ */


### PR DESCRIPTION
Remove the various extras fields from struct pisp_be_config. These fields are not used by the driver nor the hardware, so do not belong in this structure.

Also put the tiles array at the top of struct pisp_be_tiles_config to ensure any size change to struct pisp_be_config does not move the tiles struct out of alignment.

This is a userland breaking change, and libpisp must be updated accordingly.