### PR TITLE
drm/vc4: Rework UPM allocation to avoid double buffering

### DIFF
--- a/drivers/gpu/drm/vc4/tests/vc4_test_lbm_size.c
+++ b/drivers/gpu/drm/vc4/tests/vc4_test_lbm_size.c
@@ -188,6 +188,7 @@ static void drm_vc4_test_vc4_lbm_size(struct kunit *test)
 	struct drm_framebuffer *fb;
 	struct drm_plane *plane;
 	struct drm_crtc *crtc;
+	struct vc4_dev *vc4;
 	unsigned int i;
 	int ret;
 
@@ -248,7 +249,12 @@ static void drm_vc4_test_vc4_lbm_size(struct kunit *test)
 	ret = drm_atomic_check_only(state);
 	KUNIT_ASSERT_EQ(test, ret, 0);
 
-	KUNIT_EXPECT_EQ(test, vc4_plane_state->lbm.size, params->expected_lbm_size);
+	vc4 = to_vc4_dev(state->dev);
+	KUNIT_ASSERT_NOT_NULL(test, vc4);
+	KUNIT_ASSERT_NOT_NULL(test, vc4->hvs);
+	KUNIT_EXPECT_EQ(test,
+			vc4->hvs->lbm_refcounts[vc4_plane_state->lbm_handle].size,
+			params->expected_lbm_size);
 
 	for (i = 0; i < 2; i++) {
 		KUNIT_EXPECT_EQ(test,

--- a/drivers/gpu/drm/vc4/tests/vc4_test_lbm_size.c
+++ b/drivers/gpu/drm/vc4/tests/vc4_test_lbm_size.c
@@ -248,7 +248,7 @@ static void drm_vc4_test_vc4_lbm_size(struct kunit *test)
 	ret = drm_atomic_check_only(state);
 	KUNIT_ASSERT_EQ(test, ret, 0);
 
-	KUNIT_EXPECT_EQ(test, vc4_plane_state->lbm_size, params->expected_lbm_size);
+	KUNIT_EXPECT_EQ(test, vc4_plane_state->lbm.size, params->expected_lbm_size);
 
 	for (i = 0; i < 2; i++) {
 		KUNIT_EXPECT_EQ(test,

--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -322,6 +322,32 @@ struct vc4_v3d {
 	struct debugfs_regset32 regset;
 };
 
+#define VC4_NUM_LBM_HANDLES 64
+struct vc4_lbm_refcounts {
+	refcount_t refcount;
+
+	/* Allocation size */
+	size_t size;
+	/* Our allocation in LBM. */
+	struct drm_mm_node lbm;
+
+	/* Pointer back to the HVS structure */
+	struct vc4_hvs *hvs;
+};
+
+#define VC4_NUM_UPM_HANDLES 32
+struct vc4_upm_refcounts {
+	refcount_t refcount;
+
+	/* Allocation size */
+	size_t size;
+	/* Our allocation in UPM for prefetching. */
+	struct drm_mm_node upm;
+
+	/* Pointer back to the HVS structure */
+	struct vc4_hvs *hvs;
+};
+
 #define HVS_NUM_CHANNELS 3
 
 struct vc4_hvs {
@@ -345,12 +371,16 @@ struct vc4_hvs {
 	 * list.  Units are dwords.
 	 */
 	struct drm_mm dlist_mm;
+
 	/* Memory manager for the LBM memory used by HVS scaling. */
 	struct drm_mm lbm_mm;
+	struct ida lbm_handles;
+	struct vc4_lbm_refcounts lbm_refcounts[VC4_NUM_LBM_HANDLES + 1];
 
 	/* Memory manager for the UPM memory used for prefetching. */
 	struct drm_mm upm_mm;
 	struct ida upm_handles;
+	struct vc4_upm_refcounts upm_refcounts[VC4_NUM_UPM_HANDLES + 1];
 
 	spinlock_t mm_lock;
 
@@ -419,8 +449,6 @@ struct vc4_plane_state {
 	u32 dlist_size; /* Number of dwords allocated for the display list */
 	u32 dlist_count; /* Number of used dwords in the display list. */
 
-	u32 lbm_size; /* LBM requirements for this plane */
-
 	/* Offset in the dlist to various words, for pageflip or
 	 * cursor updates.
 	 */
@@ -446,8 +474,8 @@ struct vc4_plane_state {
 	bool is_unity;
 	bool is_yuv;
 
-	/* Our allocation in UPM for prefetching. */
-	struct drm_mm_node upm[DRM_FORMAT_MAX_PLANES];
+	/* Our allocation in LBM for temporary storage during scaling. */
+	unsigned int lbm_handle;
 
 	/* The Unified Pre-Fetcher Handle */
 	unsigned int upm_handle[DRM_FORMAT_MAX_PLANES];
@@ -640,9 +668,6 @@ struct vc4_crtc {
 	 * access to that value.
 	 */
 	unsigned int current_hvs_channel;
-
-	/* @lbm: Our allocation in LBM for temporary storage during scaling. */
-	struct drm_mm_node lbm;
 };
 
 #define to_vc4_crtc(_crtc)					\

--- a/drivers/gpu/drm/vc4/vc4_hvs.c
+++ b/drivers/gpu/drm/vc4/vc4_hvs.c
@@ -1282,7 +1282,6 @@ int vc4_hvs_atomic_check(struct drm_crtc *crtc, struct drm_atomic_state *state)
 	struct drm_plane *plane;
 	const struct drm_plane_state *plane_state;
 	u32 dlist_count = 0;
-	u32 lbm_count = 0;
 
 	/* The pixelvalve can only feed one encoder (and encoders are
 	 * 1:1 with connectors.)
@@ -1291,8 +1290,6 @@ int vc4_hvs_atomic_check(struct drm_crtc *crtc, struct drm_atomic_state *state)
 		return -EINVAL;
 
 	drm_atomic_crtc_state_for_each_plane_state(plane, plane_state, crtc_state) {
-		const struct vc4_plane_state *vc4_plane_state =
-						to_vc4_plane_state(plane_state);
 		u32 plane_dlist_count = vc4_plane_dlist_size(plane_state);
 
 		drm_dbg_driver(dev, "[CRTC:%d:%s] Found [PLANE:%d:%s] with DLIST size: %u\n",
@@ -1301,7 +1298,6 @@ int vc4_hvs_atomic_check(struct drm_crtc *crtc, struct drm_atomic_state *state)
 			       plane_dlist_count);
 
 		dlist_count += plane_dlist_count;
-		lbm_count += vc4_plane_state->lbm_size;
 	}
 
 	dlist_count++; /* Account for SCALER_CTL0_END. */
@@ -1314,8 +1310,6 @@ int vc4_hvs_atomic_check(struct drm_crtc *crtc, struct drm_atomic_state *state)
 		return PTR_ERR(alloc);
 
 	vc4_state->mm = alloc;
-
-	/* FIXME: Check total lbm allocation here */
 
 	return vc4_hvs_gamma_check(crtc, state);
 }
@@ -1432,10 +1426,7 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 	bool debug_dump_regs = false;
 	bool enable_bg_fill = true;
 	u32 __iomem *dlist_start, *dlist_next;
-	unsigned long irqflags;
 	unsigned int zpos = 0;
-	u32 lbm_offset = 0;
-	u32 lbm_size = 0;
 	bool found = false;
 	int idx;
 
@@ -1454,35 +1445,6 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 		vc4_hvs_dump_state(hvs);
 	}
 
-	drm_atomic_crtc_for_each_plane(plane, crtc) {
-		vc4_plane_state = to_vc4_plane_state(plane->state);
-		lbm_size += vc4_plane_state->lbm_size;
-	}
-
-	if (drm_mm_node_allocated(&vc4_crtc->lbm)) {
-		spin_lock_irqsave(&vc4_crtc->irq_lock, irqflags);
-		drm_mm_remove_node(&vc4_crtc->lbm);
-		spin_unlock_irqrestore(&vc4_crtc->irq_lock, irqflags);
-	}
-
-	if (lbm_size) {
-		int ret;
-
-		spin_lock_irqsave(&vc4_crtc->irq_lock, irqflags);
-		ret = drm_mm_insert_node_generic(&vc4->hvs->lbm_mm,
-						 &vc4_crtc->lbm,
-						 lbm_size, 1,
-						 0, 0);
-		spin_unlock_irqrestore(&vc4_crtc->irq_lock, irqflags);
-
-		if (ret) {
-			pr_err("Failed to allocate LBM ret %d\n", ret);
-			return;
-		}
-	}
-
-	lbm_offset = vc4_crtc->lbm.start;
-
 	dlist_start = vc4->hvs->dlist + vc4_state->mm->mm_node.start;
 	dlist_next = dlist_start;
 
@@ -1494,8 +1456,6 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 			if (plane->state->normalized_zpos != zpos)
 				continue;
 
-			vc4_plane_state = to_vc4_plane_state(plane->state);
-
 			/* Is this the first active plane? */
 			if (dlist_next == dlist_start) {
 				/* We need to enable background fill when a plane
@@ -1506,13 +1466,8 @@ void vc4_hvs_atomic_flush(struct drm_crtc *crtc,
 				 * already needs it or all planes on top blend from
 				 * the first or a lower plane.
 				 */
+				vc4_plane_state = to_vc4_plane_state(plane->state);
 				enable_bg_fill = vc4_plane_state->needs_bg_fill;
-			}
-
-			if (vc4_plane_state->lbm_size) {
-				vc4_plane_state->dlist[vc4_plane_state->lbm_offset] =
-								lbm_offset;
-				lbm_offset += vc4_plane_state->lbm_size;
 			}
 
 			dlist_next += vc4_plane_write_dlist(plane, dlist_next);

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -987,7 +987,7 @@ static int vc4_plane_allocate_lbm(struct drm_plane_state *state)
 					     VC4_NUM_LBM_HANDLES,
 					     GFP_KERNEL);
 		if (lbm_handle < 0) {
-			drm_err(drm, "Out of lbm_handles\n");
+			drm_dbg_driver(drm, "Out of lbm_handles\n");
 			return lbm_handle;
 		}
 		vc4_state->lbm_handle = lbm_handle;
@@ -1004,7 +1004,8 @@ static int vc4_plane_allocate_lbm(struct drm_plane_state *state)
 		spin_unlock_irqrestore(&hvs->mm_lock, irqflags);
 
 		if (ret) {
-			drm_err(drm, "Failed to allocate LBM entry: %d\n", ret);
+			drm_dbg_driver(drm, "Failed to allocate LBM entry: %d\n",
+				       ret);
 			refcount_set(&refcount->refcount, 0);
 			ida_free(&hvs->lbm_handles, lbm_handle);
 			vc4_state->lbm_handle = 0;
@@ -1076,7 +1077,7 @@ static int vc6_plane_allocate_upm(struct drm_plane_state *state)
 						     VC4_NUM_UPM_HANDLES,
 						     GFP_KERNEL);
 			if (upm_handle < 0) {
-				drm_err(drm, "Out of upm_handles\n");
+				drm_dbg_driver(drm, "Out of upm_handles\n");
 				return upm_handle;
 			}
 			vc4_state->upm_handle[i] = upm_handle;
@@ -1092,7 +1093,8 @@ static int vc6_plane_allocate_upm(struct drm_plane_state *state)
 							 0, 0);
 			spin_unlock_irqrestore(&hvs->mm_lock, irqflags);
 			if (ret) {
-				drm_err(drm, "Failed to allocate UPM entry: %d\n", ret);
+				drm_dbg_driver(drm, "Failed to allocate UPM entry: %d\n",
+					       ret);
 				refcount_set(&refcount->refcount, 0);
 				ida_free(&hvs->upm_handles, upm_handle);
 				vc4_state->upm_handle[i] = 0;

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -278,6 +278,8 @@ static bool plane_enabled(struct drm_plane_state *state)
 
 struct drm_plane_state *vc4_plane_duplicate_state(struct drm_plane *plane)
 {
+	struct vc4_dev *vc4 = to_vc4_dev(plane->dev);
+	struct vc4_hvs *hvs = vc4->hvs;
 	struct vc4_plane_state *vc4_state;
 	unsigned int i;
 
@@ -288,10 +290,10 @@ struct drm_plane_state *vc4_plane_duplicate_state(struct drm_plane *plane)
 	if (!vc4_state)
 		return NULL;
 
-	memset(&vc4_state->upm, 0, sizeof(vc4_state->upm));
-
-	for (i = 0; i < DRM_FORMAT_MAX_PLANES; i++)
-		vc4_state->upm_handle[i] = 0;
+	for (i = 0; i < DRM_FORMAT_MAX_PLANES; i++) {
+		if (vc4_state->upm_handle[i])
+			refcount_inc(&hvs->upm_refcounts[vc4_state->upm_handle[i]].refcount);
+	}
 
 	vc4_state->dlist_initialized = 0;
 
@@ -311,6 +313,21 @@ struct drm_plane_state *vc4_plane_duplicate_state(struct drm_plane *plane)
 	return &vc4_state->base;
 }
 
+void vc4_plane_release_upm_ida(struct vc4_hvs *hvs, unsigned int upm_handle)
+{
+	struct vc4_upm_refcounts *refcount = &hvs->upm_refcounts[upm_handle];
+	unsigned long irqflags;
+
+	spin_lock_irqsave(&hvs->mm_lock, irqflags);
+	drm_mm_remove_node(&refcount->upm);
+	spin_unlock_irqrestore(&hvs->mm_lock, irqflags);
+	refcount->upm.start = 0;
+	refcount->upm.size = 0;
+	refcount->size = 0;
+
+	ida_free(&hvs->upm_handles, upm_handle);
+}
+
 void vc4_plane_destroy_state(struct drm_plane *plane,
 			     struct drm_plane_state *state)
 {
@@ -320,17 +337,15 @@ void vc4_plane_destroy_state(struct drm_plane *plane,
 	unsigned int i;
 
 	for (i = 0; i < DRM_FORMAT_MAX_PLANES; i++) {
-		unsigned long irqflags;
+		struct vc4_upm_refcounts *refcount;
 
-		if (!drm_mm_node_allocated(&vc4_state->upm[i]))
+		if (!vc4_state->upm_handle[i])
 			continue;
 
-		spin_lock_irqsave(&hvs->mm_lock, irqflags);
-		drm_mm_remove_node(&vc4_state->upm[i]);
-		spin_unlock_irqrestore(&hvs->mm_lock, irqflags);
+		refcount = &hvs->upm_refcounts[vc4_state->upm_handle[i]];
 
-		if (vc4_state->upm_handle[i] > 0)
-			ida_free(&hvs->upm_handles, vc4_state->upm_handle[i]);
+		if (refcount_dec_and_test(&refcount->refcount))
+			vc4_plane_release_upm_ida(hvs, vc4_state->upm_handle[i]);
 	}
 
 	kfree(vc4_state->dlist);
@@ -945,32 +960,60 @@ static int vc6_plane_allocate_upm(struct drm_plane_state *state)
 	vc4_state->upm_buffer_lines = SCALER6_PTR0_UPM_BUFF_SIZE_2_LINES;
 
 	for (i = 0; i < info->num_planes; i++) {
+		struct vc4_upm_refcounts *refcount;
+		int upm_handle;
 		unsigned long irqflags;
 		size_t upm_size;
 
 		upm_size = vc6_upm_size(state, i);
 		if (!upm_size)
 			return -EINVAL;
+		upm_handle = vc4_state->upm_handle[i];
 
-		spin_lock_irqsave(&hvs->mm_lock, irqflags);
-		ret = drm_mm_insert_node_generic(&hvs->upm_mm,
-						 &vc4_state->upm[i],
-						 upm_size, HVS_UBM_WORD_SIZE,
-						 0, 0);
-		spin_unlock_irqrestore(&hvs->mm_lock, irqflags);
-		if (ret) {
-			drm_err(drm, "Failed to allocate UPM entry: %d\n", ret);
-			return ret;
+		if (upm_handle &&
+		    hvs->upm_refcounts[upm_handle].size == upm_size) {
+			/* Allocation is the same size as the previous user of
+			 * the plane. Keep the allocation.
+			 */
+			vc4_state->upm_handle[i] = upm_handle;
+		} else {
+			if (upm_handle &&
+			    refcount_dec_and_test(&hvs->upm_refcounts[upm_handle].refcount)) {
+				vc4_plane_release_upm_ida(hvs, upm_handle);
+				vc4_state->upm_handle[i] = 0;
+			}
+
+			upm_handle = ida_alloc_range(&hvs->upm_handles, 1,
+						     VC4_NUM_UPM_HANDLES,
+						     GFP_KERNEL);
+			if (upm_handle < 0) {
+				drm_err(drm, "Out of upm_handles\n");
+				return upm_handle;
+			}
+			vc4_state->upm_handle[i] = upm_handle;
+
+			refcount = &hvs->upm_refcounts[upm_handle];
+			refcount_set(&refcount->refcount, 1);
+			refcount->size = upm_size;
+
+			spin_lock_irqsave(&hvs->mm_lock, irqflags);
+			ret = drm_mm_insert_node_generic(&hvs->upm_mm,
+							 &refcount->upm,
+							 upm_size, HVS_UBM_WORD_SIZE,
+							 0, 0);
+			spin_unlock_irqrestore(&hvs->mm_lock, irqflags);
+			if (ret) {
+				drm_err(drm, "Failed to allocate UPM entry: %d\n", ret);
+				refcount_set(&refcount->refcount, 0);
+				ida_free(&hvs->upm_handles, upm_handle);
+				vc4_state->upm_handle[i] = 0;
+				return ret;
+			}
 		}
 
-		ret = ida_alloc_range(&hvs->upm_handles, 1, 32, GFP_KERNEL);
-		if (ret < 0)
-			return ret;
-
-		vc4_state->upm_handle[i] = ret;
-
+		refcount = &hvs->upm_refcounts[upm_handle];
 		vc4_state->dlist[vc4_state->ptr0_offset[i]] |=
-			VC4_SET_FIELD(vc4_state->upm[i].start / HVS_UBM_WORD_SIZE,
+			VC4_SET_FIELD(refcount->upm.start / HVS_UBM_WORD_SIZE,
 				      SCALER6_PTR0_UPM_BASE) |
 			VC4_SET_FIELD(vc4_state->upm_handle[i] - 1,
 				      SCALER6_PTR0_UPM_HANDLE) |
@@ -979,6 +1022,29 @@ static int vc6_plane_allocate_upm(struct drm_plane_state *state)
 	}
 
 	return 0;
+}
+
+static void vc6_plane_free_upm(struct drm_plane_state *state)
+{
+	struct vc4_plane_state *vc4_state = to_vc4_plane_state(state);
+	struct drm_device *drm = state->plane->dev;
+	struct vc4_dev *vc4 = to_vc4_dev(drm);
+	struct vc4_hvs *hvs = vc4->hvs;
+	unsigned int i;
+
+	WARN_ON_ONCE(vc4->gen < VC4_GEN_6);
+
+	for (i = 0; i < DRM_FORMAT_MAX_PLANES; i++) {
+		unsigned int upm_handle;
+
+		upm_handle = vc4_state->upm_handle[i];
+		if (!upm_handle)
+			continue;
+
+		if (refcount_dec_and_test(&hvs->upm_refcounts[upm_handle].refcount))
+			vc4_plane_release_upm_ida(hvs, upm_handle);
+		vc4_state->upm_handle[i] = 0;
+	}
 }
 
 /*
@@ -2051,8 +2117,16 @@ int vc4_plane_atomic_check(struct drm_plane *plane,
 
 	vc4_state->dlist_count = 0;
 
-	if (!plane_enabled(new_plane_state))
+	if (!plane_enabled(new_plane_state)) {
+		struct drm_plane_state *old_plane_state =
+				drm_atomic_get_old_plane_state(state, plane);
+
+		if (vc4->gen >= VC4_GEN_6 && old_plane_state &&
+		    plane_enabled(old_plane_state)) {
+			vc6_plane_free_upm(new_plane_state);
+		}
 		return 0;
+	}
 
 	if (vc4->gen >= VC4_GEN_6)
 		ret = vc6_plane_mode_set(plane, new_plane_state);

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -294,8 +294,8 @@ struct drm_plane_state *vc4_plane_duplicate_state(struct drm_plane *plane)
 		if (vc4_state->upm_handle[i])
 			refcount_inc(&hvs->upm_refcounts[vc4_state->upm_handle[i]].refcount);
 	}
-
-	memset(&vc4_state->lbm, 0, sizeof(vc4_state->lbm));
+	if (vc4_state->lbm_handle)
+		refcount_inc(&hvs->lbm_refcounts[vc4_state->lbm_handle].refcount);
 
 	vc4_state->dlist_initialized = 0;
 
@@ -313,6 +313,21 @@ struct drm_plane_state *vc4_plane_duplicate_state(struct drm_plane *plane)
 	}
 
 	return &vc4_state->base;
+}
+
+void vc4_plane_release_lbm_ida(struct vc4_hvs *hvs, unsigned int lbm_handle)
+{
+	struct vc4_lbm_refcounts *refcount = &hvs->lbm_refcounts[lbm_handle];
+	unsigned long irqflags;
+
+	spin_lock_irqsave(&hvs->mm_lock, irqflags);
+	drm_mm_remove_node(&refcount->lbm);
+	spin_unlock_irqrestore(&hvs->mm_lock, irqflags);
+	refcount->lbm.start = 0;
+	refcount->lbm.size = 0;
+	refcount->size = 0;
+
+	ida_free(&hvs->lbm_handles, lbm_handle);
 }
 
 void vc4_plane_release_upm_ida(struct vc4_hvs *hvs, unsigned int upm_handle)
@@ -338,12 +353,13 @@ void vc4_plane_destroy_state(struct drm_plane *plane,
 	struct vc4_plane_state *vc4_state = to_vc4_plane_state(state);
 	unsigned int i;
 
-	if (drm_mm_node_allocated(&vc4_state->lbm)) {
-		unsigned long irqflags;
+	if (vc4_state->lbm_handle) {
+		struct vc4_lbm_refcounts *refcount;
 
-		spin_lock_irqsave(&hvs->mm_lock, irqflags);
-		drm_mm_remove_node(&vc4_state->lbm);
-		spin_unlock_irqrestore(&hvs->mm_lock, irqflags);
+		refcount = &hvs->lbm_refcounts[vc4_state->lbm_handle];
+
+		if (refcount_dec_and_test(&refcount->refcount))
+			vc4_plane_release_lbm_ida(hvs, vc4_state->lbm_handle);
 	}
 
 	for (i = 0; i < DRM_FORMAT_MAX_PLANES; i++) {
@@ -922,10 +938,14 @@ static int vc4_plane_allocate_lbm(struct drm_plane_state *state)
 {
 	struct drm_device *drm = state->plane->dev;
 	struct vc4_dev *vc4 = to_vc4_dev(drm);
+	struct vc4_hvs *hvs = vc4->hvs;
 	struct drm_plane *plane = state->plane;
 	struct vc4_plane_state *vc4_state = to_vc4_plane_state(state);
+	struct vc4_lbm_refcounts *refcount;
 	unsigned long irqflags;
+	int lbm_handle;
 	u32 lbm_size;
+	int ret;
 
 	lbm_size = vc4_lbm_size(state);
 	if (!lbm_size)
@@ -949,27 +969,69 @@ static int vc4_plane_allocate_lbm(struct drm_plane_state *state)
 	/* Allocate the LBM memory that the HVS will use for temporary
 	 * storage due to our scaling/format conversion.
 	 */
-	if (!drm_mm_node_allocated(&vc4_state->lbm)) {
-		int ret;
+	lbm_handle = vc4_state->lbm_handle;
+	if (lbm_handle &&
+	    hvs->lbm_refcounts[lbm_handle].size == lbm_size) {
+		/* Allocation is the same size as the previous user of
+		 * the plane. Keep the allocation.
+		 */
+		vc4_state->lbm_handle = lbm_handle;
+	} else {
+		if (lbm_handle &&
+		    refcount_dec_and_test(&hvs->lbm_refcounts[lbm_handle].refcount)) {
+			vc4_plane_release_lbm_ida(hvs, lbm_handle);
+			vc4_state->lbm_handle = 0;
+		}
 
-		spin_lock_irqsave(&vc4->hvs->mm_lock, irqflags);
+		lbm_handle = ida_alloc_range(&hvs->lbm_handles, 1,
+					     VC4_NUM_LBM_HANDLES,
+					     GFP_KERNEL);
+		if (lbm_handle < 0) {
+			drm_err(drm, "Out of lbm_handles\n");
+			return lbm_handle;
+		}
+		vc4_state->lbm_handle = lbm_handle;
+
+		refcount = &hvs->lbm_refcounts[lbm_handle];
+		refcount_set(&refcount->refcount, 1);
+		refcount->size = lbm_size;
+
+		spin_lock_irqsave(&hvs->mm_lock, irqflags);
 		ret = drm_mm_insert_node_generic(&vc4->hvs->lbm_mm,
-						 &vc4_state->lbm,
+						 &refcount->lbm,
 						 lbm_size, 1,
 						 0, 0);
-		spin_unlock_irqrestore(&vc4->hvs->mm_lock, irqflags);
+		spin_unlock_irqrestore(&hvs->mm_lock, irqflags);
 
 		if (ret) {
 			drm_err(drm, "Failed to allocate LBM entry: %d\n", ret);
+			refcount_set(&refcount->refcount, 0);
+			ida_free(&hvs->lbm_handles, lbm_handle);
+			vc4_state->lbm_handle = 0;
 			return ret;
 		}
-	} else {
-		WARN_ON_ONCE(lbm_size != vc4_state->lbm.size);
 	}
 
-	vc4_state->dlist[vc4_state->lbm_offset] = vc4_state->lbm.start;
+	vc4_state->dlist[vc4_state->lbm_offset] = hvs->lbm_refcounts[lbm_handle].lbm.start;
 
 	return 0;
+}
+
+static void vc4_plane_free_lbm(struct drm_plane_state *state)
+{
+	struct vc4_plane_state *vc4_state = to_vc4_plane_state(state);
+	struct drm_device *drm = state->plane->dev;
+	struct vc4_dev *vc4 = to_vc4_dev(drm);
+	struct vc4_hvs *hvs = vc4->hvs;
+	unsigned int lbm_handle;
+
+	lbm_handle = vc4_state->lbm_handle;
+	if (!lbm_handle)
+		return;
+
+	if (refcount_dec_and_test(&hvs->lbm_refcounts[lbm_handle].refcount))
+		vc4_plane_release_lbm_ida(hvs, lbm_handle);
+	vc4_state->lbm_handle = 0;
 }
 
 static int vc6_plane_allocate_upm(struct drm_plane_state *state)
@@ -2148,9 +2210,10 @@ int vc4_plane_atomic_check(struct drm_plane *plane,
 		struct drm_plane_state *old_plane_state =
 				drm_atomic_get_old_plane_state(state, plane);
 
-		if (vc4->gen >= VC4_GEN_6 && old_plane_state &&
-		    plane_enabled(old_plane_state)) {
-			vc6_plane_free_upm(new_plane_state);
+		if (old_plane_state && plane_enabled(old_plane_state)) {
+			if (vc4->gen >= VC4_GEN_6)
+				vc6_plane_free_upm(new_plane_state);
+			vc4_plane_free_lbm(new_plane_state);
 		}
 		return 0;
 	}


### PR DESCRIPTION
The previous UPM allocation was done per plane state, when there is no overlap of usage between frames.

Allocate per plane, and only change the allocation if the required size changes. We have to reference count as plane states can be duplicated.