### PR TITLE
dtoverlays: ov9281: Add continuous clock option as an override

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3570,6 +3570,9 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
         arducam                 Slow down the regulator for slow Arducam
                                 modules.
+        clk-continuous          Switch to continuous mode on the CSI clock lane,
+                                which increases the maximum frame rate slightly.
+                                Appears not to work on Pi3.
 
 
 Name:   papirus

--- a/arch/arm/boot/dts/overlays/ov9281-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov9281-overlay.dts
@@ -64,6 +64,20 @@
 		};
 	};
 
+	fragment@6 {
+		target = <&csi_ep>;
+		__overlay__ {
+			clock-noncontinuous;
+		};
+	};
+
+	fragment@7 {
+		target = <&cam_endpoint>;
+		__overlay__ {
+			clock-noncontinuous;
+		};
+	};
+
 	__overrides__ {
 		rotation = <&cam_node>,"rotation:0";
 		orientation = <&cam_node>,"orientation:0";
@@ -75,7 +89,7 @@
 		       <&cam_node>, "avdd-supply:0=",<&cam0_reg>,
 		       <&reg_frag>, "target:0=",<&cam0_reg>;
 		arducam = <0>, "+5";
-
+		clk-continuous = <0>, "-6-7";
 	};
 };
 


### PR DESCRIPTION
The previous change to make ov9281 always run in continuous clock mode causes problems on Pi3 for reasons that aren't fully understood. Pi4 is quite happy with it.

Change the default back to being non-continuous clock, and add an override to select continuous clock mode and its slightly greater max frame rate.

https://forums.raspberrypi.com/viewtopic.php?p=2300215