### PR TITLE
drm/vc4: Fix potential null pointer read when disabling vblank

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -834,7 +834,7 @@ static void vc4_disable_vblank(struct drm_crtc *crtc)
 	if (!drm_dev_enter(dev, &idx))
 		return;
 
-	if (vc4_encoder->type != VC4_ENCODER_TYPE_DSI0)
+	if (!vc4_encoder || vc4_encoder->type != VC4_ENCODER_TYPE_DSI0)
 		CRTC_WRITE(PV_INTEN, 0);
 
 	drm_dev_exit(idx);


### PR DESCRIPTION
vc4_disable_vblank assumed that vc4_encoder was always assigned, which isn't guaranteed.

If it isn't assigned then disable the interrupt anyway as it's not connected.

https://github.com/raspberrypi/linux/issues/6146

Fixes: 63c0bcc4b747 ("drm/vc4: Add option to call from crtc to encoder on vblank")