### PR TITLE
overlays: hat_map: Add Sense and Hailo AI HATs

### DIFF
--- a/arch/arm/boot/dts/overlays/hat_map.dts
+++ b/arch/arm/boot/dts/overlays/hat_map.dts
@@ -1,6 +1,18 @@
 /dts-v1/;
 
 / {
+	hailo-8 {
+		product = "Raspberry Pi AI Hat, Model Hailo-8";
+		vendor = "Hailo Technologies";
+		overlay = "none,pciex1,pciex1_gen=3";
+	};
+
+	hailo-8l {
+		product = "Raspberry Pi AI Hat, Model Hailo-8L";
+		vendor = "Hailo Technologies";
+		overlay = "none,pciex1,pciex1_gen=3";
+	};
+
 	hifiberry-amp100-1 {
 		uuid = [ 5eb863b8 12f9 41ad 978f 4cee1b3eca62 ];
 		overlay = "hifiberry-amp100";
@@ -97,12 +109,16 @@
 	};
 
 	sensehat-v1 {
-		uuid = [ 5d960035 8e87 428f 95d8 59852d697754 ];
+		product = "Sense HAT";
+		vendor = "Raspberry Pi";
+		pver = < 0x0001 >;
 		overlay = "rpi-sense";
 	};
 
 	sensehat-v2 {
-		uuid = [ 1aa9c428 72eb 48da 9306 8c3706ed3653 ];
+		product = "Sense HAT";
+		vendor = "Raspberry Pi";
+		pver = < 0x0002 >;
 		overlay = "rpi-sense-v2";
 	};
 };


### PR DESCRIPTION
Add mappings to overlays for the Sense HATs and the Hail AI HATs. Note that mapping by product names (and not UUIDs) as used here requires an updated firmware.