### PR TITLE
IMX219: Add 4-lane option to the device tree overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2752,6 +2752,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
         cam0                    Adopt the default configuration for CAM0 on a
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
         vcm                     Configure a VCM focus drive on the sensor.
+        4lane                   Enable 4 CSI2 lanes. This requires a Compute
+                                Module (1, 3, 4, or 5) or Pi 5.
 
 
 Name:   imx258

--- a/arch/arm/boot/dts/overlays/imx219-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx219-overlay.dts
@@ -65,6 +65,22 @@
 		};
 	};
 
+	fragment@201 {
+		target = <&csi_ep>;
+		__dormant__ {
+        	data-lanes = <1 2 3 4>;
+    	};
+	};
+
+	fragment@202 {
+    	target = <&cam_endpoint>;
+    	__dormant__ {
+			data-lanes = <1 2 3 4>;
+        	link-frequencies =
+            		/bits/ 64 <363000000>;
+		};
+	};
+
 	__overrides__ {
 		rotation = <&cam_node>,"rotation:0";
 		orientation = <&cam_node>,"orientation:0";
@@ -77,6 +93,7 @@
 		       <&vcm>, "VANA-supply:0=", <&cam0_reg>;
 		vcm = <&vcm>, "status=okay",
 		      <&cam_node>,"lens-focus:0=", <&vcm>;
+		4lane = <0>, "+201+202";
 	};
 };
 


### PR DESCRIPTION
IMX219: Add 4-lane option to the deivce tree overlay