### PR TITLE
overlays: Add and document i2c_csi_dsi0 parameters

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -301,10 +301,31 @@ Params:
         i2c_baudrate            An alias for i2c_arm_baudrate
 
         i2c_csi_dsi             Set to "on" to enable the i2c_csi_dsi interface
+                                The I2C bus and GPIOs are platform specific:
+                                  B rev 1:
+                                    i2c-1 on 2 & 3
+                                  B rev 2, B+, CM, Zero, Zero W, 2B, CM2, CM3,
+                                  CM4S:
+                                    i2c-0 on 28 & 29
+                                  3B, 3B+, Zero 2W, 4B, 400, CM4:
+                                    i2c-0 on 44 & 45
+                                  5, 500:
+                                    i2c-11/i2c-4 on 40 & 41
+                                  CM5 on CM5IO:
+                                    i2c-0 on 0 & 1
+                                  CM5 on CM4IO:
+                                    i2c-10/i2c-6 on 38 & 39
 
         i2c_csi_dsi0            Set to "on" to enable the i2c_csi_dsi0 interface
+                                The I2C bus and GPIOs are platform specific:
+                                  B rev 1 & 2, B+, CM, Zero, Zero W, 2B, CM2,
+                                  CM3, CM4S, 3B, 3B+, Zero 2W, 4B, 400, CM4,
+                                  CM5 on CM4IO:
+                                    i2c-0 on 0 & 1
+                                  5, 500, CM5 on CM5IO:
+                                    i2c-10/i2c-6 on 38 & 39
 
-        i2c_csi_dsi1            Set to "on" to enable the i2c_csi_dsi1 interface
+        i2c_csi_dsi1            A Pi 5 family-specific alias for i2c_csi_dsi.
 
         i2c_vc                  Set to "on" to enable the i2c interface
                                 usually reserved for the VideoCore processor
@@ -546,7 +567,12 @@ Params: addr                    I2C bus address of device. Set based on how the
                                 Amplifier for this channel. (Default 1 sets the
                                 full scale of the channel to 4.096 Volts)
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
-        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c_csi_dsi             Choose the I2C bus connected to the main
+                                camera/display connector.
+                                See "dtparam -h i2c_csi_dsi" for details.
+        i2c_csi_dsi0            Choose the I2C bus connected to the second
+                                camera/display connector, if present.
+                                See "dtparam -h i2c_csi_dsi0" for details.
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
         i2c4                    Choose the I2C4 bus (configure with the i2c4
@@ -2086,7 +2112,13 @@ Params: addr                    Sets the address for the fan controller. Note
 
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
 
-        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c_csi_dsi             Choose the I2C bus connected to the main
+                                camera/display connector.
+                                See "dtparam -h i2c_csi_dsi" for details.
+
+        i2c_csi_dsi0            Choose the I2C bus connected to the second
+                                camera/display connector, if present.
+                                See "dtparam -h i2c_csi_dsi0" for details.
 
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
@@ -2158,7 +2190,13 @@ Params: pca9542                 Select the NXP PCA9542 device
 
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
 
-        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c_csi_dsi             Choose the I2C bus connected to the main
+                                camera/display connector.
+                                See "dtparam -h i2c_csi_dsi" for details.
+
+        i2c_csi_dsi0            Choose the I2C bus connected to the second
+                                camera/display connector, if present.
+                                See "dtparam -h i2c_csi_dsi0" for details.
 
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
@@ -2186,7 +2224,12 @@ Info:   Adds support for an NXP PCA9685A I2C PWM controller on i2c_arm
 Load:   dtoverlay=i2c-pwm-pca9685a,<param>=<val>
 Params: addr                    I2C address of PCA9685A (default 0x40)
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
-        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c_csi_dsi             Choose the I2C bus connected to the main
+                                camera/display connector.
+                                See "dtparam -h i2c_csi_dsi" for details.
+        i2c_csi_dsi0            Choose the I2C bus connected to the second
+                                camera/display connector, if present.
+                                See "dtparam -h i2c_csi_dsi0" for details.
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
         i2c4                    Choose the I2C3 bus (configure with the i2c3
@@ -2251,7 +2294,13 @@ Params: abx80x                  Select one of the ABx80x family:
 
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
 
-        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c_csi_dsi             Choose the I2C bus connected to the main
+                                camera/display connector.
+                                See "dtparam -h i2c_csi_dsi" for details.
+
+        i2c_csi_dsi0            Choose the I2C bus connected to the second
+                                camera/display connector, if present.
+                                See "dtparam -h i2c_csi_dsi0" for details.
 
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
@@ -2517,7 +2566,12 @@ Params: addr                    Set the address for the ADT7410, BH1750, BME280,
 
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
 
-        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c_csi_dsi             Choose the I2C bus connected to the main
+                                camera/display connector.
+                                See "dtparam -h i2c_csi_dsi" for details.
+        i2c_csi_dsi0            Choose the I2C bus connected to the second
+                                camera/display connector, if present.
+                                See "dtparam -h i2c_csi_dsi0" for details.
 
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
@@ -3144,7 +3198,12 @@ Params: gpiopin                 Gpio pin connected to the INTA output of the
         mcp23008                Configure an MCP23008 instead.
         noints                  Disable the interrupt GPIO line.
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
-        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c_csi_dsi             Choose the I2C bus connected to the main
+                                camera/display connector.
+                                See "dtparam -h i2c_csi_dsi" for details.
+        i2c_csi_dsi0            Choose the I2C bus connected to the second
+                                camera/display connector, if present.
+                                See "dtparam -h i2c_csi_dsi0" for details.
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
         i2c4                    Choose the I2C4 bus (configure with the i2c4
@@ -3604,7 +3663,12 @@ Params: addr                    I2C address of expander. Default 0x20.
         pca9654                 Select the Onnn PCA9654 (8 bit)
         xra1202                 Select the Exar XRA1202 (8 bit)
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
-        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c_csi_dsi             Choose the I2C bus connected to the main
+                                camera/display connector.
+                                See "dtparam -h i2c_csi_dsi" for details.
+        i2c_csi_dsi0            Choose the I2C bus connected to the second
+                                camera/display connector, if present.
+                                See "dtparam -h i2c_csi_dsi0" for details.
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
         i2c4                    Choose the I2C3 bus (configure with the i2c3
@@ -3626,7 +3690,12 @@ Params: addr                    I2C address of expander. Default
         pcf8575                 Select the NXP PCF8575 (16 bit)
         pca8574                 Select the NXP PCA8574 (8 bit)
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
-        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c_csi_dsi             Choose the I2C bus connected to the main
+                                camera/display connector.
+                                See "dtparam -h i2c_csi_dsi" for details.
+        i2c_csi_dsi0            Choose the I2C bus connected to the second
+                                camera/display connector, if present.
+                                See "dtparam -h i2c_csi_dsi0" for details.
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
         i2c4                    Choose the I2C3 bus (configure with the i2c3
@@ -4296,7 +4365,12 @@ Params: int_pin                 GPIO used for IRQ (default 24)
         addr                    Address (default 0x48)
         xtal                    On-board crystal frequency (default 14745600)
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
-        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c_csi_dsi             Choose the I2C bus connected to the main
+                                camera/display connector.
+                                See "dtparam -h i2c_csi_dsi" for details.
+        i2c_csi_dsi0            Choose the I2C bus connected to the second
+                                camera/display connector, if present.
+                                See "dtparam -h i2c_csi_dsi0" for details.
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
         i2c4                    Choose the I2C4 bus (configure with the i2c4
@@ -4325,7 +4399,12 @@ Params: int_pin                 GPIO used for IRQ (default 24)
         addr                    Address (default 0x48)
         xtal                    On-board crystal frequency (default 14745600)
         i2c0                    Choose the I2C0 bus on GPIOs 0&1
-        i2c_csi_dsi             Choose the I2C0 bus on GPIOs 44&45
+        i2c_csi_dsi             Choose the I2C bus connected to the main
+                                camera/display connector.
+                                See "dtparam -h i2c_csi_dsi" for details.
+        i2c_csi_dsi0            Choose the I2C bus connected to the second
+                                camera/display connector, if present.
+                                See "dtparam -h i2c_csi_dsi0" for details.
         i2c3                    Choose the I2C3 bus (configure with the i2c3
                                 overlay - BCM2711 only)
         i2c4                    Choose the I2C4 bus (configure with the i2c4

--- a/arch/arm/boot/dts/overlays/ads1115-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ads1115-overlay.dts
@@ -123,6 +123,8 @@
 		i2c0 = <&frag100>, "target:0=",<&i2c0>;
 		i2c_csi_dsi = <&frag100>, "target:0=",<&i2c_csi_dsi>,
 			      <0>,"+101+102";
+		i2c_csi_dsi0 = <&frag100>, "target:0=",<&i2c_csi_dsi0>,
+			      <0>,"+101+102";
 		i2c3 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c3";
 		i2c4 = <&frag100>, "target?=0",

--- a/arch/arm/boot/dts/overlays/i2c-fan-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-fan-overlay.dts
@@ -85,6 +85,8 @@
 		i2c0 =		<&frag100>,"target:0=",<&i2c0>;
 		i2c_csi_dsi =	<&frag100>,"target:0=",<&i2c_csi_dsi>,
 				<0>,"+101+102";
+		i2c_csi_dsi0 = <&frag100>, "target:0=",<&i2c_csi_dsi0>,
+			      <0>,"+101+102";
 		i2c3 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c3";
 		i2c4 = <&frag100>, "target?=0",

--- a/arch/arm/boot/dts/overlays/i2c-mux-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-mux-overlay.dts
@@ -167,6 +167,8 @@
 			      <0>,"+101+102";
 		i2c_csi_dsi = <&frag100>, "target:0=",<&i2c_csi_dsi>,
 			      <0>,"+101+102";
+		i2c_csi_dsi0 = <&frag100>, "target:0=",<&i2c_csi_dsi0>,
+			      <0>,"+101+102";
 		i2c3 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c3";
 		i2c4 = <&frag100>, "target?=0",

--- a/arch/arm/boot/dts/overlays/i2c-pwm-pca9685a-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-pwm-pca9685a-overlay.dts
@@ -49,6 +49,8 @@
 			      <0>,"+101+102";
 		i2c_csi_dsi = <&frag100>, "target:0=",<&i2c_csi_dsi>,
 			      <0>,"+101+102";
+		i2c_csi_dsi0 = <&frag100>, "target:0=",<&i2c_csi_dsi0>,
+			      <0>,"+101+102";
 		i2c3 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c3";
 		i2c4 = <&frag100>, "target?=0",

--- a/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-rtc-overlay.dts
@@ -30,6 +30,8 @@
 		i2c0 = <&frag100>, "target:0=",<&i2c0>;
 		i2c_csi_dsi = <&frag100>, "target:0=",<&i2c_csi_dsi>,
 			      <0>,"+101+102";
+		i2c_csi_dsi0 = <&frag100>, "target:0=",<&i2c_csi_dsi0>,
+			      <0>,"+101+102";
 		i2c3 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c3";
 		i2c4 = <&frag100>, "target?=0",

--- a/arch/arm/boot/dts/overlays/i2c-sensor-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-overlay.dts
@@ -30,6 +30,8 @@
 		i2c0 = <&frag100>, "target:0=",<&i2c0>;
 		i2c_csi_dsi = <&frag100>, "target:0=",<&i2c_csi_dsi>,
 			      <0>,"+101+102";
+		i2c_csi_dsi0 = <&frag100>, "target:0=",<&i2c_csi_dsi0>,
+			      <0>,"+101+102";
 		i2c3 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c3";
 		i2c4 = <&frag100>, "target?=0",

--- a/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp23017-overlay.dts
@@ -90,6 +90,8 @@
 		i2c0 = <&frag100>, "target:0=",<&i2c0>;
 		i2c_csi_dsi = <&frag100>, "target:0=",<&i2c_csi_dsi>,
 			      <0>,"+101+102";
+		i2c_csi_dsi0 = <&frag100>, "target:0=",<&i2c_csi_dsi0>,
+			      <0>,"+101+102";
 		i2c3 = <&frag100>, "target?=0",
 		       <&frag100>, "target-path=i2c3";
 		i2c4 = <&frag100>, "target?=0",

--- a/arch/arm/boot/dts/overlays/pca953x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pca953x-overlay.dts
@@ -254,6 +254,8 @@
 			      <0>,"+100+101";
 		i2c_csi_dsi = <&frag0>, "target:0=",<&i2c_csi_dsi>,
 			      <0>,"+100+101";
+		i2c_csi_dsi0 = <&frag0>, "target:0=",<&i2c_csi_dsi0>,
+			      <0>,"+100+101";
 		i2c3 = <&frag0>, "target?=0",
 		       <&frag0>, "target-path=i2c3";
 		i2c4 = <&frag0>, "target?=0",

--- a/arch/arm/boot/dts/overlays/pcf857x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pcf857x-overlay.dts
@@ -46,6 +46,8 @@
 			      <0>,"+100+101";
 		i2c_csi_dsi = <&frag0>, "target:0=",<&i2c_csi_dsi>,
 			      <0>,"+100+101";
+		i2c_csi_dsi0 = <&frag0>, "target:0=",<&i2c_csi_dsi0>,
+			      <0>,"+100+101";
 		i2c3 = <&frag0>, "target?=0",
 		       <&frag0>, "target-path=i2c3";
 		i2c4 = <&frag0>, "target?=0",

--- a/arch/arm/boot/dts/overlays/sc16is750-i2c-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is750-i2c-overlay.dts
@@ -71,6 +71,8 @@
 			      <0>,"+100+101";
 		i2c_csi_dsi = <&frag0>, "target:0=",<&i2c_csi_dsi>,
 			      <0>,"+100+101";
+		i2c_csi_dsi0 = <&frag0>, "target:0=",<&i2c_csi_dsi0>,
+			      <0>,"+100+101";
 		i2c3 = <&frag0>, "target?=0",
 		       <&frag0>, "target-path=i2c3";
 		i2c4 = <&frag0>, "target?=0",

--- a/arch/arm/boot/dts/overlays/sc16is752-i2c-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is752-i2c-overlay.dts
@@ -71,6 +71,8 @@
 			      <0>,"+100+101";
 		i2c_csi_dsi = <&frag0>, "target:0=",<&i2c_csi_dsi>,
 			      <0>,"+100+101";
+		i2c_csi_dsi0 = <&frag0>, "target:0=",<&i2c_csi_dsi0>,
+			      <0>,"+100+101";
 		i2c3 = <&frag0>, "target?=0",
 		       <&frag0>, "target-path=i2c3";
 		i2c4 = <&frag0>, "target?=0",


### PR DESCRIPTION
Add "i2c_csi_dsi0" parameters to overlays that already have an "i2c_csi_dsi" parameter.

The I2C bus and GPIO mapping of i2c_csi_dsi and i2c_csi_dsi0 varies between platforms. Document the associations against the dtparams "i2c_csi_dsi" and "i2c_csi_dsi0" - run "dtparam -h i2c_csi_dsi" and "dtparam -h i2c_csi_dsi0" to read it.