### PR TITLE
dts: rp1: Disable DMA usage for UART0

### DIFF
--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
@@ -55,9 +55,9 @@
 			interrupts = <RP1_INT_UART0 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_UART &rp1_clocks RP1_PLL_SYS_PRI_PH>;
 			clock-names = "uartclk", "apb_pclk";
-			dmas = <&rp1_dma RP1_DMA_UART0_TX>,
-			       <&rp1_dma RP1_DMA_UART0_RX>;
-			dma-names = "tx", "rx";
+			// dmas = <&rp1_dma RP1_DMA_UART0_TX>,
+			//        <&rp1_dma RP1_DMA_UART0_RX>;
+			// dma-names = "tx", "rx";
 			pinctrl-names = "default";
 			arm,primecell-periphid = <0x00541011>;
 			uart-has-rtscts;


### PR DESCRIPTION
Some recent DMA changes have led to data loss in UART0 on Pi 5. It also seems that even prior to these changes there was a problem with aborted transfers.

As this is the only RP1 UART configured for DMA, it is better to remove the DMA usage until it is shown to be reliable.

Link: https://github.com/raspberrypi/linux/issues/6365