### PR TITLE
drm/vc4: Correct one logging message that got promoted from dbg to err

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -3351,7 +3351,7 @@ static int vc4_hdmi_bind(struct device *dev, struct device *master, void *data)
 	vc4_hdmi->ddc = of_find_i2c_adapter_by_node(ddc_node);
 	of_node_put(ddc_node);
 	if (!vc4_hdmi->ddc) {
-		drm_err(drm, "Failed to get ddc i2c adapter by node\n");
+		drm_dbg(drm, "Failed to get ddc i2c adapter by node\n");
 		return -EPROBE_DEFER;
 	}
 


### PR DESCRIPTION
commit 59ac702a9320 ("drm/vc4: Get the rid of DRM_ERROR()") converted all calls to DRM_ERROR into drm_err, but also converted one DRM_DEBUG into a drm_err.

Switch it back to drm_dbg.

Fixes: 59ac702a9320 ("drm/vc4: Get the rid of DRM_ERROR()")