### PR TITLE
drm/vc4: Remove request for min clocks when hdmi output is disabled

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -1224,6 +1224,8 @@ static void vc4_hdmi_encoder_post_crtc_powerdown(struct drm_encoder *encoder,
 	if (vc4_hdmi->variant->phy_disable)
 		vc4_hdmi->variant->phy_disable(vc4_hdmi);
 
+	/* we no longer require a minimum clock rate */
+	clk_set_min_rate(vc4_hdmi->pixel_bvb_clock, 0);
 	clk_disable_unprepare(vc4_hdmi->pixel_bvb_clock);
 	clk_disable_unprepare(vc4_hdmi->pixel_clock);
 
@@ -3724,6 +3726,8 @@ static int vc4_hdmi_runtime_suspend(struct device *dev)
 	struct vc4_hdmi *vc4_hdmi = dev_get_drvdata(dev);
 
 	clk_disable_unprepare(vc4_hdmi->audio_clock);
+	/* we no longer require a minimum clock rate */
+	clk_set_min_rate(vc4_hdmi->hsm_clock, 0);
 	clk_disable_unprepare(vc4_hdmi->hsm_clock);
 
 	return 0;

--- a/drivers/gpu/drm/vc4/vc4_hvs.c
+++ b/drivers/gpu/drm/vc4/vc4_hvs.c
@@ -2361,7 +2361,10 @@ static void vc4_hvs_unbind(struct device *dev, struct device *master,
 		drm_mm_remove_node(node);
 	drm_mm_takedown(&vc4->hvs->lbm_mm);
 
+	/* we no longer require a minimum clock rate */
+	clk_set_min_rate(hvs->disp_clk, 0);
 	clk_disable_unprepare(hvs->disp_clk);
+	clk_set_min_rate(hvs->core_clk, 0);
 	clk_disable_unprepare(hvs->core_clk);
 
 	vc4->hvs = NULL;

--- a/drivers/gpu/drm/vc4/vc4_v3d.c
+++ b/drivers/gpu/drm/vc4/vc4_v3d.c
@@ -376,6 +376,8 @@ static int vc4_v3d_runtime_suspend(struct device *dev)
 
 	vc4_irq_disable(&vc4->base);
 
+	/* we no longer require a minimum clock rate */
+	clk_set_min_rate(v3d->clk, 0);
 	clk_disable_unprepare(v3d->clk);
 
 	return 0;


### PR DESCRIPTION
Currently, booting with no hdmi connected has:
pi@pi4:~ $ vcgencmd measure_clock hdmi pixel
frequency(9)=120010256
frequency(29)=74988280

After connecting hdmi we get:
pi@pi4:~ $ vcgencmd measure_clock hdmi pixel
frequency(9)=300005856
frequency(29)=149989744

and that persists after disconnecting hdmi

I can measure this on a power supply as 10mA@5.2V (52mW).

We should always remove clk_set_min_rate requests
when we no longer need them.