### PR TITLE
HID: usbhid: Insert USB bus/device ID into HID name

### DIFF
--- a/drivers/hid/usbhid/hid-core.c
+++ b/drivers/hid/usbhid/hid-core.c
@@ -1388,8 +1388,11 @@ static int usbhid_probe(struct usb_interface *intf, const struct usb_device_id *
 	else if (intf->cur_altsetting->desc.bInterfaceProtocol == 0)
 		hid->type = HID_TYPE_USBNONE;
 
-	if (dev->manufacturer)
-		strscpy(hid->name, dev->manufacturer, sizeof(hid->name));
+	snprintf(hid->name, sizeof(hid->name), "usb-%s ", dev_name(&dev->dev));
+
+	if (dev->manufacturer) {
+		strlcat(hid->name, dev->manufacturer, sizeof(hid->name));
+	}
 
 	if (dev->product) {
 		if (dev->manufacturer)
@@ -1397,8 +1400,9 @@ static int usbhid_probe(struct usb_interface *intf, const struct usb_device_id *
 		strlcat(hid->name, dev->product, sizeof(hid->name));
 	}
 
-	if (!strlen(hid->name))
-		snprintf(hid->name, sizeof(hid->name), "HID %04x:%04x",
+	if (strlen(hid->name) == strlen(dev_name(&dev->dev)))
+		snprintf(hid->name, sizeof(hid->name), "usb-%s HID %04x:%04x",
+			 dev_name(&dev->dev),
 			 le16_to_cpu(dev->descriptor.idVendor),
 			 le16_to_cpu(dev->descriptor.idProduct));
 


### PR DESCRIPTION
Draft as this isn't ideal - it renames all mouse and keyboard devices, as well as touch ones.

libinput/wlroots/Wayfire/labwc match input device by the device name only. If you add 2 identical USB connected touch devices, you can't select between them.

Add the usb bus&device name to the start of the name so that the names end up being unique,

https://forums.raspberrypi.com/viewtopic.php?t=376569

