### PR TITLE
mmc: restrict posted write counts for SD cards in CQ mode

### DIFF
--- a/drivers/mmc/core/mmc.c
+++ b/drivers/mmc/core/mmc.c
@@ -1922,6 +1922,7 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
 				pr_info("%s: Host Software Queue enabled\n",
 					mmc_hostname(host));
 			}
+			card->max_posted_writes = card->ext_csd.cmdq_depth;
 		}
 	}
 

--- a/drivers/mmc/core/queue.c
+++ b/drivers/mmc/core/queue.c
@@ -268,6 +268,11 @@ static blk_status_t mmc_mq_queue_rq(struct blk_mq_hw_ctx *hctx,
 			spin_unlock_irq(&mq->lock);
 			return BLK_STS_RESOURCE;
 		}
+		if (host->cqe_enabled && req_op(req) == REQ_OP_WRITE &&
+		    mq->pending_writes >= card->max_posted_writes) {
+			spin_unlock_irq(&mq->lock);
+			return BLK_STS_RESOURCE;
+		}
 		break;
 	default:
 		/*
@@ -284,6 +289,8 @@ static blk_status_t mmc_mq_queue_rq(struct blk_mq_hw_ctx *hctx,
 	/* Parallel dispatch of requests is not supported at the moment */
 	mq->busy = true;
 
+	if (req_op(req) == REQ_OP_WRITE)
+		mq->pending_writes++;
 	mq->in_flight[issue_type] += 1;
 	get_card = (mmc_tot_in_flight(mq) == 1);
 	cqe_retune_ok = (mmc_cqe_qcnt(mq) == 1);
@@ -323,6 +330,8 @@ static blk_status_t mmc_mq_queue_rq(struct blk_mq_hw_ctx *hctx,
 		bool put_card = false;
 
 		spin_lock_irq(&mq->lock);
+		if (req_op(req) == REQ_OP_WRITE)
+			mq->pending_writes--;
 		mq->in_flight[issue_type] -= 1;
 		if (mmc_tot_in_flight(mq) == 0)
 			put_card = true;

--- a/drivers/mmc/core/queue.h
+++ b/drivers/mmc/core/queue.h
@@ -79,6 +79,7 @@ struct mmc_queue {
 	struct request_queue	*queue;
 	spinlock_t		lock;
 	int			in_flight[MMC_ISSUE_MAX];
+	int			pending_writes;
 	unsigned int		cqe_busy;
 #define MMC_CQE_DCMD_BUSY	BIT(0)
 	bool			busy;

--- a/drivers/mmc/core/sd.c
+++ b/drivers/mmc/core/sd.c
@@ -1104,6 +1104,14 @@ static int sd_parse_ext_reg_perf(struct mmc_card *card, u8 fno, u8 page,
 		pr_debug("%s: Command Queue supported depth %u\n",
 			 mmc_hostname(card->host),
 			 card->ext_csd.cmdq_depth);
+		/*
+		 * If CQ is enabled, there is a contract between host and card such that VDD will
+		 * be maintained and removed only if a power off notification is provided.
+		 * An SD card in an accessible slot means surprise removal is a possibility.
+		 * As a middle ground, limit max posted writes to 1 unless the card is "hardwired".
+		 */
+		if (mmc_card_is_removable(card->host))
+			card->max_posted_writes = 1;
 	}
 
 	card->ext_perf.fno = fno;

--- a/include/linux/mmc/card.h
+++ b/include/linux/mmc/card.h
@@ -343,6 +343,8 @@ struct mmc_card {
 	unsigned int    nr_parts;
 
 	struct workqueue_struct *complete_wq;	/* Private workqueue */
+
+	unsigned int		max_posted_writes; /* command queue posted write limit */
 };
 
 static inline bool mmc_large_sector(struct mmc_card *card)


### PR DESCRIPTION
Command Queueing requires Write Cache and Power off Notification support from the card - but using the write cache forms a contract with the host whereby the card expects to be told about impending power-down.

The implication is that (for performance) the card can do unsafe things with pending write data - including reordering what gets committed to nonvolatile storage at what time.

Exposed SD slots and platforms powered by hotpluggable means (i.e. Raspberry Pis) can't guarantee that surprise removal won't happen.

To limit the scope for cards to invent new ways to trash filesystems, limit pending writes to 1 (equivalent to the non-CQ behaviour).