### PR TITLE
dtoverlays: Disable kernel drivers for humidity sensor on Sense HATs

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-sense-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-sense-overlay.dts
@@ -52,7 +52,7 @@
 			hts221-humid@5f {
 				compatible = "st,hts221-humid", "st,hts221";
 				reg = <0x5f>;
-				status = "okay";
+				status = "disabled";
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/rpi-sense-v2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-sense-v2-overlay.dts
@@ -46,7 +46,7 @@
 			hts221-humid@5f {
 				compatible = "st,hts221-humid", "st,hts221";
 				reg = <0x5f>;
-				status = "okay";
+				status = "disabled";
 			};
 
 			lsm9ds1-accel@6a {


### PR DESCRIPTION
The Sense HAT library talks directly to the humidity sensor via i2cdev.

The overlay has always defined the humidity sensor, but the relevant kernel module wasn't being built until
https://github.com/raspberrypi/linux/pull/6093, applied to 6.9 and above.

We now have a kernel driver claiming the I2C address, so userspace can't talk directly to the sensor.

Disable the humidity sensor in the overlays

https://forums.raspberrypi.com/viewtopic.php?p=2307047