### PR TITLE
nvme-pci: Disable Host Memory Buffer usage

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -1936,6 +1936,7 @@ static void nvme_free_host_mem(struct nvme_dev *dev)
 	dev->nr_host_mem_descs = 0;
 }
 
+#if 0
 static int __nvme_alloc_host_mem(struct nvme_dev *dev, u64 preferred,
 		u32 chunk_size)
 {
@@ -2003,9 +2004,11 @@ out:
 	dev->host_mem_descs = NULL;
 	return -ENOMEM;
 }
+#endif
 
 static int nvme_alloc_host_mem(struct nvme_dev *dev, u64 min, u64 preferred)
 {
+#if 0
 	u64 min_chunk = min_t(u64, preferred, PAGE_SIZE * MAX_ORDER_NR_PAGES);
 	u64 hmminds = max_t(u32, dev->ctrl.hmminds * 4096, PAGE_SIZE * 2);
 	u64 chunk_size;
@@ -2018,6 +2021,7 @@ static int nvme_alloc_host_mem(struct nvme_dev *dev, u64 min, u64 preferred)
 			nvme_free_host_mem(dev);
 		}
 	}
+#endif
 
 	return -ENOMEM;
 }


### PR DESCRIPTION
Some NVME drives seem to request significant amounts of DMA coherent memory - enough to exhaust our standard 64MB CMA allocation.

Try disabling the feature to see what effect it has - drives should continue to function without it.

Link: https://github.com/raspberrypi/linux/issues/6504