### PR TITLE
dtoverlays: enable SPI CS active-high

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -259,6 +259,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	spi-rtc.dtbo \
 	spi0-0cs.dtbo \
 	spi0-1cs.dtbo \
+	spi0-1cs-inverted.dtbo \
 	spi0-2cs.dtbo \
 	spi1-1cs.dtbo \
 	spi1-2cs.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4438,6 +4438,14 @@ Params: cs0_pin                 GPIO pin for CS0 (default 8)
                                 it for other uses.
 
 
+Name:   spi0-1cs-inverted
+Info:   Only use one CS pin for SPI0 and set to active-high
+Load:   dtoverlay=spi0-1cs-inverted,<param>=<val>
+Params: cs0_pin                 GPIO pin for CS0 (default 8)
+        no_miso                 Don't claim and use the MISO pin (9), freeing
+                                it for other uses.
+
+
 Name:   spi0-2cs
 Info:   Change the CS pins for SPI0
 Load:   dtoverlay=spi0-2cs,<param>=<val>

--- a/arch/arm/boot/dts/overlays/spi0-1cs-inverted-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spi0-1cs-inverted-overlay.dts
@@ -1,0 +1,59 @@
+/dts-v1/;
+/plugin/;
+
+/*
+ * There are some devices that need an inverted Chip Select (CS) to select the
+ * device signal, as an example the AZDelivery 12864 display. That means that
+ * the CS polarity is active-high. To invert the CS signal the DT needs to set
+ * the cs-gpio to GPIO_ACTIVE_HIGH (0) in the controller and set the
+ * spi-cs-high in the peripheral property. On top of that, since this is a
+ * display the DT also needs to specify the write-only property.
+*/
+
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spi0_cs_pins>;
+		frag0: __overlay__ {
+			brcm,pins = <8>;
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		frag1: __overlay__ {
+			cs-gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0_pins>;
+		__dormant__ {
+			brcm,pins = <10 11>;
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev0>;
+		__overlay__ {
+			spi-cs-high;
+		};
+	};
+
+	__overrides__ {
+		cs0_pin  = <&frag0>,"brcm,pins:0",
+			   <&frag1>,"cs-gpios:4";
+		no_miso = <0>,"=3";
+	};
+};


### PR DESCRIPTION
The documentation isn't very clear explaining how to enable SPI CS active-high and it takes a long time to understand it. Adding a specific overlay as a simple example on how to invert this signal can help understand the solution.

Link: https://forums.raspberrypi.com/viewtopic.php?t=378222