### PR TITLE
Bluetooth: hci_sync: Fix crash on NULL parent

### DIFF
--- a/net/bluetooth/hci_sync.c
+++ b/net/bluetooth/hci_sync.c
@@ -4672,7 +4672,8 @@ static const struct {
  */
 static int hci_dev_setup_sync(struct hci_dev *hdev)
 {
-	struct fwnode_handle *fwnode = dev_fwnode(hdev->dev.parent);
+	struct fwnode_handle *fwnode =
+		hdev->dev.parent ? dev_fwnode(hdev->dev.parent) : NULL;
 	int ret = 0;
 	bool invalid_bdaddr;
 	size_t i;


### PR DESCRIPTION
Although later functions can handle a NULL fwnode, fwnode can't handle being passed a NULL pointer.

See: https://github.com/raspberrypi/linux/issues/6305