### PR TITLE
dts: bcm2712: Drop snd_bcm2835 bootargs references from Pi5

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-5-b.dts
@@ -426,7 +426,7 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 
 / {
 	chosen: chosen {
-		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe snd_bcm2835.enable_compat_alsa=0 snd_bcm2835.enable_hdmi=1";
+		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe";
 		stdout-path = "serial10:115200n8";
 	};
 

--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -425,7 +425,7 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 
 / {
 	chosen: chosen {
-		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe snd_bcm2835.enable_compat_alsa=0 snd_bcm2835.enable_hdmi=1";
+		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe";
 		stdout-path = "serial10:115200n8";
 	};
 


### PR DESCRIPTION
Pi5 has no VCHIQ to support the snd_bcm2835 firmware audio driver, so remove the reference to it from bootargs.

https://forums.raspberrypi.com/viewtopic.php?p=2219395#p2219395