### PR TITLE
drm/vc4: Correct arithmetic for shifting between columns of SAND images

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -1516,7 +1516,7 @@ static int vc4_plane_mode_set(struct drm_plane *plane,
 
 			tile = src_x / pix_per_tile;
 
-			offsets[i] += pitch[i] * tile;
+			offsets[i] += pitch[i] * tile * tile_width;
 			offsets[i] += src_y / (i ? v_subsample : 1) * tile_width;
 			offsets[i] += x_off & ~(i ? 1 : 0);
 		}
@@ -1992,7 +1992,7 @@ static int vc6_plane_mode_set(struct drm_plane *plane,
 
 			tile = src_x / pix_per_tile;
 
-			offsets[i] += pitch[i] * tile;
+			offsets[i] += pitch[i] * tile * tile_width;
 			offsets[i] += src_y / (i ? v_subsample : 1) * tile_width;
 			offsets[i] += x_off & ~(i ? 1 : 0);
 


### PR DESCRIPTION
Commit 69dbba71ac11 ("drm/vc4: Add algorithmic handling for SAND") lost a multiplication by the tile width when doing the pointer arithmetic for cropping off columns for vc6.

Correct that computation.

@popcornmix - fixes your Kodi zooming on Pi5.