### PR TITLE
CM5 pciex1 qos is broken

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -118,6 +118,10 @@ rp1_target: &pcie2 {
 	status = "okay";
 };
 
+&pcie1 {
+	brcm,vdm-qos-map = <0x33333333>;
+};
+
 // Add some labels to 2712 device
 
 // The system UART


### PR DESCRIPTION
Spotted during 6.14 review - we've never set the default QoS map for the x1 RC on compute modules which will have all sorts of interesting side-effects.

Needs backporting to 6.6 too.