### PR TITLE
Revert "PCI: Warn if no host bridge NUMA node info"

### DIFF
--- a/drivers/pci/probe.c
+++ b/drivers/pci/probe.c
@@ -968,9 +968,6 @@ static int pci_register_host_bridge(struct pci_host_bridge *bridge)
 	else
 		pr_info("PCI host bridge to bus %s\n", name);
 
-	if (nr_node_ids > 1 && pcibus_to_node(bus) == NUMA_NO_NODE)
-		dev_warn(&bus->dev, "Unknown NUMA node; performance will be reduced\n");
-
 	/* Coalesce contiguous windows */
 	resource_list_for_each_entry_safe(window, n, &resources) {
 		if (list_is_last(&window->node, &resources))


### PR DESCRIPTION
This warning doesn't mean anyting on our platform and the warning causes confusion.

See: https://forums.raspberrypi.com/viewtopic.php?p=2276125#p2276125

This reverts commit ad5086108b9f0361929aa9a79cf959ab5681d249.