### PR TITLE
dts: bcm2712-rpi: For CM5IO, i2c_csi_dsi needs to be CAM/DISP1

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5io.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5io.dtsi
@@ -11,4 +11,4 @@ i2c_csi_dsi0: &i2c6 { // Note: This is for CAM/DISP 0 connector
 	symlink = "i2c-6";
 };
 
-i2c_csi_dsi: &i2c_csi_dsi0 { }; // The connector that needs no jumper to enable
+i2c_csi_dsi: &i2c_csi_dsi1 { }; // The connector that needs no jumper to enable


### PR DESCRIPTION
Noted setting up a display on CM5IO. Add
"dtoverlay=vc4-kms-dsi-ili7881-7inch" fails as it tries to find the regulator/backlight/touch on i2c_csi_dsi, which pointed at i2c_csi_dsi0 by default.

Adding the dsi0 override updated to point at dsi0, and pointed the i2c at i2c_csi_dsi0, which all works.

The default with i2c_csi_dsi needs to be consistent in using dsi1/csi1 and the corresponding i2c interface (i2c_csi_dsi1).