### PR TITLE
JPEG Control Reference in bcm2835-codec driver. Add control ID V4L2_CID_JPEG_RESTART_INTERVAL

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -2423,6 +2423,17 @@ static int bcm2835_codec_s_ctrl(struct v4l2_ctrl *ctrl)
 		ret = 0;
 		break;
 
+	case V4L2_CID_JPEG_RESTART_INTERVAL:
+		if (!ctx->component)
+			break;
+
+		ret = vchiq_mmal_port_parameter_set(ctx->dev->instance,
+						    &ctx->component->output[0],
+						    MMAL_PARAMETER_JPEG_RESTART_INTERVAL,
+						    &ctrl->val,
+						    sizeof(ctrl->val));
+		break;
+
 	case V4L2_CID_JPEG_COMPRESSION_QUALITY:
 		if (!ctx->component)
 			break;
@@ -3536,6 +3547,12 @@ static int bcm2835_codec_open(struct file *file)
 				  V4L2_CID_JPEG_COMPRESSION_QUALITY,
 				  1, 100,
 				  1, 80);
+
+		v4l2_ctrl_new_std(hdl, &bcm2835_codec_ctrl_ops,
+				  V4L2_CID_JPEG_RESTART_INTERVAL,
+				  1, 1000000,
+				  1, 100);
+
 		if (hdl->error) {
 			rc = hdl->error;
 			goto free_ctrl_handler;

--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -3551,7 +3551,7 @@ static int bcm2835_codec_open(struct file *file)
 		v4l2_ctrl_new_std(hdl, &bcm2835_codec_ctrl_ops,
 				  V4L2_CID_JPEG_RESTART_INTERVAL,
 				  1, 1000000,
-				  1, 100);
+				  1, 0);
 
 		if (hdl->error) {
 			rc = hdl->error;


### PR DESCRIPTION
I added Image Process Control ID to be able to add RSTn markers to the generated JPEG file.

Tested on a live example.
Example of use:

```C++
v4l2_control controls;
controls.id = V4L2_CID_JPEG_RESTART_INTERVAL;
controls.value = 100;
        
if(0 < ioctl(fd,  VIDIOC_S_CTRL, &controls)) {
    perror("Error  VIDIOC_S_EXT_CTRLS"); 
}
```