### PR TITLE
Add DTS override for CAMx_REG GPIOs for the Raspberry Pi 5

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi-5-b.dts
@@ -799,6 +799,8 @@ spi10_cs_pins: &spi10_cs_gpio1 {};
 	__overrides__ {
 		bdaddr = <&bluetooth>, "local-bd-address[";
 		button_debounce = <&pwr_key>, "debounce-interval:0";
+		cam0_reg = <&cam0_reg>,"status";
+		cam1_reg = <&cam1_reg>,"status";
 		cooling_fan = <&fan>, "status", <&rp1_pwm1>, "status";
 		uart0_console = <&uart0>,"status", <&aliases>, "console=",&uart0;
 		i2c0 = <&i2c0>, "status";


### PR DESCRIPTION
Adds overrides for using the CAMx_REG pins on the CAM/DISP connectors as generic GPIO. The rationale for the override is to use this GPIO as a reset pin for MIPI DSI displays.

This PR mirrors how it is done on the [CM3](https://github.com/raspberrypi/linux/blob/5e5cacce17c401e9a0ec85fcb393220f2d4a8109/arch/arm/boot/dts/bcm2710-rpi-cm3.dts#L218-L221) and [CM4](https://github.com/raspberrypi/linux/blob/5e5cacce17c401e9a0ec85fcb393220f2d4a8109/arch/arm/boot/dts/bcm2711-rpi-cm4.dts#L443-L448). I didn't add the overrides for manual specification of the camera regulator GPIO pin (as done in the Compute Modules) considering the GPIO on the CAM/DISP connector is fixed. However, if that feature is desired I can add it to this pull request.

[This forum post](https://forums.raspberrypi.com/viewtopic.php?t=358433#p2149690) by @6by9 implies that this functionality was also intended for the Raspberry Pi 5.  Because there is no `__override__` for cam0_reg or cam1_reg,  adding `dtparam=cam0_reg=off` or `dtparam=cam1_reg=off` causes an error when parsing config.txt as shown in `vclog --msg` output. The resulting effect is that the GPIOs are still listed as used and they cannot be accessed in userspace. 

Thanks in advance for considering this pull request!