### PR TITLE
staging: bcm2835-codec: 32bpp RGB formats need a 64byte alignment

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -256,14 +256,14 @@ static const struct bcm2835_codec_fmt supported_formats[] = {
 	}, {
 		.fourcc			= V4L2_PIX_FMT_BGR32,
 		.depth			= 32,
-		.bytesperline_align	= { 32, 32, 32, 32, 32 },
+		.bytesperline_align	= { 64, 64, 64, 64, 64 },
 		.flags			= 0,
 		.mmal_fmt		= MMAL_ENCODING_BGRA,
 		.size_multiplier_x2	= 2,
 	}, {
 		.fourcc			= V4L2_PIX_FMT_RGBA32,
 		.depth			= 32,
-		.bytesperline_align	= { 32, 32, 32, 32, 32 },
+		.bytesperline_align	= { 64, 64, 64, 64, 64 },
 		.flags			= 0,
 		.mmal_fmt		= MMAL_ENCODING_RGBA,
 		.size_multiplier_x2	= 2,


### PR DESCRIPTION
The firmware needs 16 pixel alignment on RGBx 32bpp formats, which would be 64 byte. The driver was only setting 32byte alignment.

https://github.com/raspberrypi/bookworm-feedback/issues/247