### PR TITLE
Allow setting I²C clock frequency via i2c_arm_baudrate dtparam when using pimidi overlay.

### DIFF
--- a/arch/arm/boot/dts/overlays/pimidi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pimidi-overlay.dts
@@ -26,7 +26,6 @@
 		target = <&i2c_arm>;
 		__overlay__ {
 			status = "okay";
-			clock-frequency=<1000000>;
 
 			pimidi_ctrl: pimidi_ctrl@20 {
 				compatible = "blokaslabs,pimidi";


### PR DESCRIPTION
This change removes the forced 1MHz clock frequency, so it can be overridden using `i2c_arm_baudrate`.