### PR TITLE
media: pisp-be: Split jobs creation and scheduling

### DIFF
--- a/drivers/media/platform/raspberrypi/pisp_be/pisp_be.c
+++ b/drivers/media/platform/raspberrypi/pisp_be/pisp_be.c
@@ -388,10 +388,7 @@ static void pispbe_xlate_addrs(struct pispbe_job_descriptor *job,
 	ret = pispbe_get_planes_addr(addrs, buf[MAIN_INPUT_NODE],
 				     &node_group->node[MAIN_INPUT_NODE]);
 	if (ret <= 0) {
-		/*
-		 * This shouldn't happen; pispbe_schedule_internal should insist
-		 * on an input.
-		 */
+		/* Shouldn't happen, we have validated an input is available. */
 		dev_warn(node_group->pispbe->dev, "ISP-BE missing input\n");
 		hw_en->bayer_enables = 0;
 		hw_en->rgb_enables = 0;

--- a/drivers/media/platform/raspberrypi/pisp_be/pisp_be.c
+++ b/drivers/media/platform/raspberrypi/pisp_be/pisp_be.c
@@ -621,25 +621,6 @@ static void pispbe_schedule(struct pispbe_dev *pispbe,
 		pispbe->hw_busy = true;
 		spin_unlock_irqrestore(&pispbe->hw_lock, flags);
 
-		if (job.config->num_tiles <= 0 ||
-		    job.config->num_tiles > PISP_BACK_END_NUM_TILES ||
-		    !((job.hw_enables.bayer_enables |
-		       job.hw_enables.rgb_enables) &
-		      PISP_BE_BAYER_ENABLE_INPUT)) {
-			/*
-			 * Bad job. We can't let it proceed as it could lock up
-			 * the hardware, or worse!
-			 *
-			 * For now, just force num_tiles to 0, which causes the
-			 * H/W to do something bizarre but survivable. It
-			 * increments (started,done) counters by more than 1,
-			 * but we seem to survive...
-			 */
-			dev_dbg(pispbe->dev, "Bad job: invalid number of tiles: %u\n",
-				job.config->num_tiles);
-			job.config->num_tiles = 0;
-		}
-
 		pispbe_queue_job(pispbe, &job);
 
 		return;
@@ -736,6 +717,13 @@ static int pisp_be_validate_config(struct pispbe_node_group *node_group,
 	    !(rgb_enables & PISP_BE_RGB_ENABLE_INPUT)) {
 		dev_dbg(dev, "%s: Not one input enabled\n", __func__);
 		return -EIO;
+	}
+
+	if (config->num_tiles == 0 ||
+	    config->num_tiles > PISP_BACK_END_NUM_TILES) {
+		dev_dbg(dev, "%s: Invalid number of tiles: %d\n", __func__,
+			config->num_tiles);
+		return -EINVAL;
 	}
 
 	/* Ensure output config strides and buffer sizes match the V4L2 formats. */


### PR DESCRIPTION
Before submitting the same change to mainline, I would like to know what you think about this. This change will make it easier to support multi-context handling without duplicating the media graph instances.

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Currently the 'pispbe_schedule()' function does two things:

1) Tries to assemble a job by inspecting all the video node queues
   to make sure all the required buffers are available
2) Submit the job to the hardware

The pispbe_schedule() function is called at:

- video device start_streaming() time
- video device qbuf() time
- irq handler

As assembling a job requires inspecting all queues, it is a rather time consuming operation which is better not run in IRQ context.

To avoid the executing the time consuming job creation in interrupt context split the job creation and job scheduling in two distinct operations. When a well-formed job is created, append it to the newly introduced 'pispbe->job_queue' where it will be dequeued from by the scheduling routine.

At start_streaming() and qbuf() time immediately try to schedule a job if one has been created as the irq handler routing is only called when a job has completed, and we can't solely rely on it for scheduling new jobs.