### PR TITLE
spi: dw: Handle any number of gpiod CS lines

### DIFF
--- a/drivers/spi/spi-dw-core.c
+++ b/drivers/spi/spi-dw-core.c
@@ -98,7 +98,8 @@ void dw_spi_set_cs(struct spi_device *spi, bool enable)
 	 * support active-high or active-low CS level.
 	 */
 	if (cs_high == enable)
-		dw_writel(dws, DW_SPI_SER, BIT(spi_get_chipselect(spi, 0)));
+		dw_writel(dws, DW_SPI_SER,
+			BIT(spi_get_csgpiod(spi, 0) ? 0 : spi_get_chipselect(spi, 0)));
 	else
 		dw_writel(dws, DW_SPI_SER, 0);
 }


### PR DESCRIPTION
Even when configured to use only gpiod CS lines, the DW SPI controller still expects a bit to be set in the SER register, otherwise transfers stall. For the csgpiod case, nominate bit 0 for the job.

See: https://github.com/raspberrypi/linux/issues/6159