### PR TITLE
dts: bcm2712d0: Add non-d0 vc6 compatible string

### DIFF
--- a/arch/arm/boot/dts/overlays/bcm2712d0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/bcm2712d0-overlay.dts
@@ -41,7 +41,7 @@
 	fragment@4 {
 		target = <&vc4>;
 		__overlay__ {
-			compatible = "brcm,bcm2712d0-vc6";
+			compatible = "brcm,bcm2712d0-vc6", "brcm,bcm2712-vc6";
 		};
 	};
 

--- a/arch/arm64/boot/dts/broadcom/bcm2712d0-rpi-5-b.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2712d0-rpi-5-b.dts
@@ -87,7 +87,7 @@
 };
 
 &vc4 {
-	compatible = "brcm,bcm2712d0-vc6";
+	compatible = "brcm,bcm2712d0-vc6", "brcm,bcm2712-vc6";
 };
 
 &uart10 {


### PR DESCRIPTION
Although the VC4/VC6 driver requires a special compatible string for the "d0" stepping, the removal of the old compatible string upsets Mesa.

Satisfy both requirements by adding the old "brcm,bcm2712-vc6" string as a fallback.