### PR TITLE
drm/v3d: Correct clock settng calls to new APIs

### DIFF
--- a/drivers/gpu/drm/v3d/v3d_submit.c
+++ b/drivers/gpu/drm/v3d/v3d_submit.c
@@ -18,7 +18,7 @@ v3d_clock_down_work(struct work_struct *work)
 		container_of(work, struct v3d_dev, clk_down_work.work);
 	int ret;
 
-	ret = clk_set_rate(v3d->clk, v3d->clk_down_rate);
+	ret = clk_set_min_rate(v3d->clk, v3d->clk_down_rate);
 	v3d->clk_up = false;
 	WARN_ON_ONCE(ret != 0);
 }
@@ -32,7 +32,7 @@ v3d_clock_up_get(struct v3d_dev *v3d)
 		if (!v3d->clk_up)  {
 			int ret;
 
-			ret = clk_set_rate(v3d->clk, v3d->clk_up_rate);
+			ret = clk_set_min_rate(v3d->clk, v3d->clk_up_rate);
 			WARN_ON_ONCE(ret != 0);
 			v3d->clk_up = true;
 		}


### PR DESCRIPTION
There was a report that 6.12 kernel has lower benchmark scores than 6.6.

I can confirm, and found it started with 6.8 kernel which moved some code into a new file (v3d_submit.c) and in two places the change to the clock api were missed.

The effect of the bug is the v3d clock sometimes
unwantedly drops to a lower rate.

With this patch the benchmark scores are good again.

Fixes: 86963038cb0c0ba99dad14665ca92936ca723f89