### PR TITLE
serial: sc16is7xx: announce support for SER_RS485_RTS_ON_SEND

### DIFF
--- a/drivers/tty/serial/sc16is7xx.c
+++ b/drivers/tty/serial/sc16is7xx.c
@@ -1457,7 +1457,7 @@ static int sc16is7xx_setup_mctrl_ports(struct sc16is7xx_port *s,
 }
 
 static const struct serial_rs485 sc16is7xx_rs485_supported = {
-	.flags = SER_RS485_ENABLED | SER_RS485_RTS_AFTER_SEND,
+	.flags = SER_RS485_ENABLED | SER_RS485_RTS_ON_SEND | SER_RS485_RTS_AFTER_SEND,
 	.delay_rts_before_send = 1,
 	.delay_rts_after_send = 1,	/* Not supported but keep returning -EINVAL */
 };


### PR DESCRIPTION
commit 068d35a7be65fa3bca4bba21c269bfe0b39158a6 upstream.

When specifying flag SER_RS485_RTS_ON_SEND in RS485 configuration, we get the following warning after commit 4afeced55baa ("serial: core: fix sanitizing check for RTS settings"):

    invalid RTS setting, using RTS_AFTER_SEND instead

This results in SER_RS485_RTS_AFTER_SEND being set and the driver always write to the register field SC16IS7XX_EFCR_RTS_INVERT_BIT, which breaks some hardware using these chips.

The hardware supports both RTS_ON_SEND and RTS_AFTER_SEND modes, so fix this by announcing support for RTS_ON_SEND.


Suggested-by: Konstantin Pugin <ria.freelander@gmail.com>
Link: https://lore.kernel.org/lkml/20240422133219.2710061-2-ria.freelander@gmail.com
Reviewed-by: Andy Shevchenko <andy@kernel.org>
Tested-by: Hugo Villeneuve <hvilleneuve@dimonoff.com>
Link: https://lore.kernel.org/r/20241007162716.3122912-1-hugo@hugovil.com