### PR TITLE
drm/v3d,vc4: Stop the active perfmon before being destroyed

### DIFF
--- a/drivers/gpu/drm/v3d/v3d_perfmon.c
+++ b/drivers/gpu/drm/v3d/v3d_perfmon.c
@@ -103,6 +103,11 @@ void v3d_perfmon_open_file(struct v3d_file_priv *v3d_priv)
 static int v3d_perfmon_idr_del(int id, void *elem, void *data)
 {
 	struct v3d_perfmon *perfmon = elem;
+	struct v3d_dev *v3d = (struct v3d_dev *)data;
+
+	/* If the active perfmon is being destroyed, stop it first */
+	if (perfmon == v3d->active_perfmon)
+		v3d_perfmon_stop(v3d, perfmon, false);
 
 	v3d_perfmon_put(perfmon);
 
@@ -111,8 +116,10 @@ static int v3d_perfmon_idr_del(int id, void *elem, void *data)
 
 void v3d_perfmon_close_file(struct v3d_file_priv *v3d_priv)
 {
+	struct v3d_dev *v3d = v3d_priv->v3d;
+
 	mutex_lock(&v3d_priv->perfmon.lock);
-	idr_for_each(&v3d_priv->perfmon.idr, v3d_perfmon_idr_del, NULL);
+	idr_for_each(&v3d_priv->perfmon.idr, v3d_perfmon_idr_del, v3d);
 	idr_destroy(&v3d_priv->perfmon.idr);
 	mutex_unlock(&v3d_priv->perfmon.lock);
 	mutex_destroy(&v3d_priv->perfmon.lock);


### PR DESCRIPTION
Upon closing the file descriptor, the active performance monitor is not stopped. Although all perfmons are destroyed in `v3d/vc4_perfmon_close_file()`, the active performance monitor's pointer (`v3d/vc4->active_perfmon`) is still retained.

If we open a new file descriptor and submit a few jobs with performance monitors, the driver will attempt to stop the active performance monitor using the stale pointer in `v3d/vc4->active_perfmon`. However, this pointer is no longer valid because the previous process has already been terminated, and all performance monitors associated with it have been destroyed and freed.

To fix this, when the active performance monitor belongs to a given process, explicitly stop it before destroying and freeing it.

Those two patches were already submitted to the dri-devel mailing list [1][2] and will eventually reach stable-6.6.

[1] https://lore.kernel.org/dri-devel/20241004123817.890016-1-mcanal@igalia.com/T/
[2] https://lore.kernel.org/dri-devel/20241004130625.918580-2-mcanal@igalia.com/T/

Closes: #6389 