### PR TITLE
ASoC: add the HiFiBerry 8-channel ADC soundcard

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -86,6 +86,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	hd44780-lcd.dtbo \
 	hdmi-backlight-hwhack-gpio.dtbo \
 	hifiberry-adc.dtbo \
+	hifiberry-adc8x.dtbo \
 	hifiberry-amp.dtbo \
 	hifiberry-amp100.dtbo \
 	hifiberry-amp3.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1778,6 +1778,12 @@ Params: leds_off                If set to 'true' the onboard indicator LED
                                 is switched off at all times.
 
 
+Name:   hifiberry-adc8x
+Info:   Configures the HifiBerry ADC8X audio card (only on Pi5)
+Load:   dtoverlay=hifiberry-adc8x
+Params: <None>
+
+
 Name:   hifiberry-amp
 Info:   Configures the HifiBerry Amp and Amp+ audio cards
 Load:   dtoverlay=hifiberry-amp

--- a/arch/arm/boot/dts/overlays/hifiberry-adc8x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-adc8x-overlay.dts
@@ -1,0 +1,50 @@
+// Definitions for HiFiBerry ADC8x
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2712";
+
+	fragment@0 {
+		target = <&gpio>;
+		__overlay__ {
+			rp1_i2s0_adc8x: rp1_i2s0_adc8x {
+				function = "i2s0";
+				pins = "gpio18", "gpio19", "gpio20",
+				       "gpio22", "gpio24", "gpio26";
+				bias-disable;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2s_clk_producer>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&rp1_i2s0_adc8x>;
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			dummy-codec {
+				#sound-dai-cells = <0>;
+				compatible = "snd-soc-dummy";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&sound>;
+		__overlay__ {
+			compatible = "hifiberry,hifiberry-adc8x";
+			i2s-controller = <&i2s_clk_producer>;
+			status = "okay";
+		};
+	};
+
+};

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -48,6 +48,10 @@
 		bcm2712;
 	};
 
+	hifiberry-adc8x {
+		bcm2712;
+	};
+
 	hifiberry-dac8x {
 		bcm2712;
 	};

--- a/sound/soc/bcm/Kconfig
+++ b/sound/soc/bcm/Kconfig
@@ -47,6 +47,13 @@ config SND_BCM2708_SOC_HIFIBERRY_ADC
          Say Y or M if you want to add support for HifiBerry ADC.
          Use this module for HiFiBerry's ADC-only sound cards
 
+config SND_BCM2708_SOC_HIFIBERRY_ADC8X
+        tristate "Support for HifiBerry ADC8X"
+        select SND_RPI_SIMPLE_SOUNDCARD
+        help
+         Say Y or M if you want to add support for HifiBerry ADC8X.
+         Note: ADC8X only works on PI5
+
 config SND_BCM2708_SOC_HIFIBERRY_DAC
         tristate "Support for HifiBerry DAC and DAC8X"
         select SND_SOC_PCM5102A

--- a/sound/soc/bcm/rpi-simple-soundcard.c
+++ b/sound/soc/bcm/rpi-simple-soundcard.c
@@ -254,6 +254,41 @@ static struct snd_rpi_simple_drvdata drvdata_hifiberrydacplusdsp = {
 	.dai       = snd_hifiberrydacplusdsp_soundcard_dai,
 };
 
+SND_SOC_DAILINK_DEFS(hifiberry_adc,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_CODEC("snd-soc-dummy", "snd-soc-dummy-dai")),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
+static int hifiberry_adc8x_init(struct snd_soc_pcm_runtime *rtd)
+{
+	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+
+	/* set limits of 8 channels and 192ksps sample rate
+	 */
+	codec_dai->driver->capture.channels_max = 8;
+	codec_dai->driver->capture.rates = SNDRV_PCM_RATE_8000_192000;
+
+	return 0;
+}
+
+static struct snd_soc_dai_link snd_hifiberry_adc8x_dai[] = {
+	{
+		.name           = "HifiBerry ADC8x",
+		.stream_name    = "HifiBerry ADC8x HiFi",
+		.dai_fmt        = SND_SOC_DAIFMT_I2S |
+					SND_SOC_DAIFMT_NB_NF |
+					SND_SOC_DAIFMT_CBS_CFS,
+		.init           = hifiberry_adc8x_init,
+		SND_SOC_DAILINK_REG(hifiberry_adc),
+	},
+};
+
+static struct snd_rpi_simple_drvdata drvdata_hifiberry_adc8x = {
+	.card_name = "snd_rpi_hifiberry_adc8x",
+	.dai       = snd_hifiberry_adc8x_dai,
+	.fixed_bclk_ratio = 64,
+};
+
 SND_SOC_DAILINK_DEFS(hifiberry_amp,
 	DAILINK_COMP_ARRAY(COMP_EMPTY()),
 	DAILINK_COMP_ARRAY(COMP_CODEC("tas5713.1-001b", "tas5713-hifi")),
@@ -445,6 +480,8 @@ static const struct of_device_id snd_rpi_simple_of_match[] = {
 		.data = (void *) &drvdata_googlevoicehat },
 	{ .compatible = "hifiberrydacplusdsp,hifiberrydacplusdsp-soundcard",
 		.data = (void *) &drvdata_hifiberrydacplusdsp },
+	{ .compatible = "hifiberry,hifiberry-adc8x",
+		.data = (void *) &drvdata_hifiberry_adc8x },
 	{ .compatible = "hifiberry,hifiberry-amp",
 		.data = (void *) &drvdata_hifiberry_amp },
 	{ .compatible = "hifiberry,hifiberry-amp3",


### PR DESCRIPTION
Additions and changes for the new 8 channel ADC card for the Pi 5.
It's a HW controlled device, so we can use the snd-soc-dummy device
for the DAI declarations.
