### PR TITLE
Enable Raspberry Touch 2 rotation with overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5249,6 +5249,7 @@ Params: sizex                   Touchscreen size x (default 720)
         invy                    Touchscreen inverted y axis
         swapxy                  Touchscreen swapped x y axis
         disable_touch           Disables the touch screen overlay driver
+        rotatation              Display rotation {0,90,180,270} (default 0)
         dsi0                    Use DSI0 and i2c_csi_dsi0 (rather than
                                 the default DSI1 and i2c_csi_dsi).
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5249,7 +5249,7 @@ Params: sizex                   Touchscreen size x (default 720)
         invy                    Touchscreen inverted y axis
         swapxy                  Touchscreen swapped x y axis
         disable_touch           Disables the touch screen overlay driver
-        rotation              Display rotation {0,90,180,270} (default 0)
+        rotation                Display rotation {0,90,180,270} (default 0)
         dsi0                    Use DSI0 and i2c_csi_dsi0 (rather than
                                 the default DSI1 and i2c_csi_dsi).
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5249,7 +5249,7 @@ Params: sizex                   Touchscreen size x (default 720)
         invy                    Touchscreen inverted y axis
         swapxy                  Touchscreen swapped x y axis
         disable_touch           Disables the touch screen overlay driver
-        rotatation              Display rotation {0,90,180,270} (default 0)
+        rotation              Display rotation {0,90,180,270} (default 0)
         dsi0                    Use DSI0 and i2c_csi_dsi0 (rather than
                                 the default DSI1 and i2c_csi_dsi).
 

--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-ili9881-7inch-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-ili9881-7inch-overlay.dts
@@ -118,5 +118,6 @@
 		invy = <0>, "+11";
 		swapxy = <&gt911>,"touchscreen-swapped-x-y?";
 		disable_touch = <&gt911>, "status=disabled";
+		rotation = <&dsi_panel>, "rotation:0";
 	};
 };


### PR DESCRIPTION
The panel-ilitek-ili9881c.c which Touch Display 2 is based on already contains orientation.
By minor update to the vc4-kms-dsi-ili9881-7inch-overlay.dts panel can be rotated with minimal effort.

Issue opened here: 
https://github.com/raspberrypi/documentation/issues/3923

Complete discussion and working dbto in the community thread:
https://community.volumio.com/t/guide-official-raspberry-touch-display-2/69791
