### PR TITLE
Two 6.12 DTS fixes

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
@@ -23,6 +23,15 @@
 	};
 #endif
 
+	arm-pmu {
+		compatible = "arm,cortex-a76-pmu";
+		interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL_HIGH>,
+			<GIC_SPI 17 IRQ_TYPE_LEVEL_HIGH>,
+			<GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>,
+			<GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-affinity = <&cpu0>, <&cpu1>, <&cpu2>, <&cpu3>;
+	};
+
 	clocks: clocks {
 		compatible = "simple-bus";
 		#address-cells = <1>;

--- a/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
@@ -815,3 +815,7 @@
 		};
 	};
 };
+
+&gio_aon {
+	brcm,gpio-direct;
+};

--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
@@ -65,9 +65,9 @@
 			interrupts = <RP1_INT_UART0 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_UART &rp1_clocks RP1_PLL_SYS_PRI_PH>;
 			clock-names = "uartclk", "apb_pclk";
-			// dmas = <&rp1_dma RP1_DMA_UART0_TX>,
-			//        <&rp1_dma RP1_DMA_UART0_RX>;
-			// dma-names = "tx", "rx";
+			dmas = <&rp1_dma RP1_DMA_UART0_TX>,
+			       <&rp1_dma RP1_DMA_UART0_RX>;
+			dma-names = "tx", "rx";
 			pinctrl-names = "default";
 			arm,primecell-periphid = <0x00541011>;
 			uart-has-rtscts;


### PR DESCRIPTION
As noticed in https://github.com/raspberrypi/linux/issues/6507, the arm-pmu declaration is missing from rpi-6.12.y. Likewise, the re-enabling of DMA to RP1's UART0.