### PR TITLE
ARM: dts: bcm2712: Fix invalid polling-delay-passive setting

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
@@ -40,7 +40,7 @@
 
 	thermal-zones {
 		cpu_thermal: cpu-thermal {
-			polling-delay-passive = <2000>;
+			polling-delay-passive = <1000>;
 			polling-delay = <1000>;
 			coefficients = <(-550) 450000>;
 			thermal-sensors = <&thermal>;


### PR DESCRIPTION
This produces a hard fail on later (6.11) kernels.

See: https://lore.kernel.org/all/5802156.DvuYhMxLoT@rjwysocki.net/