### PR TITLE
drm/bridge: panel: Ensure backlight is reachable

### DIFF
--- a/drivers/gpu/drm/bridge/panel.c
+++ b/drivers/gpu/drm/bridge/panel.c
@@ -87,8 +87,10 @@ static int panel_bridge_attach(struct drm_bridge *bridge,
 	drm_connector_attach_encoder(&panel_bridge->connector,
 					  bridge->encoder);
 
+#if IS_REACHABLE(CONFIG_BACKLIGHT_CLASS_DEVICE)
 	backlight_set_display_name(panel_bridge->panel->backlight,
 				   panel_bridge->connector.name);
+#endif
 
 	if (bridge->dev->registered) {
 		if (connector->funcs->reset)


### PR DESCRIPTION
Ensure that the various options of modules vs builtin results in being able to call into the backlight code.

https://github.com/raspberrypi/linux/issues/6198

Fixes: 573f8fd0abf1 ("drm/bridge: panel: Name an associated backlight device")