### PR TITLE
dts: bcm2712-rpi: Move rpi-otp nodes onto a bus

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi.dtsi
@@ -26,18 +26,24 @@
 };
 
 &soc {
-	nvmem_otp: nvmem_otp {
-		compatible = "raspberrypi,rpi-otp";
-		firmware = <&firmware>;
-		reg = <0 192>;
-		status = "okay";
-	};
+	nvmem {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	nvmem_cust: nvmem_cust {
-		compatible = "raspberrypi,rpi-otp";
-		firmware = <&firmware>;
-		reg = <1 8>;
-		status = "okay";
+		nvmem_otp: nvmem_otp {
+			compatible = "raspberrypi,rpi-otp";
+			firmware = <&firmware>;
+			reg = <0 192>;
+			status = "okay";
+		};
+
+		nvmem_cust: nvmem_cust {
+			compatible = "raspberrypi,rpi-otp";
+			firmware = <&firmware>;
+			reg = <1 8>;
+			status = "okay";
+		};
 	};
 };
 

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
@@ -90,26 +90,31 @@
 	/* Add the physical <-> DMA mapping for the I/O space */
 	dma-ranges = <0xc0000000  0x0 0x00000000  0x40000000>,
 		     <0x7c000000  0x0 0xfc000000  0x03800000>;
+	nvmem {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	nvmem_otp: nvmem_otp {
-		compatible = "raspberrypi,rpi-otp";
-		firmware = <&firmware>;
-		reg = <0 166>;
-		status = "okay";
-	};
+		nvmem_otp: nvmem_otp {
+			compatible = "raspberrypi,rpi-otp";
+			firmware = <&firmware>;
+			reg = <0 166>;
+			status = "okay";
+		};
 
-	nvmem_cust: nvmem_cust {
-		compatible = "raspberrypi,rpi-otp";
-		firmware = <&firmware>;
-		reg = <1 8>;
-		status = "okay";
-	};
+		nvmem_cust: nvmem_cust {
+			compatible = "raspberrypi,rpi-otp";
+			firmware = <&firmware>;
+			reg = <1 8>;
+			status = "okay";
+		};
 
-	nvmem_priv: nvmem_priv {
-		compatible = "raspberrypi,rpi-otp";
-		firmware = <&firmware>;
-		reg = <3 8>;
-		status = "okay";
+		nvmem_priv: nvmem_priv {
+			compatible = "raspberrypi,rpi-otp";
+			firmware = <&firmware>;
+			reg = <3 8>;
+			status = "okay";
+		};
 	};
 };
 

--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -45,32 +45,38 @@
 		trickle-charge-microvolt = <0>;
 	};
 
-	nvmem_otp: nvmem_otp {
-		compatible = "raspberrypi,rpi-otp";
-		firmware = <&firmware>;
-		reg = <0 192>;
-		status = "okay";
-	};
+	nvmem {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	nvmem_cust: nvmem_cust {
-		compatible = "raspberrypi,rpi-otp";
-		firmware = <&firmware>;
-		reg = <1 8>;
-		status = "okay";
-	};
+		nvmem_otp: nvmem_otp {
+			compatible = "raspberrypi,rpi-otp";
+			firmware = <&firmware>;
+			reg = <0 192>;
+			status = "okay";
+		};
 
-	nvmem_mac: nvmem_mac {
-		compatible = "raspberrypi,rpi-otp";
-		firmware = <&firmware>;
-		reg = <2 6>;
-		status = "okay";
-	};
+		nvmem_cust: nvmem_cust {
+			compatible = "raspberrypi,rpi-otp";
+			firmware = <&firmware>;
+			reg = <1 8>;
+			status = "okay";
+		};
 
-	nvmem_priv: nvmem_priv {
-		compatible = "raspberrypi,rpi-otp";
-		firmware = <&firmware>;
-		reg = <3 16>;
-		status = "okay";
+		nvmem_mac: nvmem_mac {
+			compatible = "raspberrypi,rpi-otp";
+			firmware = <&firmware>;
+			reg = <2 6>;
+			status = "okay";
+		};
+
+		nvmem_priv: nvmem_priv {
+			compatible = "raspberrypi,rpi-otp";
+			firmware = <&firmware>;
+			reg = <3 16>;
+			status = "okay";
+		};
 	};
 
 	/* Define these notional regulators for use by overlays, etc. */


### PR DESCRIPTION
The rpi-otp driver uses a virtualised, OTP-relative addressing scheme. However, when instance nodes are children of "/soc" they appear to be addressable directly by the host, which is wrong (but not in a way which causes an error unless one goes looking for one).

Add a wrapper (bus) node without a "ranges" property to make the separation clear.

See: https://github.com/raspberrypi/linux/issues/6196