### PR TITLE
BCM2712 PCIEx1 tweaks

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712.dtsi
@@ -1063,7 +1063,6 @@
 				      0x00 0x00000000
 				      0x10 0x00000000>;
 
-			brcm,enable-l1ss;
 			status = "disabled";
 		};
 
@@ -1124,7 +1123,6 @@
 				      0x00 0x00000000
 				      0x10 0x00000000>;
 
-			brcm,enable-l1ss;
 			status = "disabled";
 		};
 

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -189,6 +189,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	pcf857x.dtbo \
 	pcie-32bit-dma.dtbo \
 	pcie-32bit-dma-pi5.dtbo \
+	pciex1-compat-pi5.dtbo \
 	pibell.dtbo \
 	pifacedigital.dtbo \
 	pifi-40.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3540,6 +3540,18 @@ Info:   Force PCIe config to support 32bit DMA addresses at the expense of
 Load:   dtoverlay=pcie-32bit-dma-pi5
 Params: <None>
 
+
+Name:   pciex1-compat-pi5
+Info:   Compatibility features for pciex1 on Pi 5.
+Load:   dtoverlay=pciex1-compat-pi5,<param>=<val>
+Params: l1ss                    Enable ASPM L1 sub-state support
+        no-l0s                  Disable ASPM L0s
+        no-mip                  Revert to the MSI target in the RC, instead of
+                                the MSI-MIP peripheral. Use if a) more than 8
+                                interrupt vectors are required or b) the EP
+                                requires DMA and MSI addresses to be 32bit.
+
+
 [ The pcf2127-rtc overlay has been deleted. See i2c-rtc. ]
 
 

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -196,6 +196,10 @@
 		bcm2712;
 	};
 
+	pcie-compat-pi5 {
+		bcm2712;
+	};
+
 	pi3-act-led {
 		renamed = "act-led";
 	};

--- a/arch/arm/boot/dts/overlays/pciex1-compat-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pciex1-compat-pi5-overlay.dts
@@ -1,0 +1,40 @@
+/*
+ * Various feature switches for the 1-lane PCIe controller on Pi 5
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2712";
+
+	/* Enable L1 sub-state support */
+	fragment@0 {
+		target = <&pciex1>;
+		__dormant__ {
+			brcm,enable-l1ss;
+		};
+	};
+
+	/* Disable ASPM L0s */
+	fragment@1 {
+		target = <&pciex1>;
+		__dormant__ {
+			aspm-no-l0s;
+		};
+	};
+
+	/* Use RC MSI target instead of MIP MSIx target */
+	fragment@2 {
+		target = <&pciex1>;
+		__dormant__ {
+			msi-parent = <&pciex1>;
+		};
+	};
+
+	__overrides__ {
+		l1ss = <0>, "+0";
+		no-l0s = <0>, "+1";
+		no-mip = <0>, "+2";
+	};
+};


### PR DESCRIPTION
Turning on L1ss by default is more trouble than it's worth, so don't do that.

The compatibility overlay should eventually get the existing pciex1_* dtparams folded in to it, but they've grown documentation arms and legs so can't be immediately deprecated.