### PR TITLE
Pisound Micro: Fix for MIDI output under full load.

### DIFF
--- a/sound/drivers/upisnd/upisnd_comm.c
+++ b/sound/drivers/upisnd/upisnd_comm.c
@@ -327,7 +327,7 @@ int upisnd_comm_init(struct upisnd_instance *instance,
 
 int upisnd_comm_send_midi(struct upisnd_instance *instance, const void *data, unsigned int n)
 {
-	if (n >= UPISND_MAX_PACKET_LENGTH)
+	if (n == 0 || n >= UPISND_MAX_PACKET_LENGTH)
 		return -EINVAL;
 
 	u8 buffer[UPISND_MAX_PACKET_LENGTH];

--- a/sound/drivers/upisnd/upisnd_protocol.h
+++ b/sound/drivers/upisnd/upisnd_protocol.h
@@ -273,7 +273,8 @@ static inline u8 upisnd_cmd_decode_length(u8 b)
 
 static inline u8 upisnd_cmd_encode(enum upisnd_cmd_type_e type, u8 size)
 {
-	return (size < UPISND_MAX_PACKET_LENGTH && size > 0) ? (type | (size - 1)) : 0xff;
+	return (size <= UPISND_MAX_PACKET_LENGTH && size > 0) ? (type | (size - 1))
+		: UPISND_CMD_INVALID;
 }
 
 static inline u8 upisnd_msg_id_encode(upisnd_msg_id_t msg_id, bool response)


### PR DESCRIPTION
This fixes MIDI output of Pisound Micro after running for a while under full load and increases timing stability.