### PR TITLE
DTS: bcm2712: enable SD slot CQE by default on Pi 5

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -378,9 +378,9 @@ Params:
                                 non-lite SKU of CM4).
                                 (default "on")
 
-        sd_cqe                  Use to enable Command Queueing on the SD
-                                interface for faster Class A2 card performance
-                                (Pi 5 only, default "off")
+        sd_cqe                  Set to "off" to disable Command Queueing if you
+                                have an incompatible Class A2 SD card
+                                (Pi 5 only, default "on")
 
         sd_overclock            Clock (in MHz) to use when the MMC framework
                                 requests 50MHz

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
@@ -363,6 +363,7 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 	sd-uhs-sdr50;
 	sd-uhs-ddr50;
 	sd-uhs-sdr104;
+	supports-cqe;
 	cd-gpios = <&gio_aon 5 GPIO_ACTIVE_LOW>;
 	//no-1-8-v;
 	status = "okay";


### PR DESCRIPTION
I think this is stable enough across cards in the retail channel that we can flip the switch, i.e. all known-bad cards are ignored.

There's two unresolved questions
- What happens to the sd_cqe parameter in overlays/README, now that it does nothing?
- Does the new disable wart end up in overlays, or is it documented (somewhere) as an instruction to put `sdhci.debug_quirks=` in cmdline.txt? How have we historically handled this?

