### PR TITLE
drm: vc4: Fix interpolate bit for nearest neighbour filter

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -614,7 +614,7 @@ static void vc4_write_ppf(struct vc4_plane_state *vc4_state, u32 src, u32 dst,
 	phase &= SCALER_PPF_IPHASE_MASK;
 
 	vc4_dlist_write(vc4_state,
-			no_interpolate ? SCALER_PPF_NOINTERP : 0 |
+			(no_interpolate ? SCALER_PPF_NOINTERP : 0) |
 			SCALER_PPF_AGC |
 			VC4_SET_FIELD(scale, SCALER_PPF_SCALE) |
 			/*


### PR DESCRIPTION
Operator precedence resulted in the wrong value being written for nearest neighbour mode. Correct it.

Fixes: d6a3a3f10601 ("drm/vc4: Add support for per plane scaling filter selection")

#6362