### PR TITLE
media: i2c: arducam-pivariety: Fix mutex init and NULL pointer

### DIFF
--- a/drivers/media/i2c/arducam-pivariety.c
+++ b/drivers/media/i2c/arducam-pivariety.c
@@ -1208,6 +1208,8 @@ static int pivariety_enum_controls(struct pivariety *pivariety)
 	if (ret)
 		return ret;
 
+	mutex_init(&pivariety->mutex);
+
 	index = 0;
 	while (1) {
 		ret = pivariety_write(pivariety, CTRL_INDEX_REG, index);
@@ -1295,6 +1297,7 @@ static int pivariety_enum_controls(struct pivariety *pivariety)
 	v4l2_ctrl_handler_setup(ctrl_hdlr);
 	return 0;
 err:
+	mutex_destroy(&pivariety->mutex);
 	return -ENODEV;
 }
 


### PR DESCRIPTION
The mutex used in arducam-pivariety was not properly initialized,
which could lead to undefined behavior. This also caused a NULL
pointer dereference under certain conditions. 

This patch ensures the mutex is correctly initialized during probe
and prevents NULL pointer dereferences.