### PR TITLE
Fix clang compilation error for rpi5

### DIFF
--- a/drivers/dma-buf/heaps/system_heap.c
+++ b/drivers/dma-buf/heaps/system_heap.c
@@ -50,11 +50,16 @@ static gfp_t order_flags[] = {HIGH_ORDER_GFP, HIGH_ORDER_GFP, LOW_ORDER_GFP};
  * to match with the sizes often found in IOMMUs. Using order 4 pages instead
  * of order 0 pages can significantly improve the performance of many IOMMUs
  * by reducing TLB pressure and time spent updating page tables.
+ *
+ * Note: `module_max_order` must be set explicitly instead of using
+ * `orders[0]` to avoid Clang's "initializer element is not a
+ * compile-time constant" error.
  */
-static const unsigned int orders[] = {8, 4, 0};
+#define MAX_ORDERS_VALUE 8
+static const unsigned int orders[] = {MAX_ORDERS_VALUE, 4, 0};
 #define NUM_ORDERS ARRAY_SIZE(orders)
 
-static unsigned int module_max_order = orders[0];
+static unsigned int module_max_order = MAX_ORDERS_VALUE;
 
 module_param_named(max_order, module_max_order, uint, 0400);
 MODULE_PARM_DESC(max_order, "Maximum allocation order override.");

--- a/drivers/dma-buf/heaps/system_heap.c
+++ b/drivers/dma-buf/heaps/system_heap.c
@@ -50,10 +50,6 @@ static gfp_t order_flags[] = {HIGH_ORDER_GFP, HIGH_ORDER_GFP, LOW_ORDER_GFP};
  * to match with the sizes often found in IOMMUs. Using order 4 pages instead
  * of order 0 pages can significantly improve the performance of many IOMMUs
  * by reducing TLB pressure and time spent updating page tables.
- *
- * Note: `module_max_order` must be set explicitly instead of using
- * `orders[0]` to avoid Clang's "initializer element is not a
- * compile-time constant" error.
  */
 #define MAX_ORDERS_VALUE 8
 static const unsigned int orders[] = {MAX_ORDERS_VALUE, 4, 0};


### PR DESCRIPTION
I created an issue describing the bug: https://github.com/raspberrypi/linux/issues/6698.

To quickly summarize, i tried to compile 6.6.y kernel with clang and compilation failed on ` drivers/dma-buf/heaps/system_heap.c` with error:
```
drivers/dma-buf/heaps/system_heap.c:57:40: error: initializer element is not a compile-time constant
static unsigned int module_max_order = orders[0];
                                       ^~~~~~~~~
```

This PR is fixing the compilation error by using macro to specify compile-time constant properly.
