### PR TITLE
drivers: drm: rp1-vec: Increase width limit, for PAL 16:9 @ 18MHz

### DIFF
--- a/drivers/gpu/drm/rp1/rp1-vec/rp1_vec.c
+++ b/drivers/gpu/drm/rp1/rp1-vec/rp1_vec.c
@@ -508,8 +508,8 @@ static int rp1vec_platform_probe(struct platform_device *pdev)
 
 	vec->drm.mode_config.min_width	= 256;
 	vec->drm.mode_config.min_height = 128;
-	vec->drm.mode_config.max_width	= 848; /* for System E */
-	vec->drm.mode_config.max_height = 738; /* for System E */
+	vec->drm.mode_config.max_width	= 960; /* for "widescreen" @ 18MHz */
+	vec->drm.mode_config.max_height = 738; /* for System E only */
 	vec->drm.mode_config.preferred_depth = 32;
 	vec->drm.mode_config.prefer_shadow = 0;
 	vec->drm.mode_config.quirk_addfb_prefer_host_byte_order = true;

--- a/drivers/gpu/drm/rp1/rp1-vec/rp1_vec_hw.c
+++ b/drivers/gpu/drm/rp1/rp1-vec/rp1_vec_hw.c
@@ -195,7 +195,7 @@ static const struct rp1vec_hwmode rp1vec_hwmodes[3][2] = {
 			.misc = 0x00091c01, /* 5-tap FIR, SEQ_EN, 8 fld sync, PAL */
 			.nco_freq = 0x0a8262b2cc48c1d1,
 			.timing_regs = {
-				0x046e0cee, 0x0d8001fb, 0x025c034f, 0x00fd0b84,
+				0x04660cee, 0x0d8001fb, 0x025c034f, 0x00fd0b84,
 				0x026c0270, 0x00000004, 0x00050009, 0x00070135,
 				0x00000000, 0x00000000, 0x00000000, 0x00000000,
 				0x00170136, 0x00000000,
@@ -218,7 +218,7 @@ static const struct rp1vec_hwmode rp1vec_hwmodes[3][2] = {
 			.misc = 0x0009dc03, /* 5-tap FIR, SEQ_EN, 4 flds, 8 fld sync, ilace, PAL */
 			.nco_freq = 0x0a8262b2cc48c1d1,
 			.timing_regs = {
-				0x046e0cee, 0x0d8001fb, 0x025c034f, 0x00fd0b84,
+				0x04660cee, 0x0d8001fb, 0x025c034f, 0x00fd0b84,
 				0x026c0270, 0x00000004, 0x00050009, 0x00070135,
 				0x013f026d, 0x00060136, 0x0140026e, 0x0150026e,
 				0x00180136, 0x026f0017,


### PR DESCRIPTION
There was no technical reason for the DRM mode's width limit of 848; increase it to 960 (720*18MHz/13.5MHz) to support ~square pixels on 16:9 screens.

Tweak the PAL active window to start slightly earlier. (The maximum number of visible columns at 18MHz is about 942.)