### PR TITLE
dtoverlays: Add override for target-path on I2C overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -555,6 +555,7 @@ Params: addr                    I2C bus address of device. Set based on how the
                                 overlay - BCM2711 only)
         i2c6                    Choose the I2C6 bus (configure with the i2c6
                                 overlay - BCM2711 only)
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
         Channel parameters can be set for each enabled channel.
         A maximum of 4 channels can be enabled (letters a thru d).
@@ -1238,6 +1239,7 @@ Params: sizex                   Touchscreen size x (default 800)
         addr                    Sets the address for the touch controller. Note
                                 that the device must be configured to use the
                                 specified address.
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
 
 Name:   enc28j60
@@ -1439,6 +1441,7 @@ Info:   Enables I2C connected Goodix gt9271 multiple touch controller using
 Load:   dtoverlay=goodix,<param>=<val>
 Params: interrupt               GPIO used for interrupt (default 4)
         reset                   GPIO used for reset (default 17)
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
 
 Name:   googlevoicehat-soundcard
@@ -1730,6 +1733,7 @@ Params: addr                    I2C address of PCF8574
         display_height          Height of the display in characters (default 2)
 
         display_width           Width of the display in characters (default 16)
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
 
 Name:   hd44780-lcd
@@ -2095,6 +2099,8 @@ Params: addr                    Sets the address for the fan controller. Note
         i2c6                    Choose the I2C6 bus (configure with the i2c6
                                 overlay - BCM2711 only)
 
+        i2c-path                Override I2C path to allow for i2c-gpio buses
+
         minpwm                  PWM setting for the fan when the SoC is below
                                 mintemp (range 0-255. default 0)
         maxpwm                  PWM setting for the fan when the SoC is above
@@ -2165,6 +2171,8 @@ Params: pca9542                 Select the NXP PCA9542 device
         i2c6                    Choose the I2C6 bus (configure with the i2c6
                                 overlay - BCM2711 only)
 
+        i2c-path                Override I2C path to allow for i2c-gpio buses
+
         disconnect_on_idle      Force the mux to disconnect all child buses
                                 after every transaction.
 
@@ -2186,6 +2194,7 @@ Params: addr                    I2C address of PCA9685A (default 0x40)
                                 overlay - BCM2711 only)
         i2c6                    Choose the I2C6 bus (configure with the i2c6
                                 overlay - BCM2711 only)
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
 
 Name:   i2c-rtc
@@ -2254,6 +2263,8 @@ Params: abx80x                  Select one of the ABx80x family:
 
         i2c6                    Choose the I2C6 bus (configure with the i2c6
                                 overlay - BCM2711 only)
+
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
         addr                    Sets the address for the RTC. Note that the
                                 device must be configured to use the specified
@@ -2519,6 +2530,8 @@ Params: addr                    Set the address for the ADT7410, BH1750, BME280,
         i2c6                    Choose the I2C6 bus (configure with the i2c6
                                 overlay - BCM2711 only)
 
+        i2c-path                Override I2C path to allow for i2c-gpio buses
+
 
 Name:   i2c0
 Info:   Change i2c0 pin usage. Not all pin combinations are usable on all
@@ -2661,6 +2674,7 @@ Params: interrupt               GPIO used for interrupt (default 4)
                                 touchscreen (in pixels)
         sizey                   Touchscreen size y, vertical resolution of
                                 touchscreen (in pixels)
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
 
 Name:   imx219
@@ -3138,6 +3152,7 @@ Params: gpiopin                 Gpio pin connected to the INTA output of the
                                 overlay - BCM2711 only)
         i2c6                    Choose the I2C6 bus (configure with the i2c6
                                 overlay - BCM2711 only)
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
 
 Name:   mcp23s17
@@ -3587,6 +3602,17 @@ Params: addr                    I2C address of expander. Default 0x20.
         cat9554                 Select the Onnn CAT9554 (8 bit)
         pca9654                 Select the Onnn PCA9654 (8 bit)
         xra1202                 Select the Exar XRA1202 (8 bit)
+        i2c0                    Choose the I2C0 bus on GPIOs 0&1
+        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c3                    Choose the I2C3 bus (configure with the i2c3
+                                overlay - BCM2711 only)
+        i2c4                    Choose the I2C3 bus (configure with the i2c3
+                                overlay - BCM2711 only)
+        i2c5                    Choose the I2C5 bus (configure with the i2c4
+                                overlay - BCM2711 only)
+        i2c6                    Choose the I2C6 bus (configure with the i2c6
+                                overlay - BCM2711 only)
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
 
 Name:   pcf857x
@@ -3598,6 +3624,17 @@ Params: addr                    I2C address of expander. Default
         pcf8574a                Select the NXP PCF8574A (8 bit)
         pcf8575                 Select the NXP PCF8575 (16 bit)
         pca8574                 Select the NXP PCA8574 (8 bit)
+        i2c0                    Choose the I2C0 bus on GPIOs 0&1
+        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c3                    Choose the I2C3 bus (configure with the i2c3
+                                overlay - BCM2711 only)
+        i2c4                    Choose the I2C3 bus (configure with the i2c3
+                                overlay - BCM2711 only)
+        i2c5                    Choose the I2C5 bus (configure with the i2c4
+                                overlay - BCM2711 only)
+        i2c6                    Choose the I2C6 bus (configure with the i2c6
+                                overlay - BCM2711 only)
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
 
 Name:   pcie-32bit-dma
@@ -4257,6 +4294,17 @@ Load:   dtoverlay=sc16is750-i2c,<param>=<val>
 Params: int_pin                 GPIO used for IRQ (default 24)
         addr                    Address (default 0x48)
         xtal                    On-board crystal frequency (default 14745600)
+        i2c0                    Choose the I2C0 bus on GPIOs 0&1
+        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c3                    Choose the I2C3 bus (configure with the i2c3
+                                overlay - BCM2711 only)
+        i2c4                    Choose the I2C4 bus (configure with the i2c4
+                                overlay - BCM2711 only)
+        i2c5                    Choose the I2C5 bus (configure with the i2c5
+                                overlay - BCM2711 only)
+        i2c6                    Choose the I2C6 bus (configure with the i2c6
+                                overlay - BCM2711 only)
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
 
 Name:   sc16is750-spi0
@@ -4275,6 +4323,17 @@ Load:   dtoverlay=sc16is752-i2c,<param>=<val>
 Params: int_pin                 GPIO used for IRQ (default 24)
         addr                    Address (default 0x48)
         xtal                    On-board crystal frequency (default 14745600)
+        i2c0                    Choose the I2C0 bus on GPIOs 0&1
+        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c3                    Choose the I2C3 bus (configure with the i2c3
+                                overlay - BCM2711 only)
+        i2c4                    Choose the I2C4 bus (configure with the i2c4
+                                overlay - BCM2711 only)
+        i2c5                    Choose the I2C5 bus (configure with the i2c5
+                                overlay - BCM2711 only)
+        i2c6                    Choose the I2C6 bus (configure with the i2c6
+                                overlay - BCM2711 only)
+        i2c-path                Override I2C path to allow for i2c-gpio buses
 
 
 Name:   sc16is752-spi0

--- a/arch/arm/boot/dts/overlays/ads1115-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ads1115-overlay.dts
@@ -131,5 +131,7 @@
 		       <&frag100>, "target-path=i2c5";
 		i2c6 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c6";
+		i2c-path = <&frag100>, "target?=0",
+		       <&frag100>, "target-path";
 	};
 };

--- a/arch/arm/boot/dts/overlays/edt-ft5406-overlay.dts
+++ b/arch/arm/boot/dts/overlays/edt-ft5406-overlay.dts
@@ -41,6 +41,9 @@
 		i2c6 = <&ts_i2c_frag>, "target?=0",
 		       <&ts_i2c_frag>, "target-path=i2c6",
 		       <0>,"-0-1";
+		i2c-path = <&ts_i2c_frag>, "target?=0",
+		       <&ts_i2c_frag>, "target-path",
+		       <0>,"-0-1";
 		addr = <&ft5406>,"reg:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/goodix-overlay.dts
+++ b/arch/arm/boot/dts/overlays/goodix-overlay.dts
@@ -16,7 +16,7 @@
 		};
 	};
 
-	fragment@1 {
+	i2c_frag: fragment@1 {
 		target = <&i2c1>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -42,5 +42,7 @@
 			<&gt9271>,"irq-gpios:4";
 		reset = <&goodix_pins>,"brcm,pins:4",
 			<&gt9271>,"reset-gpios:4";
+		i2c-path = <&i2c_frag>, "target?=0",
+			   <&i2c_frag>, "target-path";
 	};
 };

--- a/arch/arm/boot/dts/overlays/hd44780-i2c-lcd-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hd44780-i2c-lcd-overlay.dts
@@ -4,7 +4,7 @@
 / {
 	compatible = "brcm,bcm2835";
 
-	fragment@0 {
+	i2c_frag: fragment@0 {
 		target = <&i2c_arm>;
 		__overlay__ {
 			status = "okay";
@@ -52,6 +52,8 @@
 		display_height = <&lcd_screen>,"display-height-chars:0";
 		display_width = <&lcd_screen>,"display-width-chars:0";
 		addr = <&pcf857x>,"reg:0";
+		i2c-path = <&i2c_frag>, "target?=0",
+			   <&i2c_frag>, "target-path";
 	};
 
 };

--- a/arch/arm/boot/dts/overlays/i2c-fan-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-fan-overlay.dts
@@ -93,6 +93,8 @@
 		       <&frag100>, "target-path=i2c5";
 		i2c6 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c6";
+		i2c-path = <&frag100>, "target?=0",
+			   <&frag100>, "target-path";
 		addr =		<&emc2301>,"reg:0";
 		minpwm =	<&emc2301>,"emc2305,pwm-min.0";
 		maxpwm =	<&emc2301>,"emc2305,pwm-max.0";

--- a/arch/arm/boot/dts/overlays/i2c-mux-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-mux-overlay.dts
@@ -175,6 +175,8 @@
 		       <&frag100>, "target-path=i2c5";
 		i2c6 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c6";
+		i2c-path = <&frag100>, "target?=0",
+			   <&frag100>, "target-path";
 		disconnect_on_idle =
 			<&pca9542>,"idle-state:0=", <MUX_IDLE_DISCONNECT>,
 			<&pca9545>,"idle-state:0=", <MUX_IDLE_DISCONNECT>,

--- a/arch/arm/boot/dts/overlays/i2c-pwm-pca9685a-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-pwm-pca9685a-overlay.dts
@@ -57,5 +57,7 @@
 		       <&frag100>, "target-path=i2c5";
 		i2c6 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c6";
+		i2c-path = <&frag100>, "target?=0",
+			   <&frag100>, "target-path";
 	};
 };

--- a/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
@@ -38,5 +38,7 @@
 		       <&frag100>, "target-path=i2c5";
 		i2c6 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c6";
+		i2c-path = <&frag100>, "target?=0",
+			   <&frag100>, "target-path";
 	};
 };

--- a/arch/arm/boot/dts/overlays/i2c-sensor-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-overlay.dts
@@ -38,5 +38,7 @@
 		       <&frag100>, "target-path=i2c5";
 		i2c6 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c6";
+		i2c-path = <&frag100>, "target?=0",
+			   <&frag100>, "target-path";
 	};
 };

--- a/arch/arm/boot/dts/overlays/ilitek251x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ilitek251x-overlay.dts
@@ -16,7 +16,7 @@
 		};
 	};
 
- 	fragment@1 {
+	frag1: fragment@1 {
 		target = <&i2c1>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -41,5 +41,7 @@
 			<&ili251x>,"interrupts:0";
 		sizex = <&ili251x>,"touchscreen-size-x:0";
 		sizey = <&ili251x>,"touchscreen-size-y:0";
+		i2c-path = <&frag1>, "target?=0",
+			   <&frag1>, "target-path";
 	};
 };

--- a/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
@@ -98,6 +98,8 @@
 		       <&frag100>, "target-path=i2c5";
 		i2c6 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c6";
+		i2c-path = <&frag100>, "target?=0",
+		       <&frag100>, "target-path";
 	};
 };
 

--- a/arch/arm/boot/dts/overlays/pca953x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pca953x-overlay.dts
@@ -5,7 +5,7 @@
 /{
 	compatible = "brcm,bcm2835";
 
-	fragment@0 {
+	frag0: fragment@0 {
 		target = <&i2c_arm>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -204,6 +204,20 @@
 		};
 	};
 
+	fragment@100 {
+		target = <&i2c0if>;
+		__dormant__ {
+			status = "okay";
+		};
+	};
+
+	fragment@101 {
+		target = <&i2c0mux>;
+		__dormant__ {
+			status = "okay";
+		};
+	};
+
 	__overrides__ {
 		addr = <&pca>,"reg:0";
 		pca6416 = <0>, "+1";
@@ -236,5 +250,19 @@
 		cat9554 = <0>, "+28";
 		pca9654 = <0>, "+29";
 		xra1202 = <0>, "+30";
+		i2c0 = <&frag0>, "target:0=",<&i2c0>,
+			      <0>,"+100+101";
+		i2c_csi_dsi = <&frag0>, "target:0=",<&i2c_csi_dsi>,
+			      <0>,"+100+101";
+		i2c3 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c3";
+		i2c4 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c4";
+		i2c5 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c5";
+		i2c6 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c6";
+		i2c-path = <&frag0>, "target?=0",
+			   <&frag0>, "target-path";
 	};
 };

--- a/arch/arm/boot/dts/overlays/pcf857x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pcf857x-overlay.dts
@@ -6,7 +6,7 @@
 / {
 	compatible = "brcm,bcm2835";
 
-	fragment@0 {
+	frag0: fragment@0 {
 		target = <&i2c_arm>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -22,11 +22,39 @@
 		};
 	};
 
+	fragment@100 {
+		target = <&i2c0if>;
+		__dormant__ {
+			status = "okay";
+		};
+	};
+
+	fragment@101 {
+		target = <&i2c0mux>;
+		__dormant__ {
+			status = "okay";
+		};
+	};
+
 	__overrides__ {
 		pcf8574  = <&pcf857x>,"compatible=nxp,pcf8574",  <&pcf857x>,"reg:0=0x20";
 		pcf8574a = <&pcf857x>,"compatible=nxp,pcf8574a", <&pcf857x>,"reg:0=0x38";
 		pcf8575  = <&pcf857x>,"compatible=nxp,pcf8575",  <&pcf857x>,"reg:0=0x20";
 		pca8574  = <&pcf857x>,"compatible=nxp,pca8574", <&pcf857x>,"reg:0=0x20";
 		addr = <&pcf857x>,"reg:0";
+		i2c0 = <&frag0>, "target:0=",<&i2c0>,
+			      <0>,"+100+101";
+		i2c_csi_dsi = <&frag0>, "target:0=",<&i2c_csi_dsi>,
+			      <0>,"+100+101";
+		i2c3 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c3";
+		i2c4 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c4";
+		i2c5 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c5";
+		i2c6 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c6";
+		i2c-path = <&frag0>, "target?=0",
+			   <&frag0>, "target-path";
 	};
 };

--- a/arch/arm/boot/dts/overlays/sc16is750-i2c-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is750-i2c-overlay.dts
@@ -4,7 +4,7 @@
 / {
 	compatible = "brcm,bcm2835";
 
-	fragment@0 {
+	frag0: fragment@0 {
 		target = <&i2c_arm>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -48,10 +48,38 @@
 		};
 	};
 
+	fragment@100 {
+		target = <&i2c0if>;
+		__dormant__ {
+			status = "okay";
+		};
+	};
+
+	fragment@101 {
+		target = <&i2c0mux>;
+		__dormant__ {
+			status = "okay";
+		};
+	};
+
 	__overrides__ {
 		int_pin = <&sc16is750>,"interrupts:0", <&int_pins>,"brcm,pins:0",
 			  <&int_pins>,"reg:0";
 		addr = <&sc16is750>,"reg:0", <&sc16is750_clk>,"name";
 		xtal = <&sc16is750_clk>,"clock-frequency:0";
+		i2c0 = <&frag0>, "target:0=",<&i2c0>,
+			      <0>,"+100+101";
+		i2c_csi_dsi = <&frag0>, "target:0=",<&i2c_csi_dsi>,
+			      <0>,"+100+101";
+		i2c3 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c3";
+		i2c4 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c4";
+		i2c5 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c5";
+		i2c6 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c6";
+		i2c-path = <&frag0>, "target?=0",
+			   <&frag0>, "target-path";
 	};
 };

--- a/arch/arm/boot/dts/overlays/sc16is752-i2c-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is752-i2c-overlay.dts
@@ -4,7 +4,7 @@
 / {
 	compatible = "brcm,bcm2835";
 
-	fragment@0 {
+	frag0: fragment@0 {
 		target = <&i2c_arm>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -48,10 +48,38 @@
 		};
 	};
 
+	fragment@100 {
+		target = <&i2c0if>;
+		__dormant__ {
+			status = "okay";
+		};
+	};
+
+	fragment@101 {
+		target = <&i2c0mux>;
+		__dormant__ {
+			status = "okay";
+		};
+	};
+
 	__overrides__ {
 		int_pin = <&sc16is752>,"interrupts:0", <&int_pins>,"brcm,pins:0",
 			  <&int_pins>,"reg:0";
 		addr = <&sc16is752>,"reg:0",<&sc16is752_clk>,"name";
 		xtal = <&sc16is752_clk>,"clock-frequency:0";
+		i2c0 = <&frag0>, "target:0=",<&i2c0>,
+			      <0>,"+100+101";
+		i2c_csi_dsi = <&frag0>, "target:0=",<&i2c_csi_dsi>,
+			      <0>,"+100+101";
+		i2c3 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c3";
+		i2c4 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c4";
+		i2c5 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c5";
+		i2c6 = <&frag0>, "target?=0",
+		       <&frag0>, "target-path=i2c6";
+		i2c-path = <&frag0>, "target?=0",
+			   <&frag0>, "target-path";
 	};
 };


### PR DESCRIPTION
To allow for attaching any of the standard overlays to a bitbashed i2c-gpio bus, allow specifying the target path for the overlay.

Suggested by:
https://forums.raspberrypi.com/viewtopic.php?t=381059 2 overlays implemented as examples, but could be applied to all.

Example:
```
dtoverlay=i2c-gpio,i2c_gpio_sda=10,i2c_gpio_scl=11
dtoverlay=mcp23017,i2c-path=/i2c@0
dtoverlay=i2c-gpio,i2c_gpio_sda=12,i2c_gpio_scl=13,bus=3
dtoverlay=mcp23017,i2c-path=/i2c@3
```