### PR TITLE
ARM: dts: Remove duplicate tags

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-400.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-400.dts
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0
-/dts-v1/;
 #include "bcm2711-rpi-4-b.dts"
 
 / {

--- a/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
@@ -1,7 +1,4 @@
 // Definitions for I2C based sensors using the Industrial IO or HWMON interface.
-/dts-v1/;
-/plugin/;
-
 #include <dt-bindings/gpio/gpio.h>
 
 / {

--- a/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
+++ b/arch/arm/boot/dts/overlays/imx290_327-overlay.dtsi
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Partial definitions for IMX290 or IMX327 camera module on VC I2C bus
 // The compatible string should be set in an overlay that then includes this one
-/dts-v1/;
-/plugin/;
 
 #include <dt-bindings/gpio/gpio.h>
 

--- a/arch/arm/boot/dts/overlays/pisound-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pisound-pi5-overlay.dts
@@ -17,9 +17,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-/dts-v1/;
-/plugin/;
-
 #include "pisound-overlay.dts"
 
 &pisound_spi {

--- a/arch/arm/boot/dts/overlays/vc4-fkms-v3d-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-fkms-v3d-overlay.dts
@@ -2,9 +2,6 @@
  * vc4-fkms-v3d-overlay.dts
  */
 
-/dts-v1/;
-/plugin/;
-
 #include "cma-overlay.dts"
 
 / {

--- a/arch/arm/boot/dts/overlays/vc4-fkms-v3d-pi4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-fkms-v3d-pi4-overlay.dts
@@ -2,9 +2,6 @@
  * vc4-fkms-v3d-overlay.dts
  */
 
-/dts-v1/;
-/plugin/;
-
 #include "cma-overlay.dts"
 
 &frag0 {

--- a/arch/arm/boot/dts/overlays/vc4-kms-v3d-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-v3d-overlay.dts
@@ -2,9 +2,6 @@
  * vc4-kms-v3d-overlay.dts
  */
 
-/dts-v1/;
-/plugin/;
-
 #include <dt-bindings/clock/bcm2835.h>
 
 #include "cma-overlay.dts"

--- a/arch/arm/boot/dts/overlays/vc4-kms-v3d-pi4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-v3d-pi4-overlay.dts
@@ -2,9 +2,6 @@
  * vc4-kms-v3d-pi4-overlay.dts
  */
 
-/dts-v1/;
-/plugin/;
-
 #include <dt-bindings/clock/bcm2835.h>
 
 #include "cma-overlay.dts"

--- a/arch/arm/boot/dts/overlays/w1-gpio-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/w1-gpio-pi5-overlay.dts
@@ -1,6 +1,3 @@
-/dts-v1/;
-/plugin/;
-
 #include "w1-gpio-overlay.dts"
 
 / {

--- a/arch/arm/boot/dts/overlays/w1-gpio-pullup-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/w1-gpio-pullup-pi5-overlay.dts
@@ -1,6 +1,3 @@
-/dts-v1/;
-/plugin/;
-
 #include "w1-gpio-pullup-overlay.dts"
 
 / {

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5l.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5l.dtsi
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0
-/dts-v1/;
 
 #include "bcm2712-rpi-cm5.dtsi"
 


### PR DESCRIPTION
A dts file should have exactly one /dts-v1/ tag, and overlays should also have one /plugin/ tag. Through careless inclusion of other files, some Device Trees and overlays end up with duplicated tags - this commit removes them.

The change is largely cosmetic, unless using an old version of dtc.