### PR TITLE
arm64: dts: Prepare for #size-cells = 2

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
@@ -17,7 +17,11 @@
 	/* Will be filled by the bootloader */
 	memory@0 {
 		device_type = "memory";
+#ifndef FIRMWARE_UPDATED
 		reg = <0 0 0x28000000>;
+#else
+		reg = <0 0  0x0 0x28000000>;
+#endif
 	};
 
 	leds: leds {

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -16,7 +16,11 @@
 	/* Will be filled by the bootloader */
 	memory@0 {
 		device_type = "memory";
+#ifndef FIRMWARE_UPDATED
 		reg = <0 0 0x28000000>;
+#else
+		reg = <0 0  0x0 0x28000000>;
+#endif
 	};
 
 	leds: leds {

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -279,7 +279,11 @@ pciex4: &pcie2 { };
 		compatible = "raspberrypi,bootloader-config", "nvmem-rmem";
 		#address-cells = <1>;
 		#size-cells = <1>;
+#ifndef FIRMWARE_UPDATED
 		reg = <0x0 0x0 0x0>;
+#else
+		reg = <0x0 0x0 0x0 0x0>;
+#endif
 		no-map;
 		status = "disabled";
 	};
@@ -291,7 +295,11 @@ pciex4: &pcie2 { };
 		compatible = "raspberrypi,bootloader-public-key", "nvmem-rmem";
 		#address-cells = <1>;
 		#size-cells = <1>;
+#ifndef FIRMWARE_UPDATED
 		reg = <0x0 0x0 0x0>;
+#else
+		reg = <0x0 0x0 0x0 0x0>;
+#endif
 		no-map;
 		status = "disabled";
 	};

--- a/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
@@ -463,7 +463,12 @@
 
 	hvs: hvs@107c580000 {
 		compatible = "brcm,bcm2712-hvs";
+
+#ifndef FIRMWARE_UPDATED
 		reg = <0x10 0x7c580000 0x1a000>;
+#else
+		reg = <0x10 0x7c580000  0x0 0x1a000>;
+#endif
 		interrupt-parent = <&disp_intr>;
 		interrupts = <2>, <9>, <16>;
 		interrupt-names = "ch0-eof", "ch1-eof", "ch2-eof";


### PR DESCRIPTION
With a future release of the firmware, it will be possible to use dts files with a top-level #size-cells of 2. This patch adds the remaining necessary changes to make that work, gated by the macro symbol FIRMWARE_UDPATED.