### PR TITLE
mmc: don't reference requests after finishing them

### DIFF
--- a/drivers/mmc/core/block.c
+++ b/drivers/mmc/core/block.c
@@ -1524,6 +1524,7 @@ static void mmc_blk_cqe_complete_rq(struct mmc_queue *mq, struct request *req)
 	struct request_queue *q = req->q;
 	struct mmc_host *host = mq->card->host;
 	enum mmc_issue_type issue_type = mmc_issue_type(mq, req);
+	bool write = req_op(req) == REQ_OP_WRITE;
 	unsigned long flags;
 	bool put_card;
 	int err;
@@ -1555,7 +1556,7 @@ static void mmc_blk_cqe_complete_rq(struct mmc_queue *mq, struct request *req)
 
 	spin_lock_irqsave(&mq->lock, flags);
 
-	if (req_op(req) == REQ_OP_WRITE)
+	if (write)
 		mq->pending_writes--;
 	mq->in_flight[issue_type] -= 1;
 
@@ -2170,15 +2171,16 @@ static void mmc_blk_mq_poll_completion(struct mmc_queue *mq,
 }
 
 static void mmc_blk_mq_dec_in_flight(struct mmc_queue *mq, enum mmc_issue_type issue_type,
-				     struct request *req)
+				     bool write)
 {
 	unsigned long flags;
 	bool put_card;
 
 	spin_lock_irqsave(&mq->lock, flags);
 
-	if (req_op(req) == REQ_OP_WRITE)
+	if (write)
 		mq->pending_writes--;
+
 	mq->in_flight[issue_type] -= 1;
 
 	put_card = (mmc_tot_in_flight(mq) == 0);
@@ -2193,6 +2195,7 @@ static void mmc_blk_mq_post_req(struct mmc_queue *mq, struct request *req,
 				bool can_sleep)
 {
 	enum mmc_issue_type issue_type = mmc_issue_type(mq, req);
+	bool write = req_op(req) == REQ_OP_WRITE;
 	struct mmc_queue_req *mqrq = req_to_mmc_queue_req(req);
 	struct mmc_request *mrq = &mqrq->brq.mrq;
 	struct mmc_host *host = mq->card->host;
@@ -2212,7 +2215,7 @@ static void mmc_blk_mq_post_req(struct mmc_queue *mq, struct request *req,
 			blk_mq_complete_request(req);
 	}
 
-	mmc_blk_mq_dec_in_flight(mq, issue_type, req);
+	mmc_blk_mq_dec_in_flight(mq, issue_type, write);
 }
 
 void mmc_blk_mq_recovery(struct mmc_queue *mq)


### PR DESCRIPTION
First candidate fix for #6349 - obvious bug when you think about it.

I'll make a separate combination PR for clearing all Async requests if a Sync request needs the CQE to halt.