### PR TITLE
Fixup SD posted write limit and an upstream regression

### DIFF
--- a/drivers/mmc/core/mmc.c
+++ b/drivers/mmc/core/mmc.c
@@ -1663,6 +1663,7 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
 		card->ocr = ocr;
 		card->type = MMC_TYPE_MMC;
 		card->rca = 1;
+		card->max_posted_writes = 1;
 		memcpy(card->raw_cid, cid, sizeof(card->raw_cid));
 	}
 

--- a/drivers/mmc/core/queue.c
+++ b/drivers/mmc/core/queue.c
@@ -268,7 +268,7 @@ static blk_status_t mmc_mq_queue_rq(struct blk_mq_hw_ctx *hctx,
 			spin_unlock_irq(&mq->lock);
 			return BLK_STS_RESOURCE;
 		}
-		if (host->cqe_enabled && req_op(req) == REQ_OP_WRITE &&
+		if (!host->hsq_enabled && host->cqe_enabled && req_op(req) == REQ_OP_WRITE &&
 		    mq->pending_writes >= card->max_posted_writes) {
 			spin_unlock_irq(&mq->lock);
 			return BLK_STS_RESOURCE;

--- a/drivers/mmc/core/sd.c
+++ b/drivers/mmc/core/sd.c
@@ -1105,13 +1105,14 @@ static int sd_parse_ext_reg_perf(struct mmc_card *card, u8 fno, u8 page,
 			 mmc_hostname(card->host),
 			 card->ext_csd.cmdq_depth);
 		/*
-		 * If CQ is enabled, there is a contract between host and card such that VDD will
-		 * be maintained and removed only if a power off notification is provided.
-		 * An SD card in an accessible slot means surprise removal is a possibility.
-		 * As a middle ground, limit max posted writes to 1 unless the card is "hardwired".
+		 * If CQ is enabled, there is a contract between host and card such that
+		 * VDD will be maintained and removed only if a power off notification
+		 * is provided. An SD card in an accessible slot means surprise removal
+		 * is a possibility. As a middle ground, keep the default maximum of 1
+		 * posted write unless the card is "hardwired".
 		 */
-		if (mmc_card_is_removable(card->host))
-			card->max_posted_writes = 1;
+		if (!mmc_card_is_removable(card->host))
+			card->max_posted_writes = card->ext_csd.cmdq_depth;
 	}
 
 	card->ext_perf.fno = fno;
@@ -1383,6 +1384,7 @@ retry:
 
 		card->ocr = ocr;
 		card->type = MMC_TYPE_SD;
+		card->max_posted_writes = 1;
 		memcpy(card->raw_cid, cid, sizeof(card->raw_cid));
 	}
 

--- a/drivers/mmc/host/sdhci-brcmstb.c
+++ b/drivers/mmc/host/sdhci-brcmstb.c
@@ -430,6 +430,7 @@ static const struct brcmstb_match_priv match_priv_7216 = {
 };
 
 static const struct brcmstb_match_priv match_priv_2712 = {
+	.flags = BRCMSTB_MATCH_FLAGS_USE_CARD_BUSY,
 	.hs400es = sdhci_brcmstb_hs400es,
 	.cfginit = sdhci_brcmstb_cfginit_2712,
 	.ops = &sdhci_brcmstb_ops_2712,


### PR DESCRIPTION
See #6266 - Pi 0-3 got broken, and probably non-A2 cards on Pi 5 as well.

Also the error `mmc0: cannot verify signal voltage switch` seen in https://forums.raspberrypi.com/viewtopic.php?t=367459&start=50#p2236478 was the result of an upstream change.