### PR TITLE
drm/vc4: Allow option to transpose the output on the writeback connector

### DIFF
--- a/drivers/gpu/drm/drm_atomic.c
+++ b/drivers/gpu/drm/drm_atomic.c
@@ -451,7 +451,7 @@ static void drm_atomic_crtc_print_state(struct drm_printer *p,
 	drm_printf(p, "\tactive_changed=%d\n", state->active_changed);
 	drm_printf(p, "\tconnectors_changed=%d\n", state->connectors_changed);
 	drm_printf(p, "\tcolor_mgmt_changed=%d\n", state->color_mgmt_changed);
-	drm_printf(p, "\tplane_mask=%x\n", state->plane_mask);
+	drm_printf(p, "\tplane_mask=%llx\n", state->plane_mask);
 	drm_printf(p, "\tconnector_mask=%x\n", state->connector_mask);
 	drm_printf(p, "\tencoder_mask=%x\n", state->encoder_mask);
 	drm_printf(p, "\tmode: " DRM_MODE_FMT "\n", DRM_MODE_ARG(&state->mode));

--- a/drivers/gpu/drm/drm_atomic_uapi.c
+++ b/drivers/gpu/drm/drm_atomic_uapi.c
@@ -811,6 +811,8 @@ static int drm_atomic_connector_set_property(struct drm_connector *connector,
 		state->max_requested_bpc = val;
 	} else if (property == connector->privacy_screen_sw_state_property) {
 		state->privacy_screen_sw_state = val;
+	} else if (property == connector->rotation_property) {
+		state->rotation = val;
 	} else if (connector->funcs->atomic_set_property) {
 		return connector->funcs->atomic_set_property(connector,
 				state, property, val);
@@ -900,6 +902,8 @@ drm_atomic_connector_get_property(struct drm_connector *connector,
 		*val = state->max_requested_bpc;
 	} else if (property == connector->privacy_screen_sw_state_property) {
 		*val = state->privacy_screen_sw_state;
+	} else if (property == connector->rotation_property) {
+		*val = state->rotation;
 	} else if (connector->funcs->atomic_get_property) {
 		return connector->funcs->atomic_get_property(connector,
 				state, property, val);

--- a/drivers/gpu/drm/drm_blend.c
+++ b/drivers/gpu/drm/drm_blend.c
@@ -263,6 +263,8 @@ EXPORT_SYMBOL(drm_plane_create_alpha_property);
  * 	"reflect-x"
  * DRM_MODE_REFLECT_Y:
  * 	"reflect-y"
+ * DRM_MODE_TRANSPOSE:
+ * 	"transpose"
  *
  * Rotation is the specified amount in degrees in counter clockwise direction,
  * the X and Y axis are within the source rectangle, i.e.  the X/Y axis before
@@ -280,6 +282,7 @@ int drm_plane_create_rotation_property(struct drm_plane *plane,
 		{ __builtin_ffs(DRM_MODE_ROTATE_270) - 1, "rotate-270" },
 		{ __builtin_ffs(DRM_MODE_REFLECT_X) - 1,  "reflect-x" },
 		{ __builtin_ffs(DRM_MODE_REFLECT_Y) - 1,  "reflect-y" },
+		{ __builtin_ffs(DRM_MODE_TRANSPOSE) - 1,  "transpose" },
 	};
 	struct drm_property *prop;
 

--- a/drivers/gpu/drm/drm_connector.c
+++ b/drivers/gpu/drm/drm_connector.c
@@ -361,7 +361,8 @@ static int __drm_connector_init(struct drm_device *dev,
 
 	drm_object_attach_property(&connector->base,
 				   config->non_desktop_property,
-				   0);
+				   (connector_type != DRM_MODE_CONNECTOR_VIRTUAL &&
+				   connector_type != DRM_MODE_CONNECTOR_WRITEBACK) ? 0 : 1);
 	drm_object_attach_property(&connector->base,
 				   config->tile_property,
 				   0);

--- a/drivers/gpu/drm/drm_framebuffer.c
+++ b/drivers/gpu/drm/drm_framebuffer.c
@@ -959,7 +959,7 @@ static int atomic_remove_fb(struct drm_framebuffer *fb)
 	struct drm_connector *conn __maybe_unused;
 	struct drm_connector_state *conn_state;
 	int i, ret;
-	unsigned plane_mask;
+	u64 plane_mask;
 	bool disable_crtcs = false;
 
 retry_disable:

--- a/drivers/gpu/drm/drm_mode_config.c
+++ b/drivers/gpu/drm/drm_mode_config.c
@@ -636,7 +636,7 @@ void drm_mode_config_validate(struct drm_device *dev)
 	struct drm_encoder *encoder;
 	struct drm_crtc *crtc;
 	struct drm_plane *plane;
-	u32 primary_with_crtc = 0, cursor_with_crtc = 0;
+	u64 primary_with_crtc = 0, cursor_with_crtc = 0;
 	unsigned int num_primary = 0;
 
 	if (!drm_core_check_feature(dev, DRIVER_MODESET))

--- a/drivers/gpu/drm/drm_plane.c
+++ b/drivers/gpu/drm/drm_plane.c
@@ -249,7 +249,7 @@ static int __drm_universal_plane_init(struct drm_device *dev,
 	int ret;
 
 	/* plane index is used with 32bit bitmasks */
-	if (WARN_ON(config->num_total_plane >= 32))
+	if (WARN_ON(config->num_total_plane >= 64))
 		return -EINVAL;
 
 	/*

--- a/drivers/gpu/drm/imx/ipuv3/ipuv3-crtc.c
+++ b/drivers/gpu/drm/imx/ipuv3/ipuv3-crtc.c
@@ -230,7 +230,7 @@ static int ipu_crtc_atomic_check(struct drm_crtc *crtc,
 {
 	struct drm_crtc_state *crtc_state = drm_atomic_get_new_crtc_state(state,
 									  crtc);
-	u32 primary_plane_mask = drm_plane_mask(crtc->primary);
+	u64 primary_plane_mask = drm_plane_mask(crtc->primary);
 
 	if (crtc_state->active && (primary_plane_mask & crtc_state->plane_mask) == 0)
 		return -EINVAL;

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -1291,7 +1291,8 @@ static int vc4_plane_mode_set(struct drm_plane *plane,
 	width = vc4_state->src_w[0] >> 16;
 	height = vc4_state->src_h[0] >> 16;
 
-	if (!width || !height || !vc4_state->crtc_w || !vc4_state->crtc_h) {
+	if (!vc4_state->src_w[0] || !vc4_state->src_h[0] ||
+	    !vc4_state->crtc_w || !vc4_state->crtc_h) {
 		/* 0 source size probably means the plane is offscreen */
 		vc4_state->dlist_initialized = 1;
 		return 0;
@@ -1829,7 +1830,8 @@ static int vc6_plane_mode_set(struct drm_plane *plane,
 	width = vc4_state->src_w[0] >> 16;
 	height = vc4_state->src_h[0] >> 16;
 
-	if (!width || !height || !vc4_state->crtc_w || !vc4_state->crtc_h) {
+	if (!vc4_state->src_w[0] || !vc4_state->src_h[0] ||
+	    !vc4_state->crtc_w || !vc4_state->crtc_h) {
 		/* 0 source size probably means the plane is offscreen.
 		 * 0 destination size is a redundant plane.
 		 */

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -2657,7 +2657,7 @@ struct drm_plane *vc4_plane_init(struct drm_device *dev,
 	return plane;
 }
 
-#define VC4_NUM_OVERLAY_PLANES	16
+#define VC4_NUM_OVERLAY_PLANES	48
 
 int vc4_plane_create_additional_planes(struct drm_device *drm)
 {

--- a/drivers/gpu/drm/vc4/vc4_txp.c
+++ b/drivers/gpu/drm/vc4/vc4_txp.c
@@ -15,6 +15,7 @@
 
 #include <drm/drm_atomic.h>
 #include <drm/drm_atomic_helper.h>
+#include <drm/drm_blend.h>
 #include <drm/drm_drv.h>
 #include <drm/drm_edid.h>
 #include <drm/drm_fb_dma_helper.h>
@@ -259,10 +260,15 @@ static int vc4_txp_connector_atomic_check(struct drm_connector *conn,
 	crtc_state = drm_atomic_get_new_crtc_state(state, conn_state->crtc);
 
 	fb = conn_state->writeback_job->fb;
-	if (fb->width != crtc_state->mode.hdisplay ||
-	    fb->height != crtc_state->mode.vdisplay) {
-		DRM_DEBUG_KMS("Invalid framebuffer size %ux%u\n",
-			      fb->width, fb->height);
+	if ((conn_state->rotation == DRM_MODE_ROTATE_0 &&
+	     fb->width != crtc_state->mode.hdisplay &&
+	     fb->height != crtc_state->mode.vdisplay) ||
+	    (conn_state->rotation == (DRM_MODE_ROTATE_0 | DRM_MODE_TRANSPOSE) &&
+	     fb->width != crtc_state->mode.vdisplay &&
+	     fb->height != crtc_state->mode.hdisplay)) {
+		DRM_DEBUG_KMS("Invalid framebuffer size %ux%u vs mode %ux%u\n",
+			      fb->width, fb->height,
+			      crtc_state->mode.hdisplay, crtc_state->mode.vdisplay);
 		return -EINVAL;
 	}
 
@@ -329,6 +335,9 @@ static void vc4_txp_connector_atomic_commit(struct drm_connector *conn,
 		 * hardware will force the output padding to be 0xff.
 		 */
 		ctrl |= TXP_ALPHA_INVERT;
+
+	if (conn_state->rotation & DRM_MODE_TRANSPOSE)
+		ctrl |= TXP_TRANSPOSE;
 
 	if (!drm_dev_enter(drm, &idx))
 		return;
@@ -607,6 +616,10 @@ static int vc4_txp_bind(struct device *dev, struct device *master, void *data)
 							drm_fmts, ARRAY_SIZE(drm_fmts));
 	if (ret)
 		return ret;
+
+	drm_connector_create_rotation_property(&txp->connector.base, DRM_MODE_ROTATE_0,
+					       DRM_MODE_ROTATE_0 |
+					       DRM_MODE_TRANSPOSE);
 
 	ret = devm_request_irq(dev, irq, vc4_txp_interrupt, 0,
 			       dev_name(dev), txp);

--- a/include/drm/drm_blend.h
+++ b/include/drm/drm_blend.h
@@ -34,6 +34,7 @@
 struct drm_device;
 struct drm_atomic_state;
 struct drm_plane;
+struct drm_connector;
 
 static inline bool drm_rotation_90_or_270(unsigned int rotation)
 {
@@ -58,4 +59,8 @@ int drm_atomic_normalize_zpos(struct drm_device *dev,
 			      struct drm_atomic_state *state);
 int drm_plane_create_blend_mode_property(struct drm_plane *plane,
 					 unsigned int supported_modes);
+
+int drm_connector_create_rotation_property(struct drm_connector *conn,
+					   unsigned int rotation,
+					   unsigned int supported_rotations);
 #endif

--- a/include/drm/drm_connector.h
+++ b/include/drm/drm_connector.h
@@ -1029,6 +1029,11 @@ struct drm_connector_state {
 	 * DRM blob property for HDR output metadata
 	 */
 	struct drm_property_blob *hdr_output_metadata;
+
+	/**
+	 * @rotation: Connector property to rotate the maximum output image.
+	 */
+	u32 rotation;
 };
 
 /**
@@ -1695,6 +1700,12 @@ struct drm_connector {
 	 * connector to report the actual integrated privacy screen state.
 	 */
 	struct drm_property *privacy_screen_hw_state_property;
+
+	/**
+	 * @rotation_property: Optional DRM property controlling rotation of the
+	 * output.
+	 */
+	struct drm_property *rotation_property;
 
 #define DRM_CONNECTOR_POLL_HPD (1 << 0)
 #define DRM_CONNECTOR_POLL_CONNECT (1 << 1)

--- a/include/drm/drm_crtc.h
+++ b/include/drm/drm_crtc.h
@@ -192,7 +192,7 @@ struct drm_crtc_state {
 	 * @plane_mask: Bitmask of drm_plane_mask(plane) of planes attached to
 	 * this CRTC.
 	 */
-	u32 plane_mask;
+	u64 plane_mask;
 
 	/**
 	 * @connector_mask: Bitmask of drm_connector_mask(connector) of

--- a/include/drm/drm_plane.h
+++ b/include/drm/drm_plane.h
@@ -915,9 +915,9 @@ static inline unsigned int drm_plane_index(const struct drm_plane *plane)
  * drm_plane_mask - find the mask of a registered plane
  * @plane: plane to find mask for
  */
-static inline u32 drm_plane_mask(const struct drm_plane *plane)
+static inline u64 drm_plane_mask(const struct drm_plane *plane)
 {
-	return 1 << drm_plane_index(plane);
+	return 1ULL << drm_plane_index(plane);
 }
 
 struct drm_plane * drm_plane_from_index(struct drm_device *dev, int idx);

--- a/include/uapi/drm/drm_mode.h
+++ b/include/uapi/drm/drm_mode.h
@@ -203,6 +203,7 @@ extern "C" {
  */
 #define DRM_MODE_REFLECT_X      (1<<4)
 #define DRM_MODE_REFLECT_Y      (1<<5)
+#define DRM_MODE_TRANSPOSE      (1<<6)
 
 /*
  * DRM_MODE_REFLECT_MASK


### PR DESCRIPTION
The hardware behind the writeback connector can do a transpose as it writes the image out.
DRM offers no mechanism to select that, but as a simple test we can note when the width/height of the buffer are swapped wrt the mode, and enable the transpose. The atomic_check obviously has to be updated too to permit that combination.

Transposing a square output buffer is left as future problem to solve.