### PR TITLE
dtoverlays: waveshare-panel: Disable new touch controller by default

### DIFF
--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-waveshare-panel-overlay.dts
@@ -55,6 +55,7 @@
 			touch2: ilitek@41 {
 				compatible = "ilitek,ili251x";
 				reg = <0x41>;
+				status = "disabled";
 			};
 		};
 	};
@@ -125,8 +126,10 @@
 				   <&touch>, "touchscreen-inverted-x?",
 				   <&touch>, "touchscreen-inverted-y?";
 		8_8_inch = <&panel>, "compatible=waveshare,8.8inch-panel";
-		13_3_inch_4lane = <&panel>, "compatible=waveshare,13.3inch-4lane-panel";
-		13_3_inch_2lane = <&panel>, "compatible=waveshare,13.3inch-2lane-panel";
+		13_3_inch_4lane = <&panel>, "compatible=waveshare,13.3inch-4lane-panel",
+				  <&touch2>, "status=okay";
+		13_3_inch_2lane = <&panel>, "compatible=waveshare,13.3inch-2lane-panel",
+				  <&touch2>, "status=okay";
 		i2c1 = <&i2c_frag>, "target:0=",<&i2c1>,
 		       <0>, "-3-4+5";
 		disable_touch = <&touch>, "status=disabled";


### PR DESCRIPTION
Commit e442e5c1ab6b ("arch:arm:boot:dts:overlays: Added waveshare 13.3inch panel support") added an extra touch controller for the new panels. On systems with old panels, it ends up spamming the kernel log as that touch controller isn't there to respond.

Fixes: e442e5c1ab6b ("arch:arm:boot:dts:overlays: Added waveshare 13.3inch panel support")

#6608 