### PR TITLE
regulator/rpi-panel: Remove the ID read

### DIFF
--- a/drivers/regulator/rpi-panel-attiny-regulator.c
+++ b/drivers/regulator/rpi-panel-attiny-regulator.c
@@ -229,39 +229,6 @@ static void attiny_gpio_set(struct gpio_chip *gc, unsigned int off, int val)
 	mutex_unlock(&state->lock);
 }
 
-static int attiny_i2c_read(struct i2c_client *client, u8 reg, unsigned int *buf)
-{
-	struct i2c_msg msgs[1];
-	u8 addr_buf[1] = { reg };
-	u8 data_buf[1] = { 0, };
-	int ret;
-
-	/* Write register address */
-	msgs[0].addr = client->addr;
-	msgs[0].flags = 0;
-	msgs[0].len = ARRAY_SIZE(addr_buf);
-	msgs[0].buf = addr_buf;
-
-	ret = i2c_transfer(client->adapter, msgs, ARRAY_SIZE(msgs));
-	if (ret != ARRAY_SIZE(msgs))
-		return -EIO;
-
-	usleep_range(5000, 10000);
-
-	/* Read data from register */
-	msgs[0].addr = client->addr;
-	msgs[0].flags = I2C_M_RD;
-	msgs[0].len = 1;
-	msgs[0].buf = data_buf;
-
-	ret = i2c_transfer(client->adapter, msgs, ARRAY_SIZE(msgs));
-	if (ret != ARRAY_SIZE(msgs))
-		return -EIO;
-
-	*buf = data_buf[0];
-	return 0;
-}
-
 /*
  * I2C driver interface functions
  */
@@ -273,7 +240,6 @@ static int attiny_i2c_probe(struct i2c_client *i2c)
 	struct regulator_dev *rdev;
 	struct attiny_lcd *state;
 	struct regmap *regmap;
-	unsigned int data;
 	int ret;
 
 	state = devm_kzalloc(&i2c->dev, sizeof(*state), GFP_KERNEL);
@@ -288,22 +254,6 @@ static int attiny_i2c_probe(struct i2c_client *i2c)
 		ret = PTR_ERR(regmap);
 		dev_err(&i2c->dev, "Failed to allocate register map: %d\n",
 			ret);
-		goto error;
-	}
-
-	ret = attiny_i2c_read(i2c, REG_ID, &data);
-	if (ret < 0) {
-		dev_err(&i2c->dev, "Failed to read REG_ID reg: %d\n", ret);
-		goto error;
-	}
-
-	switch (data) {
-	case 0xde: /* ver 1 */
-	case 0xc3: /* ver 2 */
-		break;
-	default:
-		dev_err(&i2c->dev, "Unknown Atmel firmware revision: 0x%02x\n", data);
-		ret = -ENODEV;
 		goto error;
 	}
 


### PR DESCRIPTION
Reading from the Atmel has always been troublesome due to clock stretching, and the driver does nothing with it anyway.

Remove the read and assume that if the overlay has been configured (most likely through the firmware autodetection) that the hardware is present.