### PR TITLE
arm64: dts: Sort out CM5 and I/O board I2C ports

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm4io.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm4io.dtsi
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0
+
+i2c_csi_dsi0: &i2c0 { // Note: For CAM0 and DISP0 connectors
+};
+
+i2c_csi_dsi1: &i2c6 { // Note: For CAM1, DISP1, on-board RTC, and fan controller
+	pinctrl-0 = <&rp1_i2c6_38_39>;
+	pinctrl-names = "default";
+	clock-frequency = <100000>;
+	symlink = "i2c-6";
+};
+
+i2c_csi_dsi: &i2c_csi_dsi1 { }; // The connector that needs no jumper to enable
+
+&aliases {
+    /delete-property/ i2c11;
+    i2c10 = &i2c_csi_dsi;
+};
+
+// The RP1 USB3 interfaces are not usable on CM4IO
+
+&rp1_usb0 {
+	status = "disabled";
+};
+
+&rp1_usb1 {
+	status = "disabled";
+};

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-cm4io.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-cm4io.dts
@@ -2,19 +2,4 @@
 /dts-v1/;
 
 #include "bcm2712-rpi-cm5.dtsi"
-
-// The RP1 USB3 interfaces are not usable on CM4IO
-
-&rp1_usb0 {
-	status = "disabled";
-};
-
-&rp1_usb1 {
-	status = "disabled";
-};
-
-/ {
-	__overrides__ {
-		i2c_csi_dsi = <&i2c_csi_dsi>, "status";
-	};
-};
+#include "bcm2712-rpi-cm4io.dtsi"

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-cm5io.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-cm5io.dts
@@ -2,9 +2,4 @@
 /dts-v1/;
 
 #include "bcm2712-rpi-cm5.dtsi"
-
-/ {
-	__overrides__ {
-		i2c_csi_dsi = <&i2c_csi_dsi>, "status";
-	};
-};
+#include "bcm2712-rpi-cm5io.dtsi"

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -234,19 +234,6 @@ aux: &dummy {};
 
 #include "bcm2712-rpi.dtsi"
 
-i2c_csi_dsi0: &i2c6 { // Note: This is for MIPI0 connector only
-	pinctrl-0 = <&rp1_i2c6_38_39>;
-	pinctrl-names = "default";
-	clock-frequency = <100000>;
-	symlink = "i2c-6";
-};
-
-i2c_csi_dsi1: &i2c0 { // Note: This is for MIPI1 connector
-	symlink = "i2c-11";
-};
-
-i2c_csi_dsi: &i2c_csi_dsi1 { }; // An alias for compatibility
-
 cam1_reg: &cam0_reg { // Shares CAM_GPIO with cam0_reg
 };
 

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5io.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5io.dtsi
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+
+i2c_csi_dsi1: &i2c0 { // Note: This is for CAM/DISP 1 connector
+	symlink = "i2c-11";
+};
+
+i2c_csi_dsi0: &i2c6 { // Note: This is for CAM/DISP 0 connector
+	pinctrl-0 = <&rp1_i2c6_38_39>;
+	pinctrl-names = "default";
+	clock-frequency = <100000>;
+	symlink = "i2c-6";
+};
+
+i2c_csi_dsi: &i2c_csi_dsi0 { }; // The connector that needs no jumper to enable

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5l-cm4io.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5l-cm4io.dts
@@ -2,19 +2,4 @@
 /dts-v1/;
 
 #include "bcm2712-rpi-cm5l.dtsi"
-
-// The RP1 USB3 interfaces are not usable on CM4IO
-
-&rp1_usb0 {
-	status = "disabled";
-};
-
-&rp1_usb1 {
-	status = "disabled";
-};
-
-/ {
-	__overrides__ {
-		i2c_csi_dsi = <&i2c_csi_dsi>, "status";
-	};
-};
+#include "bcm2712-rpi-cm4io.dtsi"

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5l-cm5io.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5l-cm5io.dts
@@ -2,9 +2,4 @@
 /dts-v1/;
 
 #include "bcm2712-rpi-cm5l.dtsi"
-
-/ {
-	__overrides__ {
-		i2c_csi_dsi = <&i2c_csi_dsi>, "status";
-	};
-};
+#include "bcm2712-rpi-cm5io.dtsi"

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5l.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5l.dtsi
@@ -5,10 +5,6 @@
 
 / {
 	model = "Raspberry Pi Compute Module 5 Lite";
-
-	__overrides__ {
-		i2c_csi_dsi = <&i2c_csi_dsi>, "status";
-	};
 };
 
 &sd_io_1v8_reg {


### PR DESCRIPTION
There is a difference in I2C usage between CM4IO and CM5IO. Present a simple, consistent view of the world by moving the assignment of the bus IDs into carrier-specific files.

Fixes: 36faab69e8ee ("dts: bcm2712-rpi: Add aliases for the CSI/DSI I2Cs")
See: https://github.com/raspberrypi/linux/pull/6421