### PR TITLE
mm/vmscan: Maintain TLB coherency in LRU code

### DIFF
--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -4736,7 +4736,7 @@ void lru_gen_look_around(struct page_vma_mapped_walk *pvmw)
 		if (!folio)
 			continue;
 
-		if (!ptep_test_and_clear_young(vma, addr, pte + i))
+		if (!ptep_clear_flush_young(vma, addr, pte + i))
 			VM_WARN_ON_ONCE(true);
 
 		young++;


### PR DESCRIPTION
As a workaround (and possibly a fix) for CPU spins observed on BCM2837, use ptep_clear_flush_young instead of ptep_test_and_clear_young inside lru_gen_look_around in order to expose PTE changes to the MMU. Note that on architectures that don't require an explicit flush, ptep_clear_flush_young just calls ptep_test_and_clear_young.