### PR TITLE
dtoverlays: Add an overlay for Waveshare's 800x480 4.3" DSI screen

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -319,6 +319,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	vc4-kms-dsi-ili9881-7inch.dtbo \
 	vc4-kms-dsi-lt070me05000.dtbo \
 	vc4-kms-dsi-lt070me05000-v2.dtbo \
+	vc4-kms-dsi-waveshare-800x480.dtbo \
 	vc4-kms-dsi-waveshare-panel.dtbo \
 	vc4-kms-kippah-7inch.dtbo \
 	vc4-kms-v3d.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5248,6 +5248,23 @@ Load:   dtoverlay=vc4-kms-dsi-lt070me05000-v2
 Params: <None>
 
 
+Name:   vc4-kms-dsi-waveshare-800x480
+Info:   Enable the Waveshare 4.3" 800x480 DSI screen.
+        It tries to look like the Pi 7" display, but won't accept some of the
+        timings.
+        Includes the edt-ft5406 for the touchscreen element.
+        Requires vc4-kms-v3d to be loaded.
+Load:   dtoverlay=vc4-kms-dsi-waveshare-800x480,<param>=<val>
+Params: sizex                   Touchscreen size x (default 800)
+        sizey                   Touchscreen size y (default 480)
+        invx                    Touchscreen inverted x axis
+        invy                    Touchscreen inverted y axis
+        swapxy                  Touchscreen swapped x y axis
+        disable_touch           Disables the touch screen overlay driver
+        dsi0                    Use DSI0 and i2c_csi_dsi0 (rather than
+                                the default DSI1 and i2c_csi_dsi).
+
+
 Name:   vc4-kms-dsi-waveshare-panel
 Info:   Enable a Waveshare DSI touchscreen
         Includes the Goodix driver for the touchscreen element.

--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-800x480-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-800x480-overlay.dts
@@ -1,0 +1,119 @@
+/*
+ * Device Tree overlay for Waveshare 4.3" 800x480 panel.
+ * It tries to look like a Pi 7" panel, but fails with some of the timing
+ * options.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include "edt-ft5406.dtsi"
+
+/ {
+	/* No compatible as it will have come from edt-ft5406.dtsi */
+
+	dsi_frag: fragment@0 {
+		target = <&dsi1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+			port {
+				dsi_out: endpoint {
+					remote-endpoint = <&panel_dsi_port>;
+				};
+			};
+
+			panel: panel-dsi-generic@0 {
+				// See panel-dsi.yaml binding
+				compatible = "waveshare,4-3-inch-dsi","panel-dsi";
+				reg = <0>;
+				power-supply = <&reg_display>;
+				backlight = <&reg_display>;
+				dsi-color-format = "RGB888";
+				mode = "MODE_VIDEO";
+				width-mm = <0>;
+				height-mm = <0>;
+
+				port {
+					panel_dsi_port: endpoint {
+						data-lanes = <1>;
+						remote-endpoint = <&dsi_out>;
+					};
+				};
+
+				timing: panel-timing {
+					clock-frequency = <27777000>;
+					hactive = <800>;
+					vactive = <480>;
+					hfront-porch = <59>;
+					hsync-len = <2>;
+					hback-porch = <45>;
+					vfront-porch = <7>;
+					vsync-len = <2>;
+					vback-porch = <22>;
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			reg_bridge: reg_bridge@1 {
+				reg = <1>;
+				compatible = "regulator-fixed";
+				regulator-name = "bridge_reg";
+				gpio = <&reg_display 0 0>;
+				vin-supply = <&reg_display>;
+				enable-active-high;
+			};
+		};
+	};
+
+	i2c_frag: fragment@2 {
+		target = <&i2c_csi_dsi>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			reg_display: reg_display@45 {
+				compatible = "raspberrypi,7inch-touchscreen-panel-regulator";
+				reg = <0x45>;
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&i2c0if>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@4 {
+		target = <&i2c0mux>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+	fragment@5 {
+		target = <&ft5406>;
+		__overlay__ {
+			vcc-supply = <&reg_display>;
+			reset-gpio = <&reg_display 1 1>;
+		};
+	};
+
+	__overrides__ {
+		dsi0 = <&dsi_frag>, "target:0=",<&dsi0>,
+		       <&i2c_frag>, "target:0=",<&i2c_csi_dsi0>,
+		       <&ts_i2c_frag>, "target:0=",<&i2c_csi_dsi0>,
+		       <&reg_bridge>, "reg:0=0",
+		       <&reg_bridge>, "regulator-name=bridge_reg_0";
+		disable_touch = <&ft5406>, "status=disabled";
+	};
+};


### PR DESCRIPTION
It tried to be a clone of the Pi 7" display, but isn't, and gives corrupt images with the current timings.

Add a new overlay for it.

#6414 