### PR TITLE
media: dt-bindings: i2c: Add Sony IMX500

### DIFF
--- a/Documentation/devicetree/bindings/media/i2c/sony,imx500.yaml
+++ b/Documentation/devicetree/bindings/media/i2c/sony,imx500.yaml
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/media/i2c/sony,imx500.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Sony CMOS Digital Image Sensor and CNN
+
+maintainers:
+  - Raspberry Pi <kernel-list@raspberrypi.com>
+
+description: |-
+  The Sony IMX500 is a stacked 1/2.3-inch CMOS digital image sensor and inbuilt
+  AI processor with an active array CNN (Convolutional Neural Network) inference
+  engine.  The native sensor size is 4056H x 3040V, and the module also contains
+  an in-built ISP for the CNN. The module is programmable through an I2C
+  interface with firmware and neural network uploads being made over SPI. The
+  default I2C address is 0x1A, with an address of 0x10 being selectable via
+  SLASEL. The module also has a second I2C interface available with a fixed
+  address of 0x36.  Image data is sent through MIPI CSI-2, which is configured
+  as either 2 or 4 data lanes.
+
+properties:
+  compatible:
+    const: sony,imx500
+
+  reg:
+    description: I2C device address
+    maxItems: 1
+
+  clocks:
+    maxItems: 1
+
+  clock-names:
+    description: |-
+      Input clock (12 to 27 MHz)
+    items:
+      - const: inck
+
+  interrupts:
+    maxItems: 1
+
+  vana-supply:
+    description: Supply voltage (analog) - 2.7 V
+
+  vdig-supply:
+    description: Supply voltage (digital) - 0.84 V
+
+  vif-supply:
+    description: Supply voltage (interface) - 1.8 V
+
+  reset-gpios:
+    description: |-
+      Sensor reset (XCLR) GPIO
+
+      Chip clear in lieu of built-in power on reset. To be set 'High' after
+      power supplies are brought up and INCK supplied.
+
+  port:
+    $ref: /schemas/graph.yaml#/$defs/port-base
+    additionalProperties: false
+    description: |
+      Video output port
+
+    properties:
+      endpoint:
+        $ref: /schemas/media/video-interfaces.yaml#
+        type: object
+        unevaluatedProperties: false
+        properties:
+          data-lanes:
+            items:
+              - const: 1
+              - const: 2
+          clock-noncontinuous: true
+          link-frequencies: true
+          clock-lanes:
+            items:
+              - const: 0
+        required:
+          - link-frequencies
+          - clock-lanes
+          - data-lanes
+
+required:
+  - compatible
+  - reg
+
+allOf:
+  - $ref: /schemas/spi/spi-peripheral-props.yaml#
+  - if:
+      required:
+        - spi-max-frequency
+    then:
+      properties:
+        # SPI node
+        clocks: false
+        clock-names: false
+        vana-supply: false
+        vdig-supply: false
+        vif-supply: false
+        reset-gpios: false
+        port: false
+    else:
+      required:
+        - clocks
+        - clock-names
+        - vana-supply
+        - vdig-supply
+        - vif-supply
+        - reset-gpios
+        - port
+
+unevaluatedProperties: false
+
+examples:
+  - |
+    #include <dt-bindings/gpio/gpio.h>
+
+    i2c {
+      #address-cells = <1>;
+      #size-cells = <0>;
+
+      imx500: sensor@1a {
+        compatible = "sony,imx500";
+        reg = <0x1a>;
+
+        clocks = <&imx500_clk>;
+        clock-names = "inck";
+
+        vana-supply = <&imx500_vana>; /* 2.7  +/- 0.1  V */
+        vdig-supply = <&imx500_vdig>; /* 0.84 +/- 0.04 V */
+        vif-supply  = <&imx500_vif>;  /* 1.8  +/- 0.1  V */
+
+        reset-gpios = <&gpio_sensor 0 GPIO_ACTIVE_LOW>;
+
+        port {
+          imx500_0: endpoint {
+            clock-lanes = <0>;
+            remote-endpoint = <&csi1_ep>;
+            data-lanes = <1 2>;
+            clock-noncontinuous;
+            link-frequencies = /bits/ 64 <499500000>;
+          };
+        };
+      };
+    };
+
+    spi {
+      #address-cells = <1>;
+      #size-cells = <0>;
+
+      sensor@0 {
+        compatible = "sony,imx500";
+        reg = <0>;
+        spi-max-frequency = <35000000>;
+      };
+    };
+
+...
+

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -20103,6 +20103,13 @@ F:	Documentation/devicetree/bindings/media/i2c/imx378.yaml
 F:	Documentation/devicetree/bindings/media/i2c/imx477.yaml
 F:	drivers/media/i2c/imx477.c
 
+SONY IMX500 SENSOR DRIVER
+M:	Raspberry Pi Kernel Maintenance <kernel-list@raspberrypi.com>
+L:	linux-media@vger.kernel.org
+S:	Maintained
+T:	git git://linuxtv.org/media_tree.git
+F:	Documentation/devicetree/bindings/media/i2c/sony,imx500.yaml
+
 SONY IMX519 SENSOR DRIVER
 M:	Arducam Kernel Maintenance <info@arducam.com>
 L:	linux-media@vger.kernel.org


### PR DESCRIPTION
Add YAML device tree binding for the Sony IMX500 CMOS image sensor / CNN inference engine.  Also, add a MAINTAINERS entry.