### PR TITLE
dtoverlays: Add overlay for HD44780 via I2C PCF8574 backpack

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -82,6 +82,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	gpio-no-irq.dtbo \
 	gpio-poweroff.dtbo \
 	gpio-shutdown.dtbo \
+	hd44780-i2c-lcd.dtbo \
 	hd44780-lcd.dtbo \
 	hdmi-backlight-hwhack-gpio.dtbo \
 	hifiberry-amp.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1752,9 +1752,9 @@ Params: pin_d4                  GPIO pin for data pin D4 (default 6)
         pin_bl                  Optional pin for enabling/disabling the
                                 display backlight. (default disabled)
 
-        display_height          Height of the display in characters
+        display_height          Height of the display in characters (default 2)
 
-        display_width           Width of the display in characters
+        display_width           Width of the display in characters (default 16)
 
 
 Name:   hdmi-backlight-hwhack-gpio

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1705,6 +1705,33 @@ Params: gpio_pin                GPIO pin to trigger on (default 3)
                                 (default 100)
 
 
+Name:   hd44780-i2c-lcd
+Info:   Configures an HD44780 compatible LCD display connected via a PCF8574 as
+        is often found as a backpack interface for these displays.
+Load:   dtoverlay=hd44780-i2c-lcd,<param>=<val>
+Params: addr                    I2C address of PCF8574
+        pin_d4                  GPIO pin for data pin D4 (default 4)
+
+        pin_d5                  GPIO pin for data pin D5 (default 5)
+
+        pin_d6                  GPIO pin for data pin D6 (default 6)
+
+        pin_d7                  GPIO pin for data pin D7 (default 7)
+
+        pin_en                  GPIO pin for "Enable" (default 2)
+
+        pin_rs                  GPIO pin for "Register Select" (default 0)
+
+        pin_rw                  GPIO pin for R/W select (default 1)
+
+        pin_bl                  GPIO pin for enabling/disabling the display
+                                backlight. (default 3)
+
+        display_height          Height of the display in characters (default 2)
+
+        display_width           Width of the display in characters (default 16)
+
+
 Name:   hd44780-lcd
 Info:   Configures an HD44780 compatible LCD display. Uses 4 gpio pins for
         data, 2 gpio pins for enable and register select and 1 optional pin

--- a/arch/arm/boot/dts/overlays/hd44780-i2c-lcd-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hd44780-i2c-lcd-overlay.dts
@@ -1,0 +1,57 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			status = "okay";
+
+			pcf857x: pcf857x@27 {
+				compatible = "nxp,pcf8574";
+				reg = <0x27>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			lcd_screen: auxdisplay {
+				compatible = "hit,hd44780";
+
+				data-gpios = <&pcf857x 4 0>,
+					     <&pcf857x 5 0>,
+					     <&pcf857x 6 0>,
+					     <&pcf857x 7 0>;
+				enable-gpios = <&pcf857x 2 0>;
+				rs-gpios = <&pcf857x 0 0>;
+				rw-gpios = <&pcf857x 1 0>;
+				backlight-gpios = <&pcf857x 3 0>;
+
+				display-width-chars = <16>;
+				display-height-chars = <2>;
+			};
+		};
+	};
+
+	__overrides__ {
+		pin_d4 = <&lcd_screen>,"data-gpios:4";
+		pin_d5 = <&lcd_screen>,"data-gpios:16";
+		pin_d6 = <&lcd_screen>,"data-gpios:28";
+		pin_d7 = <&lcd_screen>,"data-gpios:40";
+		pin_en = <&lcd_screen>,"enable-gpios:4";
+		pin_rs = <&lcd_screen>,"rs-gpios:4";
+		pin_rw = <&lcd_screen>,"rw-gpios:4";
+		pin_bl = <&lcd_screen>,"backlight-gpios:4";
+		display_height = <&lcd_screen>,"display-height-chars:0";
+		display_width = <&lcd_screen>,"display-width-chars:0";
+		addr = <&pcf857x>,"reg:0";
+	};
+
+};


### PR DESCRIPTION
Many HD44780 LCD displays are connected via very common I2C GPIO expander.
We have an overlay for connecting the displays directly to GPIOs, but not one for it connected via a backpack. Add such an overlay.

Requested https://forums.raspberrypi.com/viewtopic.php?t=374408