### PR TITLE
media: uvcvideo: Increase number of URBs for UVC

### DIFF
--- a/drivers/media/usb/uvc/uvcvideo.h
+++ b/drivers/media/usb/uvc/uvcvideo.h
@@ -48,7 +48,7 @@
 #define DRIVER_VERSION		"1.1.1"
 
 /* Number of isochronous URBs. */
-#define UVC_URBS		5
+#define UVC_URBS		16
 /* Maximum number of packets per URB. */
 #define UVC_MAX_PACKETS		32
 


### PR DESCRIPTION
Speculative for https://forums.raspberrypi.com/viewtopic.php?t=371104 based on a past experience with "fast" USB3 UVC devices on "slow" processors, and running out of URBs resulting in dropped image data.