### PR TITLE
dts: Add noanthogs parameter to CM4 and CM5

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts
@@ -493,6 +493,8 @@ i2c_csi_dsi0: &i2c0 {
 			<&ant1>, "output-low?=on",
 			<&ant2>, "output-high?=off",
 			<&ant2>, "output-low?=on";
+		noanthogs = <&ant1>,"status=disabled",
+			<&ant2>, "status=disabled";
 
 		pcie_tperst_clk_ms = <&pcie0>,"brcm,tperst-clk-ms:0";
 	};

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -153,6 +153,12 @@ Params:
 
         noant                   Disable both antennas. CM4/5 only.
 
+        noanthogs               Disable the GPIO hogs on the antenna controls
+                                so they can be controlled at runtime. Note that
+                                using this parameter without suitable OS
+                                support will result in attenuated WiFi and
+                                Bluetooth signals. CM4/5 only.
+
         audio                   Set to "on" to enable the onboard ALSA audio
                                 interface (default "off")
 

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -750,5 +750,7 @@ spi10_cs_pins: &spi10_cs_gpio1 {};
 			<&ant1>, "output-low?=on",
 			<&ant2>, "output-high?=off",
 			<&ant2>, "output-low?=on";
+		noanthogs = <&ant1>,"status=disabled",
+			<&ant2>, "status=disabled";
 	};
 };


### PR DESCRIPTION
By default, the antenna selection on CM4 and CM5 is fixed at boot time, with the dtparams ant1, ant2 and noant selecting which should be enabled. Add a new dtparam - noanthogs - which leaves the GPIOs free to be controlled at runtime by the OS.

N.B. Using this parameter without suitable OS support will leave both antennae disabled, resulting in attenuated WiFi and Bluetooth signals.