### PR TITLE
spi: dw: Wait for idle after TX

### DIFF
--- a/drivers/spi/spi-dw-dma.c
+++ b/drivers/spi/spi-dw-dma.c
@@ -304,6 +304,11 @@ static int dw_spi_dma_wait_tx_done(struct dw_spi *dws,
 		return -EIO;
 	}
 
+	if (!xfer->rx_buf) {
+		while (dw_readl(dws, DW_SPI_SR) & DW_SPI_SR_BUSY)
+			cpu_relax();
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
This is probably part 1 of a fix for TX only transfers. Part 2 is likely to change dw_spi_dma_transfer to not call dw_spi_wait_tx_done in the event that there is an RX buffer.

Link: https://forums.raspberrypi.com/viewtopic.php?t=383027