### PR TITLE
overlays: qca7000: replace URL with textual hint

### DIFF
--- a/arch/arm/boot/dts/overlays/qca7000-overlay.dts
+++ b/arch/arm/boot/dts/overlays/qca7000-overlay.dts
@@ -1,5 +1,5 @@
 // Overlay for the Qualcomm Atheros QCA7000 on PLC Stamp micro EVK
-// Visit: https://chargebyte.com/products/evaluation-tools/plc-stamp-micro-2-evaluation-board for details
+// Visit: https://chargebyte.com -> Controllers & Modules -> Evaluation Tools -> PLC Stamp Micro 2 Evaluation Board for details
 
 /dts-v1/;
 /plugin/;

--- a/arch/arm/boot/dts/overlays/qca7000-uart0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/qca7000-uart0-overlay.dts
@@ -1,5 +1,5 @@
 // Overlay for the Qualcomm Atheros QCA7000 on PLC Stamp micro EVK
-// Visit: https://in-tech-smartcharging.com/products/evaluation-tools/plc-stamp-micro-2-evaluation-board for details
+// Visit: https://chargebyte.com -> Controllers & Modules -> Evaluation Tools -> PLC Stamp Micro 2 Evaluation Board for details
 
 /dts-v1/;
 /plugin/;


### PR DESCRIPTION
The deep link into the website is not that stable, so let's replace it with a textual description where to find the product information.