### PR TITLE
fixup! dmaengine: dw-axi-dmac: Fixes for RP1

### DIFF
--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
@@ -1255,6 +1255,9 @@ static void axi_chan_block_xfer_complete(struct axi_dma_chan *chan)
 		/* Remove the completed descriptor from issued list before completing */
 		list_del(&vd->node);
 		vchan_cookie_complete(vd);
+
+		/* Submit queued descriptors after processing the completed ones */
+		axi_chan_start_first_queued(chan);
 	}
 
 out:


### PR DESCRIPTION
A small patch to the RP1 DMA driver got lost between rpi-6.8.y and rpi-6.9.y. Re-applying it fixes https://github.com/raspberrypi/utils/issues/123.