### PR TITLE
PCI: pcie-brcmstb: fake MSIx support on internal MSI target

### DIFF
--- a/drivers/pci/controller/pcie-brcmstb.c
+++ b/drivers/pci/controller/pcie-brcmstb.c
@@ -666,7 +666,7 @@ static struct irq_chip brcm_msi_irq_chip = {
 
 static struct msi_domain_info brcm_msi_domain_info = {
 	.flags	= MSI_FLAG_USE_DEF_DOM_OPS | MSI_FLAG_USE_DEF_CHIP_OPS |
-		  MSI_FLAG_NO_AFFINITY | MSI_FLAG_MULTI_PCI_MSI,
+		  MSI_FLAG_NO_AFFINITY | MSI_FLAG_MULTI_PCI_MSI | MSI_FLAG_PCI_MSIX,
 	.chip	= &brcm_msi_irq_chip,
 };
 


### PR DESCRIPTION
Trial fix for #6751 - my OEM SK Hynix drive now probes successfully. No idea why not having lots of vectors makes tag allocation fail.