### PR TITLE
fix Hsync and Vsync polarity can't change from negatieve to positief …

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -1872,7 +1872,6 @@ static void vc4_hdmi_encoder_post_crtc_enable(struct drm_encoder *encoder,
 	bool hsync_pos = mode->flags & DRM_MODE_FLAG_PHSYNC;
 	bool vsync_pos = mode->flags & DRM_MODE_FLAG_PVSYNC;
 	unsigned long flags;
-	long unsigned int HDMI_VID_CTL_value;
 	int ret;
 	int idx;
 
@@ -1883,22 +1882,16 @@ static void vc4_hdmi_encoder_post_crtc_enable(struct drm_encoder *encoder,
 
 	spin_lock_irqsave(&vc4_hdmi->hw_lock, flags);
 
-	HDMI_VID_CTL_value = HDMI_READ(HDMI_VID_CTL) |
-		   VC4_HD_VID_CTL_ENABLE |
-		   VC4_HD_VID_CTL_CLRRGB |
-		   VC4_HD_VID_CTL_UNDERFLOW_ENABLE |
-		   VC4_HD_VID_CTL_FRAME_COUNTER_RESET |
-		   VC4_HD_VID_CTL_BLANK_INSERT_EN;
-	if(hsync_pos)
-		HDMI_VID_CTL_value &= ~VC4_HD_VID_CTL_HSYNC_LOW;
-	else
-		HDMI_VID_CTL_value |= VC4_HD_VID_CTL_HSYNC_LOW;
-	if(vsync_pos)
-		HDMI_VID_CTL_value &= ~VC4_HD_VID_CTL_VSYNC_LOW;
-	else
-		HDMI_VID_CTL_value |= VC4_HD_VID_CTL_VSYNC_LOW;
-	
-	HDMI_WRITE(HDMI_VID_CTL, HDMI_VID_CTL_value);
+	HDMI_WRITE(HDMI_VID_CTL,
+	   (HDMI_READ(HDMI_VID_CTL) &~ 
+	   (VC4_HD_VID_CTL_VSYNC_LOW | VC4_HD_VID_CTL_HSYNC_LOW)) |
+	   VC4_HD_VID_CTL_ENABLE |
+	   VC4_HD_VID_CTL_CLRRGB |
+	   VC4_HD_VID_CTL_UNDERFLOW_ENABLE |
+	   VC4_HD_VID_CTL_FRAME_COUNTER_RESET |
+	   VC4_HD_VID_CTL_BLANK_INSERT_EN |
+	   (vsync_pos ? 0 : VC4_HD_VID_CTL_VSYNC_LOW) |
+	   (hsync_pos ? 0 : VC4_HD_VID_CTL_HSYNC_LOW));
 
 	HDMI_WRITE(HDMI_VID_CTL,
 		   HDMI_READ(HDMI_VID_CTL) & ~VC4_HD_VID_CTL_BLANKPIX);

--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -1872,6 +1872,7 @@ static void vc4_hdmi_encoder_post_crtc_enable(struct drm_encoder *encoder,
 	bool hsync_pos = mode->flags & DRM_MODE_FLAG_PHSYNC;
 	bool vsync_pos = mode->flags & DRM_MODE_FLAG_PVSYNC;
 	unsigned long flags;
+	long unsigned int HDMI_VID_CTL_value;
 	int ret;
 	int idx;
 
@@ -1882,15 +1883,22 @@ static void vc4_hdmi_encoder_post_crtc_enable(struct drm_encoder *encoder,
 
 	spin_lock_irqsave(&vc4_hdmi->hw_lock, flags);
 
-	HDMI_WRITE(HDMI_VID_CTL,
-		   HDMI_READ(HDMI_VID_CTL) |
+	HDMI_VID_CTL_value = HDMI_READ(HDMI_VID_CTL) |
 		   VC4_HD_VID_CTL_ENABLE |
 		   VC4_HD_VID_CTL_CLRRGB |
 		   VC4_HD_VID_CTL_UNDERFLOW_ENABLE |
 		   VC4_HD_VID_CTL_FRAME_COUNTER_RESET |
-		   VC4_HD_VID_CTL_BLANK_INSERT_EN |
-		   (vsync_pos ? 0 : VC4_HD_VID_CTL_VSYNC_LOW) |
-		   (hsync_pos ? 0 : VC4_HD_VID_CTL_HSYNC_LOW));
+		   VC4_HD_VID_CTL_BLANK_INSERT_EN;
+	if(hsync_pos)
+		HDMI_VID_CTL_value &= ~VC4_HD_VID_CTL_HSYNC_LOW;
+	else
+		HDMI_VID_CTL_value |= VC4_HD_VID_CTL_HSYNC_LOW;
+	if(vsync_pos)
+		HDMI_VID_CTL_value &= ~VC4_HD_VID_CTL_VSYNC_LOW;
+	else
+		HDMI_VID_CTL_value |= VC4_HD_VID_CTL_VSYNC_LOW;
+	
+	HDMI_WRITE(HDMI_VID_CTL, HDMI_VID_CTL_value);
 
 	HDMI_WRITE(HDMI_VID_CTL,
 		   HDMI_READ(HDMI_VID_CTL) & ~VC4_HD_VID_CTL_BLANKPIX);


### PR DESCRIPTION
…vc4_hdmi.c

There was a small issue where if you change the polarity from + to -, you could not change back because you never undo the written bit in the register. This is because only | is used, when & is needed to change back to positive (+).