### PR TITLE
dmaengine: dw-axi-dmac: Allow client-chosen width 

### DIFF
--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
@@ -55,9 +55,9 @@
 			interrupts = <RP1_INT_UART0 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_UART &rp1_clocks RP1_PLL_SYS_PRI_PH>;
 			clock-names = "uartclk", "apb_pclk";
-			// dmas = <&rp1_dma RP1_DMA_UART0_TX>,
-			//        <&rp1_dma RP1_DMA_UART0_RX>;
-			// dma-names = "tx", "rx";
+			dmas = <&rp1_dma RP1_DMA_UART0_TX>,
+			       <&rp1_dma RP1_DMA_UART0_RX>;
+			dma-names = "tx", "rx";
 			pinctrl-names = "default";
 			arm,primecell-periphid = <0x00541011>;
 			uart-has-rtscts;

--- a/drivers/spi/spi-dw-dma.c
+++ b/drivers/spi/spi-dw-dma.c
@@ -330,7 +330,6 @@ static int dw_spi_dma_config_tx(struct dw_spi *dws)
 	txconf.direction = DMA_MEM_TO_DEV;
 	txconf.dst_addr = dws->dma_addr;
 	txconf.dst_maxburst = dws->txburst;
-	txconf.src_addr_width = DMA_SLAVE_BUSWIDTH_4_BYTES;
 	txconf.dst_addr_width = dw_spi_dma_convert_width(dws->n_bytes);
 	txconf.device_fc = false;
 
@@ -431,7 +430,6 @@ static int dw_spi_dma_config_rx(struct dw_spi *dws)
 	rxconf.direction = DMA_DEV_TO_MEM;
 	rxconf.src_addr = dws->dma_addr;
 	rxconf.src_maxburst = dws->rxburst;
-	rxconf.dst_addr_width = DMA_SLAVE_BUSWIDTH_4_BYTES;
 	rxconf.src_addr_width = dw_spi_dma_convert_width(dws->n_bytes);
 	rxconf.device_fc = false;
 

--- a/drivers/tty/serial/amba-pl011.c
+++ b/drivers/tty/serial/amba-pl011.c
@@ -468,6 +468,7 @@ static void pl011_dma_probe(struct uart_amba_port *uap)
 			.src_addr = uap->port.mapbase +
 				pl011_reg_to_offset(uap, REG_DR),
 			.src_addr_width = DMA_SLAVE_BUSWIDTH_1_BYTE,
+			.dst_addr_width = DMA_SLAVE_BUSWIDTH_1_BYTE,
 			.direction = DMA_DEV_TO_MEM,
 			.src_maxburst = uap->fifosize >> 2,
 			.device_fc = false,


### PR DESCRIPTION
For devices where transfer lengths are not known upfront, there is a
danger when the destination is wider than the source that partial words
can be lost at the end of a transfer. Ideally the controller would be
able to flush the residue, but it can't - it's not even possible to tell
that there is any.

Instead, allow the client driver to avoid the problem by setting a
smaller width.