### PR TITLE
ARM: dts: Fix camera sync parameters

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm270x-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm270x-rpi.dtsi
@@ -100,16 +100,16 @@
 
 		cam1_sync = <&csi1>, "sync-gpios:0=", <&gpio>,
 			    <&csi1>, "sync-gpios:4",
-			    <&csi1>, "sync-gpios:8=0", <GPIO_ACTIVE_HIGH>;
+			    <&csi1>, "sync-gpios:8=", <GPIO_ACTIVE_HIGH>;
 		cam1_sync_inverted = <&csi1>, "sync-gpios:0=", <&gpio>,
 			    <&csi1>, "sync-gpios:4",
-			    <&csi1>, "sync-gpios:8=0", <GPIO_ACTIVE_LOW>;
+			    <&csi1>, "sync-gpios:8=", <GPIO_ACTIVE_LOW>;
 		cam0_sync = <&csi0>, "sync-gpios:0=", <&gpio>,
 			    <&csi0>, "sync-gpios:4",
-			    <&csi0>, "sync-gpios:8=0", <GPIO_ACTIVE_HIGH>;
+			    <&csi0>, "sync-gpios:8=", <GPIO_ACTIVE_HIGH>;
 		cam0_sync_inverted = <&csi0>, "sync-gpios:0=", <&gpio>,
 			    <&csi0>, "sync-gpios:4",
-			    <&csi0>, "sync-gpios:8=0", <GPIO_ACTIVE_LOW>;
+			    <&csi0>, "sync-gpios:8=", <GPIO_ACTIVE_LOW>;
 
 		strict_gpiod = <&chosen>, "bootargs=pinctrl_bcm2835.persist_gpio_outputs=n";
 	};


### PR DESCRIPTION
The camera sync parameter declarations include are invalid in that they have both embedded string values and following cell values. The intention here was to use the cell values, but the embedded "0" was not removed as it should have been.

The implication of this mistake is that inverted sync flags would be ignored because the 0 value corresponds to GPIO_ACTIVE_HIGH. The extra cell value would be treated as the start of another override, but then ignored because the end of the parameter is reached.

These errors should have been picked up by the automated checks, but the base dts files weren't subjected to the same validation. This has now been corrected.