### PR TITLE
media: i2c: imx415: Correct hmax_min values for 891Mbps/lane

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -2873,6 +2873,9 @@ Params: addr                    Set I2C address of sensor. Valid values are
         cam0                    Adopt the default configuration for CAM0 on a
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
         vcm                     Enable ad5398 VCM associated with the sensor.
+        clk-37125               Alternative to clock-frequency=37125000 and
+                                link-frequency=445500000 for Waveshare modules
+                                with 37.125MHz clock sources.
 
 
 Name:   imx462

--- a/arch/arm/boot/dts/overlays/imx415-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx415-overlay.dts
@@ -103,6 +103,8 @@
 		      <&cam_node>,"lens-focus:0=", <&vcm>;
 		clock-frequency = <&cam_clk>, "clock-frequency:0";
 		link-frequency = <&cam_endpoint>,"link-frequencies#0";
+		clk-37125 = <&cam_endpoint>,"link-frequencies#0=445500000",
+			   <&cam_clk>, "clock-frequency:0=37125000";
 		4lane = <0>, "+201+202";
 	};
 };

--- a/drivers/media/i2c/imx415.c
+++ b/drivers/media/i2c/imx415.c
@@ -522,7 +522,7 @@ static const struct imx415_mode supported_modes[] = {
 	},
 	{
 		.lane_rate = 891000000,
-		.hmax_min = { 1100, 550 },
+		.hmax_min = { 2200, 1100 },
 		.reg_list = {
 			.num_of_regs = ARRAY_SIZE(imx415_linkrate_891mbps),
 			.regs = imx415_linkrate_891mbps,
@@ -725,6 +725,7 @@ static int imx415_s_ctrl(struct v4l2_ctrl *ctrl)
 		 * Deliberately fall through as exposure is set based on VMAX
 		 * which has just changed.
 		 */
+		ctrl = sensor->exposure;
 		fallthrough;
 	case V4L2_CID_EXPOSURE:
 		/* clamp the exposure value to VMAX. */
@@ -752,10 +753,11 @@ static int imx415_s_ctrl(struct v4l2_ctrl *ctrl)
 		break;
 
 	case V4L2_CID_HBLANK:
-		return cci_write(sensor->regmap, IMX415_HMAX,
-				 (format->width + ctrl->val) /
+		ret = cci_write(sensor->regmap, IMX415_HMAX,
+				(format->width + ctrl->val) /
 						IMX415_HMAX_MULTIPLIER,
 				 NULL);
+		break;
 
 	default:
 		ret = -EINVAL;


### PR DESCRIPTION
I obviously backported V1 of the patchset sent to mainline, as code review there picked up these incorrect hmax_min values. https://lore.kernel.org/all/AS4PR08MB773533B9D04BE15F51548FEBF7182@AS4PR08MB7735.eurprd08.prod.outlook.com/

The upstream patches also fixed a return without pm_runtime_put and the fall-through from V4L2_CID_VBLANK to V4L2_CID_EXPOSURE not updating ctrl, so the wrong exposure would get set.

Backport these fixes from mainline.