### PR TITLE
drivers: media: imx500: Fixes for vblank control

### DIFF
--- a/drivers/media/i2c/imx500.c
+++ b/drivers/media/i2c/imx500.c
@@ -47,7 +47,7 @@
 /* V_TIMING internal */
 #define IMX500_REG_FRAME_LENGTH CCI_REG16(0x0340)
 #define IMX500_FRAME_LENGTH_MAX 0xffdc
-#define IMX500_VBLANK_MIN 4
+#define IMX500_VBLANK_MIN 1117
 
 /* H_TIMING internal */
 #define IMX500_REG_LINE_LENGTH CCI_REG16(0x0342)
@@ -922,7 +922,7 @@ static const struct imx500_mode imx500_supported_modes[] = {
 			.width = 4056,
 			.height = 3040,
 		},
-		.framerate_default = 40,
+		.framerate_default = 30,
 		.reg_list = {
 			.num_of_regs = ARRAY_SIZE(mode_2028x1520_regs),
 			.regs = mode_2028x1520_regs,
@@ -1771,10 +1771,10 @@ static void imx500_set_framing_limits(struct imx500 *imx500)
 
 	/* Update limits and set FPS to default */
 	__v4l2_ctrl_modify_range(
-		imx500->vblank, 1,
+		imx500->vblank, IMX500_VBLANK_MIN,
 		((1 << IMX500_LONG_EXP_SHIFT_MAX) * IMX500_FRAME_LENGTH_MAX) -
 			mode->height,
-		IMX500_VBLANK_MIN, frm_length_default - mode->height);
+		1, frm_length_default - mode->height);
 
 	/* Setting this will adjust the exposure limits as well. */
 	__v4l2_ctrl_s_ctrl(imx500->vblank, frm_length_default - mode->height);


### PR DESCRIPTION
Reduce the default/max framerate of the 2x2 binned mode to 30fps. The current limit of 50fps can cause the sensor to produce corrupt frames and cause missing framing events.

Also fixup the vblank control min/max/default/step paramters when setting up.