### PR TITLE
ARM64: dts: Add sd and sd_poll_once params to CM5

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -402,7 +402,7 @@ Params:
                                 (2712 only, default "0")
 
         sd                      Set to "off" to disable the SD card (or eMMC on
-                                non-lite SKU of CM4).
+                                non-lite SKU of CM4/5).
                                 (default "on")
 
         sd_cqe                  Modify Command Queuing behaviour on the main SD

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -719,6 +719,8 @@ spi10_cs_pins: &spi10_cs_gpio1 {};
 			<&ant2>, "output-low?=on";
 		noanthogs = <&ant1>,"status=disabled",
 			<&ant2>, "status=disabled";
+		sd = <&sdio1>, "status";
+		sd_poll_once = <&sdio1>, "non-removable?";
 		sd_cqe = <&sdio1>, "supports-cqe:0";
 	};
 };


### PR DESCRIPTION
The CM5 lacks a card detect signal, so it can be useful to be able to disable the external SD card slot (or onboard EMMC on a non-Lite board).

See: https://github.com/raspberrypi/linux/issues/6647