### PR TITLE
dts: bcm2711: Don't mark timer regs unconfigured

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2711.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2711.dtsi
@@ -451,8 +451,6 @@
 					  IRQ_TYPE_LEVEL_LOW)>,
 			     <GIC_PPI 10 (GIC_CPU_MASK_SIMPLE(4) |
 					  IRQ_TYPE_LEVEL_LOW)>;
-		/* This only applies to the ARMv7 stub */
-		arm,cpu-registers-not-fw-configured;
 	};
 
 	cpus: cpus {

--- a/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
@@ -741,8 +741,6 @@
 					  IRQ_TYPE_LEVEL_LOW)>,
 			     <GIC_PPI 10 (GIC_CPU_MASK_SIMPLE(4) |
 					  IRQ_TYPE_LEVEL_LOW)>;
-		/* This only applies to the ARMv7 stub */
-		arm,cpu-registers-not-fw-configured;
 	};
 
 	cpus: cpus {


### PR DESCRIPTION
The DT property arm,cpu-registers-not-fw-configured tells the kernel that the ARM architectural timer has not been configured by the firmware. This prevents the use of a vDSO - a faster alternative to a syscall for some common kernel operations.

However, on Pi 4 the firmware does configure the timer, so this property is unnecessary. Delete it.

Also remove it from the bcm2712.dtsi where it should never have been, since it is only relevant to 32-bit ARM kernels.