### PR TITLE
vc04_services: codec: Allocate the max number of buffers on the VPU

### DIFF
--- a/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
+++ b/drivers/staging/vc04_services/bcm2835-codec/bcm2835-v4l2-codec.c
@@ -2871,8 +2871,14 @@ static int bcm2835_codec_queue_setup(struct vb2_queue *vq,
 
 	if (*nbuffers < port->minimum_buffer.num)
 		*nbuffers = port->minimum_buffer.num;
-	/* Add one buffer to take an EOS */
-	port->current_buffer.num = *nbuffers + 1;
+
+	/*
+	 * The VPU uses this number to allocate a pool of headers at port_enable.
+	 * We can't increase it later, so use of CREATE_BUFS is going to result
+	 * in bad things happening. Adopt worst-case allocation, and add one
+	 * buffer to take an EOS
+	 */
+	port->current_buffer.num = VB2_MAX_FRAME + 1;
 
 	return 0;
 }


### PR DESCRIPTION
The VPU's API can't match the use of VIDIOC_CREATE_BUFS to add buffers to the internal pool whilst a port is enabled, therefore allocate the maximum number of buffers possible in V4L2 to avoid the issue. As these are only buffer headers, the overhead is relatively small.

@jc-kynesim. This fixes up the kernel splats in your test case. 

I do still get the error
```
** (vidtest:1157): WARNING **: 17:02:45.336: videodecoder: 8 frames 218-225 left undrained after CMD_STOP, eos sent too early: bug in decoder -- please file a bug
```
after the first couple of loops. That's a funny one, but likely down in the codec rather than framework. Yet more logging required.