### PR TITLE
overlays: goodix: Allow override i2c address

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1439,7 +1439,8 @@ Name:   goodix
 Info:   Enables I2C connected Goodix gt9271 multiple touch controller using
         GPIOs 4 and 17 (pins 7 and 11 on GPIO header) for interrupt and reset.
 Load:   dtoverlay=goodix,<param>=<val>
-Params: interrupt               GPIO used for interrupt (default 4)
+Params: addr                    I2C address (default 0x14)
+        interrupt               GPIO used for interrupt (default 4)
         reset                   GPIO used for reset (default 17)
         i2c-path                Override I2C path to allow for i2c-gpio buses
 

--- a/arch/arm/boot/dts/overlays/goodix-overlay.dts
+++ b/arch/arm/boot/dts/overlays/goodix-overlay.dts
@@ -37,6 +37,7 @@
 	};
 
 	__overrides__ {
+		addr = <&gt9271>,"reg:0";
 		interrupt = <&goodix_pins>,"brcm,pins:0",
 			<&gt9271>,"interrupts:0",
 			<&gt9271>,"irq-gpios:4";


### PR DESCRIPTION
Some Goodix devices e.g. gt911 use address 0x5d instead of 0x14. So, make the address overridable.