### PR TITLE
misc: rp1-pio: SM_CONFIG_XFER32 = larger DMA bufs

### DIFF
--- a/drivers/misc/rp1-pio.c
+++ b/drivers/misc/rp1-pio.c
@@ -710,6 +710,14 @@ static int rp1_pio_sm_config_xfer_user(struct rp1_pio_client *client, void *para
 					       args->buf_size, args->buf_count);
 }
 
+static int rp1_pio_sm_config_xfer32_user(struct rp1_pio_client *client, void *param)
+{
+	struct rp1_pio_sm_config_xfer32_args *args = param;
+
+	return rp1_pio_sm_config_xfer_internal(client, args->sm, args->dir,
+					       args->buf_size, args->buf_count);
+}
+
 static int rp1_pio_sm_tx_user(struct rp1_pio_device *pio, struct dma_info *dma,
 				  const void __user *userbuf, size_t bytes)
 {
@@ -970,6 +978,7 @@ struct handler_info {
 	HANDLER(SM_CONFIG_XFER, sm_config_xfer_user),
 	HANDLER(SM_XFER_DATA, sm_xfer_data_user),
 	HANDLER(SM_XFER_DATA32, sm_xfer_data32_user),
+	HANDLER(SM_CONFIG_XFER32, sm_config_xfer32_user),
 
 	HANDLER(CAN_ADD_PROGRAM, can_add_program),
 	HANDLER(ADD_PROGRAM, add_program),

--- a/include/uapi/misc/rp1_pio_if.h
+++ b/include/uapi/misc/rp1_pio_if.h
@@ -160,6 +160,13 @@ struct rp1_pio_sm_config_xfer_args {
 	uint16_t buf_count;
 };
 
+struct rp1_pio_sm_config_xfer32_args {
+	uint16_t sm;
+	uint16_t dir;
+	uint32_t buf_size;
+	uint32_t buf_count;
+};
+
 struct rp1_pio_sm_xfer_data_args {
 	uint16_t sm;
 	uint16_t dir;
@@ -185,6 +192,7 @@ struct rp1_access_hw_args {
 #define PIO_IOC_SM_CONFIG_XFER _IOW(PIO_IOC_MAGIC, 0, struct rp1_pio_sm_config_xfer_args)
 #define PIO_IOC_SM_XFER_DATA _IOW(PIO_IOC_MAGIC, 1, struct rp1_pio_sm_xfer_data_args)
 #define PIO_IOC_SM_XFER_DATA32 _IOW(PIO_IOC_MAGIC, 2, struct rp1_pio_sm_xfer_data32_args)
+#define PIO_IOC_SM_CONFIG_XFER32 _IOW(PIO_IOC_MAGIC, 3, struct rp1_pio_sm_config_xfer32_args)
 
 #define PIO_IOC_READ_HW _IOW(PIO_IOC_MAGIC, 8, struct rp1_access_hw_args)
 #define PIO_IOC_WRITE_HW _IOW(PIO_IOC_MAGIC, 9, struct rp1_access_hw_args)


### PR DESCRIPTION
Add an ioctl type - SM_CONFIG_XFER32 - that takes uints for the buf_size and buf_count values.