### PR TITLE
BCM2711, BCM2712 and RP1 UARTs are r1p5

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2711.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2711.dtsi
@@ -134,7 +134,7 @@
 			clocks = <&clocks BCM2835_CLOCK_UART>,
 				 <&clocks BCM2835_CLOCK_VPU>;
 			clock-names = "uartclk", "apb_pclk";
-			arm,primecell-periphid = <0x00241011>;
+			arm,primecell-periphid = <0x00341011>;
 			status = "disabled";
 		};
 
@@ -145,7 +145,7 @@
 			clocks = <&clocks BCM2835_CLOCK_UART>,
 				 <&clocks BCM2835_CLOCK_VPU>;
 			clock-names = "uartclk", "apb_pclk";
-			arm,primecell-periphid = <0x00241011>;
+			arm,primecell-periphid = <0x00341011>;
 			status = "disabled";
 		};
 
@@ -156,7 +156,7 @@
 			clocks = <&clocks BCM2835_CLOCK_UART>,
 				 <&clocks BCM2835_CLOCK_VPU>;
 			clock-names = "uartclk", "apb_pclk";
-			arm,primecell-periphid = <0x00241011>;
+			arm,primecell-periphid = <0x00341011>;
 			status = "disabled";
 		};
 
@@ -167,7 +167,7 @@
 			clocks = <&clocks BCM2835_CLOCK_UART>,
 				 <&clocks BCM2835_CLOCK_VPU>;
 			clock-names = "uartclk", "apb_pclk";
-			arm,primecell-periphid = <0x00241011>;
+			arm,primecell-periphid = <0x00341011>;
 			status = "disabled";
 		};
 
@@ -1155,6 +1155,7 @@
 };
 
 &uart0 {
+	arm,primecell-periphid = <0x00341011>;
 	interrupts = <GIC_SPI 121 IRQ_TYPE_LEVEL_HIGH>;
 };
 

--- a/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
@@ -190,7 +190,7 @@
 			clocks = <&clk_uart>,
 				 <&clk_vpu>;
 			clock-names = "uartclk", "apb_pclk";
-			arm,primecell-periphid = <0x00241011>;
+			arm,primecell-periphid = <0x00341011>;
 			status = "disabled";
 		};
 
@@ -201,7 +201,7 @@
 			clocks = <&clk_uart>,
 				 <&clk_vpu>;
 			clock-names = "uartclk", "apb_pclk";
-			arm,primecell-periphid = <0x00241011>;
+			arm,primecell-periphid = <0x00341011>;
 			status = "disabled";
 		};
 
@@ -212,7 +212,7 @@
 			clocks = <&clk_uart>,
 				 <&clk_vpu>;
 			clock-names = "uartclk", "apb_pclk";
-			arm,primecell-periphid = <0x00241011>;
+			arm,primecell-periphid = <0x00341011>;
 			status = "disabled";
 		};
 

--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
@@ -69,7 +69,7 @@
 			       <&rp1_dma RP1_DMA_UART0_RX>;
 			dma-names = "tx", "rx";
 			pinctrl-names = "default";
-			arm,primecell-periphid = <0x00541011>;
+			arm,primecell-periphid = <0x00341011>;
 			uart-has-rtscts;
 			cts-event-workaround;
 			skip-init;
@@ -86,7 +86,7 @@
 			//        <&rp1_dma RP1_DMA_UART1_RX>;
 			// dma-names = "tx", "rx";
 			pinctrl-names = "default";
-			arm,primecell-periphid = <0x00541011>;
+			arm,primecell-periphid = <0x00341011>;
 			uart-has-rtscts;
 			cts-event-workaround;
 			skip-init;
@@ -103,7 +103,7 @@
 			//        <&rp1_dma RP1_DMA_UART2_RX>;
 			// dma-names = "tx", "rx";
 			pinctrl-names = "default";
-			arm,primecell-periphid = <0x00541011>;
+			arm,primecell-periphid = <0x00341011>;
 			uart-has-rtscts;
 			cts-event-workaround;
 			skip-init;
@@ -120,7 +120,7 @@
 			//        <&rp1_dma RP1_DMA_UART3_RX>;
 			// dma-names = "tx", "rx";
 			pinctrl-names = "default";
-			arm,primecell-periphid = <0x00541011>;
+			arm,primecell-periphid = <0x00341011>;
 			uart-has-rtscts;
 			cts-event-workaround;
 			skip-init;
@@ -137,7 +137,7 @@
 			//        <&rp1_dma RP1_DMA_UART4_RX>;
 			// dma-names = "tx", "rx";
 			pinctrl-names = "default";
-			arm,primecell-periphid = <0x00541011>;
+			arm,primecell-periphid = <0x00341011>;
 			uart-has-rtscts;
 			cts-event-workaround;
 			skip-init;
@@ -154,7 +154,7 @@
 			//        <&rp1_dma RP1_DMA_UART5_RX>;
 			// dma-names = "tx", "rx";
 			pinctrl-names = "default";
-			arm,primecell-periphid = <0x00541011>;
+			arm,primecell-periphid = <0x00341011>;
 			uart-has-rtscts;
 			cts-event-workaround;
 			skip-init;


### PR DESCRIPTION
The r1p5 revision of the PL011 increases the FIFO sizes to 32 entries. Declare BCM2711, BCM2712 and RP1 appropriately.