### PR TITLE
Spi0 6cs

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -265,6 +265,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	spi0-1cs.dtbo \
 	spi0-1cs-inverted.dtbo \
 	spi0-2cs.dtbo \
+	spi0-6cs.dtbo \
 	spi1-1cs.dtbo \
 	spi1-2cs.dtbo \
 	spi1-3cs.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2570,6 +2570,9 @@ Params: addr                    Set the address for the ADT7410, BH1750, BME280,
                                 humidity sensors. Valid addresses 0x44-0x45,
                                 default 0x44
 
+        shtc3                   Select the Sensirion SHTC3 temperature and
+                                humidity sensors.
+
         si7020                  Select the Silicon Labs Si7013/20/21 humidity/
                                 temperature sensor
 

--- a/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
@@ -547,6 +547,21 @@
 		};
 	};
 
+	fragment@36 {
+		target = <&i2cbus>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			shtc3: shtc3@70 {
+				compatible = "sensirion,shtc3";
+				reg = <0x70>;
+				status = "okay";
+			};
+		};
+	};
+
 	fragment@99 {
 		target = <&gpio>;
 		__dormant__ {
@@ -595,6 +610,7 @@
 		sht4x = <0>,"+32";
 		adt7410 = <0>,"+34";
 		ina238 = <0>,"+35";
+		shtc3 = <0>,"+36";
 
 		addr =	<&bme280>,"reg:0", <&bmp280>,"reg:0", <&tmp102>,"reg:0",
 			<&lm75>,"reg:0", <&hdc100x>,"reg:0", <&sht3x>,"reg:0",


### PR DESCRIPTION
I need 6 chip selects on a custom board of mine, And I'm sure someone else out there might also need more than 2, but I'm not at all sure if this is the right way to implement this.  It's kinda ugly that we have to have a separate dts for every possible number of CS# lines. Looking for feedback/ideas.