### PR TITLE
dtoverlays: Fix up imx500 overlays to have unique clock nodes

### DIFF
--- a/arch/arm/boot/dts/overlays/imx500-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx500-overlay.dts
@@ -72,16 +72,16 @@
 		};
 	};
 
-	clocks_frag: fragment@104 {
+	fragment@104 {
 		target-path = "/clocks";
 		__overlay__ {
-			clk_aicam: clk-aicam {
+			clk_aicam: clk-aicam1 {
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-frequency = <24000000>;
 			};
 
-			clk_aicam_gated: clk-aicam-gated {
+			clk_aicam_gated: clk-aicam-gated1 {
 				compatible = "gpio-gate-clock";
 				clocks = <&clk_aicam>;
 				#clock-cells = <0>;
@@ -98,7 +98,9 @@
 		       <&csi_frag>, "target:0=",<&csi0>,
 			   <&spi_bridge>, "power-supply:0=",<&cam0_reg>,
 		       <&reg_frag>, "target:0=",<&cam0_reg>,
-		       <&cam_node>, "VANA-supply:0=",<&cam0_reg>;
+		       <&cam_node>, "VANA-supply:0=",<&cam0_reg>,
+		       <&clk_aicam>,"name=clk-aicam0",
+		       <&clk_aicam_gated>,"name=clk-aicam-gated0";
 		bypass-cache = <&spi_bridge>,"bypass-cache?";
 	};
 };

--- a/arch/arm/boot/dts/overlays/imx500-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx500-pi5-overlay.dts
@@ -75,16 +75,16 @@
 		};
 	};
 
-	clocks_frag: fragment@104 {
+	fragment@104 {
 		target-path = "/clocks";
 		__overlay__ {
-			clk_aicam: clk-aicam {
+			clk_aicam: clk-aicam1 {
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-frequency = <24000000>;
 			};
 
-			clk_aicam_gated: clk-aicam-gated {
+			clk_aicam_gated: clk-aicam-gated1 {
 				compatible = "gpio-gate-clock";
 				clocks = <&clk_aicam>;
 				#clock-cells = <0>;
@@ -103,7 +103,9 @@
 			   <&spi_frag_overlay>, "fast_xfer-gpios:16=35", // CD0_IO1_MICDAT0 (clock)
 			   <&spi_bridge>, "power-supply:0=",<&cam0_reg>,
 		       <&reg_frag>, "target:0=",<&cam0_reg>,
-		       <&cam_node>, "VANA-supply:0=",<&cam0_reg>;
+		       <&cam_node>, "VANA-supply:0=",<&cam0_reg>,
+		       <&clk_aicam>,"name=clk-aicam0",
+		       <&clk_aicam_gated>,"name=clk-aicam-gated0";
 		bypass-cache = <&spi_bridge>,"bypass-cache?";
 	};
 };


### PR DESCRIPTION
The overlay was creating DT nodes /clocks/clk-aicam and /clocks/clk-aicam-gated for both cam0 and cam1, which resulted in one failing.

The clock infrastructure creates the clock name from the node name without any @N reg extension, so we can't just use that. The nodes therefore have to be renamed.

@naushir
@roliver-rpi 
https://forums.raspberrypi.com/viewtopic.php?t=377822 (alpha team sub-forum, so not generally accessible).