### PR TITLE
dtoverlays: Fix noints mode of mcp23017

### DIFF
--- a/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
@@ -34,6 +34,8 @@
 		target = <&mcp23017>;
 		mcp23017_irq: __overlay__ {
 			#interrupt-cells=<2>;
+			pinctrl-name = "default";
+			pinctrl-0 = <&mcp23017_pins>;
 			interrupt-parent = <&gpio>;
 			interrupts = <4 2>;
 			interrupt-controller;
@@ -49,8 +51,6 @@
 
 			mcp23017: mcp@20 {
 				compatible = "microchip,mcp23017";
-				pinctrl-name = "default";
-				pinctrl-0 = <&mcp23017_pins>;
 				reg = <0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;


### PR DESCRIPTION
noints mode disables 2 fragments that configure a GPIO to be used for the interrupt line from the MCP23017, but fails to remove the pinctrl-0 reference or pinctrl-names. It therefore fails to load due to an invalid phandle.

Move the pinctrl-0 and pinctrl-names properties so they also get disabled by the noints override.

https://forums.raspberrypi.com/viewtopic.php?t=370907

Draft awaiting confirmation from OP that it works.