### PR TITLE
piscreen-overlay: Add invx, invy and swapxy

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3694,6 +3694,12 @@ Params: speed                   Display SPI bus speed
         drm                     Select the DRM/KMS driver instead of the FBTFT
                                 one
 
+        invx                    Touchscreen inverted x axis
+
+        invy                    Touchscreen inverted y axis
+
+        swapxy                  Touchscreen swapped x y axis
+
 
 Name:   piscreen2r
 Info:   PiScreen 2 with resistive TP display by OzzMaker.com

--- a/arch/arm/boot/dts/overlays/piscreen-overlay.dts
+++ b/arch/arm/boot/dts/overlays/piscreen-overlay.dts
@@ -103,5 +103,8 @@
 		xohms =		<&piscreen_ts>,"ti,x-plate-ohms;0";
 		drm =		<&piscreen>,"compatible=waveshare,rpi-lcd-35",
 				<&piscreen>,"reset-gpios:8=",<GPIO_ACTIVE_HIGH>;
+		invx =		<&piscreen_ts>,"touchscreen-inverted-x?";
+		invy =		<&piscreen_ts>,"touchscreen-inverted-y?";
+		swapxy =	<&piscreen_ts>,"touchscreen-swapped-x-y!";
 	};
 };


### PR DESCRIPTION
This PR adds touchscreen x,y swap and inversion options, using the `invx`, `invy`, and `swapxy` as per the discussion at https://github.com/raspberrypi/linux/issues/3263?notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDEyMjAwNTIwNzExOjEwOTY3MDE%3D#issuecomment-2327607601 , which will ideally work for the Waveshare 3.5a touchscreen.

I have changed the parameter names to match the common parameter name usage in other device tree overlay files in the same dir.