### PR TITLE
arm64: dts: remove broken DTSI links

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi
@@ -1,1 +1,0 @@
-../../../../arm/boot/dts/bcm283x-rpi-csi1-2lane.dtsi

--- a/arch/arm64/boot/dts/broadcom/bcm283x-rpi-lan7515.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm283x-rpi-lan7515.dtsi
@@ -1,1 +1,0 @@
-../../../../arm/boot/dts/bcm283x-rpi-lan7515.dtsi


### PR DESCRIPTION
Both [bcm283x-rpi-csi1-2lane.dtsi](https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm64/boot/dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi) and [bcm283x-rpi-lan7515.dtsi](https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm64/boot/dts/broadcom/bcm283x-rpi-lan7515.dtsi) are linked to ["../arm/boot/dts/"](https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm64/boot/dts) instead of ["../arm/boot/dts/broadcom"](https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm64/boot/dts/broadcom), so the links are broken.

Fixes: d060fc0b4568 ("BCM2708: Add core Device Tree support")

OpenWrt reference: https://github.com/openwrt/openwrt/pull/15762