### PR TITLE
fixup! drivers: mmc: sdhci-brcmstb: bcm2712 supports HS400es and cloc…

### DIFF
--- a/drivers/mmc/host/sdhci-brcmstb.c
+++ b/drivers/mmc/host/sdhci-brcmstb.c
@@ -429,7 +429,6 @@ static const struct brcmstb_match_priv match_priv_7216 = {
 };
 
 static const struct brcmstb_match_priv match_priv_2712 = {
-	.flags = BRCMSTB_MATCH_FLAGS_HAS_CLOCK_GATE,
 	.hs400es = sdhci_brcmstb_hs400es,
 	.cfginit = sdhci_brcmstb_cfginit_2712,
 	.ops = &sdhci_brcmstb_ops_2712,


### PR DESCRIPTION
…k gating

Declaring auto-clockgate support for a host that can interface with SDIO cards is a bug.

See: https://github.com/raspberrypi/linux/issues/6237