### PR TITLE
Add overlay for a generic I2S clock-master DAC

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -125,6 +125,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	i2c6.dtbo \
 	i2s-dac.dtbo \
 	i2s-gpio28-31.dtbo \
+	i2s-master-dac.dtbo \
 	ilitek251x.dtbo \
 	imx219.dtbo \
 	imx258.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2633,6 +2633,12 @@ Load:   dtoverlay=i2s-gpio28-31
 Params: <None>
 
 
+Name:   i2s-master-dac
+Info:   Configures a generic I2S DAC soundcard that acts as a clock master.
+Load:   dtoverlay=i2s-master-dac
+Params: <None>
+
+
 Name:   ilitek251x
 Info:   Enables I2C connected Ilitek 251x multiple touch controller using
         GPIO 4 (pin 7 on GPIO header) for interrupt.

--- a/arch/arm/boot/dts/overlays/i2s-master-dac-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2s-master-dac-overlay.dts
@@ -1,0 +1,50 @@
+// Definitions for a generic I2S DAC that acts as clock master on the bus.
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2s_clk_consumer>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			codec_bare: codec_bare {
+				compatible = "linux,spdif-dit";
+				#sound-dai-cells = <0>;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&sound>;
+		__overlay__ {
+			compatible = "simple-audio-card";
+			i2s-controller = <&i2s_clk_consumer>;
+			status = "okay";
+
+			simple-audio-card,name = "i2s-master-dac";
+			simple-audio-card,format = "i2s";
+
+			simple-audio-card,bitclock-master = <&snd_codec>;
+			simple-audio-card,frame-master = <&snd_codec>;
+
+			simple-audio-card,cpu {
+				sound-dai = <&i2s_clk_consumer>;
+				dai-tdm-slot-num = <2>;
+				dai-tdm-slot-width = <32>;
+			};
+
+			snd_codec: simple-audio-card,codec {
+				sound-dai = <&codec_bare>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
This adds support for any generic stereo I2S DAC that acts as a clock master on the bus.
The feature is very useful when the audio sink cannot synchronize to the clock of the RaspberryPi and does not have a sample rate converter. In that case, the only solution is to use the clock from the domain of the DAC.

Tested with an STM32 as I2S clock master. 

This borrows from `audioinjector-bare-i2s-overlay.dts`, but makes the DAC the clock master, instead of the CPU.