### PR TITLE
bcm2708_fb: Explicitly initialise the IOMEM ops

### DIFF
--- a/drivers/video/fbdev/Kconfig
+++ b/drivers/video/fbdev/Kconfig
@@ -65,9 +65,7 @@ config FB_BCM2708
 	tristate "BCM2708 framebuffer support"
 	depends on FB && RASPBERRYPI_FIRMWARE
 	select FB_DEVICE
-	select FB_CFB_FILLRECT
-	select FB_CFB_COPYAREA
-	select FB_CFB_IMAGEBLIT
+	select FB_IOMEM_HELPERS
 	help
 	  This framebuffer device driver is for the BCM2708 framebuffer.
 

--- a/drivers/video/fbdev/bcm2708_fb.c
+++ b/drivers/video/fbdev/bcm2708_fb.c
@@ -790,12 +790,6 @@ static int bcm2708_compat_ioctl(struct fb_info *info, unsigned int cmd,
 }
 #endif
 
-static void bcm2708_fb_fillrect(struct fb_info *info,
-				const struct fb_fillrect *rect)
-{
-	cfb_fillrect(info, rect);
-}
-
 /* A helper function for configuring dma control block */
 static void set_dma_cb(struct bcm2708_dma_cb *cb,
 		int        burst_size,
@@ -947,12 +941,6 @@ static void bcm2708_fb_copyarea(struct fb_info *info,
 	mutex_unlock(&fbdev->dma_mutex);
 }
 
-static void bcm2708_fb_imageblit(struct fb_info *info,
-				 const struct fb_image *image)
-{
-	cfb_imageblit(info, image);
-}
-
 static irqreturn_t bcm2708_fb_dma_irq(int irq, void *cxt)
 {
 	struct bcm2708_fb_dev *fbdev = cxt;
@@ -973,18 +961,20 @@ static irqreturn_t bcm2708_fb_dma_irq(int irq, void *cxt)
 
 static struct fb_ops bcm2708_fb_ops = {
 	.owner = THIS_MODULE,
+	__FB_DEFAULT_IOMEM_OPS_RDWR,
 	.fb_check_var = bcm2708_fb_check_var,
 	.fb_set_par = bcm2708_fb_set_par,
 	.fb_setcolreg = bcm2708_fb_setcolreg,
 	.fb_blank = bcm2708_fb_blank,
-	.fb_fillrect = bcm2708_fb_fillrect,
+	.fb_fillrect = cfb_fillrect,
 	.fb_copyarea = bcm2708_fb_copyarea,
-	.fb_imageblit = bcm2708_fb_imageblit,
+	.fb_imageblit = cfb_imageblit,
 	.fb_pan_display = bcm2708_fb_pan_display,
 	.fb_ioctl = bcm2708_ioctl,
 #ifdef CONFIG_COMPAT
 	.fb_compat_ioctl = bcm2708_compat_ioctl,
 #endif
+	__FB_DEFAULT_IOMEM_OPS_MMAP,
 };
 
 static int bcm2708_fb_register(struct bcm2708_fb *fb)


### PR DESCRIPTION
Prior to [1], an fb_ops member of 0 was intepreted as a request for a default value. This saves source code but requires special handling by the framework, slowing down all accesses for no runtime benefit.

Use the new `__FB_DEFAULT_` macros to explicitly select default handlers in the bcm2708_fb driver. Also remove the pointless wrappers around cfb_fillrect and cfn_imageblit - call them directly.

Link: https://forums.raspberrypi.com/viewtopic.php?p=2286016#p2286016
Signed-off-by: Phil Elwell <phil@raspberrypi.com>
[1] 8813e86f6d82 ("fbdev: Remove default file-I/O implementations")