### PR TITLE
CQE incremental fixes part 2

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -378,9 +378,9 @@ Params:
                                 non-lite SKU of CM4).
                                 (default "on")
 
-        sd_cqe                  Use to enable Command Queueing on the SD
-                                interface for faster Class A2 card performance
-                                (Pi 5 only, default "off")
+        sd_cqe                  Set to "off" to disable Command Queueing if you
+                                have an incompatible Class A2 SD card
+                                (Pi 5 only, default "on")
 
         sd_overclock            Clock (in MHz) to use when the MMC framework
                                 requests 50MHz

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
@@ -365,6 +365,7 @@ dpi_16bit_gpio2:        &rp1_dpi_16bit_gpio2        { };
 	sd-uhs-sdr50;
 	sd-uhs-ddr50;
 	sd-uhs-sdr104;
+	supports-cqe;
 	cd-gpios = <&gio_aon 5 GPIO_ACTIVE_LOW>;
 	//no-1-8-v;
 	status = "okay";

--- a/drivers/mmc/core/block.c
+++ b/drivers/mmc/core/block.c
@@ -1524,6 +1524,7 @@ static void mmc_blk_cqe_complete_rq(struct mmc_queue *mq, struct request *req)
 	struct request_queue *q = req->q;
 	struct mmc_host *host = mq->card->host;
 	enum mmc_issue_type issue_type = mmc_issue_type(mq, req);
+	bool write = req_op(req) == REQ_OP_WRITE;
 	unsigned long flags;
 	bool put_card;
 	int err;
@@ -1555,7 +1556,7 @@ static void mmc_blk_cqe_complete_rq(struct mmc_queue *mq, struct request *req)
 
 	spin_lock_irqsave(&mq->lock, flags);
 
-	if (req_op(req) == REQ_OP_WRITE)
+	if (write)
 		mq->pending_writes--;
 	mq->in_flight[issue_type] -= 1;
 
@@ -2170,15 +2171,16 @@ static void mmc_blk_mq_poll_completion(struct mmc_queue *mq,
 }
 
 static void mmc_blk_mq_dec_in_flight(struct mmc_queue *mq, enum mmc_issue_type issue_type,
-				     struct request *req)
+				     bool write)
 {
 	unsigned long flags;
 	bool put_card;
 
 	spin_lock_irqsave(&mq->lock, flags);
 
-	if (req_op(req) == REQ_OP_WRITE)
+	if (write)
 		mq->pending_writes--;
+
 	mq->in_flight[issue_type] -= 1;
 
 	put_card = (mmc_tot_in_flight(mq) == 0);
@@ -2193,6 +2195,7 @@ static void mmc_blk_mq_post_req(struct mmc_queue *mq, struct request *req,
 				bool can_sleep)
 {
 	enum mmc_issue_type issue_type = mmc_issue_type(mq, req);
+	bool write = req_op(req) == REQ_OP_WRITE;
 	struct mmc_queue_req *mqrq = req_to_mmc_queue_req(req);
 	struct mmc_request *mrq = &mqrq->brq.mrq;
 	struct mmc_host *host = mq->card->host;
@@ -2212,7 +2215,7 @@ static void mmc_blk_mq_post_req(struct mmc_queue *mq, struct request *req,
 			blk_mq_complete_request(req);
 	}
 
-	mmc_blk_mq_dec_in_flight(mq, issue_type, req);
+	mmc_blk_mq_dec_in_flight(mq, issue_type, write);
 }
 
 void mmc_blk_mq_recovery(struct mmc_queue *mq)

--- a/drivers/mmc/core/quirks.h
+++ b/drivers/mmc/core/quirks.h
@@ -162,6 +162,15 @@ static const struct mmc_fixup __maybe_unused mmc_blk_fixups[] = {
 	MMC_FIXUP("SD32G", 0x41, 0x3432, add_quirk, MMC_QUIRK_ERASE_BROKEN),
 	MMC_FIXUP("SD64G", 0x41, 0x3432, add_quirk, MMC_QUIRK_ERASE_BROKEN),
 
+	/*
+	 * Larger Integral SD cards using rebranded Phison controllers trash
+	 * nearby flash blocks after erases.
+	 */
+	MMC_FIXUP("SD64G", 0x27, 0x5048, add_quirk, MMC_QUIRK_ERASE_BROKEN),
+	MMC_FIXUP("SD128", 0x27, 0x5048, add_quirk, MMC_QUIRK_ERASE_BROKEN),
+	MMC_FIXUP("SD256", 0x27, 0x5048, add_quirk, MMC_QUIRK_ERASE_BROKEN),
+	MMC_FIXUP("SD512", 0x27, 0x5048, add_quirk, MMC_QUIRK_ERASE_BROKEN),
+
 	END_FIXUP
 };
 

--- a/drivers/mmc/core/quirks.h
+++ b/drivers/mmc/core/quirks.h
@@ -33,6 +33,18 @@ static const struct mmc_fixup __maybe_unused mmc_sd_fixups[] = {
 		   0, -1ull, SDIO_ANY_ID, SDIO_ANY_ID, add_quirk_sd,
 		   MMC_QUIRK_BROKEN_SD_CACHE, EXT_CSD_REV_ANY),
 
+	/*
+	 * Early Sandisk Extreme and Extreme Pro A2 cards never finish SD cache
+	 * flush in CQ mode. Latest card date this was seen on is 10/2020.
+	 */
+	_FIXUP_EXT(CID_NAME_ANY, CID_MANFID_SANDISK_SD, 0x5344, 2019, CID_MONTH_ANY,
+		   0, -1ull, SDIO_ANY_ID, SDIO_ANY_ID, add_quirk_sd,
+		   MMC_QUIRK_BROKEN_SD_CACHE, EXT_CSD_REV_ANY),
+
+	_FIXUP_EXT(CID_NAME_ANY, CID_MANFID_SANDISK_SD, 0x5344, 2020, CID_MONTH_ANY,
+		   0, -1ull, SDIO_ANY_ID, SDIO_ANY_ID, add_quirk_sd,
+		   MMC_QUIRK_BROKEN_SD_CACHE, EXT_CSD_REV_ANY),
+
 	END_FIXUP
 };
 

--- a/drivers/mmc/core/sd.c
+++ b/drivers/mmc/core/sd.c
@@ -1274,14 +1274,6 @@ static int sd_flush_cache(struct mmc_host *host)
 	reg_buf = card->ext_reg_buf;
 
 	/*
-	 * Flushing requires sending CMD49 (adtc), which can't be done as a DCMD
-	 * and conflicts with CQHCI - temporarily turn CQE off to use the SDHCI
-	 * command/argument registers.
-	 */
-	if (host->cqe_on)
-		host->cqe_ops->cqe_off(host);
-
-	/*
 	 * Set Flush Cache at bit 0 in the performance enhancement register at
 	 * 261 bytes offset.
 	 */


### PR DESCRIPTION
If #6418 fixes the generic case of a hang on boot with an A2 card, then this PR should be merged.

The 2nd commit should be a no-op, as I placed an assert in cqe_off() for cq_host->qcnt != 0 and it never fired. As it turns out, mmcblk /does/ serialise async requests if a synchronous one arrives, and the existing claim mechanism should prevent other contexts from running in parallel. Retuning is a bit special as it is invoked prior to starting either a cqe or regular request, but it appears to have been thought about.

The third commit should disable CQ on older Sandisk cards such as https://forums.raspberrypi.com/viewtopic.php?t=367459&start=25#p2208495 (and I have one of these).