### PR TITLE
add shtc3 to i2c-sensors

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2570,6 +2570,9 @@ Params: addr                    Set the address for the ADT7410, BH1750, BME280,
                                 humidity sensors. Valid addresses 0x44-0x45,
                                 default 0x44
 
+        shtc3                   Select the Sensirion SHTC3 temperature and
+                                humidity sensors.
+
         si7020                  Select the Silicon Labs Si7013/20/21 humidity/
                                 temperature sensor
 

--- a/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
@@ -547,6 +547,21 @@
 		};
 	};
 
+	fragment@36 {
+		target = <&i2cbus>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			shtc3: shtc3@70 {
+				compatible = "sensirion,shtc3";
+				reg = <0x70>;
+				status = "okay";
+			};
+		};
+	};
+
 	fragment@99 {
 		target = <&gpio>;
 		__dormant__ {
@@ -595,6 +610,7 @@
 		sht4x = <0>,"+32";
 		adt7410 = <0>,"+34";
 		ina238 = <0>,"+35";
+		shtc3 = <0>,"+36";
 
 		addr =	<&bme280>,"reg:0", <&bmp280>,"reg:0", <&tmp102>,"reg:0",
 			<&lm75>,"reg:0", <&hdc100x>,"reg:0", <&sht3x>,"reg:0",


### PR DESCRIPTION
This patch adds the shtc3 device tree parameters to the i2c-sensors overlay.  The shtc3 driver needs no other configuration parameters, as the i2c address is permanently baked in to the silicon.  The driver is already being built as a module so this is just a dtbo enhancement.