### PR TITLE
Align AXI DMAC configuration and peripheral client use

### DIFF
--- a/Documentation/devicetree/bindings/sound/snps,designware-i2s.yaml
+++ b/Documentation/devicetree/bindings/sound/snps,designware-i2s.yaml
@@ -69,6 +69,10 @@ properties:
       - description: RX DMA Channel
     minItems: 1
 
+  dma-maxburst:
+    description: FIFO DMA burst threshold limit
+    maxItems: 1
+
   dma-names:
     items:
       - const: tx

--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
@@ -400,6 +400,7 @@
 			#sound-dai-cells = <0>;
 			dmas = <&rp1_dma RP1_DMA_I2S0_TX>,<&rp1_dma RP1_DMA_I2S0_RX>;
 			dma-names = "tx", "rx";
+			dma-maxburst = <4>;
 			status = "disabled";
 		};
 
@@ -413,6 +414,7 @@
 			#sound-dai-cells = <0>;
 			dmas = <&rp1_dma RP1_DMA_I2S1_TX>,<&rp1_dma RP1_DMA_I2S1_RX>;
 			dma-names = "tx", "rx";
+			dma-maxburst = <4>;
 			status = "disabled";
 		};
 

--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
@@ -1064,7 +1064,7 @@
 			snps,data-width = <4>; // (8 << 4) == 128 bits
 			snps,block-size = <0x40000 0x40000 0x40000 0x40000 0x40000 0x40000 0x40000 0x40000>;
 			snps,priority = <0 1 2 3 4 5 6 7>;
-			snps,axi-max-burst-len = <8>;
+			snps,axi-max-burst-len = <4>;
 			status = "disabled";
 		};
 

--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
@@ -261,6 +261,15 @@ static u32 axi_chan_get_xfer_width(struct axi_dma_chan *chan, dma_addr_t src,
 	return __ffs(src | dst | len | BIT(max_width));
 }
 
+static u32 axi_dma_encode_msize(u32 max_burst)
+{
+	if (max_burst <= 1)
+		return DWAXIDMAC_BURST_TRANS_LEN_1;
+	if (max_burst > 1024)
+		return DWAXIDMAC_BURST_TRANS_LEN_1024;
+	return fls(max_burst) - 2;
+}
+
 static inline const char *axi_chan_name(struct axi_dma_chan *chan)
 {
 	return dma_chan_name(&chan->vc.chan);
@@ -685,41 +694,41 @@ static int dw_axi_dma_set_hw_desc(struct axi_dma_chan *chan,
 	size_t axi_block_ts;
 	size_t block_ts;
 	u32 ctllo, ctlhi;
-	u32 burst_len;
+	u32 burst_len = 0, mem_burst_msize, reg_burst_msize;
 
 	axi_block_ts = chan->chip->dw->hdata->block_size[chan->id];
 
 	mem_width = __ffs(data_width | mem_addr | len);
-	if (mem_width > DWAXIDMAC_TRANS_WIDTH_32)
-		mem_width = DWAXIDMAC_TRANS_WIDTH_32;
 
 	if (!IS_ALIGNED(mem_addr, 4)) {
 		dev_err(chan->chip->dev, "invalid buffer alignment\n");
 		return -EINVAL;
 	}
 
+	/* Use a reasonable upper limit otherwise residue reporting granularity grows large */
+	mem_burst_msize = axi_dma_encode_msize(16);
+
 	switch (chan->direction) {
 	case DMA_MEM_TO_DEV:
+		reg_burst_msize = axi_dma_encode_msize(chan->config.dst_maxburst);
 		reg_width = __ffs(chan->config.dst_addr_width);
 		device_addr = phys_to_dma(chan->chip->dev, chan->config.dst_addr);
 		ctllo = reg_width << CH_CTL_L_DST_WIDTH_POS |
 			mem_width << CH_CTL_L_SRC_WIDTH_POS |
-			DWAXIDMAC_BURST_TRANS_LEN_1 << CH_CTL_L_DST_MSIZE_POS |
-			DWAXIDMAC_BURST_TRANS_LEN_4 << CH_CTL_L_SRC_MSIZE_POS |
+			reg_burst_msize << CH_CTL_L_DST_MSIZE_POS |
+			mem_burst_msize << CH_CTL_L_SRC_MSIZE_POS |
 			DWAXIDMAC_CH_CTL_L_NOINC << CH_CTL_L_DST_INC_POS |
 			DWAXIDMAC_CH_CTL_L_INC << CH_CTL_L_SRC_INC_POS;
 		block_ts = len >> mem_width;
 		break;
 	case DMA_DEV_TO_MEM:
+		reg_burst_msize = axi_dma_encode_msize(chan->config.src_maxburst);
 		reg_width = __ffs(chan->config.src_addr_width);
-		/* Prevent partial access units getting lost */
-		if (mem_width > reg_width)
-			mem_width = reg_width;
 		device_addr = phys_to_dma(chan->chip->dev, chan->config.src_addr);
 		ctllo = reg_width << CH_CTL_L_SRC_WIDTH_POS |
 			mem_width << CH_CTL_L_DST_WIDTH_POS |
-			DWAXIDMAC_BURST_TRANS_LEN_4 << CH_CTL_L_DST_MSIZE_POS |
-			DWAXIDMAC_BURST_TRANS_LEN_1 << CH_CTL_L_SRC_MSIZE_POS |
+			mem_burst_msize << CH_CTL_L_DST_MSIZE_POS |
+			reg_burst_msize << CH_CTL_L_SRC_MSIZE_POS |
 			DWAXIDMAC_CH_CTL_L_INC << CH_CTL_L_DST_INC_POS |
 			DWAXIDMAC_CH_CTL_L_NOINC << CH_CTL_L_SRC_INC_POS;
 		block_ts = len >> reg_width;
@@ -760,6 +769,12 @@ static int dw_axi_dma_set_hw_desc(struct axi_dma_chan *chan,
 	set_desc_src_master(hw_desc);
 
 	hw_desc->len = len;
+
+	if (burst_len && (chan->config.src_maxburst > burst_len))
+		dev_warn_ratelimited(chan2dev(chan),
+				     "%s: requested source burst length %u exceeds supported burst length %u - data may be lost\n",
+				     axi_chan_name(chan), chan->config.src_maxburst, burst_len);
+
 	return 0;
 }
 
@@ -776,9 +791,6 @@ static size_t calculate_block_len(struct axi_dma_chan *chan,
 	case DMA_MEM_TO_DEV:
 		data_width = BIT(chan->chip->dw->hdata->m_data_width);
 		mem_width = __ffs(data_width | dma_addr | buf_len);
-		if (mem_width > DWAXIDMAC_TRANS_WIDTH_32)
-			mem_width = DWAXIDMAC_TRANS_WIDTH_32;
-
 		block_len = axi_block_ts << mem_width;
 		break;
 	case DMA_DEV_TO_MEM:

--- a/drivers/spi/spi-dw-core.c
+++ b/drivers/spi/spi-dw-core.c
@@ -225,12 +225,17 @@ static irqreturn_t dw_spi_transfer_handler(struct dw_spi *dws)
 	 * final stage of the transfer. By doing so we'll get the next IRQ
 	 * right when the leftover incoming data is received.
 	 */
-	dw_reader(dws);
-	if (!dws->rx_len) {
-		dw_spi_mask_intr(dws, 0xff);
+	if (dws->rx_len) {
+		dw_reader(dws);
+		if (!dws->rx_len) {
+			dw_spi_mask_intr(dws, 0xff);
+			spi_finalize_current_transfer(dws->host);
+		} else if (dws->rx_len <= dw_readl(dws, DW_SPI_RXFTLR)) {
+			dw_writel(dws, DW_SPI_RXFTLR, dws->rx_len - 1);
+		}
+	} else if (!dws->tx_len) {
+		dw_spi_mask_intr(dws, DW_SPI_INT_TXEI);
 		spi_finalize_current_transfer(dws->host);
-	} else if (dws->rx_len <= dw_readl(dws, DW_SPI_RXFTLR)) {
-		dw_writel(dws, DW_SPI_RXFTLR, dws->rx_len - 1);
 	}
 
 	/*
@@ -239,12 +244,9 @@ static irqreturn_t dw_spi_transfer_handler(struct dw_spi *dws)
 	 * have the TXE IRQ flood at the final stage of the transfer.
 	 */
 	if (irq_status & DW_SPI_INT_TXEI) {
-		dw_writer(dws);
-		if (!dws->tx_len) {
+		if (!dws->tx_len)
 			dw_spi_mask_intr(dws, DW_SPI_INT_TXEI);
-			if (!dws->rx_len)
-				spi_finalize_current_transfer(dws->host);
-		}
+		dw_writer(dws);
 	}
 
 	return IRQ_HANDLED;
@@ -436,6 +438,11 @@ static int dw_spi_transfer_one(struct spi_controller *host,
 	dws->tx_len = transfer->len / dws->n_bytes;
 	dws->rx = transfer->rx_buf;
 	dws->rx_len = dws->tx_len;
+
+	if (!dws->rx) {
+		dws->rx_len = 0;
+		cfg.tmode = DW_SPI_CTRLR0_TMOD_TO;
+	}
 
 	/* Ensure the data above is visible for all CPUs */
 	smp_mb();

--- a/drivers/spi/spi-dw-core.c
+++ b/drivers/spi/spi-dw-core.c
@@ -367,18 +367,18 @@ static void dw_spi_irq_setup(struct dw_spi *dws)
 	 * will be adjusted at the final stage of the IRQ-based SPI transfer
 	 * execution so not to lose the leftover of the incoming data.
 	 */
-	level = min_t(unsigned int, dws->fifo_len / 2, dws->tx_len);
+	level = min_t(unsigned int, dws->fifo_len / 2, dws->tx_len ? dws->tx_len : dws->rx_len);
 	dw_writel(dws, DW_SPI_TXFTLR, level);
 	dw_writel(dws, DW_SPI_RXFTLR, level - 1);
 
 	dws->transfer_handler = dw_spi_transfer_handler;
 
-	imask = 0;
-	if (dws->tx_len)
-		imask |= DW_SPI_INT_TXEI | DW_SPI_INT_TXOI;
+	imask = DW_SPI_INT_TXEI | DW_SPI_INT_TXOI;
 	if (dws->rx_len)
 		imask |= DW_SPI_INT_RXUI | DW_SPI_INT_RXOI | DW_SPI_INT_RXFI;
 	dw_spi_umask_intr(dws, imask);
+	if (!dws->tx_len)
+		dw_writel(dws, DW_SPI_DR, 0);
 }
 
 /*
@@ -401,13 +401,18 @@ static int dw_spi_poll_transfer(struct dw_spi *dws,
 	delay.unit = SPI_DELAY_UNIT_SCK;
 	nbits = dws->n_bytes * BITS_PER_BYTE;
 
+	if (!dws->tx_len)
+		dw_writel(dws, DW_SPI_DR, 0);
+
 	do {
-		dw_writer(dws);
+		if (dws->tx_len)
+			dw_writer(dws);
 
 		delay.value = nbits * (dws->rx_len - dws->tx_len);
 		spi_delay_exec(&delay, transfer);
 
-		dw_reader(dws);
+		if (dws->rx_len)
+			dw_reader(dws);
 
 		ret = dw_spi_check_status(dws, true);
 		if (ret)
@@ -427,6 +432,7 @@ static int dw_spi_transfer_one(struct spi_controller *host,
 		.dfs = transfer->bits_per_word,
 		.freq = transfer->speed_hz,
 	};
+	int buswidth;
 	int ret;
 
 	dws->dma_mapped = 0;
@@ -443,6 +449,18 @@ static int dw_spi_transfer_one(struct spi_controller *host,
 		dws->rx_len = 0;
 		cfg.tmode = DW_SPI_CTRLR0_TMOD_TO;
 	}
+
+	if (!dws->rx) {
+		dws->rx_len = 0;
+		cfg.tmode = DW_SPI_CTRLR0_TMOD_TO;
+	}
+	if (!dws->tx) {
+		dws->tx_len = 0;
+		cfg.tmode = DW_SPI_CTRLR0_TMOD_RO;
+		cfg.ndf = dws->rx_len;
+	}
+	buswidth = transfer->rx_buf ? transfer->rx_nbits :
+		  (transfer->tx_buf ? transfer->tx_nbits : 1);
 
 	/* Ensure the data above is visible for all CPUs */
 	smp_mb();
@@ -961,7 +979,6 @@ int dw_spi_add_host(struct device *dev, struct dw_spi *dws)
 			dev_warn(dev, "DMA init failed\n");
 		} else {
 			host->can_dma = dws->dma_ops->can_dma;
-			host->flags |= SPI_CONTROLLER_MUST_TX;
 		}
 	}
 

--- a/drivers/spi/spi-dw-core.c
+++ b/drivers/spi/spi-dw-core.c
@@ -200,7 +200,18 @@ int dw_spi_check_status(struct dw_spi *dws, bool raw)
 
 	/* Generically handle the erroneous situation */
 	if (ret) {
-		dw_spi_reset_chip(dws);
+		/*
+		 * Forcibly halting the controller can cause DMA to hang.
+		 * Defer to dw_spi_handle_err outside of interrupt context
+		 * and mask further interrupts for the current transfer.
+		 */
+		if (dws->dma_mapped) {
+			dw_spi_mask_intr(dws, 0xff);
+			dw_readl(dws, DW_SPI_ICR);
+		} else {
+			dw_spi_reset_chip(dws);
+		}
+
 		if (dws->host->cur_msg)
 			dws->host->cur_msg->status = ret;
 	}

--- a/drivers/spi/spi-dw-dma.c
+++ b/drivers/spi/spi-dw-dma.c
@@ -316,10 +316,8 @@ static void dw_spi_dma_tx_done(void *arg)
 	struct dw_spi *dws = arg;
 
 	clear_bit(DW_SPI_TX_BUSY, &dws->dma_chan_busy);
-	if (test_bit(DW_SPI_RX_BUSY, &dws->dma_chan_busy)) {
-		dw_writel(dws, DW_SPI_DMARDLR, 0);
+	if (test_bit(DW_SPI_RX_BUSY, &dws->dma_chan_busy))
 		return;
-	}
 
 	complete(&dws->dma_completion);
 }
@@ -656,8 +654,6 @@ static int dw_spi_dma_transfer(struct dw_spi *dws, struct spi_transfer *xfer)
 	int ret;
 
 	nents = max(xfer->tx_sg.nents, xfer->rx_sg.nents);
-
-	dw_writel(dws, DW_SPI_DMARDLR, xfer->tx_buf ? (dws->rxburst - 1) : 0);
 
 	/*
 	 * Execute normal DMA-based transfer (which submits the Rx and Tx SG

--- a/drivers/spi/spi-dw-dma.c
+++ b/drivers/spi/spi-dw-dma.c
@@ -6,6 +6,7 @@
  */
 
 #include <linux/completion.h>
+#include <linux/delay.h>
 #include <linux/dma-mapping.h>
 #include <linux/dmaengine.h>
 #include <linux/irqreturn.h>
@@ -472,13 +473,12 @@ static int dw_spi_dma_setup(struct dw_spi *dws, struct spi_transfer *xfer)
 	u16 imr, dma_ctrl;
 	int ret;
 
-	if (!xfer->tx_buf)
-		return -EINVAL;
-
 	/* Setup DMA channels */
-	ret = dw_spi_dma_config_tx(dws);
-	if (ret)
-		return ret;
+	if (xfer->tx_buf) {
+		ret = dw_spi_dma_config_tx(dws);
+		if (ret)
+			return ret;
+	}
 
 	if (xfer->rx_buf) {
 		ret = dw_spi_dma_config_rx(dws);
@@ -487,13 +487,17 @@ static int dw_spi_dma_setup(struct dw_spi *dws, struct spi_transfer *xfer)
 	}
 
 	/* Set the DMA handshaking interface */
-	dma_ctrl = DW_SPI_DMACR_TDMAE;
+	dma_ctrl = 0;
+	if (xfer->tx_buf)
+		dma_ctrl |= DW_SPI_DMACR_TDMAE;
 	if (xfer->rx_buf)
 		dma_ctrl |= DW_SPI_DMACR_RDMAE;
 	dw_writel(dws, DW_SPI_DMACR, dma_ctrl);
 
 	/* Set the interrupt mask */
-	imr = DW_SPI_INT_TXOI;
+	imr = 0;
+	if (xfer->tx_buf)
+		imr |= DW_SPI_INT_TXOI;
 	if (xfer->rx_buf)
 		imr |= DW_SPI_INT_RXUI | DW_SPI_INT_RXOI;
 	dw_spi_umask_intr(dws, imr);
@@ -510,15 +514,16 @@ static int dw_spi_dma_transfer_all(struct dw_spi *dws,
 {
 	int ret;
 
-	/* Submit the DMA Tx transfer */
-	ret = dw_spi_dma_submit_tx(dws, xfer->tx_sg.sgl, xfer->tx_sg.nents);
-	if (ret)
-		goto err_clear_dmac;
+	/* Submit the DMA Tx transfer if required */
+	if (xfer->tx_buf) {
+		ret = dw_spi_dma_submit_tx(dws, xfer->tx_sg.sgl, xfer->tx_sg.nents);
+		if (ret)
+			goto err_clear_dmac;
+	}
 
 	/* Submit the DMA Rx transfer if required */
 	if (xfer->rx_buf) {
-		ret = dw_spi_dma_submit_rx(dws, xfer->rx_sg.sgl,
-					   xfer->rx_sg.nents);
+		ret = dw_spi_dma_submit_rx(dws, xfer->rx_sg.sgl, xfer->rx_sg.nents);
 		if (ret)
 			goto err_clear_dmac;
 
@@ -526,7 +531,15 @@ static int dw_spi_dma_transfer_all(struct dw_spi *dws,
 		dma_async_issue_pending(dws->rxchan);
 	}
 
-	dma_async_issue_pending(dws->txchan);
+	if (xfer->tx_buf) {
+		dma_async_issue_pending(dws->txchan);
+	} else {
+		/* Pause to allow DMA channel to fetch RX descriptor */
+		usleep_range(5, 10);
+
+		/* Write something to the TX FIFO to start the transfer */
+		dw_writel(dws, DW_SPI_DR, 0);
+	}
 
 	ret = dw_spi_dma_wait(dws, xfer->len, xfer->effective_speed_hz);
 

--- a/drivers/tty/serial/amba-pl011.c
+++ b/drivers/tty/serial/amba-pl011.c
@@ -487,6 +487,12 @@ static void pl011_dma_probe(struct uart_amba_port *uap)
 					"RX DMA disabled - no residue processing\n");
 				return;
 			}
+			/*
+			 * DMA controllers with smaller burst capabilities than 1/4
+			 * the FIFO depth will leave more bytes than expected in the
+			 * RX FIFO if mismatched.
+			 */
+			rx_conf.src_maxburst = min(caps.max_burst, rx_conf.src_maxburst);
 		}
 		dmaengine_slave_config(chan, &rx_conf);
 		uap->dmarx.chan = chan;

--- a/sound/soc/dwc/dwc-i2s.c
+++ b/sound/soc/dwc/dwc-i2s.c
@@ -236,6 +236,8 @@ static void dw_i2s_config(struct dw_i2s_dev *dev, int stream)
 	u32 ch_reg;
 	struct i2s_clk_config_data *config = &dev->config;
 	u32 dmacr;
+	u32 comp1 = i2s_read_reg(dev->i2s_base, dev->i2s_reg_comp1);
+	u32 fifo_depth = 1 << (1 + COMP1_FIFO_DEPTH_GLOBAL(comp1));
 
 	i2s_disable_channels(dev, stream);
 
@@ -251,7 +253,7 @@ static void dw_i2s_config(struct dw_i2s_dev *dev, int stream)
 			i2s_write_reg(dev->i2s_base, TCR(ch_reg),
 				      dev->xfer_resolution);
 			i2s_write_reg(dev->i2s_base, TFCR(ch_reg),
-				      dev->fifo_th - 1);
+				      fifo_depth - dev->fifo_th - 1);
 			i2s_write_reg(dev->i2s_base, TER(ch_reg), TER_TXCHEN |
 				      dev->tdm_mask << TER_TXSLOT_SHIFT);
 			dmacr |= (DMACR_DMAEN_TXCH0 << ch_reg);
@@ -783,8 +785,8 @@ static int dw_configure_dai_by_pd(struct dw_i2s_dev *dev,
 		dev->capture_dma_data.pd.data = pdata->capture_dma_data;
 		dev->play_dma_data.pd.addr = res->start + I2S_TXDMA;
 		dev->capture_dma_data.pd.addr = res->start + I2S_RXDMA;
-		dev->play_dma_data.pd.max_burst = 16;
-		dev->capture_dma_data.pd.max_burst = 16;
+		dev->play_dma_data.pd.max_burst = dev->fifo_th;
+		dev->capture_dma_data.pd.max_burst = dev->fifo_th;
 		dev->play_dma_data.pd.addr_width = bus_widths[idx];
 		dev->capture_dma_data.pd.addr_width = bus_widths[idx];
 		dev->play_dma_data.pd.filter = pdata->filter;
@@ -815,7 +817,10 @@ static int dw_configure_dai_by_dt(struct dw_i2s_dev *dev,
 		dev->play_dma_data.dt.addr = res->start + I2S_TXDMA;
 		dev->play_dma_data.dt.fifo_size = fifo_depth *
 			(fifo_width[idx2]) >> 8;
-		dev->play_dma_data.dt.maxburst = 16;
+		if (dev->max_dma_burst)
+			dev->play_dma_data.dt.maxburst = dev->max_dma_burst;
+		else
+			dev->play_dma_data.dt.maxburst = fifo_depth / 2;
 	}
 	if (COMP1_RX_ENABLED(comp1)) {
 		idx2 = COMP2_RX_WORDSIZE_0(comp2);
@@ -824,9 +829,14 @@ static int dw_configure_dai_by_dt(struct dw_i2s_dev *dev,
 		dev->capture_dma_data.dt.addr = res->start + I2S_RXDMA;
 		dev->capture_dma_data.dt.fifo_size = fifo_depth *
 			(fifo_width[idx2] >> 8);
-		dev->capture_dma_data.dt.maxburst = 16;
+		if (dev->max_dma_burst)
+			dev->capture_dma_data.dt.maxburst = dev->max_dma_burst;
+		else
+			dev->capture_dma_data.dt.maxburst = fifo_depth / 2;
 	}
 
+	if (dev->max_dma_burst)
+		dev->fifo_th = min(dev->max_dma_burst, dev->fifo_th);
 	return 0;
 
 }
@@ -1070,6 +1080,7 @@ static int dw_i2s_probe(struct platform_device *pdev)
 		}
 	}
 
+	of_property_read_u32(pdev->dev.of_node, "dma-maxburst", &dev->max_dma_burst);
 	dev->bclk_ratio = 0;
 	dev->i2s_reg_comp1 = I2S_COMP_PARAM_1;
 	dev->i2s_reg_comp2 = I2S_COMP_PARAM_2;

--- a/sound/soc/dwc/local.h
+++ b/sound/soc/dwc/local.h
@@ -133,6 +133,7 @@ struct dw_i2s_dev {
 	u32 ccr;
 	u32 xfer_resolution;
 	u32 fifo_th;
+	u32 max_dma_burst;
 	u32 l_reg;
 	u32 r_reg;
 	bool is_jh7110; /* Flag for StarFive JH7110 SoC */


### PR DESCRIPTION
This is a bit of an omni-PR, but it solves two important issues:
- TV hat unreliability on Pi 5
- Hardware limitations of the DMAC causing mismatches between client expectations of bytes transferred vs descriptor lengths

In the first case, the limitations of the DMAC severely restrict SPI throughput so operating a) in a unidirectional mode b) with corrected burst lengths are both required. Doing b) means that other peripheral drivers using the DMAC need to set burst thresholds (particularly RX) correctly.