### PR TITLE
RGB order override for DPI

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4988,6 +4988,10 @@ Params: clock-frequency         Display clock frequency (Hz)
                                 Set the default brightness. Normal range 1-16.
                                 (default 16).
         rotate                  Display rotation {0,90,180,270} (default 0)
+        rgb-order               Allow override of RGB order from DPI.
+                                Options for vc4 are "rgb", "bgr", "grb", and
+                                "brg". Other values will be ignored.
+
 
 
 Name:   vc4-kms-dpi-hyperpixel2r

--- a/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dpi-generic-overlay.dts
@@ -77,5 +77,6 @@
 		rgb888 = <&panel_generic>, "bus-format:0=0x100a",
 			<&dpi_node_generic>, "pinctrl-0:0=",<&dpi_gpio0>;
 		bus-format = <&panel_generic>, "bus-format:0";
+		rgb-order = <&dpi_node_generic>, "rgb_order";
 	};
 };

--- a/drivers/gpu/drm/vc4/vc4_dpi.c
+++ b/drivers/gpu/drm/vc4/vc4_dpi.c
@@ -95,6 +95,8 @@ struct vc4_dpi {
 	struct clk *core_clock;
 
 	struct debugfs_regset32 regset;
+
+	int rgb_order_override;
 };
 
 #define to_vc4_dpi(_encoder)						\
@@ -205,6 +207,11 @@ static void vc4_dpi_encoder_enable(struct drm_encoder *encoder)
 			}
 		}
 
+		if (dpi->rgb_order_override >= 0) {
+			dpi_c &= ~DPI_ORDER_MASK;
+			dpi_c |= VC4_SET_FIELD(dpi->rgb_order_override, DPI_ORDER);
+		}
+
 		if (connector->display_info.bus_flags & DRM_BUS_FLAG_PIXDATA_DRIVE_NEGEDGE)
 			dpi_c |= DPI_PIXEL_CLK_INVERT;
 
@@ -313,6 +320,7 @@ static int vc4_dpi_bind(struct device *dev, struct device *master, void *data)
 {
 	struct platform_device *pdev = to_platform_device(dev);
 	struct drm_device *drm = dev_get_drvdata(master);
+	const char *rgb_order = NULL;
 	struct vc4_dpi *dpi;
 	int ret;
 
@@ -360,6 +368,20 @@ static int vc4_dpi_bind(struct device *dev, struct device *master, void *data)
 	ret = devm_add_action_or_reset(dev, vc4_dpi_disable_clock, dpi);
 	if (ret)
 		return ret;
+
+	dpi->rgb_order_override = -1;
+	if (!of_property_read_string(dev->of_node, "rgb_order", &rgb_order)) {
+		if (!strcmp(rgb_order, "rgb"))
+			dpi->rgb_order_override = DPI_ORDER_RGB;
+		else if (!strcmp(rgb_order, "bgr"))
+			dpi->rgb_order_override = DPI_ORDER_BGR;
+		else if (!strcmp(rgb_order, "grb"))
+			dpi->rgb_order_override = DPI_ORDER_GRB;
+		else if (!strcmp(rgb_order, "brg"))
+			dpi->rgb_order_override = DPI_ORDER_BRG;
+		else
+			DRM_ERROR("Invalid dpi order %s - ignored\n", rgb_order);
+	}
 
 	ret = drmm_encoder_init(drm, &dpi->encoder.base,
 				&vc4_dpi_encoder_funcs,


### PR DESCRIPTION
Quick (untested) mod for https://github.com/raspberrypi/linux/issues/6155

It's either this or adding a load of extra MEDIA_BUS_FMTs.