### PR TITLE
nvme-pci: Add quirk for disabling broken ASPM L0s/L1 implementations …

### DIFF
--- a/drivers/nvme/host/nvme.h
+++ b/drivers/nvme/host/nvme.h
@@ -166,6 +166,16 @@ enum nvme_quirks {
 	 * MSI (but not MSI-X) interrupts are broken and never fire.
 	 */
 	NVME_QUIRK_BROKEN_MSI			= (1 << 21),
+
+	/*
+	 * Broken ASPM L0s implementation.
+	 */
+	NVME_QUIRK_BROKEN_ASPM_L0S              = (1 << 21),
+
+	/*
+	 * Broken ASPM L1 implementation.
+	*/
+	NVME_QUIRK_BROKEN_ASPM_L1               = (1 << 22),
 };
 
 /*


### PR DESCRIPTION
…on Phison E13 controller (1987:5013)

Drives with the Phison E13 tend to throw PCIe ASPM errors and they can't be used as boot drives unless ASPM L0s/L1 is disabled with the pciex1-compat-pi5 overlay.

This quirk applies the required configuration based on NVMe vendor and device identifier. This change makes those drives compatible with a clean install of Raspberry Pi OS.

ASPM errors on Phison E13 controllers show up in PCIe GEN 3 on PIP boards with poor layout and no impedance control on the ribbon cable. They are also present in PCIe GEN 2 when the drive is used behind a packet switch.

Implementation is based on the Hailo PCIe driver that also disables ASPM LOs/L1 when the device is initialized.

List of affected drives:

- Pineboards Pinedrive 2280 [SSD98-256CG-PB]
- Pineboards Pinedrive 2242 [SSD94-2563CG-PB]
- Patriot M.2 P300
- Apacer AS2280P4 256GB [AP256GAS2280P4-1] – Crucial P2 1000 [CT1000P2SSD8]
- DEXP L3 PCIe Gen3x4 [EPA256GNLNXE30CD-DRL3]
- Gigabyte GP-GSM2NE256GNTD 256GB
- GIGABYTE NVMe SSD [GP-GSM2NE3256GNTD]
- Kingston NV1 500GB SNVS-500G
- MSI SPATIUM M370 1TB
- MSI SPATIUM M371 1TB
- Patriot P300 256GB
- Seagate Barracuda Q5 500GB ZP500CV3A001
- Smartbuy Stream E13T [SBSSD-512GT-PH13T-M2P4]
- Smartbuy Stream E13T Pro [SBSSD-128GT-PH13P-M2P4] – Team Group MP33 256GB [TM8FP6256G0C101]
- SSD OWC Aura P13 Pro 1TB M.2 2242 PCI-E x4 Gen3.1 NVMe [OWCS3DN3P3T10]