### PR TITLE
ASoC: enable simultaneous usage of ADC8x and DAC8x

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1879,6 +1879,9 @@ Params: <None>
 
 Name:   hifiberry-dac8x
 Info:   Configures the HifiBerry DAC8X audio cards (only on Pi5)
+        This driver also detects a stacked ADC8x and activates the
+        capture capabilities.
+        Note: for standalone use of the ADC8x activate the ADC8x module.
 Load:   dtoverlay=hifiberry-dac8x
 Params: <None>
 

--- a/arch/arm/boot/dts/overlays/hifiberry-dac8x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hifiberry-dac8x-overlay.dts
@@ -1,6 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0
 // Definitions for HiFiBerry DAC8x
 /dts-v1/;
 /plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
 
 / {
 	compatible = "brcm,bcm2712";
@@ -10,8 +13,10 @@
 		__overlay__ {
 			rp1_i2s0_dac8x: rp1_i2s0_dac8x {
 				function = "i2s0";
-				pins = "gpio18", "gpio19", "gpio21",
-				       "gpio23", "gpio25", "gpio27";
+				pins = "gpio18", "gpio19", "gpio20",
+				       "gpio21", "gpio22", "gpio23",
+				       "gpio24", "gpio25", "gpio26",
+				       "gpio27";
 				bias-disable;
 				status = "okay";
 			};
@@ -30,9 +35,9 @@
 	fragment@2 {
 		target-path = "/";
 		__overlay__ {
-			pcm5102a-codec {
+			dummy-codec {
 				#sound-dai-cells = <0>;
-				compatible = "ti,pcm5102a";
+				compatible = "snd-soc-dummy";
 				status = "okay";
 			};
 		};
@@ -43,6 +48,7 @@
 		__overlay__ {
 			compatible = "hifiberry,hifiberry-dac8x";
 			i2s-controller = <&i2s_clk_producer>;
+			hasadc-gpio = <&gpio 5 GPIO_ACTIVE_LOW>;
 			status = "okay";
 		};
 	};

--- a/sound/soc/bcm/rpi-simple-soundcard.c
+++ b/sound/soc/bcm/rpi-simple-soundcard.c
@@ -354,15 +354,45 @@ static struct snd_rpi_simple_drvdata drvdata_hifiberry_dac = {
 	.dai       = snd_hifiberry_dac_dai,
 };
 
+SND_SOC_DAILINK_DEFS(hifiberry_dac8x,
+	DAILINK_COMP_ARRAY(COMP_EMPTY()),
+	DAILINK_COMP_ARRAY(COMP_CODEC("snd-soc-dummy", "snd-soc-dummy-dai")),
+	DAILINK_COMP_ARRAY(COMP_EMPTY()));
+
 static int hifiberry_dac8x_init(struct snd_soc_pcm_runtime *rtd)
 {
 	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+	struct snd_soc_card *card = rtd->card;
+	struct gpio_desc *gpio_desc;
+	bool has_adc;
 
-	/* override the defaults to reflect 4 x PCM5102A on the card
-	 * and limit the sample rate to 192ksps
-	 */
+	/* Configure the codec for 8 channel playback */
 	codec_dai->driver->playback.channels_max = 8;
 	codec_dai->driver->playback.rates = SNDRV_PCM_RATE_8000_192000;
+
+	/* Activate capture based on ADC8x detection */
+	gpio_desc = devm_gpiod_get(card->dev, "hasadc", GPIOD_IN);
+	if (IS_ERR(gpio_desc)) {
+		dev_err(card->dev, "Failed to get GPIO: %ld\n", PTR_ERR(gpio_desc));
+		return PTR_ERR(gpio_desc);
+	}
+
+	has_adc = gpiod_get_value(gpio_desc);
+
+	if (has_adc) {
+		struct snd_soc_dai_link *dai = rtd->dai_link;
+
+		dev_info(card->dev, "ADC8x detected: capture enabled\n");
+		codec_dai->driver->symmetric_rate = 1;
+		codec_dai->driver->symmetric_channels = 1;
+		codec_dai->driver->symmetric_sample_bits = 1;
+		codec_dai->driver->capture.rates = SNDRV_PCM_RATE_8000_192000;
+		dai->name = "HiFiBerry DAC8xADC8x";
+		dai->stream_name = "HiFiBerry DAC8xADC8x HiFi";
+	} else {
+		dev_info(card->dev, "no ADC8x detected\n");
+		rtd->dai_link->playback_only = 1;  // Disable capture
+	}
 
 	return 0;
 }
@@ -375,7 +405,7 @@ static struct snd_soc_dai_link snd_hifiberry_dac8x_dai[] = {
 					SND_SOC_DAIFMT_NB_NF |
 					SND_SOC_DAIFMT_CBS_CFS,
 		.init           = hifiberry_dac8x_init,
-		SND_SOC_DAILINK_REG(hifiberry_dac),
+		SND_SOC_DAILINK_REG(hifiberry_dac8x),
 	},
 };
 


### PR DESCRIPTION
This modification enables the DAC8x driver to auto-detect a stacked ADC8x board. The combo allows 8 channel capture and play.
It uses all I2S data pins, and GPIO5 for detection. Needs to use the dummy-DAI instead of the 'play'-only formerly used pcm5102-DAI. Symmetric operation only for obvious reasons.

For potential standalone operation of the ADC8x we keep the ADC8x-dedicated code as is.