### PR TITLE
drm: vc4: txp: Do not allow 24bpp formats when transposing

### DIFF
--- a/drivers/gpu/drm/drm_atomic_uapi.c
+++ b/drivers/gpu/drm/drm_atomic_uapi.c
@@ -812,6 +812,12 @@ static int drm_atomic_connector_set_property(struct drm_connector *connector,
 	} else if (property == connector->privacy_screen_sw_state_property) {
 		state->privacy_screen_sw_state = val;
 	} else if (property == connector->rotation_property) {
+		if (!is_power_of_2(val & DRM_MODE_ROTATE_MASK)) {
+			drm_dbg_atomic(connector->dev,
+				       "[CONNECTOR:%d:%s] bad rotation bitmask: 0x%llx\n",
+				       connector->base.id, connector->name, val);
+			return -EINVAL;
+		}
 		state->rotation = val;
 	} else if (connector->funcs->atomic_set_property) {
 		return connector->funcs->atomic_set_property(connector,

--- a/drivers/gpu/drm/vc4/vc4_txp.c
+++ b/drivers/gpu/drm/vc4/vc4_txp.c
@@ -272,6 +272,13 @@ static int vc4_txp_connector_atomic_check(struct drm_connector *conn,
 		return -EINVAL;
 	}
 
+	if (conn_state->rotation & DRM_MODE_TRANSPOSE &&
+	    (fb->format->format == DRM_FORMAT_RGB888 ||
+	     fb->format->format == DRM_FORMAT_BGR888)) {
+		DRM_DEBUG_KMS("24bpp formats not supported when transposing\n");
+		return -EINVAL;
+	}
+
 	for (i = 0; i < ARRAY_SIZE(drm_fmts); i++) {
 		if (fb->format->format == drm_fmts[i])
 			break;


### PR DESCRIPTION
The hardware doesn't support transposing to 24bpp (RGB888/BGR888) formats. There's no way to advertise this through DRM, so block it from atomic_check instead.

https://forums.raspberrypi.com/viewtopic.php?t=380129