### PR TITLE
dts: Make camN_reg and camN_reg_gpio overrides generic

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi-cm.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi-cm.dtsi
@@ -19,9 +19,5 @@ i2c_vc: &i2c0 {
 		act_led_gpio = <&led_act>,"gpios:4";
 		act_led_activelow = <&led_act>,"gpios:8";
 		act_led_trigger = <&led_act>,"linux,default-trigger";
-		cam0_reg = <&cam0_reg>,"status";
-		cam0_reg_gpio = <&cam0_reg>,"gpio:4";
-		cam1_reg = <&cam1_reg>,"status";
-		cam1_reg_gpio = <&cam1_reg>,"gpio:4";
 	};
 };

--- a/arch/arm/boot/dts/broadcom/bcm2709-rpi-cm2.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2709-rpi-cm2.dts
@@ -211,9 +211,5 @@ i2c_csi_dsi0: &i2c0 {
 		act_led_gpio = <&led_act>,"gpios:4";
 		act_led_activelow = <&led_act>,"gpios:8";
 		act_led_trigger = <&led_act>,"linux,default-trigger";
-		cam0_reg = <&cam0_reg>,"status";
-		cam0_reg_gpio = <&cam0_reg>,"gpio:4";
-		cam1_reg = <&cam1_reg>,"status";
-		cam1_reg_gpio = <&cam1_reg>,"gpio:4";
 	};
 };

--- a/arch/arm/boot/dts/broadcom/bcm270x-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm270x-rpi.dtsi
@@ -111,6 +111,13 @@
 			    <&csi0>, "sync-gpios:4",
 			    <&csi0>, "sync-gpios:8=", <GPIO_ACTIVE_LOW>;
 
+		cam0_reg = <&cam0_reg>,"status";
+		cam0_reg_gpio = <&cam0_reg>,"gpio:4",
+				<&cam0_reg>,"gpio:0=", <&gpio>;
+		cam1_reg = <&cam1_reg>,"status";
+		cam1_reg_gpio = <&cam1_reg>,"gpio:4",
+				<&cam1_reg>,"gpio:0=", <&gpio>;
+
 		strict_gpiod = <&chosen>, "bootargs=pinctrl_bcm2835.persist_gpio_outputs=n";
 	};
 };

--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-cm3.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-cm3.dts
@@ -211,9 +211,5 @@ i2c_csi_dsi0: &i2c0 {
 		act_led_gpio = <&led_act>,"gpios:4";
 		act_led_activelow = <&led_act>,"gpios:8";
 		act_led_trigger = <&led_act>,"linux,default-trigger";
-		cam0_reg = <&cam0_reg>,"status";
-		cam0_reg_gpio = <&cam0_reg>,"gpio:4";
-		cam1_reg = <&cam1_reg>,"status";
-		cam1_reg_gpio = <&cam1_reg>,"gpio:4";
 	};
 };

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts
@@ -498,13 +498,6 @@ i2c_csi_dsi0: &i2c0 {
 			<&ant2>, "output-high?=off",
 			<&ant2>, "output-low?=on";
 
-		cam0_reg = <&cam0_reg>,"status";
-		cam0_reg_gpio = <&cam0_reg>,"gpio:4",
-				  <&cam0_reg>,"gpio:0=", <&gpio>;
-		cam1_reg = <&cam1_reg>,"status";
-		cam1_reg_gpio = <&cam1_reg>,"gpio:4",
-				  <&cam1_reg>,"gpio:0=", <&gpio>;
-
 		pcie_tperst_clk_ms = <&pcie0>,"brcm,tperst-clk-ms:0";
 	};
 };

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
@@ -289,10 +289,5 @@ i2c_csi_dsi0: &i2c0 {
 		act_led_gpio = <&led_act>,"gpios:4";
 		act_led_activelow = <&led_act>,"gpios:8";
 		act_led_trigger = <&led_act>,"linux,default-trigger";
-
-		cam0_reg = <&cam0_reg>,"status";
-		cam0_reg_gpio = <&cam0_reg>,"gpio:4";
-		cam1_reg = <&cam1_reg>,"status";
-		cam1_reg_gpio = <&cam1_reg>,"gpio:4";
 	};
 };

--- a/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -106,6 +106,14 @@
 		nvmem_priv_rw = <&nvmem_priv>,"rw?";
 		nvmem_mac_rw = <&nvmem_mac>,"rw?";
 		strict_gpiod = <&chosen>, "bootargs=pinctrl_rp1.persist_gpio_outputs=n";
+
+		cam0_reg = <&cam0_reg>,"status";
+		cam0_reg_gpio = <&cam0_reg>,"gpio:4",
+				<&cam0_reg>,"gpio:0=", <&gpio>;
+		cam1_reg = <&cam1_reg>,"status";
+		cam1_reg_gpio = <&cam1_reg>,"gpio:4",
+				<&cam1_reg>,"gpio:0=", <&gpio>;
+
 	};
 };
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -171,21 +171,21 @@ Params:
         button_debounce         Set the debounce delay (in ms) on the power/
                                 shutdown button (default 50ms)
 
-        cam0_reg                Enables CAM 0 regulator.
-                                Only required on CM1 & 3.
+        cam0_reg                Controls CAM 0 regulator.
+                                Disabled by default on CM1 & 3.
+                                Enabled by default on all other boards.
 
         cam0_reg_gpio           Set GPIO for CAM 0 regulator.
-                                Default 31 on CM1, 3, and 4S.
-                                Default of GPIO expander 5 on CM4, but override
-                                switches to normal GPIO.
+                                NB override switches to the normal GPIO driver,
+                                even if the original was on the GPIO expander.
 
-        cam1_reg                Enables CAM 1 regulator.
-                                Only required on CM1 & 3.
+        cam1_reg                Controls CAM 1 regulator.
+                                Disabled by default on CM1 & 3.
+                                Enabled by default on all other boards.
 
         cam1_reg_gpio           Set GPIO for CAM 1 regulator.
-                                Default 3 on CM1, 3, and 4S.
-                                Default of GPIO expander 5 on CM4, but override
-                                switches to normal GPIO.
+                                NB override switches to the normal GPIO driver,
+                                even if the original was on the GPIO expander.
 
         cam0_sync               Enable a GPIO to reflect frame sync from CSI0,
                                 going high on frame start, and low on frame end.


### PR DESCRIPTION
The camera regulator GPIO can be used for other purposes, so the camN_reg override to allow disabling is potentially useful on any platform.
camN_gpio is less useful, but isn't invalid.

Move these overrides from the CM dt files to bcm270x-rpi.dtsi / bcm2712-rpi.dtsi