### PR TITLE
fs/ntfs3: Fix memory corruption when page_size changes

### DIFF
--- a/fs/ntfs3/fslog.c
+++ b/fs/ntfs3/fslog.c
@@ -3907,6 +3907,8 @@ check_restart_area:
 		log->l_size = log->orig_file_size;
 		log->page_size = norm_file_page(t32, &log->l_size,
 						t32 == DefaultLogPageSize);
+		log->page_mask = log->page_size - 1;
+		log->page_bits = blksize_bits(log->page_size);
 	}
 
 	if (log->page_size != t32 ||


### PR DESCRIPTION
The rework in fs/ntfs3: Reduce stack usage
changes log->page_size but doesn't change the associated log->page_mask and log->page_bits.

That results in the bytes value in read_log_page
getting a negative value, which is bad when it is
passed to memcpy.

The kernel panic can be observed when connecting an ntfs formatted drive that has previously been connected to a Windows machine to a Raspberry Pi 5, which by defauilt uses a 16K kernel pagesize.

Fixes: 865e7a7700d9 ("fs/ntfs3: Reduce stack usage")