### PR TITLE
media/rpivid: Make SPS / PPS optional in a request

### DIFF
--- a/drivers/staging/media/rpivid/rpivid.c
+++ b/drivers/staging/media/rpivid/rpivid.c
@@ -40,14 +40,14 @@ static const struct rpivid_control rpivid_ctrls[] = {
 			.id	= V4L2_CID_STATELESS_HEVC_SPS,
 			.ops	= &rpivid_hevc_sps_ctrl_ops,
 		},
-		.required	= true,
+		.required	= false,
 	},
 	{
 		.cfg = {
 			.id	= V4L2_CID_STATELESS_HEVC_PPS,
 			.ops	= &rpivid_hevc_pps_ctrl_ops,
 		},
-		.required	= true,
+		.required	= false,
 	},
 	{
 		.cfg = {

--- a/drivers/staging/media/rpivid/rpivid_h265.c
+++ b/drivers/staging/media/rpivid/rpivid_h265.c
@@ -1726,6 +1726,12 @@ static void rpivid_h265_setup(struct rpivid_ctx *ctx, struct rpivid_run *run)
 		unsigned int ctb_size_y;
 		bool sps_changed = false;
 
+		if (!is_sps_set(run->h265.sps)) {
+			v4l2_warn(&dev->v4l2_dev, "SPS never set\n");
+			goto fail;
+		}
+		// Can't check for PPS easily as all 0's looks valid to me
+
 		if (memcmp(&s->sps, run->h265.sps, sizeof(s->sps)) != 0) {
 			/* SPS changed */
 			v4l2_info(&dev->v4l2_dev, "SPS changed\n");

--- a/drivers/staging/media/rpivid/rpivid_video.c
+++ b/drivers/staging/media/rpivid/rpivid_video.c
@@ -257,11 +257,6 @@ static int rpivid_hevc_validate_sps(const struct v4l2_ctrl_hevc_sps * const sps)
 	return 1;
 }
 
-static inline int is_sps_set(const struct v4l2_ctrl_hevc_sps * const sps)
-{
-	return sps && sps->pic_width_in_luma_samples != 0;
-}
-
 static u32 pixelformat_from_sps(const struct v4l2_ctrl_hevc_sps * const sps,
 				const int index)
 {

--- a/drivers/staging/media/rpivid/rpivid_video.h
+++ b/drivers/staging/media/rpivid/rpivid_video.h
@@ -20,6 +20,11 @@ struct rpivid_format {
 	unsigned int	capabilities;
 };
 
+static inline int is_sps_set(const struct v4l2_ctrl_hevc_sps * const sps)
+{
+	return sps && sps->pic_width_in_luma_samples != 0;
+}
+
 extern const struct v4l2_ioctl_ops rpivid_ioctl_ops;
 
 int rpivid_queue_init(void *priv, struct vb2_queue *src_vq,


### PR DESCRIPTION
SPS & PPS are optional in requests. Fix. The framework keeps the last value so this is mostly a matter of changing .required to false when requesting the controls. Check that SPS has ever been set on frame start, PPS is valid if all zeros so is at best tricky to check.