### PR TITLE
IMX500: Add support for rotation and image flip

### DIFF
--- a/drivers/media/i2c/imx500.c
+++ b/drivers/media/i2c/imx500.c
@@ -217,6 +217,9 @@
 /* Rotate angle */
 #define IMX500_REG_ADDR_ROTATION CCI_REG8(0xD680)
 
+/* Flip vertical/horizontal */
+#define IMX500_REG_ADDR_IMG_ORIENTATION CCI_REG8(0x0101)
+
 /* Embedded sizes */
 #define IMX500_MAX_EMBEDDED_SIZE \
 	(2 * ((((IMX500_PIXEL_ARRAY_WIDTH * 10) >> 3) + 15) & ~15))
@@ -239,6 +242,7 @@ enum pad_types { IMAGE_PAD, METADATA_PAD, NUM_PADS };
 #define V4L2_CID_USER_IMX500_INFERENCE_WINDOW (V4L2_CID_USER_IMX500_BASE + 0)
 #define V4L2_CID_USER_IMX500_NETWORK_FW_FD (V4L2_CID_USER_IMX500_BASE + 1)
 #define V4L2_CID_USER_IMX500_ROTATION (V4L2_CID_USER_IMX500_BASE + 2)
+#define V4L2_CID_USER_IMX500_IMG_FLIP (V4L2_CID_USER_IMX500_BASE + 3)
 
 #define ONE_MIB (1024 * 1024)
 
@@ -1981,6 +1985,9 @@ static int imx500_set_ctrl(struct v4l2_ctrl *ctrl)
 	case V4L2_CID_USER_IMX500_ROTATION:
 		ret = cci_write(imx500->regmap, IMX500_REG_ADDR_ROTATION, ctrl->val, NULL);
 		break;
+	case V4L2_CID_USER_IMX500_IMG_FLIP:
+		ret = cci_write(imx500->regmap, IMX500_REG_ADDR_IMG_ORIENTATION, ctrl->val, NULL);
+		break;
 	default:
 		dev_info(&client->dev,
 			 "ctrl(id:0x%x,val:0x%x) is not handled\n", ctrl->id,
@@ -2848,6 +2855,19 @@ static const struct v4l2_ctrl_config rotation_angle = {
 	.def		= 0,
 };
 
+/* Custom control for image flip */
+static const struct v4l2_ctrl_config img_flip = {
+	.name		= "IMX500 Image Flip",
+	.id		= V4L2_CID_USER_IMX500_IMG_FLIP,
+	.ops		= &imx500_ctrl_ops,
+	.type		= V4L2_CTRL_TYPE_INTEGER,
+	.flags		= V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+	.min		= 0,
+	.max		= 3,
+	.step		= 1,
+	.def		= 0,
+};
+
 /* Initialize control handlers */
 static int imx500_init_controls(struct imx500 *imx500)
 {
@@ -2912,6 +2932,7 @@ static int imx500_init_controls(struct imx500 *imx500)
 	imx500->network_fw_ctrl =
 		v4l2_ctrl_new_custom(ctrl_hdlr, &network_fw_fd, NULL);
 	v4l2_ctrl_new_custom(ctrl_hdlr, &rotation_angle, NULL);
+	v4l2_ctrl_new_custom(ctrl_hdlr, &img_flip, NULL);
 
 	if (ctrl_hdlr->error) {
 		ret = ctrl_hdlr->error;

--- a/drivers/media/i2c/imx500.c
+++ b/drivers/media/i2c/imx500.c
@@ -214,6 +214,9 @@
 #define IMX500_COLOUR_BALANCE_STEP 0x0001
 #define IMX500_COLOUR_BALANCE_DEFAULT 0x0100
 
+/* Rotate angle */
+#define IMX500_REG_ADDR_ROTATION CCI_REG8(0xD680)
+
 /* Embedded sizes */
 #define IMX500_MAX_EMBEDDED_SIZE \
 	(2 * ((((IMX500_PIXEL_ARRAY_WIDTH * 10) >> 3) + 15) & ~15))
@@ -235,6 +238,7 @@ enum pad_types { IMAGE_PAD, METADATA_PAD, NUM_PADS };
 
 #define V4L2_CID_USER_IMX500_INFERENCE_WINDOW (V4L2_CID_USER_IMX500_BASE + 0)
 #define V4L2_CID_USER_IMX500_NETWORK_FW_FD (V4L2_CID_USER_IMX500_BASE + 1)
+#define V4L2_CID_USER_IMX500_ROTATION (V4L2_CID_USER_IMX500_BASE + 2)
 
 #define ONE_MIB (1024 * 1024)
 
@@ -1974,6 +1978,9 @@ static int imx500_set_ctrl(struct v4l2_ctrl *ctrl)
 		       sizeof(struct v4l2_rect));
 		ret = imx500_set_inference_window(imx500);
 		break;
+	case V4L2_CID_USER_IMX500_ROTATION:
+		ret = cci_write(imx500->regmap, IMX500_REG_ADDR_ROTATION, ctrl->val, NULL);
+		break;
 	default:
 		dev_info(&client->dev,
 			 "ctrl(id:0x%x,val:0x%x) is not handled\n", ctrl->id,
@@ -2828,6 +2835,19 @@ static const struct v4l2_ctrl_config network_fw_fd = {
 	.def		= -1,
 };
 
+/* Custom control for rotation angle */
+static const struct v4l2_ctrl_config rotation_angle = {
+	.name		= "IMX500 Rotation Angle",
+	.id		= V4L2_CID_USER_IMX500_ROTATION,
+	.ops		= &imx500_ctrl_ops,
+	.type		= V4L2_CTRL_TYPE_INTEGER,
+	.flags		= V4L2_CTRL_FLAG_EXECUTE_ON_WRITE,
+	.min		= 0,
+	.max		= 3,
+	.step		= 1,
+	.def		= 0,
+};
+
 /* Initialize control handlers */
 static int imx500_init_controls(struct imx500 *imx500)
 {
@@ -2891,6 +2911,7 @@ static int imx500_init_controls(struct imx500 *imx500)
 	v4l2_ctrl_new_custom(ctrl_hdlr, &inf_window_ctrl, NULL);
 	imx500->network_fw_ctrl =
 		v4l2_ctrl_new_custom(ctrl_hdlr, &network_fw_fd, NULL);
+	v4l2_ctrl_new_custom(ctrl_hdlr, &rotation_angle, NULL);
 
 	if (ctrl_hdlr->error) {
 		ret = ctrl_hdlr->error;


### PR DESCRIPTION
This PR adds support for rotation and image flip functionality for the IMX500.

### Rotation Support
- 0: 0 degrees
- 1: 90 degrees
- 2: 180 degrees
- 3: 270 degrees

### Image Flip Support
- 0: No flip
- 1: Flip horizontal
- 2: Flip vertical
- 3: Flip horizontal and vertical