### PR TITLE
dtoverlays: Use continuous clock mode for ov9281

### DIFF
--- a/arch/arm/boot/dts/overlays/ov9281-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov9281-overlay.dts
@@ -29,7 +29,6 @@
 				csi_ep: endpoint {
 					remote-endpoint = <&cam_endpoint>;
 					data-lanes = <1 2>;
-					clock-noncontinuous;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/overlays/ov9281.dtsi
+++ b/arch/arm/boot/dts/overlays/ov9281.dtsi
@@ -19,7 +19,6 @@ cam_node: ov9281@60 {
 		cam_endpoint: endpoint {
 			clock-lanes = <0>;
 			data-lanes = <1 2>;
-			clock-noncontinuous;
 			link-frequencies =
 				/bits/ 64 <400000000>;
 		};


### PR DESCRIPTION
This increases the maximum frame rate from 247 to 260fps in 10-bit mode.