### PR TITLE
dtoverlays: Add Arducam override for ov9281

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3538,6 +3538,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 configuring the sensor (default on)
         cam0                    Adopt the default configuration for CAM0 on a
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
+        arducam                 Slow down the regulator for slow Arducam
+                                modules.
 
 
 Name:   papirus

--- a/arch/arm/boot/dts/overlays/ov9281-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov9281-overlay.dts
@@ -57,6 +57,14 @@
 		};
 	};
 
+	reg_frag: fragment@5 {
+		target = <&cam1_reg>;
+		__dormant__ {
+			startup-delay-us = <20000>;
+			off-on-delay-us = <30000>;
+		};
+	};
+
 	__overrides__ {
 		rotation = <&cam_node>,"rotation:0";
 		orientation = <&cam_node>,"orientation:0";
@@ -65,7 +73,10 @@
 		       <&csi_frag>, "target:0=",<&csi0>,
 		       <&clk_frag>, "target:0=",<&cam0_clk>,
 		       <&cam_node>, "clocks:0=",<&cam0_clk>,
-		       <&cam_node>, "avdd-supply:0=",<&cam0_reg>;
+		       <&cam_node>, "avdd-supply:0=",<&cam0_reg>,
+		       <&reg_frag>, "target:0=",<&cam0_reg>;
+		arducam = <0>, "+5";
+
 	};
 };
 


### PR DESCRIPTION
The Arducam module is slow starting up, so add an override to slow the regulator down.
https://forums.raspberrypi.com/viewtopic.php?t=380236