### PR TITLE
imx500: Fix for long exposure setup

### DIFF
--- a/drivers/media/i2c/imx500.c
+++ b/drivers/media/i2c/imx500.c
@@ -57,6 +57,7 @@
 /* Long exposure multiplier */
 #define IMX500_LONG_EXP_SHIFT_MAX 7
 #define IMX500_LONG_EXP_SHIFT_REG CCI_REG8(0x3210)
+#define IMX500_LONG_EXP_CIT_SHIFT_REG CCI_REG8(0x3100)
 
 /* Exposure control */
 #define IMX500_REG_EXPOSURE CCI_REG16(0x0202)
@@ -1769,6 +1770,11 @@ static int imx500_set_frame_length(struct imx500 *imx500, unsigned int val)
 	}
 
 	ret = cci_write(imx500->regmap, IMX500_REG_FRAME_LENGTH, val, NULL);
+	if (ret)
+		return ret;
+
+	ret = cci_write(imx500->regmap, IMX500_LONG_EXP_CIT_SHIFT_REG,
+			imx500->long_exp_shift, NULL);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
The IMX500 (unlike the IMX477/IMX708) requires two regsiters to be set for the exposure shift value to work correctly. The additional register write (which was missing) is for the integration time shift.