### PR TITLE
dts: 2712: Drop some numa options from bootargs

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -99,7 +99,7 @@
 
 / {
 	chosen: chosen {
-		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe cgroup_disable=memory numa_policy=interleave iommu_dma_numa_policy=interleave system_heap.max_order=0";
+		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe cgroup_disable=memory numa_policy=interleave";
 		stdout-path = "serial10:115200n8";
 	};
 


### PR DESCRIPTION
iommu_dma_numa_policy=interleave is not valid in the current tree It generates an unknown setting will be passed to usespace warning

system_heap.max_order=0 is wanted when numa is enabled, but may not be when it is disabled.

Add it on firmware side when we know if `numa=fake=<n>` is used.