### PR TITLE
partially fix aarch64 BE on the zero2w

### DIFF
--- a/drivers/clk/bcm/clk-raspberrypi.c
+++ b/drivers/clk/bcm/clk-raspberrypi.c
@@ -198,6 +198,8 @@ static int raspberrypi_fw_is_prepared(struct clk_hw *hw)
 	if (ret)
 		return 0;
 
+        val = le32_to_cpu(val);
+
 	return !!(val & RPI_FIRMWARE_STATE_ENABLE_BIT);
 }
 
@@ -214,6 +216,8 @@ static unsigned long raspberrypi_fw_get_rate(struct clk_hw *hw,
 					 RPI_FIRMWARE_GET_CLOCK_RATE, &val);
 	if (ret)
 		return 0;
+
+        val = le32_to_cpu(val);
 
 	return val;
 }
@@ -310,6 +314,9 @@ static struct clk_hw *raspberrypi_clk_register(struct raspberrypi_clk *rpi,
 		return ERR_PTR(ret);
 	}
 
+        min_rate = le32_to_cpu(min_rate);
+        max_rate = le32_to_cpu(max_rate);
+
 	ret = devm_clk_hw_register(rpi->dev, &data->hw);
 	if (ret)
 		return ERR_PTR(ret);
@@ -370,6 +377,9 @@ static int raspberrypi_discover_clocks(struct raspberrypi_clk *rpi,
 		return ret;
 
 	while (clks->id) {
+                clks->id = le32_to_cpu(clks->id);
+                clks->parent = le32_to_cpu(clks->parent);
+
 		struct raspberrypi_clk_variant *variant;
 
 		if (clks->id >= RPI_FIRMWARE_NUM_CLK_ID) {

--- a/drivers/hwmon/raspberrypi-hwmon.c
+++ b/drivers/hwmon/raspberrypi-hwmon.c
@@ -31,7 +31,7 @@ static void rpi_firmware_get_throttled(struct rpi_hwmon_data *data)
 	int ret;
 
 	/* Request firmware to clear sticky bits */
-	value = 0xffff;
+	value = cpu_to_le32(0xffff);
 
 	ret = rpi_firmware_property(data->fw, RPI_FIRMWARE_GET_THROTTLED,
 				    &value, sizeof(value));
@@ -40,6 +40,7 @@ static void rpi_firmware_get_throttled(struct rpi_hwmon_data *data)
 			     ret);
 		return;
 	}
+        value = le32_to_cpu(value);
 
 	new_uv = value & UNDERVOLTAGE_STICKY_BIT;
 	old_uv = data->last_throttled & UNDERVOLTAGE_STICKY_BIT;

--- a/drivers/mmc/host/bcm2835-sdhost.c
+++ b/drivers/mmc/host/bcm2835-sdhost.c
@@ -1568,13 +1568,13 @@ void bcm2835_sdhost_set_clock(struct bcm2835_host *host, unsigned int clock)
 	host->mmc->actual_clock = 0;
 
 	if (host->firmware_sets_cdiv) {
-		u32 msg[3] = { clock, 0, 0 };
+		u32 msg[3] = { cpu_to_le32(clock), 0, 0 };
 
 		rpi_firmware_property(host->fw,
 				      RPI_FIRMWARE_SET_SDHOST_CLOCK,
 				      &msg, sizeof(msg));
 
-		clock = max(msg[1], msg[2]);
+		clock = max(le32_to_cpu(msg[1]), le32_to_cpu(msg[2]));
 		spin_lock_irqsave(&host->lock, flags);
 	} else {
 		spin_lock_irqsave(&host->lock, flags);
@@ -2142,14 +2142,14 @@ static int bcm2835_sdhost_probe(struct platform_device *pdev)
 		mmc->caps |= MMC_CAP_4_BIT_DATA;
 
 	msg[0] = 0;
-	msg[1] = ~0;
-	msg[2] = ~0;
+	msg[1] = cpu_to_le32(~0);
+	msg[2] = cpu_to_le32(~0);
 
 	rpi_firmware_property(host->fw,
 			      RPI_FIRMWARE_SET_SDHOST_CLOCK,
 			      &msg, sizeof(msg));
 
-	host->firmware_sets_cdiv = (msg[1] != ~0);
+	host->firmware_sets_cdiv = (le32_to_cpu(msg[1]) != ~0);
 
 	platform_set_drvdata(pdev, host);
 

--- a/drivers/pmdomain/bcm/raspberrypi-power.c
+++ b/drivers/pmdomain/bcm/raspberrypi-power.c
@@ -141,14 +141,14 @@ rpi_has_new_domain_support(struct rpi_power_domains *rpi_domains)
 	struct rpi_power_domain_packet packet;
 	int ret;
 
-	packet.domain = RPI_POWER_DOMAIN_ARM;
-	packet.on = ~0;
+	packet.domain = cpu_to_le32(RPI_POWER_DOMAIN_ARM);
+	packet.on = cpu_to_le32(~0);
 
 	ret = rpi_firmware_property(rpi_domains->fw,
 				    RPI_FIRMWARE_GET_DOMAIN_STATE,
 				    &packet, sizeof(packet));
 
-	return ret == 0 && packet.on != ~0;
+	return ret == 0 && le32_to_cpu(packet.on) != ~0;
 }
 
 static int rpi_power_probe(struct platform_device *pdev)


### PR DESCRIPTION
this PR allows booting big-endian linux on a zero2w

what works:
* serial console
* dwc2 gadget mode

what partially works:
* mailbox framebuffer byte order is backwards, but it does display text
* cpufreq is reporting incorrect clocks
* wifi (if the sdhci driver is modified to not use DMA, TODO)

what doesnt work:
* vchiq
* dma (TODO)
* sdhost
* dwc

untested:
* kms/fkms