### PR TITLE
DTS: overlays: add mmio-hi parameter to pciex1-compat-pi5

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3550,6 +3550,8 @@ Params: l1ss                    Enable ASPM L1 sub-state support
                                 the MSI-MIP peripheral. Use if a) more than 8
                                 interrupt vectors are required or b) the EP
                                 requires DMA and MSI addresses to be 32bit.
+        mmio-hi                 Move the start of outbound 32bit addresses to
+                                2GB and expand 64bit outbound space to 14GB.
 
 
 [ The pcf2127-rtc overlay has been deleted. See i2c-rtc. ]

--- a/arch/arm/boot/dts/overlays/pciex1-compat-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pciex1-compat-pi5-overlay.dts
@@ -32,9 +32,29 @@
 		};
 	};
 
+	/*
+	 * Shift the start of the 32bit outbound window to 2GB,
+	 * so there are no BARs starting at 0x0. Expand the 64bit
+	 * outbound window to use the spare 2GB.
+	 */
+	fragment@3 {
+		target = <&pciex1>;
+		__dormant__ {
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges = <0x02000000 0x00 0x80000000
+				  0x1b 0x80000000
+				  0x00 0x7ffffffc>,
+				 <0x43000000 0x04 0x00000000
+				  0x18 0x00000000
+				  0x03 0x80000000>;
+		};
+	};
+
 	__overrides__ {
 		l1ss = <0>, "+0";
 		no-l0s = <0>, "+1";
 		no-mip = <0>, "+2";
+		mmio-hi = <0>, "+3";
 	};
 };


### PR DESCRIPTION
I225-V network adapters have a buggy ROM that won't complete internal initialisation if (at least) BAR0 has an assigned address of 0x0.

Add a parameter to the pciex1-compat-pi5 overlay to make outbound addresses start at 2GB.

see #6134 