### PR TITLE
pcm3168a: driver workaround to support ezsound soundcard

### DIFF
--- a/Documentation/devicetree/bindings/sound/ti,pcm3168a.yaml
+++ b/Documentation/devicetree/bindings/sound/ti,pcm3168a.yaml
@@ -58,6 +58,14 @@ properties:
   VCCDA2-supply:
     description: DAC power supply regulator 2 (+5V)
 
+  adc-force-cons:
+    description: Force ADC to operate in consumer mode. Useful if ADC and DAC
+      clock pins are tied together with DAC as producer.
+
+  dac-force-cons:
+    description: Force DAC to operate in consumer mode. Useful if ADC and DAC
+      clock pins are tied together with ADC as producer.
+
   ports:
     $ref: audio-graph-port.yaml#/definitions/port-base
     unevaluatedProperties: false

--- a/sound/soc/codecs/pcm3168a.c
+++ b/sound/soc/codecs/pcm3168a.c
@@ -60,6 +60,7 @@ struct pcm3168a_priv {
 	struct clk *scki;
 	struct gpio_desc *gpio_rst;
 	unsigned long sysclk;
+	bool adc_fc, dac_fc; // Force clock consumer mode
 
 	struct pcm3168a_io_params io_params[2];
 	struct snd_soc_dai_driver dai_drv[2];
@@ -478,6 +479,12 @@ static int pcm3168a_hw_params(struct snd_pcm_substream *substream,
 		ms = 0;
 	}
 
+	// Force clock consumer mode if needed
+	if (pcm3168a->adc_fc && dai->id == PCM3168A_DAI_ADC)
+		ms = 0;
+	if (pcm3168a->dac_fc && dai->id == PCM3168A_DAI_DAC)
+		ms = 0;
+
 	format = io_params->format;
 
 	if (io_params->slot_width)
@@ -755,6 +762,11 @@ int pcm3168a_probe(struct device *dev, struct regmap *regmap)
 	}
 
 	pcm3168a->sysclk = clk_get_rate(pcm3168a->scki);
+
+	pcm3168a->adc_fc = of_property_read_bool(dev->of_node,
+		"adc-force-cons");
+	pcm3168a->dac_fc = of_property_read_bool(dev->of_node,
+		"dac-force-cons");
 
 	for (i = 0; i < ARRAY_SIZE(pcm3168a->supplies); i++)
 		pcm3168a->supplies[i].supply = pcm3168a_supply_names[i];


### PR DESCRIPTION
ASoC has a limitation preventing my new soundcard from working. Basically, it can't configure the codec driver correctly to use bidirectional I2S with an external crystal as the clock and a single set of clock lines for Rx & Tx (like the RPi has).
This workaround forces the driver to configure itself correctly and enables my new soundcard to work perfectly for 6.12 kernels. As the soundcard is only for RPi5, it doesn't make sense to do this upstream.

See https://forums.raspberrypi.com/viewtopic.php?t=380915 for links to the linux-sound mail threads discussing the SoC limitation. 

Merry Christmas!
