### PR TITLE
Add association between DRM panels and backlight where defined

### DIFF
--- a/drivers/gpu/drm/bridge/panel.c
+++ b/drivers/gpu/drm/bridge/panel.c
@@ -14,6 +14,7 @@
 #include <drm/drm_panel.h>
 #include <drm/drm_print.h>
 #include <drm/drm_probe_helper.h>
+#include <linux/backlight.h>
 
 struct panel_bridge {
 	struct drm_bridge bridge;
@@ -85,6 +86,9 @@ static int panel_bridge_attach(struct drm_bridge *bridge,
 
 	drm_connector_attach_encoder(&panel_bridge->connector,
 					  bridge->encoder);
+
+	backlight_set_display_name(panel_bridge->panel->backlight,
+				   panel_bridge->connector.name);
 
 	if (bridge->dev->registered) {
 		if (connector->funcs->reset)

--- a/drivers/regulator/rpi-panel-v2-regulator.c
+++ b/drivers/regulator/rpi-panel-v2-regulator.c
@@ -87,6 +87,39 @@ static const struct backlight_ops rpi_panel_v2_bl = {
 	.update_status	= rpi_panel_v2_update_status,
 };
 
+static int rpi_panel_v2_i2c_read(struct i2c_client *client, u8 reg, unsigned int *buf)
+{
+	struct i2c_msg msgs[1];
+	u8 addr_buf[1] = { reg };
+	u8 data_buf[1] = { 0, };
+	int ret;
+
+	/* Write register address */
+	msgs[0].addr = client->addr;
+	msgs[0].flags = 0;
+	msgs[0].len = ARRAY_SIZE(addr_buf);
+	msgs[0].buf = addr_buf;
+
+	ret = i2c_transfer(client->adapter, msgs, ARRAY_SIZE(msgs));
+	if (ret != ARRAY_SIZE(msgs))
+		return -EIO;
+
+	usleep_range(5000, 10000);
+
+	/* Read data from register */
+	msgs[0].addr = client->addr;
+	msgs[0].flags = I2C_M_RD;
+	msgs[0].len = 1;
+	msgs[0].buf = data_buf;
+
+	ret = i2c_transfer(client->adapter, msgs, ARRAY_SIZE(msgs));
+	if (ret != ARRAY_SIZE(msgs))
+		return -EIO;
+
+	*buf = data_buf[0];
+	return 0;
+}
+
 /*
  * I2C driver interface functions
  */
@@ -114,7 +147,7 @@ static int rpi_panel_v2_i2c_probe(struct i2c_client *i2c)
 		goto error;
 	}
 
-	ret = regmap_read(regmap, REG_ID, &data);
+	ret = rpi_panel_v2_i2c_read(i2c, REG_ID, &data);
 	if (ret < 0) {
 		dev_err(&i2c->dev, "Failed to read REG_ID reg: %d\n", ret);
 		goto error;

--- a/drivers/video/backlight/backlight.c
+++ b/drivers/video/backlight/backlight.c
@@ -285,6 +285,15 @@ static ssize_t max_brightness_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(max_brightness);
 
+static ssize_t display_name_show(struct device *dev,
+				 struct device_attribute *attr, char *buf)
+{
+	struct backlight_device *bd = to_backlight_device(dev);
+
+	return sprintf(buf, "%s\n", bd->props.display_name);
+}
+static DEVICE_ATTR_RO(display_name);
+
 static ssize_t actual_brightness_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
@@ -365,6 +374,7 @@ static struct attribute *bl_device_attrs[] = {
 	&dev_attr_max_brightness.attr,
 	&dev_attr_scale.attr,
 	&dev_attr_type.attr,
+	&dev_attr_display_name.attr,
 	NULL,
 };
 ATTRIBUTE_GROUPS(bl_device);
@@ -661,6 +671,17 @@ static int of_parent_match(struct device *dev, const void *data)
 {
 	return dev->parent && dev->parent->of_node == data;
 }
+
+int backlight_set_display_name(struct backlight_device *bd, const char *name)
+{
+	if (!bd)
+		return -EINVAL;
+
+	strscpy_pad(bd->props.display_name, name, sizeof(bd->props.display_name));
+
+	return 0;
+}
+EXPORT_SYMBOL(backlight_set_display_name);
 
 /**
  * of_find_backlight_by_node() - find backlight device by device-tree node

--- a/include/linux/backlight.h
+++ b/include/linux/backlight.h
@@ -270,6 +270,13 @@ struct backlight_properties {
 	 * @scale: The type of the brightness scale.
 	 */
 	enum backlight_scale scale;
+
+#define BL_DISPLAY_NAME_LEN 32
+	/**
+	 * @display_name: Optional name that can be registered to associate a
+	 * backlight device with a display device.
+	 */
+	char display_name[BL_DISPLAY_NAME_LEN];
 };
 
 /**
@@ -478,12 +485,20 @@ of_find_backlight_by_node(struct device_node *node)
 
 #if IS_ENABLED(CONFIG_BACKLIGHT_CLASS_DEVICE)
 struct backlight_device *devm_of_find_backlight(struct device *dev);
+int backlight_set_display_name(struct backlight_device *bd, const char *name);
 #else
 static inline struct backlight_device *
 devm_of_find_backlight(struct device *dev)
 {
 	return NULL;
 }
+
+static inline int backlight_set_display_name(struct backlight_device *bd,
+					     const char *name)
+{
+	return 0;
+}
+
 #endif
 
 #endif


### PR DESCRIPTION
For comment from SimonL for UI backlight control.

For ease of testing this also includes the patches from 6176 as it's useful to have the panel fully working.