### PR TITLE
staging: bcm2835-codec: Disable HEADER_ON_OPEN for video encode

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -2731,6 +2731,13 @@ static int bcm2835_codec_create_component(struct bcm2835_codec_ctx *ctx)
 					      &params,
 					      sizeof(params));
 
+	} else if (dev->role == ENCODE) {
+		enable = 0;
+		vchiq_mmal_port_parameter_set(dev->instance,
+					      &ctx->component->control,
+					      MMAL_PARAMETER_VIDEO_ENCODE_HEADER_ON_OPEN,
+					      &enable,
+					      sizeof(enable));
 	} else if (dev->role == ENCODE_IMAGE) {
 		enable = 0;
 		vchiq_mmal_port_parameter_set(dev->instance,


### PR DESCRIPTION
Video encode can defer generating the header until the first frame is presented, which allows it to take the colourspace information from the frame rather than just the format.

Enable that for the V4L2 driver now that the firmware populates all the parameters.

https://github.com/raspberrypi/firmware/issues/1885