### PR TITLE
drm: panel: waveshare: Remove duplicated sentinel on compatible list

### DIFF
--- a/drivers/gpu/drm/panel/panel-waveshare-dsi.c
+++ b/drivers/gpu/drm/panel/panel-waveshare-dsi.c
@@ -467,7 +467,6 @@ static const struct of_device_id ws_panel_of_ids[] = {
 		.compatible = "waveshare,8.8inch-panel",
 		.data = &ws_panel_8_8_mode,
 	}, {
-	}, {
 		/* sentinel */
 	}
 };


### PR DESCRIPTION
Remove the duplicated sentinel that got added, otherwise we have an extra blank compatible string match in the module, and that matches everything.

$ modinfo panel_waveshare_dsi
filename:       /lib/modules/6.6.50-v8+/kernel/drivers/gpu/drm/panel/panel-waveshare-dsi.ko.xz
license:        GPL
description:    Waveshare DSI panel driver
author:         Dave Stevenson <dave.stevenson@raspberrypi.com>
srcversion:     E767180DABD8B00B45571AF
alias:          of:N*T*C*
alias:          of:N*T*
alias:          of:N*T*Cwaveshare,8.8inch-panelC*
alias:          of:N*T*Cwaveshare,8.8inch-panel

Fixes: f955b7838f9c ("drivers:gpu:drm:panel: Added waveshare 5.0inch, 6.25inch, and 8.8inch dsi screen devices")