### PR TITLE
Fix use-after-free in rpisense-js driver

### DIFF
--- a/drivers/input/joystick/rpisense-js.c
+++ b/drivers/input/joystick/rpisense-js.c
@@ -107,8 +107,11 @@ static int rpisense_js_probe(struct platform_device *pdev)
 		goto err_keys_reg;
 	}
 	return 0;
+
 err_keys_reg:
 	input_unregister_device(rpisense_js->keys_dev);
+	return ret;
+
 err_keys_alloc:
 	input_free_device(rpisense_js->keys_dev);
 	return ret;
@@ -119,7 +122,6 @@ static int rpisense_js_remove(struct platform_device *pdev)
 	struct rpisense_js *rpisense_js = &rpisense->joystick;
 
 	input_unregister_device(rpisense_js->keys_dev);
-	input_free_device(rpisense_js->keys_dev);
 	return 0;
 }
 


### PR DESCRIPTION
Currently the driver calls `input_free_device` after `input_unregister_device` if it fails in the probe function or in the remove function. Because the `input_unregister_device` function frees the device at any time:

> Once device is unregistered the caller should not try to access it as it may get freed at any moment.

the `input_free_device` will cause a 
```console
refcount_t: underflow; use-after-free.
```


Linux kernel docs I use for reference:
- https://www.kernel.org/doc/html/v4.14/driver-api/input.html#c.input_allocate_device
- https://www.kernel.org/doc/html/v4.14/driver-api/input.html#c.input_unregister_device
- https://www.kernel.org/doc/html/v4.14/driver-api/input.html#c.input_free_device