### PR TITLE
Make bcm2835 DMA address handling less egregious

### DIFF
--- a/drivers/dma/bcm2835-dma.c
+++ b/drivers/dma/bcm2835-dma.c
@@ -18,7 +18,6 @@
  *	Copyright 2012 Marvell International Ltd.
  */
 #include <linux/dmaengine.h>
-#include <linux/dma-direct.h>
 #include <linux/dma-mapping.h>
 #include <linux/dmapool.h>
 #include <linux/err.h>
@@ -1024,12 +1023,14 @@ static struct dma_async_tx_descriptor *bcm2835_dma_prep_slave_sg(
 	if (direction == DMA_DEV_TO_MEM) {
 		if (c->cfg.src_addr_width != DMA_SLAVE_BUSWIDTH_4_BYTES)
 			return NULL;
-		src = phys_to_dma(chan->device->dev, c->cfg.src_addr);
+		src = dma_map_resource(chan->device->dev, DMA_SLAVE_BUSWIDTH_4_BYTES,
+				       c->cfg.src_addr, DMA_FROM_DEVICE, 0);
 		info |= BCM2835_DMA_S_DREQ | BCM2835_DMA_D_INC;
 	} else {
 		if (c->cfg.dst_addr_width != DMA_SLAVE_BUSWIDTH_4_BYTES)
 			return NULL;
-		dst = phys_to_dma(chan->device->dev, c->cfg.dst_addr);
+		dst = dma_map_resource(chan->device->dev, DMA_SLAVE_BUSWIDTH_4_BYTES,
+				       c->cfg.dst_addr, DMA_TO_DEVICE, 0);
 		info |= BCM2835_DMA_D_DREQ | BCM2835_DMA_S_INC;
 	}
 
@@ -1099,13 +1100,15 @@ static struct dma_async_tx_descriptor *bcm2835_dma_prep_dma_cyclic(
 	if (direction == DMA_DEV_TO_MEM) {
 		if (c->cfg.src_addr_width != DMA_SLAVE_BUSWIDTH_4_BYTES)
 			return NULL;
-		src = phys_to_dma(chan->device->dev, c->cfg.src_addr);
+		src = dma_map_resource(chan->device->dev, DMA_SLAVE_BUSWIDTH_4_BYTES,
+				       c->cfg.src_addr, DMA_FROM_DEVICE, 0);
 		dst = buf_addr;
 		info |= BCM2835_DMA_S_DREQ | BCM2835_DMA_D_INC;
 	} else {
 		if (c->cfg.dst_addr_width != DMA_SLAVE_BUSWIDTH_4_BYTES)
 			return NULL;
-		dst = phys_to_dma(chan->device->dev, c->cfg.dst_addr);
+		dst = dma_map_resource(chan->device->dev, DMA_SLAVE_BUSWIDTH_4_BYTES,
+				       c->cfg.dst_addr, DMA_TO_DEVICE, 0);
 		src = buf_addr;
 		info |= BCM2835_DMA_D_DREQ | BCM2835_DMA_S_INC;
 

--- a/kernel/dma/direct.c
+++ b/kernel/dma/direct.c
@@ -505,7 +505,7 @@ out_unmap:
 dma_addr_t dma_direct_map_resource(struct device *dev, phys_addr_t paddr,
 		size_t size, enum dma_data_direction dir, unsigned long attrs)
 {
-	dma_addr_t dma_addr = paddr;
+	dma_addr_t dma_addr = phys_to_dma_direct(dev, paddr);
 
 	if (unlikely(!dma_capable(dev, dma_addr, size, false))) {
 		dev_err_once(dev,


### PR DESCRIPTION
Replace calls to `phys_to_dma` (and function that belongs to the internals of the DMA framework) with `dma_map_resource`. Note that this patch does not include matching calls to `dma_unmap_resource` because the dma_device struct does not include a method to release a dma_async_tx_descriptor, requiring other means to decide when it's no longer needed, and because it does nothing if direct DMA is being used - the mapping process is just an address calculation.