### PR TITLE
DTS: bcm2712: set nonzero QoS values for PCIE1

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-5-b.dts
@@ -170,6 +170,10 @@ rp1_target: &pcie2 {
 	status = "okay";
 };
 
+&pcie1 {
+	brcm,vdm-qos-map = <0x33333333>;
+};
+
 // Add some labels to 2712 device
 
 // The system UART


### PR DESCRIPTION
If PCIE1 is left with the default (zero) AXI QoS values, endpoints can receive extremely poor service for non-posted transactions e.g. reads. Such transactions can take milliseconds to complete on a contended system.

Bump priorities for every TC above the non-realtime greedy peripherals in BCM2712, to allow reasonable service without competing against hard realtime peripherals.