### PR TITLE
usb: xhci-hcd: add a gratuitous doorbell read

### DIFF
--- a/drivers/usb/host/xhci-ring.c
+++ b/drivers/usb/host/xhci-ring.c
@@ -505,6 +505,8 @@ void xhci_ring_ep_doorbell(struct xhci_hcd *xhci,
 
 	trace_xhci_ring_ep_doorbell(slot_id, DB_VALUE(ep_index, stream_id));
 
+	/* Incurs ~1.2us round-trip time (and wakes the link) */
+	readl(db_addr);
 	writel(DB_VALUE(ep_index, stream_id), db_addr);
 	/* flush the write */
 	readl(db_addr);

--- a/include/net/bluetooth/hci.h
+++ b/include/net/bluetooth/hci.h
@@ -425,8 +425,8 @@ enum {
 /* HCI timeouts */
 #define HCI_DISCONN_TIMEOUT	msecs_to_jiffies(2000)	/* 2 seconds */
 #define HCI_PAIRING_TIMEOUT	msecs_to_jiffies(60000)	/* 60 seconds */
-#define HCI_INIT_TIMEOUT	msecs_to_jiffies(10000)	/* 10 seconds */
-#define HCI_CMD_TIMEOUT		msecs_to_jiffies(2000)	/* 2 seconds */
+#define HCI_INIT_TIMEOUT	msecs_to_jiffies(20000)	/* 20 seconds */
+#define HCI_CMD_TIMEOUT		msecs_to_jiffies(20000)	/* 20 seconds */
 #define HCI_NCMD_TIMEOUT	msecs_to_jiffies(4000)	/* 4 seconds */
 #define HCI_ACL_TX_TIMEOUT	msecs_to_jiffies(45000)	/* 45 seconds */
 #define HCI_AUTO_OFF_TIMEOUT	msecs_to_jiffies(2000)	/* 2 seconds */


### PR DESCRIPTION
This may assist in debugging https://github.com/raspberrypi/linux/issues/6141

The symptom is that the Interrupt endpoint for the dongle sometimes has one outstanding TRB, but the lack of USB bus activity suggests that the xHC didn't correctly register the TRB as valid when the doorbell ring happened.

Adding this dummy read seems to fix it.

--

There are probably less-bad ways to ensure consistency of memory before issuing a doorbell write, but this blunt instrument seems to work for me. 

I can't tell if the root cause is the same as the gpio bitbash compression (RC swallowing writes), or some peculiarity of the xHC TRB fetch engine making this type of transfer vulnerable to stalling.