### PR TITLE
dts: bcm2712-rpi: Add aliases for the CSI/DSI I2Cs

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
@@ -255,12 +255,14 @@ i2c_csi_dsi0: &i2c6 { // Note: This is for MIPI0 connector only
 	pinctrl-0 = <&rp1_i2c6_38_39>;
 	pinctrl-names = "default";
 	clock-frequency = <100000>;
+	symlink = "i2c-6";
 };
 
 i2c_csi_dsi1: &i2c4 { // Note: This is for MIPI1 connector only
 	pinctrl-0 = <&rp1_i2c4_40_41>;
 	pinctrl-names = "default";
 	clock-frequency = <100000>;
+	symlink = "i2c-4";
 };
 
 i2c_csi_dsi: &i2c_csi_dsi1 { }; // An alias for compatibility

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -238,9 +238,11 @@ i2c_csi_dsi0: &i2c6 { // Note: This is for MIPI0 connector only
 	pinctrl-0 = <&rp1_i2c6_38_39>;
 	pinctrl-names = "default";
 	clock-frequency = <100000>;
+	symlink = "i2c-6";
 };
 
 i2c_csi_dsi1: &i2c0 { // Note: This is for MIPI1 connector
+	symlink = "i2c-11";
 };
 
 i2c_csi_dsi: &i2c_csi_dsi1 { }; // An alias for compatibility

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -117,12 +117,11 @@
 		i2c = &i2c_arm;
 		i2c0 = &i2c0;
 		i2c1 = &i2c1;
-		i2c10 = &i2c_rp1boot;
 		i2c2 = &i2c2;
 		i2c3 = &i2c3;
-		i2c4 = &i2c4;
-		i2c5 = &i2c5;
-		i2c6 = &i2c6;
+		i2c10 = &i2c_csi_dsi0;
+		i2c11 = &i2c_csi_dsi1;
+		i2c12 = &i2c_rp1boot;
 		mailbox = &mailbox;
 		mmc0 = &sdio1;
 		serial0 = &uart0;


### PR DESCRIPTION
Older Pis arrange that the camera I2C ports appear as /dev/i2c-10. Add aliases so that on the Pi 5 family, i2c_csi_dsi0 becomes i2c-10 and i2c_csi_dsi1 becomes i2c-11. Only the I2C buses that appear on the 40-pin header, i.e. I2C0 to I2C3, get a low bus number.

Also add hints for our udev rules about which symlinks to create for backwards-compatibility with the previous bus numbers. Note that lower numbers have priority, so i2c-0 on CM5 masks i2c-11, forcing i2c-11 to be a symlink to i2c-0, not vice versa.