### PR TITLE
drivers: usb: xhci: set HID bit in streaming endpoint contexts

### DIFF
--- a/drivers/usb/host/xhci-mem.c
+++ b/drivers/usb/host/xhci-mem.c
@@ -716,6 +716,14 @@ void xhci_setup_streams_ep_input_ctx(struct xhci_hcd *xhci,
 	ep_ctx->ep_info &= cpu_to_le32(~EP_MAXPSTREAMS_MASK);
 	ep_ctx->ep_info |= cpu_to_le32(EP_MAXPSTREAMS(max_primary_streams)
 				       | EP_HAS_LSA);
+
+	/*
+	 * Set Host Initiated Data Move Disable to always defer stream
+	 * selection to the device. xHC implementations may treat this
+	 * field as "don't care, forced to 1" anyway - xHCI 1.2 s4.12.1.
+	 */
+	ep_ctx->ep_info2 |= EP_HID;
+
 	ep_ctx->deq  = cpu_to_le64(stream_info->ctx_array_dma);
 }
 

--- a/drivers/usb/host/xhci.h
+++ b/drivers/usb/host/xhci.h
@@ -492,6 +492,8 @@ struct xhci_ep_ctx {
 #define CTX_TO_EP_MAXPSTREAMS(p)	(((p) & EP_MAXPSTREAMS_MASK) >> 10)
 /* Endpoint is set up with a Linear Stream Array (vs. Secondary Stream Array) */
 #define	EP_HAS_LSA		(1 << 15)
+/* Host initiated data move disable in info2 */
+#define EP_HID			(1 << 7)
 /* hosts with LEC=1 use bits 31:24 as ESIT high bits. */
 #define CTX_TO_MAX_ESIT_PAYLOAD_HI(p)	(((p) >> 24) & 0xff)
 


### PR DESCRIPTION
This fixes @naushir's reboot IO errors and also stops shallow IO depths from getting spurious NAKed packets.

The rationale in the commit message applies globally, which is why this isn't an RP1-specific quirk. I believe the VL805 implements this field as ignored-1.