### PR TITLE
input: edt-ft5x06: Extend the power on delay

### DIFF
--- a/drivers/input/touchscreen/edt-ft5x06.c
+++ b/drivers/input/touchscreen/edt-ft5x06.c
@@ -81,7 +81,7 @@
 #define M06_REG_CMD(factory) ((factory) ? 0xf3 : 0xfc)
 #define M06_REG_ADDR(factory, addr) ((factory) ? (addr) & 0x7f : (addr) & 0x3f)
 
-#define RESET_DELAY_MS			300	/* reset deassert to I2C */
+#define RESET_DELAY_MS			500	/* reset deassert to I2C */
 #define FIRST_POLL_DELAY_MS		300	/* in addition to the above */
 #define POLL_INTERVAL_MS		17	/* 17ms = 60fps */
 


### PR DESCRIPTION
There's a report of a touch panel not being identified correctly, but unloading and reloading the module brings it to life.

About the only thing this can be is that it hasn't come out of reset properly, so extend that delay.

https://github.com/raspberrypi/bookworm-feedback/issues/330