### PR TITLE
Fix the IQaudIO handling of 16-bit samples

### DIFF
--- a/sound/soc/bcm/iqaudio-codec.c
+++ b/sound/soc/bcm/iqaudio-codec.c
@@ -127,10 +127,16 @@ static int snd_rpi_iqaudio_codec_init(struct snd_soc_pcm_runtime *rtd)
 	snd_soc_dapm_disable_pin(&rtd->card->dapm, "AUX Jack");
 	snd_soc_dapm_sync(&rtd->card->dapm);
 
-	/* Set bclk ratio to align with codec's BCLK rate */
+	/* Impose BCLK ratios otherwise the codec may cheat */
 	ret = snd_soc_dai_set_bclk_ratio(cpu_dai, 64);
 	if (ret) {
 		dev_err(rtd->dev, "Failed to set CPU BLCK ratio\n");
+		return ret;
+	}
+
+	ret = snd_soc_dai_set_bclk_ratio(codec_dai, 64);
+	if (ret) {
+		dev_err(rtd->dev, "Failed to set codec BCLK ratio\n");
 		return ret;
 	}
 

--- a/sound/soc/codecs/da7213.c
+++ b/sound/soc/codecs/da7213.c
@@ -1181,6 +1181,8 @@ static int da7213_hw_params(struct snd_pcm_substream *substream,
 	switch (params_width(params)) {
 	case 16:
 		dai_ctrl |= DA7213_DAI_WORD_LENGTH_S16_LE;
+		if (da7213->bclk_ratio == 64)
+			break;
 		dai_clk_mode = DA7213_DAI_BCLKS_PER_WCLK_32; /* 32bit for 1ch and 2ch */
 		break;
 	case 20:
@@ -1195,6 +1197,9 @@ static int da7213_hw_params(struct snd_pcm_substream *substream,
 	default:
 		return -EINVAL;
 	}
+
+	if (da7213->bclk_ratio == 32 && params_width(params) != 16)
+		return -EINVAL;
 
 	/* Set sampling rate */
 	switch (params_rate(params)) {
@@ -1354,6 +1359,21 @@ static int da7213_set_dai_fmt(struct snd_soc_dai *codec_dai, unsigned int fmt)
 	snd_soc_component_update_bits(component, DA7213_DAI_CTRL, DA7213_DAI_FORMAT_MASK,
 			    dai_ctrl);
 	snd_soc_component_write(component, DA7213_DAI_OFFSET, dai_offset);
+
+	return 0;
+}
+
+static int da7213_set_bclk_ratio(struct snd_soc_dai *dai, unsigned int ratio)
+{
+	struct snd_soc_component *component = dai->component;
+	struct da7213_priv *da7213 = snd_soc_component_get_drvdata(component);
+
+	if (ratio != 32 && ratio != 64) {
+		dev_err(component->dev, "Invalid bclk ratio %d\n", ratio);
+		return -EINVAL;
+	}
+
+	da7213->bclk_ratio = ratio;
 
 	return 0;
 }
@@ -1554,6 +1574,7 @@ static int da7213_set_component_pll(struct snd_soc_component *component,
 static const struct snd_soc_dai_ops da7213_dai_ops = {
 	.hw_params	= da7213_hw_params,
 	.set_fmt	= da7213_set_dai_fmt,
+	.set_bclk_ratio	= da7213_set_bclk_ratio,
 	.mute_stream	= da7213_mute,
 	.no_capture_mute = 1,
 };

--- a/sound/soc/codecs/da7213.h
+++ b/sound/soc/codecs/da7213.h
@@ -538,6 +538,7 @@ struct da7213_priv {
 	struct clk *mclk;
 	unsigned int mclk_rate;
 	unsigned int out_rate;
+	unsigned int bclk_ratio;
 	int clk_src;
 	bool master;
 	bool alc_calib_auto;


### PR DESCRIPTION
Between rpi-6.1.y and rpi-6.6.y the DA7213 codec driver picked up a patch selecting a BCLK ratio of 32 for 16-bit audio. This breaks the CPU DAI if it is expecting a BCLK ratio of 64. Instead of baking the knowledge of the codec's foibles into the soundcard driver, give the codec a set_bclk_ratio method and make the soundcard driver use it.