### PR TITLE
dtoverlays: Add adxl345 to i2c-sensor

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2419,6 +2419,9 @@ Params: addr                    Set the address for the ADT7410, AS73211,
                                 temperature sensors
                                 Valid address 0x48-0x4b, default 0x48
 
+        adxl345                 Select the Analog Devices ADXL345 3-axis
+                                accelerometer
+
         aht10                   Select the Aosong AHT10 temperature and humidity
                                 sensor
 

--- a/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
+++ b/arch/arm/boot/dts/overlays/i2c-sensor-common.dtsi
@@ -648,6 +648,24 @@
 		};
 	};
 
+	fragment@42 {
+		target = <&i2cbus>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adxl345: adxl345@53 {
+				compatible = "adi,adxl345";
+				reg = <0x53>;
+				interrupt-parent = <&gpio>;
+				interrupts = <4 IRQ_TYPE_LEVEL_HIGH>;
+				pinctrl-0 = <&int_pins>;
+				pinctrl-names = "default";
+			};
+		};
+	};
+
 	fragment@99 {
 		target = <&gpio>;
 		__dormant__ {
@@ -702,6 +720,7 @@
 		hdc3020 = <0>,"+39+99";
 		as73211 = <0>,"+40+99";
 		as7331 = <0>,"+41+99";
+		adxl345 = <0>,"+42+99";
 
 		addr =	<&bme280>,"reg:0", <&bmp280>,"reg:0", <&tmp102>,"reg:0",
 			<&lm75>,"reg:0", <&hdc100x>,"reg:0", <&sht3x>,"reg:0",
@@ -713,7 +732,7 @@
 			<&bno055>,"reg:0", <&sht4x>,"reg:0",
 			<&bmp380>,"reg:0", <&adt7410>,"reg:0", <&ina238>,"reg:0",
 			<&hdc3020>,"reg:0", <&as73211>,"reg:0",
-			<&as7331>,"reg:0";
+			<&as7331>,"reg:0", <&adxl345>,"reg:0";
 		int_pin = <&int_pins>, "brcm,pins:0",
 			<&int_pins>, "reg:0",
 			<&max30102>, "interrupts:0",
@@ -722,7 +741,8 @@
 			<&hts221>, "interrupts:0",
 			<&hdc3020>, "interrupts:0",
 			<&as73211>, "interrupts:0",
-			<&as7331>, "interrupts:0";
+			<&as7331>, "interrupts:0",
+			<&adxl345>, "interrupts:0";
 		no_timeout = <&jc42>, "smbus-timeout-disable?";
 		reset_pin = <&bno055>,"reset-gpios:4", <0>,"+30";
 		shunt_resistor = <&ina238>,"shunt-resistor:0";


### PR DESCRIPTION
https://forums.raspberrypi.com/viewtopic.php?t=384788

The module in drivers/input/misc was already being built.

There is a second iio driver under drivers/iio/accel, but it is mutually exclusive to the drivers/input/misc one. That's not tested.