### PR TITLE
Handle probe dependencies and hard errors better

### DIFF
--- a/drivers/firmware/rp1.c
+++ b/drivers/firmware/rp1.c
@@ -114,7 +114,8 @@ static void rp1_firmware_delete(struct kref *kref)
 
 void rp1_firmware_put(struct rp1_firmware *fw)
 {
-	kref_put(&fw->consumers, rp1_firmware_delete);
+	if (!IS_ERR_OR_NULL(fw))
+		kref_put(&fw->consumers, rp1_firmware_delete);
 }
 EXPORT_SYMBOL_GPL(rp1_firmware_put);
 
@@ -157,7 +158,7 @@ struct rp1_firmware *rp1_firmware_get(struct device_node *client)
 	const char *match = rp1_firmware_of_match[0].compatible;
 	struct platform_device *pdev;
 	struct device_node *fwnode;
-	struct rp1_firmware *fw;
+	struct rp1_firmware *fw = NULL;
 
 	if (!client)
 		return NULL;
@@ -166,17 +167,17 @@ struct rp1_firmware *rp1_firmware_get(struct device_node *client)
 		return NULL;
 	if (!of_device_is_compatible(fwnode, match)) {
 		of_node_put(fwnode);
-		return NULL;
+		return ERR_PTR(-ENXIO);
 	}
 
 	pdev = of_find_device_by_node(fwnode);
 	of_node_put(fwnode);
 
 	if (!pdev)
-		goto err_exit;
+		return ERR_PTR(-ENXIO);
 
 	fw = platform_get_drvdata(pdev);
-	if (!fw)
+	if (IS_ERR_OR_NULL(fw))
 		goto err_exit;
 
 	if (!kref_get_unless_zero(&fw->consumers))
@@ -188,7 +189,7 @@ struct rp1_firmware *rp1_firmware_get(struct device_node *client)
 
 err_exit:
 	put_device(&pdev->dev);
-	return NULL;
+	return fw;
 }
 EXPORT_SYMBOL_GPL(rp1_firmware_get);
 
@@ -204,8 +205,8 @@ struct rp1_firmware *devm_rp1_firmware_get(struct device *dev, struct device_nod
 	int ret;
 
 	fw = rp1_firmware_get(client);
-	if (!fw)
-		return NULL;
+	if (IS_ERR_OR_NULL(fw))
+		return fw;
 
 	ret = devm_add_action_or_reset(dev, devm_rp1_firmware_put, fw);
 	if (ret)
@@ -270,19 +271,18 @@ static int rp1_firmware_probe(struct platform_device *pdev)
 	init_completion(&fw->c);
 	kref_init(&fw->consumers);
 
-	platform_set_drvdata(pdev, fw);
-
 	ret = rp1_firmware_message(fw, GET_FIRMWARE_VERSION,
 				   NULL, 0, &version, sizeof(version));
 	if (ret == sizeof(version)) {
 		dev_info(dev, "RP1 Firmware version %08x%08x%08x%08x%08x\n",
 			 version[0], version[1], version[2], version[3], version[4]);
-		ret = 0;
-	} else if (ret >= 0) {
-		ret = -EIO;
+		platform_set_drvdata(pdev, fw);
+	} else {
+		rp1_firmware_put(fw);
+		platform_set_drvdata(pdev, ERR_PTR(-ENOENT));
 	}
 
-	return ret;
+	return 0;
 }
 
 static int rp1_firmware_remove(struct platform_device *pdev)

--- a/drivers/mailbox/rp1-mailbox.c
+++ b/drivers/mailbox/rp1-mailbox.c
@@ -133,8 +133,6 @@ static struct mbox_chan *rp1_mbox_xlate(struct mbox_controller *mbox,
 		return ERR_PTR(-EINVAL);
 
 	chan = &mbox->chans[doorbell];
-	if (chan->con_priv)
-		return ERR_PTR(-EBUSY);
 
 	chan->con_priv = (void *)(uintptr_t)(1 << doorbell);
 

--- a/drivers/misc/rp1-pio.c
+++ b/drivers/misc/rp1-pio.c
@@ -1277,8 +1277,10 @@ static int rp1_pio_probe(struct platform_device *pdev)
 		return dev_err_probe(dev, pdev->id, "alias is missing\n");
 
 	fw = devm_rp1_firmware_get(dev, dev->of_node);
-	if (IS_ERR_OR_NULL(fw))
-		return dev_err_probe(dev, -ENOENT, "failed to contact RP1 firmware\n");
+	if (!fw)
+		return dev_err_probe(dev, -EPROBE_DEFER, "failed to find RP1 firmware driver\n");
+	if (IS_ERR(fw))
+		return dev_err_probe(dev, PTR_ERR(fw), "failed to contact RP1 firmware\n");
 	ret = rp1_firmware_get_feature(fw, FOURCC_PIO, &op_base, &op_count);
 	if (ret < 0)
 		return ret;
@@ -1355,6 +1357,11 @@ static void rp1_pio_remove(struct platform_device *pdev)
 
 	if (g_pio == pio)
 		g_pio = NULL;
+
+	device_destroy(pio->dev_class, pio->dev_num);
+	cdev_del(&pio->cdev);
+	class_destroy(pio->dev_class);
+	unregister_chrdev_region(pio->dev_num, 1);
 }
 
 static const struct of_device_id rp1_pio_ids[] = {


### PR DESCRIPTION
#6642 is a report of intermittent failures for the PIO driver to contact the firmware. These failures can be traced to the failure of PIO driver to distinguish hard errors and transient failures. The commits in this PR fix the PIO driver in this regard, but also improve the firmware driver to avoid pointless retries in the event that the firmware is not compatible.