### PR TITLE
drm: panel: ili9881: Correct symmetry on enable/disable return codes

### DIFF
--- a/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c
+++ b/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c
@@ -1745,7 +1745,9 @@ static int ili9881c_disable(struct drm_panel *panel)
 {
 	struct ili9881c *ctx = panel_to_ili9881c(panel);
 
-	return mipi_dsi_dcs_set_display_off(ctx->dsi);
+	mipi_dsi_dcs_set_display_off(ctx->dsi);
+
+	return 0;
 }
 
 static int ili9881c_unprepare(struct drm_panel *panel)


### PR DESCRIPTION
ili9881c_enable is always returning 0.

ili9881c_disable was returning the error code from mipi_dsi_dcs_set_display_off.
If non-zero, the drm_panel framework will leave the panel marked as enabled, and not run the enable hook next time around. That isn't helpful, particularly as we're expecting unprepare to disable resets and regulators.

Change ili9881c_disable to match enable in always returning 0.