### PR TITLE
rtc: pcf8523: Fix oscillator stop bit handling reading from Control_1 register

### DIFF
--- a/drivers/rtc/rtc-pcf8523.c
+++ b/drivers/rtc/rtc-pcf8523.c
@@ -108,10 +108,10 @@ static int pcf8523_rtc_read_time(struct device *dev, struct rtc_time *tm)
 	if (err < 0)
 		return err;
 
-	if ((regs[0] & PCF8523_CONTROL1_STOP) || (regs[3] & PCF8523_SECONDS_OS))
+	if (regs[PCF8523_REG_CONTROL1] & PCF8523_CONTROL1_STOP)
 		return -EINVAL;
 
-	if (regs[0] & PCF8523_SECONDS_OS) {
+	if (regs[PCF8523_REG_SECONDS] & PCF8523_SECONDS_OS) {
 		/*
 		 * If the oscillator was stopped, try to clear the flag. Upon
 		 * power-up the flag is always set, but if we cannot clear it
@@ -120,10 +120,10 @@ static int pcf8523_rtc_read_time(struct device *dev, struct rtc_time *tm)
 		 * that the clock cannot be assumed to be correct.
 		 */
 
-		regs[0] &= ~PCF8523_SECONDS_OS;
+		regs[PCF8523_REG_SECONDS] &= ~PCF8523_SECONDS_OS;
 
 		err = regmap_write(pcf8523->regmap, PCF8523_REG_SECONDS,
-				   regs[0]);
+				   regs[PCF8523_REG_SECONDS]);
 		if (err < 0)
 			return err;
 
@@ -135,7 +135,7 @@ static int pcf8523_rtc_read_time(struct device *dev, struct rtc_time *tm)
 		if (value & PCF8523_SECONDS_OS)
 			return -EAGAIN;
 
-		regs[0] = value;
+		regs[PCF8523_REG_SECONDS] = value;
 	}
 
 	tm->tm_sec = bcd2bin(regs[3] & 0x7f);


### PR DESCRIPTION
The check if the oscillator stop bit is set was reading from Control_1 register instead of the Seconds register. This caused the Seconds register to be incorrectly changed if bit 7 of Control_1 happens to be set. 

Without this, the pcf8523 driver is completely broken, as reading from the clock causes the value to change by up to 1 minute. 