### PR TITLE
mmc: bcm2835-sdhost Observe SWIOTLB memory limit

### DIFF
--- a/drivers/mmc/host/bcm2835-sdhost.c
+++ b/drivers/mmc/host/bcm2835-sdhost.c
@@ -1971,7 +1971,7 @@ int bcm2835_sdhost_add_host(struct platform_device *pdev)
 	}
 
 	mmc->max_segs = 128;
-	mmc->max_req_size = 524288;
+	mmc->max_req_size = min_t(size_t, 524288, dma_max_mapping_size(&pdev->dev));
 	mmc->max_seg_size = mmc->max_req_size;
 	mmc->max_blk_size = 512;
 	mmc->max_blk_count =  65535;


### PR DESCRIPTION
Make sure the sdhost driver doesn't use requests bigger than SWIOTLB can handle.

Copied from [1].

Link: https://github.com/raspberrypi/linux/issues/6589
Signed-off-by: Phil Elwell <phil@raspberrypi.com>
[1] d4dd9bccf485 ("mmc: bcm2835: Take SWIOTLB memory size limitation into account")