### PR TITLE
Fix two more RP1 DMA bugs

### DIFF
--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
@@ -367,7 +367,8 @@ static void axi_desc_put(struct axi_dma_desc *desc)
 
 	for (descs_put = 0; descs_put < count; descs_put++) {
 		hw_desc = &desc->hw_desc[descs_put];
-		dma_pool_free(chan->desc_pool, hw_desc->lli, hw_desc->llp);
+		if (hw_desc->lli)
+			dma_pool_free(chan->desc_pool, hw_desc->lli, hw_desc->llp);
 	}
 
 	kfree(desc->hw_desc);

--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
@@ -750,11 +750,6 @@ static int dw_axi_dma_set_hw_desc(struct axi_dma_chan *chan,
 
 	mem_width = __ffs(data_width | mem_addr | len);
 
-	if (!IS_ALIGNED(mem_addr, 4)) {
-		dev_err(chan->chip->dev, "invalid buffer alignment\n");
-		return -EINVAL;
-	}
-
 	/* Use a reasonable upper limit otherwise residue reporting granularity grows large */
 	mem_burst_msize = axi_dma_encode_msize(16);
 
@@ -796,6 +791,11 @@ static int dw_axi_dma_set_hw_desc(struct axi_dma_chan *chan,
 		block_ts = len >> reg_width;
 		break;
 	default:
+		return -EINVAL;
+	}
+
+	if (len % reg_width) {
+		dev_err(chan->chip->dev, "length not aligned to device width\n");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Two bugs discovered while investigating https://github.com/raspberrypi/linux/issues/6733:
1. axi_desc_put should not assume that all the LLIs owned by the descriptor have been initialised.
2. It is not illegal for a memory address or transfer length to be word-odd (not a multiple of 4). However, it is illegal for the transfer length to not be a multiple of the device/register width.
