### PR TITLE
drm/vc4: Add support for per plane scaling filter selection

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -358,6 +358,7 @@ struct vc4_hvs {
 	struct work_struct free_dlist_work;
 
 	struct drm_mm_node mitchell_netravali_filter;
+	struct drm_mm_node nearest_neighbour_filter;
 
 	struct debugfs_regset32 regset;
 

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -573,7 +573,9 @@ static void vc4_write_tpz(struct vc4_plane_state *vc4_state, u32 src, u32 dst)
 /* phase magnitude bits */
 #define PHASE_BITS 6
 
-static void vc4_write_ppf(struct vc4_plane_state *vc4_state, u32 src, u32 dst, u32 xy, int channel, int chroma_offset)
+static void vc4_write_ppf(struct vc4_plane_state *vc4_state, u32 src, u32 dst,
+			  u32 xy, int channel, int chroma_offset,
+			  bool no_interpolate)
 {
 	struct vc4_dev *vc4 = to_vc4_dev(vc4_state->base.plane->dev);
 	u32 scale = src / dst;
@@ -612,6 +614,7 @@ static void vc4_write_ppf(struct vc4_plane_state *vc4_state, u32 src, u32 dst, u
 	phase &= SCALER_PPF_IPHASE_MASK;
 
 	vc4_dlist_write(vc4_state,
+			no_interpolate ? SCALER_PPF_NOINTERP : 0 |
 			SCALER_PPF_AGC |
 			VC4_SET_FIELD(scale, SCALER_PPF_SCALE) |
 			/*
@@ -806,15 +809,17 @@ static void vc4_write_scaling_parameters(struct drm_plane_state *state,
 	/* Ch0 H-PPF Word 0: Scaling Parameters */
 	if (vc4_state->x_scaling[channel] == VC4_SCALING_PPF) {
 		vc4_write_ppf(vc4_state,
-			      vc4_state->src_w[channel], vc4_state->crtc_w, vc4_state->src_x, channel,
-			      state->chroma_siting_h);
+			      vc4_state->src_w[channel], vc4_state->crtc_w, vc4_state->src_x,
+			      channel, state->chroma_siting_h,
+			      state->scaling_filter == DRM_SCALING_FILTER_NEAREST_NEIGHBOR);
 	}
 
 	/* Ch0 V-PPF Words 0-1: Scaling Parameters, Context */
 	if (vc4_state->y_scaling[channel] == VC4_SCALING_PPF) {
 		vc4_write_ppf(vc4_state,
-			      vc4_state->src_h[channel], vc4_state->crtc_h, vc4_state->src_y, channel,
-			      state->chroma_siting_v);
+			      vc4_state->src_h[channel], vc4_state->crtc_h, vc4_state->src_y,
+			      channel, state->chroma_siting_v,
+			      state->scaling_filter == DRM_SCALING_FILTER_NEAREST_NEIGHBOR);
 		vc4_dlist_write(vc4_state, 0xc0c0c0c0);
 	}
 
@@ -1547,7 +1552,18 @@ static int vc4_plane_mode_set(struct drm_plane *plane,
 		    vc4_state->y_scaling[0] == VC4_SCALING_PPF ||
 		    vc4_state->x_scaling[1] == VC4_SCALING_PPF ||
 		    vc4_state->y_scaling[1] == VC4_SCALING_PPF) {
-			u32 kernel = VC4_SET_FIELD(vc4->hvs->mitchell_netravali_filter.start,
+			struct drm_mm_node *filter;
+
+			switch (state->scaling_filter) {
+			case DRM_SCALING_FILTER_DEFAULT:
+			default:
+				filter = &vc4->hvs->mitchell_netravali_filter;
+				break;
+			case DRM_SCALING_FILTER_NEAREST_NEIGHBOR:
+				filter = &vc4->hvs->nearest_neighbour_filter;
+				break;
+			}
+			u32 kernel = VC4_SET_FIELD(filter->start,
 						   SCALER_PPF_KERNEL_OFFSET);
 
 			/* HPPF plane 0 */
@@ -1958,9 +1974,19 @@ static int vc6_plane_mode_set(struct drm_plane *plane,
 		    vc4_state->y_scaling[0] == VC4_SCALING_PPF ||
 		    vc4_state->x_scaling[1] == VC4_SCALING_PPF ||
 		    vc4_state->y_scaling[1] == VC4_SCALING_PPF) {
-			u32 kernel =
-				VC4_SET_FIELD(vc4->hvs->mitchell_netravali_filter.start,
-					      SCALER_PPF_KERNEL_OFFSET);
+			struct drm_mm_node *filter;
+
+			switch (state->scaling_filter) {
+			case DRM_SCALING_FILTER_DEFAULT:
+			default:
+				filter = &vc4->hvs->mitchell_netravali_filter;
+				break;
+			case DRM_SCALING_FILTER_NEAREST_NEIGHBOR:
+				filter = &vc4->hvs->nearest_neighbour_filter;
+				break;
+			}
+			u32 kernel = VC4_SET_FIELD(filter->start,
+						   SCALER_PPF_KERNEL_OFFSET);
 
 			/* HPPF plane 0 */
 			vc4_dlist_write(vc4_state, kernel);
@@ -2441,6 +2467,10 @@ struct drm_plane *vc4_plane_init(struct drm_device *dev,
 					  BIT(DRM_COLOR_YCBCR_FULL_RANGE),
 					  DRM_COLOR_YCBCR_BT709,
 					  DRM_COLOR_YCBCR_LIMITED_RANGE);
+
+	drm_plane_create_scaling_filter_property(plane,
+						 BIT(DRM_SCALING_FILTER_DEFAULT) |
+						 BIT(DRM_SCALING_FILTER_NEAREST_NEIGHBOR));
 
 	drm_plane_create_chroma_siting_properties(plane, 0, 0);
 


### PR DESCRIPTION
Seeing as the HVS can be configured with regard the scaling filter, and DRM now supports selecting scaling filters at a per CRTC or per plane level, we can implement it.

Default remains as the Mitchell/Netravali filter, but nearest neighbour is now also implemented.

https://forums.raspberrypi.com/viewtopic.php?p=2239565

Draft whilst I evaluate whether it is really that useful. The original discussion where the standard property was added was suggesting that the emulation folks wanted it to give the really blocky graphics.