### PR TITLE
Follow pwm_apply_might_sleep() rename in gpio-pwm and ir-rx51

### DIFF
--- a/drivers/gpio/gpio-pwm.c
+++ b/drivers/gpio/gpio-pwm.c
@@ -34,7 +34,7 @@ static void pwm_gpio_set(struct gpio_chip *gc, unsigned int off, int val)
 
 	pwm_get_state(pwm_gpio->pwm[off], &state);
 	state.duty_cycle = val ? state.period : 0;
-	pwm_apply_state(pwm_gpio->pwm[off], &state);
+	pwm_apply_might_sleep(pwm_gpio->pwm[off], &state);
 }
 
 static int pwm_gpio_parse_dt(struct pwm_gpio *pwm_gpio,
@@ -79,7 +79,7 @@ static int pwm_gpio_parse_dt(struct pwm_gpio *pwm_gpio,
 		pwm_init_state(pwm_gpio->pwm[i], &state);
 
 		state.duty_cycle = 0;
-		pwm_apply_state(pwm_gpio->pwm[i], &state);
+		pwm_apply_might_sleep(pwm_gpio->pwm[i], &state);
 	}
 
 	pwm_gpio->gc.ngpio = num_gpios;


### PR DESCRIPTION
[raspberrypi/linux#6018](https://github.com/raspberrypi/linux/pull/6018) introduces commit https://github.com/raspberrypi/linux/commit/b23e6d7dbd3198b38ab131f51ffdfd8986a8c041 ("pwm: Rename pwm_apply_state() to pwm_apply_might_sleep()"), but didn't rename these 2 modules which use the renamed function. Rename them to allow building them in NixOS which tries to build every module as a module.