### PR TITLE
dts: 2712: Reduce default cma usage on Pi5

### DIFF
--- a/arch/arm/boot/dts/overlays/vc4-kms-v3d-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-v3d-pi5-overlay.dts
@@ -3,7 +3,7 @@
 #include "cma-overlay.dts"
 
 &frag0 {
-	size = <((320-4)*1024*1024)>;
+	size = <(64*1024*1024)>;
 };
 
 / {


### PR DESCRIPTION
Significant cma shouldn't really be needed on Pi5 as the hardware blocks support iommu and can access system memory.

We've migrated codec and camera support to system memory, and 3d has always (even on Pi4) used system memory.

A large cma block causes issues with enabling NUMA on a low memory (2G) Pi5, as cma cannot span numa regions.