### PR TITLE
rpi-6.10.y/vchiq dma mask updates

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -3898,6 +3898,13 @@ static int bcm2835_codec_probe(struct vchiq_device *device)
 	struct media_device *mdev;
 	int ret = 0;
 
+	ret = dma_set_mask_and_coherent(&device->dev, DMA_BIT_MASK(32));
+	if (ret) {
+		dev_err(&device->dev, "dma_set_mask_and_coherent failed: %d\n",
+			ret);
+		return ret;
+	}
+
 	drv = devm_kzalloc(&device->dev, sizeof(*drv), GFP_KERNEL);
 	if (!drv)
 		return -ENOMEM;

--- a/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
+++ b/drivers/staging/vc04_services/bcm2835-isp/bcm2835-v4l2-isp.c
@@ -1775,6 +1775,13 @@ static int bcm2835_isp_probe(struct vchiq_device *device)
 	unsigned int i;
 	int ret;
 
+	ret = dma_set_mask_and_coherent(&device->dev, DMA_BIT_MASK(32));
+	if (ret) {
+		dev_err(&device->dev, "dma_set_mask_and_coherent failed: %d\n",
+			ret);
+		return ret;
+	}
+
 	bcm2835_isp_instances = devm_kzalloc(&device->dev,
 					     sizeof(bcm2835_isp_instances) *
 						      BCM2835_ISP_NUM_INSTANCES,

--- a/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
+++ b/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
@@ -1477,7 +1477,16 @@ err_remove_debugfs:
 /* Driver loading. */
 static int bcm2835_vc_sm_cma_probe(struct vchiq_device *device)
 {
+	int err;
+
 	pr_info("%s: Videocore shared memory driver\n", __func__);
+
+	err = dma_set_mask_and_coherent(&device->dev, DMA_BIT_MASK(32));
+	if (err) {
+		dev_err(&device->dev, "dma_set_mask_and_coherent failed: %d\n",
+			err);
+		return err;
+	}
 
 	sm_state = devm_kzalloc(&device->dev, sizeof(*sm_state), GFP_KERNEL);
 	if (!sm_state)


### PR DESCRIPTION
These update the (remaining) vchiq bus devices to explicitly set the DMA_MASK.

In particular, the VC-SM-CMA triggers a warning at boot without this.

This implementation updates the SM-CMA, ISP, and Codec to match the audio and camera device. Though I do wonder if we should instead make the vchiq_bus probe() just register this on all vchiq devices directly instead!

(I assume all vchiq based devices would have an identical DMA mask).