### PR TITLE
ASoC: bcm2835-i2s: Set the PERIOD_BYTES min to 256

### DIFF
--- a/sound/soc/bcm/bcm2835-i2s.c
+++ b/sound/soc/bcm/bcm2835-i2s.c
@@ -619,6 +619,10 @@ static int bcm2835_i2s_prepare(struct snd_pcm_substream *substream,
 	struct bcm2835_i2s_dev *dev = snd_soc_dai_get_drvdata(dai);
 	uint32_t cs_reg;
 
+	snd_pcm_hw_constraint_minmax(substream->runtime,
+		SNDRV_PCM_HW_PARAM_PERIOD_BYTES, 256,
+					~0);
+
 	/*
 	 * Clear both FIFOs if the one that should be started
 	 * is not empty at the moment. This should only happen
@@ -699,6 +703,10 @@ static int bcm2835_i2s_startup(struct snd_pcm_substream *substream,
 
 	/* Should this still be running stop it */
 	bcm2835_i2s_stop_clock(dev);
+
+	snd_pcm_hw_constraint_minmax(substream->runtime,
+				     SNDRV_PCM_HW_PARAM_PERIOD_BYTES,
+				     256, ~0);
 
 	/* Enable PCM block */
 	regmap_update_bits(dev->i2s_regmap, BCM2835_I2S_CS_A_REG,


### PR DESCRIPTION
Commit [1] set the minimum PERIOD_BYTES value to the product of the DMA burst size and 8. For the I2S interface on BCM2835 that equates to 16 where it used to be 256. ffmpeg uses the minimum value as its preferred value, leading to many, many very small periods, which affects performance and leads to complaints about DTS timestamps.

Restore the previous behaviour and performance by making the bcm2835-i2s driver set a minimum PERIOD_BYTES value of 256.

Link: https://github.com/raspberrypi/linux/issues/5709

[1] 300689fb04b3 ("ASoC: soc-generic-dmaengine-pcm: set period_bytes_min based on maxburst")