### PR TITLE
Disable DMA for Pi 5's UART0

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -454,15 +454,11 @@ Params:
                                 and entering the low power state (default 600).
                                 Requires EEE to be enabled - see "eee".
 
-        uart0                   Set to "on" to enable and "off" to disable uart0
-                                (default "off" on 2712, otherwise "on")
+        uart0                   Set to "off" to disable uart0 (default "on")
 
         uart0_console           Move the kernel boot console to UART0 on pins
                                 6, 8 and 10 of the 40-way header (2712 only,
                                 default "off")
-
-        uart0_nodma             Enable uart0 without DMA (2712 only, default
-                                "off")
 
         uart1                   Set to "on" or "off" to enable or disable uart1
                                 (default varies)

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -220,7 +220,6 @@ pio: &rp1_pio {
 		suspend = <&pwr_key>, "linux,code:0=205";
 		uart0 = <&uart0>, "status";
 		uart0_console = <&uart0>,"status", <&aliases>, "console=",&uart0;
-		uart0_nodma = <&uart0>,"status", <&uart0>,"dma-names?=0";
 		wifiaddr = <&wifi>, "local-mac-address[";
 
 		cam0_reg = <&cam0_reg>,"status";

--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
@@ -65,9 +65,9 @@
 			interrupts = <RP1_INT_UART0 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&rp1_clocks RP1_CLK_UART &rp1_clocks RP1_PLL_SYS_PRI_PH>;
 			clock-names = "uartclk", "apb_pclk";
-			dmas = <&rp1_dma RP1_DMA_UART0_TX>,
-			       <&rp1_dma RP1_DMA_UART0_RX>;
-			dma-names = "tx", "rx";
+			// dmas = <&rp1_dma RP1_DMA_UART0_TX>,
+			//        <&rp1_dma RP1_DMA_UART0_RX>;
+			// dma-names = "tx", "rx";
 			pinctrl-names = "default";
 			arm,primecell-periphid = <0x00341011>;
 			uart-has-rtscts;


### PR DESCRIPTION
Previous Pis have managed without using DMA with the UARTs, and it has been seen to cause problems on the receive side, so play safe and disable it.