### PR TITLE
mmc: sd: disable sd cqhci by default

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -378,9 +378,9 @@ Params:
                                 non-lite SKU of CM4).
                                 (default "on")
 
-        sd_cqe                  Set to "off" to disable Command Queueing if you
-                                have an incompatible Class A2 SD card
-                                (Pi 5 only, default "on")
+        sd_cqe                  Use to enable Command Queueing on the SD
+                                interface for faster Class A2 card performance
+                                (Pi 5 only, default "off")
 
         sd_overclock            Clock (in MHz) to use when the MMC framework
                                 requests 50MHz

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
@@ -363,7 +363,6 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 	sd-uhs-sdr50;
 	sd-uhs-ddr50;
 	sd-uhs-sdr104;
-	supports-cqe;
 	cd-gpios = <&gio_aon 5 GPIO_ACTIVE_LOW>;
 	//no-1-8-v;
 	status = "okay";


### PR DESCRIPTION
The fixup method isn't ideal as it doesn't allow for date range specifiers, so this array will become unwieldy.

For now, constrain to whole years which span production dates of cards that misbehave.

Link: https://forums.raspberrypi.com/viewtopic.php?t=367459
Also see #6349 