### PR TITLE
imx219 support for 4 CSI2 data lanes

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2795,6 +2795,8 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
         cam0                    Adopt the default configuration for CAM0 on a
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
         vcm                     Configure a VCM focus drive on the sensor.
+        4lane                   Enable 4 CSI2 lanes. This requires a Compute
+                                Module (1, 3, 4, or 5) or Pi 5.
 
 
 Name:   imx258

--- a/arch/arm/boot/dts/overlays/imx219-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx219-overlay.dts
@@ -71,6 +71,22 @@
 		};
 	};
 
+	fragment@201 {
+		target = <&csi_ep>;
+		__dormant__ {
+			data-lanes = <1 2 3 4>;
+		};
+	};
+
+	fragment@202 {
+		target = <&cam_endpoint>;
+		__dormant__ {
+			data-lanes = <1 2 3 4>;
+			link-frequencies =
+					/bits/ 64 <363000000>;
+		};
+	};
+
 	__overrides__ {
 		rotation = <&cam_node>,"rotation:0";
 		orientation = <&cam_node>,"orientation:0";
@@ -83,6 +99,7 @@
 		       <&vcm>, "VANA-supply:0=", <&cam0_reg>;
 		vcm = <&vcm>, "status=okay",
 		      <&cam_node>,"lens-focus:0=", <&vcm>;
+		4lane = <0>, "+201+202";
 	};
 };
 


### PR DESCRIPTION
rpi-6.12.y version of #6580 and #6575

I happened to be on a 6.12 branch, and want to upstream this, hence targeting the more recent kernel. I'll backport to 6.6 in due course.

@peyton-howe are you happy with the contents? I'll be upstreaming the driver patch with your name in the Co-developed tags as per the commit text so you get the appropriate credit.