### PR TITLE
dts: Simplify bootargs

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi-bt.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi-bt.dtsi
@@ -23,6 +23,10 @@
 };
 
 / {
+	chosen {
+		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
+	};
+
 	aliases {
 		bluetooth = &bt;
 	};

--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi-zero-w.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi-zero-w.dts
@@ -11,10 +11,6 @@
 	compatible = "raspberrypi,model-zero-w", "brcm,bcm2835";
 	model = "Raspberry Pi Zero W";
 
-	chosen {
-		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
-	};
-
 	aliases {
 		serial0 = &uart1;
 		serial1 = &uart0;

--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b-plus.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b-plus.dts
@@ -12,10 +12,6 @@
 	compatible = "raspberrypi,3-model-b-plus", "brcm,bcm2837";
 	model = "Raspberry Pi 3 Model B+";
 
-	chosen {
-		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
-	};
-
 	aliases {
 		serial0 = &uart1;
 		serial1 = &uart0;

--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b.dts
@@ -12,10 +12,6 @@
 	compatible = "raspberrypi,3-model-b", "brcm,bcm2837";
 	model = "Raspberry Pi 3 Model B";
 
-	chosen {
-		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
-	};
-
 	aliases {
 		serial0 = &uart1;
 		serial1 = &uart0;

--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-zero-2-w.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-zero-2-w.dts
@@ -11,10 +11,6 @@
 	compatible = "raspberrypi,model-zero-2-w", "brcm,bcm2837";
 	model = "Raspberry Pi Zero 2 W";
 
-	chosen {
-		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
-	};
-
 	aliases {
 		serial0 = &uart1;
 		serial1 = &uart0;

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
@@ -2,7 +2,7 @@
 #include "bcm270x-rpi.dtsi"
 
 / {
-	chosen: chosen {
+	chosen {
 		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0 numa_policy=interleave";
 	};
 

--- a/arch/arm/boot/dts/broadcom/bcm271x-rpi-bt.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm271x-rpi-bt.dtsi
@@ -23,6 +23,10 @@
 };
 
 / {
+	chosen {
+		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
+	};
+
 	aliases {
 		bluetooth = &bt;
 	};


### PR DESCRIPTION
Reduce the number of different places that bootargs is set in Pi dts files. The variants are all combinations of with/without Bluetooth and with/without NUMA support (2711).

This is effectively a cosmetic change - the resulting dtbs are unchanged.