### PR TITLE
drivers: staging: fbtft: Fix fb_ssd1306 driver for 128x32 Display

### DIFF
--- a/drivers/staging/fbtft/fb_ssd1306.c
+++ b/drivers/staging/fbtft/fb_ssd1306.c
@@ -133,7 +133,6 @@ static void set_addr_win_64x48(struct fbtft_par *par)
 	write_reg(par, 0x5);
 }
 
-
 static void set_addr_win_128x32(struct fbtft_par *par)
 {
 	/* Set Column Address */

--- a/drivers/staging/fbtft/fb_ssd1306.c
+++ b/drivers/staging/fbtft/fb_ssd1306.c
@@ -133,6 +133,20 @@ static void set_addr_win_64x48(struct fbtft_par *par)
 	write_reg(par, 0x5);
 }
 
+
+static void set_addr_win_128x32(struct fbtft_par *par)
+{
+	/* Set Column Address */
+	write_reg(par, 0x21);
+	write_reg(par, 0x00);
+	write_reg(par, 0x7F);
+
+	/* Set Page Address */
+	write_reg(par, 0x22);
+	write_reg(par, 0x00);
+	write_reg(par, 0x03);
+}
+
 static void set_addr_win(struct fbtft_par *par, int xs, int ys, int xe, int ye)
 {
 	/* Set Lower Column Start Address for Page Addressing Mode */
@@ -144,6 +158,8 @@ static void set_addr_win(struct fbtft_par *par, int xs, int ys, int xe, int ye)
 
 	if (par->info->var.xres == 64 && par->info->var.yres == 48)
 		set_addr_win_64x48(par);
+	else if (par->info->var.xres == 128 && par->info->var.yres == 32)
+		set_addr_win_128x32(par);
 }
 
 static int blank(struct fbtft_par *par, bool on)


### PR DESCRIPTION
The driver incorrectly sets the column and page addresses for a 128x32 display.
Display used is from the [Environmental Sensor Board](https://coral.ai/products/environmental/) kit.
The final values ​​of the addresses should be:
- 0x7F for cols because it is `128 - 1`
- 0x03 for rows because it is `32 / 8 (bits, vertical addressing) - 1`

Before:
![image](https://github.com/user-attachments/assets/82263af7-22e1-4d75-ab77-31535ec0b71e)

After:
![image](https://github.com/user-attachments/assets/b6bb1228-f320-4516-93a6-caf42daba35f)
