### PR TITLE
Revert "Update DAC8x to support 384khz"

### DIFF
--- a/sound/soc/bcm/rpi-simple-soundcard.c
+++ b/sound/soc/bcm/rpi-simple-soundcard.c
@@ -324,10 +324,10 @@ static int hifiberry_dac8x_init(struct snd_soc_pcm_runtime *rtd)
 	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
 
 	/* override the defaults to reflect 4 x PCM5102A on the card
-	 * and limit the sample rate to 384ksps
+	 * and limit the sample rate to 192ksps
 	 */
 	codec_dai->driver->playback.channels_max = 8;
-	codec_dai->driver->playback.rates = SNDRV_PCM_RATE_8000_384000;
+	codec_dai->driver->playback.rates = SNDRV_PCM_RATE_8000_192000;
 
 	return 0;
 }


### PR DESCRIPTION
Reverts raspberrypi/linux#6187
Detailed Commit Information:

- Reason for Reverting: The update to support 384kHz for DAC8x resulted in instability during audio playback at such a high bitrate. To ensure consistent and stable audio performance, we are reverting this change.

- Affected File: sound/soc/bcm/rpi-simple-soundcard.c

- Changes Made:
   - Reverted the sample rate limit from 384kHz back to 192kHz.
   - Modified the playback rate definition accordingly.