### PR TITLE
IMX290 120fps support

### DIFF
--- a/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
+++ b/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
@@ -70,7 +70,7 @@
 		__dormant__ {
 			data-lanes = <1 2 3 4>;
 			link-frequencies =
-				/bits/ 64 <222750000 148500000>;
+				/bits/ 64 <445500000 297000000>;
 		};
 	};
 


### PR DESCRIPTION
https://forums.raspberrypi.com/viewtopic.php?t=378189

Quick hack to enable the 120fps mode on IMX290, but at the expense of longer exposure times.

Creating PR for CI builds.