### PR TITLE
[RFC] Staging: Adding Sfera Labs drivers

### DIFF
--- a/drivers/staging/Kconfig
+++ b/drivers/staging/Kconfig
@@ -64,4 +64,6 @@ source "drivers/staging/fieldbus/Kconfig"
 
 source "drivers/staging/vme_user/Kconfig"
 
+source "drivers/staging/sferalabs/Kconfig"
+
 endif # STAGING

--- a/drivers/staging/Makefile
+++ b/drivers/staging/Makefile
@@ -21,3 +21,4 @@ obj-$(CONFIG_GREYBUS)		+= greybus/
 obj-$(CONFIG_BCM2835_VCHIQ)	+= vc04_services/
 obj-$(CONFIG_XIL_AXIS_FIFO)	+= axis-fifo/
 obj-$(CONFIG_FIELDBUS_DEV)     += fieldbus/
+obj-y                           += sferalabs/

--- a/drivers/staging/sferalabs/Kconfig
+++ b/drivers/staging/sferalabs/Kconfig
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0
+
+source "drivers/staging/sferalabs/ionopi-v3/Kconfig"

--- a/drivers/staging/sferalabs/Makefile
+++ b/drivers/staging/sferalabs/Makefile
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: GPL-2.0
+obj-$(CONFIG_IONO_PI_V3)     += ionopi-v3/

--- a/drivers/staging/sferalabs/commons/atecc/atecc.c
+++ b/drivers/staging/sferalabs/commons/atecc/atecc.c
@@ -1,0 +1,124 @@
+#include "atecc.h"
+
+#include <linux/delay.h>
+#include <linux/i2c.h>
+#include <linux/module.h>
+#include <linux/version.h>
+
+struct AteccBean {
+  uint8_t serialNumber[9];
+  bool probed;
+};
+
+static struct AteccBean _atecc = {
+    .probed = false,
+};
+
+static void _getCRC16LittleEndian(size_t length, const uint8_t *data,
+                                  uint8_t *crc_le) {
+  size_t counter;
+  uint16_t crc = 0;
+  uint16_t polynom = 0x8005;
+  uint8_t shift;
+  uint8_t data_bit, crc_bit;
+
+  for (counter = 0; counter < length; counter++) {
+    for (shift = 0x01; shift > 0x00; shift <<= 1) {
+      data_bit = (data[counter] & shift) ? 1 : 0;
+      crc_bit = crc >> 15;
+      crc <<= 1;
+      if (data_bit != crc_bit) {
+        crc ^= polynom;
+      }
+    }
+  }
+  crc_le[0] = (uint8_t)(crc & 0x00FF);
+  crc_le[1] = (uint8_t)(crc >> 8);
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+static int _atecc_i2c_probe(struct i2c_client *client) {
+#else
+static int _atecc_i2c_probe(struct i2c_client *client,
+                            const struct i2c_device_id *id) {
+#endif
+  uint8_t i;
+  int ret = -1;
+  uint8_t i2c_response[35];
+  uint8_t crc_le[2];
+
+  /*
+   * 0x03 = normal command
+   * 0x07 = total bytes for CRC generation (2 CRC bytes included)
+   * 0x02 = read operation
+   * 0x80 = read 32 bytes from configuration memory area
+   * 0x00 = configuration memory address part 1
+   * 0x00 = configuration memory address part 2
+   * 0x09 = CRC byte 1 in little endian format
+   * 0xAD = CRC byte 2 in little endian format
+   */
+  uint8_t cmd_read_sn[8] = {0x03, 0x07, 0x02, 0x80, 0x00, 0x00, 0x09, 0xAD};
+  uint8_t cmd_wake = 0x00;
+
+  for (i = 0; i < 10; i++) {
+    i2c_master_send(client, &cmd_wake, 1);
+    msleep(1);
+    if (i2c_master_send(client, cmd_read_sn, 8) == 8) {
+      msleep(1);
+      if (i2c_master_recv(client, i2c_response, 35) == 35) {
+        _getCRC16LittleEndian(33, i2c_response, crc_le);
+        if (crc_le[0] == i2c_response[33] && crc_le[1] == i2c_response[34]) {
+          memcpy(&_atecc.serialNumber[0], &i2c_response[1], 4);
+          memcpy(&_atecc.serialNumber[4], &i2c_response[9], 5);
+          _atecc.probed = true;
+          ret = 0;
+          break;
+        }
+      }
+    }
+    msleep(10);
+  }
+
+  return ret;
+}
+
+const struct of_device_id _atecc_of_match[] = {
+    {
+        .compatible = "sferalabs,atecc",
+    },
+    {},
+};
+MODULE_DEVICE_TABLE(of, _atecc_of_match);
+
+static const struct i2c_device_id _atecc_i2c_id[] = {
+    {"atecc", 0},
+    {},
+};
+MODULE_DEVICE_TABLE(i2c, _atecc_i2c_id);
+
+static struct i2c_driver _atecc_i2c_driver = {
+    .driver =
+        {
+            .name = "atecc",
+            .owner = THIS_MODULE,
+            .of_match_table = of_match_ptr(_atecc_of_match),
+        },
+    .probe = _atecc_i2c_probe,
+    .id_table = _atecc_i2c_id,
+};
+
+ssize_t devAttrAteccSerial_show(struct device *dev,
+                                struct device_attribute *attr, char *buf) {
+  if (!_atecc.probed) {
+    i2c_add_driver(&_atecc_i2c_driver);
+    i2c_del_driver(&_atecc_i2c_driver);
+    if (!_atecc.probed) {
+      return -ENODEV;
+    }
+  }
+  return sprintf(
+      buf, "%02hX %02hX %02hX %02hX %02hX %02hX %02hX %02hX %02hX\n",
+      _atecc.serialNumber[0], _atecc.serialNumber[1], _atecc.serialNumber[2],
+      _atecc.serialNumber[3], _atecc.serialNumber[4], _atecc.serialNumber[5],
+      _atecc.serialNumber[6], _atecc.serialNumber[7], _atecc.serialNumber[8]);
+}

--- a/drivers/staging/sferalabs/commons/atecc/atecc.h
+++ b/drivers/staging/sferalabs/commons/atecc/atecc.h
@@ -1,0 +1,8 @@
+#ifndef _SL_ATECC_H
+#define _SL_ATECC_H
+
+#include <linux/device.h>
+
+ssize_t devAttrAteccSerial_show(struct device *dev,
+                                struct device_attribute *attr, char *buf);
+#endif

--- a/drivers/staging/sferalabs/commons/gpio/gpio.c
+++ b/drivers/staging/sferalabs/commons/gpio/gpio.c
@@ -1,0 +1,440 @@
+#include "gpio.h"
+
+#include <linux/delay.h>
+#include <linux/interrupt.h>
+
+#include "../misc/misc.h"
+
+static struct platform_device *_pdev;
+
+/**
+ * convert common user inputs into boolean values
+ * @s: input string
+ * @res: result
+ *
+ * This routine returns 0 iff the first character is one of 'Yy1Nn0', or
+ * [oO][NnFf] for "on" and "off". Otherwise it will return -EINVAL.  Value
+ * pointed to by res is updated upon finding a match.
+ */
+static int mkstrtobool(const char *s, bool *res) {
+  if (!s) return -EINVAL;
+
+  switch (s[0]) {
+    case 'y':
+      // fall through
+    case 'Y':
+      // fall through
+    case '1':
+      *res = true;
+      return 0;
+    case 'n':
+      // fall through
+    case 'N':
+      // fall through
+    case '0':
+      *res = false;
+      return 0;
+    case 'o':
+      // fall through
+    case 'O':
+      switch (s[1]) {
+        case 'n':
+          // fall through
+        case 'N':
+          *res = true;
+          return 0;
+        case 'f':
+          // fall through
+        case 'F':
+          *res = false;
+          return 0;
+        default:
+          break;
+      }
+      break;
+    default:
+      break;
+  }
+
+  return -EINVAL;
+}
+
+static void debounceTimerRestart(struct DebouncedGpioBean *deb) {
+  unsigned long debTime_usec;
+
+  if (gpioGetVal(&deb->gpio)) {
+    debTime_usec = deb->onMinTime_usec;
+  } else {
+    debTime_usec = deb->offMinTime_usec;
+  }
+
+  hrtimer_cancel(&deb->timer);
+  hrtimer_start(&deb->timer, ktime_set(0, debTime_usec * 1000),
+                HRTIMER_MODE_REL);
+}
+
+static irqreturn_t debounceIrqHandler(int irq, void *dev) {
+  struct DebouncedGpioBean *deb;
+  deb = (struct DebouncedGpioBean *)dev;
+  if (deb->irq != irq) {
+    // should never happen
+    return IRQ_HANDLED;
+  }
+  debounceTimerRestart(deb);
+  return IRQ_HANDLED;
+}
+
+static enum hrtimer_restart debounceTimerHandler(struct hrtimer *tmr) {
+  struct DebouncedGpioBean *deb;
+  int val;
+
+  deb = container_of(tmr, struct DebouncedGpioBean, timer);
+  val = gpioGetVal(&deb->gpio);
+
+  if (deb->value != val) {
+    deb->value = val;
+    if (val) {
+      deb->onCnt++;
+    } else {
+      deb->offCnt++;
+    }
+    if (deb->notifKn != NULL) {
+      sysfs_notify_dirent(deb->notifKn);
+    }
+  }
+
+  return HRTIMER_NORESTART;
+}
+
+void gpioSetPlatformDev(struct platform_device *pdev) { _pdev = pdev; }
+
+int gpioInit(struct GpioBean *g) {
+  g->desc = gpiod_get(&_pdev->dev, g->name, g->flags);
+  return IS_ERR(g->desc);
+}
+
+int gpioInitDebounce(struct DebouncedGpioBean *d) {
+  int res;
+
+  res = gpioInit(&d->gpio);
+  if (res) {
+    return res;
+  }
+
+  d->irqRequested = false;
+  d->value = DEBOUNCE_STATE_NOT_DEFINED;
+  d->onMinTime_usec = DEBOUNCE_DEFAULT_TIME_USEC;
+  d->offMinTime_usec = DEBOUNCE_DEFAULT_TIME_USEC;
+  d->onCnt = 0;
+  d->offCnt = 0;
+
+  hrtimer_init(&d->timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+  d->timer.function = &debounceTimerHandler;
+
+  d->irq = gpiod_to_irq(d->gpio.desc);
+  res = request_irq(d->irq, debounceIrqHandler,
+                    (IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING), d->gpio.name,
+                    d);
+  if (res) {
+    return res;
+  }
+  d->irqRequested = true;
+
+  debounceTimerRestart(d);
+
+  return res;
+}
+
+void gpioFree(struct GpioBean *g) {
+  if (g->desc != NULL && !IS_ERR(g->desc)) {
+    gpiod_put(g->desc);
+  }
+}
+
+void gpioFreeDebounce(struct DebouncedGpioBean *d) {
+  gpioFree(&d->gpio);
+  if (d->irqRequested) {
+    free_irq(d->irq, d);
+    hrtimer_cancel(&d->timer);
+    d->irqRequested = false;
+  }
+}
+
+int gpioGetVal(struct GpioBean *g) {
+  int v;
+  v = gpiod_get_value(g->desc);
+  if (g->invert) {
+    v = v == 0 ? 1 : 0;
+  }
+  return v;
+}
+
+void gpioSetVal(struct GpioBean *g, int val) {
+  if (g->invert) {
+    val = val == 0 ? 1 : 0;
+  }
+  gpiod_set_value(g->desc, val);
+}
+
+ssize_t devAttrGpioMode_show(struct device *dev, struct device_attribute *attr,
+                             char *buf) {
+  struct GpioBean *g;
+  const char *vals = NULL;
+  g = gpioGetBean(dev, attr, &vals);
+  if (g == NULL) {
+    return -EFAULT;
+  }
+  if (g->flags == GPIOD_IN) {
+    return sprintf(buf, "in\n");
+  }
+  if (g->flags == GPIOD_OUT_HIGH || g->flags == GPIOD_OUT_LOW) {
+    return sprintf(buf, "out\n");
+  }
+  return sprintf(buf, "x\n");
+}
+
+ssize_t devAttrGpioMode_store(struct device *dev, struct device_attribute *attr,
+                              const char *buf, size_t count) {
+  struct GpioBean *g;
+  const char *vals = NULL;
+  g = gpioGetBean(dev, attr, &vals);
+  if (g == NULL) {
+    return -EFAULT;
+  }
+
+  if (g->owner != NULL && g->owner != attr) {
+    return -EBUSY;
+  }
+
+  gpioFree(g);
+  g->owner = NULL;
+
+  if (toUpper(buf[0]) == 'I') {
+    g->flags = GPIOD_IN;
+  } else if (toUpper(buf[0]) == 'O') {
+    g->flags = GPIOD_OUT_LOW;
+  } else {
+    g->flags = 0;
+  }
+
+  if (g->flags != 0) {
+    if (gpioInit(g)) {
+      g->flags = 0;
+      return -EFAULT;
+    } else {
+      g->owner = attr;
+    }
+  }
+
+  return count;
+}
+
+ssize_t devAttrGpio_show(struct device *dev, struct device_attribute *attr,
+                         char *buf) {
+  struct GpioBean *g;
+  const char *vals = NULL;
+  g = gpioGetBean(dev, attr, &vals);
+  if (g == NULL) {
+    return -EFAULT;
+  }
+  if (g->flags != GPIOD_IN && g->flags != GPIOD_OUT_LOW &&
+      g->flags != GPIOD_OUT_HIGH) {
+    return -EPERM;
+  }
+  return valToStr(buf, gpioGetVal(g), vals, false, 0, 10, 0);
+}
+
+ssize_t devAttrGpio_store(struct device *dev, struct device_attribute *attr,
+                          const char *buf, size_t count) {
+  bool bVal;
+  int64_t val;
+  struct GpioBean *g;
+  const char *vals = NULL;
+  g = gpioGetBean(dev, attr, &vals);
+  if (g == NULL) {
+    return -EFAULT;
+  }
+  if (g->flags != GPIOD_OUT_HIGH && g->flags != GPIOD_OUT_LOW) {
+    return -EPERM;
+  }
+
+  if (vals == NULL) {
+    if (mkstrtobool(buf, &bVal) < 0) {
+      if (toUpper(buf[0]) == 'E') {  // Enable
+        bVal = true;
+      } else if (toUpper(buf[0]) == 'D') {  // Disable
+        bVal = false;
+      } else if (toUpper(buf[0]) == 'F' ||
+                 toUpper(buf[0]) == 'T') {  // Flip/Toggle
+        bVal = gpioGetVal(g) == 1 ? false : true;
+      } else {
+        return -EINVAL;
+      }
+    }
+    val = bVal ? 1 : 0;
+  } else {
+    val = strToVal(buf, vals, false, 10);
+    if (val < 0) {
+      return val;
+    }
+  }
+
+  gpioSetVal(g, val);
+  return count;
+}
+
+ssize_t devAttrGpioBlink_store(struct device *dev,
+                               struct device_attribute *attr, const char *buf,
+                               size_t count) {
+  int i;
+  long on = 0;
+  long off = 0;
+  long rep = 1;
+  char *end = NULL;
+  struct GpioBean *g;
+  const char *vals = NULL;
+  g = gpioGetBean(dev, attr, &vals);
+  if (g == NULL) {
+    return -EFAULT;
+  }
+  if (g->flags != GPIOD_OUT_HIGH && g->flags != GPIOD_OUT_LOW) {
+    return -EPERM;
+  }
+  on = simple_strtol(buf, &end, 10);
+  if (++end < buf + count) {
+    off = simple_strtol(end, &end, 10);
+    if (++end < buf + count) {
+      rep = simple_strtol(end, NULL, 10);
+    }
+  }
+  if (rep < 1) {
+    rep = 1;
+  }
+  if (on > 0) {
+    for (i = 0; i < rep; i++) {
+      gpioSetVal(g, 1);
+      msleep(on);
+      gpioSetVal(g, 0);
+      if (i < rep - 1) {
+        msleep(off);
+      }
+    }
+  }
+  return count;
+}
+
+static struct DebouncedGpioBean *gpioGetDebouncedBean(struct device *dev,
+                                               struct device_attribute *attr) {
+  struct GpioBean *g;
+  struct DebouncedGpioBean *d;
+  const char *vals = NULL;
+  g = gpioGetBean(dev, attr, &vals);
+  if (g == NULL) {
+    return NULL;
+  }
+  d = container_of(g, struct DebouncedGpioBean, gpio);
+  return d;
+}
+
+ssize_t devAttrGpioDeb_show(struct device *dev, struct device_attribute *attr,
+                            char *buf) {
+  struct DebouncedGpioBean *d;
+  d = gpioGetDebouncedBean(dev, attr);
+  if (d == NULL) {
+    return -EFAULT;
+  }
+
+  if (d->notifKn == NULL) {
+    d->notifKn = sysfs_get_dirent(dev->kobj.sd, attr->attr.name);
+  }
+
+  return sprintf(buf, "%d\n", d->value);
+}
+
+ssize_t devAttrGpioDebMsOn_show(struct device *dev,
+                                struct device_attribute *attr, char *buf) {
+  struct DebouncedGpioBean *d;
+  d = gpioGetDebouncedBean(dev, attr);
+  if (d == NULL) {
+    return -EFAULT;
+  }
+  return sprintf(buf, "%lu\n", d->onMinTime_usec / 1000);
+}
+
+ssize_t devAttrGpioDebMsOff_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf) {
+  struct DebouncedGpioBean *d;
+  d = gpioGetDebouncedBean(dev, attr);
+  if (d == NULL) {
+    return -EFAULT;
+  }
+  return sprintf(buf, "%lu\n", d->offMinTime_usec / 1000);
+}
+
+ssize_t devAttrGpioDebMsOn_store(struct device *dev,
+                                 struct device_attribute *attr, const char *buf,
+                                 size_t count) {
+  unsigned int val;
+  int ret;
+  struct DebouncedGpioBean *d;
+
+  d = gpioGetDebouncedBean(dev, attr);
+  if (d == NULL) {
+    return -EFAULT;
+  }
+  ret = kstrtouint(buf, 10, &val);
+  if (ret < 0) {
+    return ret;
+  }
+  d->onMinTime_usec = val * 1000;
+  d->onCnt = 0;
+  d->offCnt = 0;
+  d->value = DEBOUNCE_STATE_NOT_DEFINED;
+  debounceTimerRestart(d);
+
+  return count;
+}
+
+ssize_t devAttrGpioDebMsOff_store(struct device *dev,
+                                  struct device_attribute *attr,
+                                  const char *buf, size_t count) {
+  unsigned int val;
+  int ret;
+  struct DebouncedGpioBean *d;
+
+  d = gpioGetDebouncedBean(dev, attr);
+  if (d == NULL) {
+    return -EFAULT;
+  }
+  ret = kstrtouint(buf, 10, &val);
+  if (ret < 0) {
+    return ret;
+  }
+  d->offMinTime_usec = val * 1000;
+  d->onCnt = 0;
+  d->offCnt = 0;
+  d->value = DEBOUNCE_STATE_NOT_DEFINED;
+  debounceTimerRestart(d);
+
+  return count;
+}
+
+ssize_t devAttrGpioDebOnCnt_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf) {
+  struct DebouncedGpioBean *d;
+  d = gpioGetDebouncedBean(dev, attr);
+  if (d == NULL) {
+    return -EFAULT;
+  }
+  return sprintf(buf, "%lu\n", d->onCnt);
+}
+
+ssize_t devAttrGpioDebOffCnt_show(struct device *dev,
+                                  struct device_attribute *attr, char *buf) {
+  struct DebouncedGpioBean *d;
+  d = gpioGetDebouncedBean(dev, attr);
+  if (d == NULL) {
+    return -EFAULT;
+  }
+  return sprintf(buf, "%lu\n", d->offCnt);
+}

--- a/drivers/staging/sferalabs/commons/gpio/gpio.h
+++ b/drivers/staging/sferalabs/commons/gpio/gpio.h
@@ -1,0 +1,88 @@
+#ifndef _SL_GPIO_H
+#define _SL_GPIO_H
+
+#include <linux/gpio/consumer.h>
+#include <linux/platform_device.h>
+#include <linux/version.h>
+
+#define DEBOUNCE_DEFAULT_TIME_USEC 50000ul
+#define DEBOUNCE_STATE_NOT_DEFINED -1
+
+struct GpioBean {
+  const char *name;
+  struct gpio_desc *desc;
+  enum gpiod_flags flags;
+  bool invert;
+  void *owner;
+};
+
+struct DebouncedGpioBean {
+  struct GpioBean gpio;
+  int value;
+  int irq;
+  bool irqRequested;
+  unsigned long onMinTime_usec;
+  unsigned long offMinTime_usec;
+  unsigned long onCnt;
+  unsigned long offCnt;
+  struct hrtimer timer;
+  struct kernfs_node *notifKn;
+};
+
+void gpioSetPlatformDev(struct platform_device *pdev);
+
+int gpioInit(struct GpioBean *g);
+
+int gpioInitDebounce(struct DebouncedGpioBean *d);
+
+void gpioFree(struct GpioBean *g);
+
+void gpioFreeDebounce(struct DebouncedGpioBean *d);
+
+int gpioGetVal(struct GpioBean *g);
+
+void gpioSetVal(struct GpioBean *g, int val);
+
+ssize_t devAttrGpioMode_show(struct device *dev, struct device_attribute *attr,
+                             char *buf);
+
+ssize_t devAttrGpioMode_store(struct device *dev, struct device_attribute *attr,
+                              const char *buf, size_t count);
+
+ssize_t devAttrGpio_show(struct device *dev, struct device_attribute *attr,
+                         char *buf);
+
+ssize_t devAttrGpio_store(struct device *dev, struct device_attribute *attr,
+                          const char *buf, size_t count);
+
+ssize_t devAttrGpioDeb_show(struct device *dev, struct device_attribute *attr,
+                            char *buf);
+
+ssize_t devAttrGpioDebMsOn_show(struct device *dev,
+                                struct device_attribute *attr, char *buf);
+
+ssize_t devAttrGpioDebMsOn_store(struct device *dev,
+                                 struct device_attribute *attr, const char *buf,
+                                 size_t count);
+
+ssize_t devAttrGpioDebMsOff_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf);
+
+ssize_t devAttrGpioDebMsOff_store(struct device *dev,
+                                  struct device_attribute *attr,
+                                  const char *buf, size_t count);
+
+ssize_t devAttrGpioDebOnCnt_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf);
+
+ssize_t devAttrGpioDebOffCnt_show(struct device *dev,
+                                  struct device_attribute *attr, char *buf);
+
+ssize_t devAttrGpioBlink_store(struct device *dev,
+                               struct device_attribute *attr, const char *buf,
+                               size_t count);
+
+struct GpioBean *gpioGetBean(struct device *dev, struct device_attribute *attr,
+                             const char **vals);
+
+#endif

--- a/drivers/staging/sferalabs/commons/misc/misc.c
+++ b/drivers/staging/sferalabs/commons/misc/misc.c
@@ -1,0 +1,133 @@
+#include "misc.h"
+
+#include <linux/kernel.h>
+#include <linux/math64.h>
+
+static char *_itoa(int64_t value, char *buf, int base, uint32_t mask) {
+  char tmp[64 + 1];
+  char *tp = tmp;
+  uint32_t i;
+  uint64_t v;
+  bool sign;
+  bool pad0;
+  char *sp;
+
+  if (buf == NULL) {
+    return NULL;
+  }
+
+  sign = value < 0;
+  if (sign) {
+    v = -value;
+    pad0 = false;
+  } else {
+    v = (uint64_t)value;
+    pad0 = base != 10 && mask != 0;
+    if (pad0) {
+      v |= mask + 1;
+    }
+  }
+
+  while (v || tp == tmp) {
+    v = div_u64_rem(v, base, &i);
+    if (i < 10)
+      *tp++ = '0' + i;
+    else
+      *tp++ = 'a' + i - 10;
+  }
+  if (pad0) tp--;
+
+  sp = buf;
+
+  if (sign) *sp++ = '-';
+  while (tp > tmp) *sp++ = *--tp;
+  *sp = '\n';
+  return sp;
+}
+
+unsigned long long to_usec(struct timespec64 *t) {
+  return (t->tv_sec * 1000000) + (t->tv_nsec / 1000);
+}
+
+unsigned long long diff_usec(struct timespec64 *t1, struct timespec64 *t2) {
+  struct timespec64 diff;
+  diff = timespec64_sub(*t2, *t1);
+  return to_usec(&diff);
+}
+
+char toUpper(char c) {
+  if (c >= 97 && c <= 122) {
+    return c - 32;
+  }
+  return c;
+}
+
+int valToStr(char *buf, int64_t val, const char *vals, bool sign, uint8_t len,
+             uint8_t base, uint32_t mask) {
+  char *end;
+  if (vals == NULL) {
+    if (base == 0) {
+      base = 10;
+    }
+    if (sign) {
+      if (len < 3) {
+        if (len == 1) {
+          if ((val & 0x80) == 0x80) {
+            // negative => add sign bits
+            val |= 0xff00;
+          }
+        }
+        end = _itoa((int16_t)val, buf, base, mask);
+      } else {
+        if (len == 3) {
+          if ((val & 0x800000) == 0x800000) {
+            // negative => add sign bits
+            val |= 0xff000000;
+          }
+        }
+        end = _itoa((int32_t)val, buf, base, mask);
+      }
+    } else {
+      end = _itoa(val, buf, base, mask);
+    }
+    return end - buf + 1;
+  } else {
+    if (val > vals[0] - 1) {
+      return -EFAULT;
+    }
+    return sprintf(buf, "%c\n", vals[val + 1]);
+  }
+}
+
+int64_t strToVal(const char *buf, const char *vals, bool sign, uint8_t base) {
+  int i, ret;
+  int64_t val;
+  char valC;
+  if (vals == NULL) {
+    if (base == 0) {
+      base = 10;
+    }
+    ret = kstrtoll(buf, base, &val);
+    if (ret < 0) {
+      return -EINVAL;
+    }
+  } else {
+    val = -1;
+    valC = toUpper(buf[0]);
+    for (i = 0; i < vals[0]; i++) {
+      if (vals[i + 1] == valC) {
+        val = i;
+        break;
+      }
+    }
+    if (val == -1) {
+      return -EINVAL;
+    }
+  }
+
+  if (!sign && val < 0) {
+    return -EINVAL;
+  }
+
+  return val & 0xffffffff;
+}

--- a/drivers/staging/sferalabs/commons/misc/misc.h
+++ b/drivers/staging/sferalabs/commons/misc/misc.h
@@ -1,0 +1,13 @@
+#ifndef _SL_COMMONS_H
+#define _SL_COMMONS_H
+
+#include <linux/time.h>
+
+unsigned long long to_usec(struct timespec64 *t);
+unsigned long long diff_usec(struct timespec64 *t1, struct timespec64 *t2);
+char toUpper(char c);
+int valToStr(char *buf, int64_t val, const char *vals, bool sign, uint8_t len,
+             uint8_t base, uint32_t mask);
+int64_t strToVal(const char *buf, const char *vals, bool sign, uint8_t base);
+
+#endif

--- a/drivers/staging/sferalabs/commons/wiegand/wiegand.c
+++ b/drivers/staging/sferalabs/commons/wiegand/wiegand.c
@@ -1,0 +1,438 @@
+#include "wiegand.h"
+
+#include <linux/interrupt.h>
+
+#include "../misc/misc.h"
+
+#define WIEGAND_MAX_BITS 64
+
+int wCount = 0;
+
+static enum hrtimer_restart wiegandTimerHandler(struct hrtimer *tmr) {
+  struct WiegandBean *w;
+  w = container_of(tmr, struct WiegandBean, timer);
+  if (w->notifKn != NULL) {
+    sysfs_notify_dirent(w->notifKn);
+  }
+  return HRTIMER_NORESTART;
+}
+
+void wiegandInit(struct WiegandBean *w) {
+  w->d0.irqRequested = false;
+  w->d1.irqRequested = false;
+  w->enabled = false;
+  w->pulseWidthMin_usec = 10;
+  w->pulseWidthMax_usec = 150;
+  w->pulseIntervalMin_usec = 1200;
+  w->pulseIntervalMax_usec = 2700;
+  w->noise = 0;
+  w->id = '0' + (++wCount);
+  hrtimer_init(&w->timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+  w->timer.function = &wiegandTimerHandler;
+}
+
+static void wiegandReset(struct WiegandBean *w) {
+  w->enabled = true;
+  w->data = 0;
+  w->bitCount = 0;
+  w->activeLine = NULL;
+  w->d0.wasLow = false;
+  w->d1.wasLow = false;
+}
+
+void wiegandDisable(struct WiegandBean *w) {
+  if (w->enabled) {
+    hrtimer_cancel(&w->timer);
+
+    gpioFree(w->d0.gpio);
+    gpioFree(w->d1.gpio);
+
+    if (w->d0.irqRequested) {
+      free_irq(w->d0.irq, w);
+      w->d0.irqRequested = false;
+    }
+
+    if (w->d1.irqRequested) {
+      free_irq(w->d1.irq, w);
+      w->d1.irqRequested = false;
+    }
+
+    w->d0.gpio->owner = NULL;
+    w->d1.gpio->owner = NULL;
+    w->enabled = false;
+  }
+}
+
+static irqreturn_t wiegandDataIrqHandler(int irq, void *dev) {
+  bool isLow;
+  struct timespec64 now;
+  unsigned long long diff;
+  struct WiegandBean *w;
+  struct WiegandLine *l;
+
+  w = (struct WiegandBean *)dev;
+  l = NULL;
+
+  if (w->enabled) {
+    if (irq == w->d0.irq) {
+      l = &w->d0;
+    } else if (irq == w->d1.irq) {
+      l = &w->d1;
+    }
+  }
+
+  if (l == NULL) {
+    return IRQ_HANDLED;
+  }
+
+  isLow = gpioGetVal(l->gpio) == 0;
+
+  ktime_get_raw_ts64(&now);
+
+  if (l->wasLow == isLow) {
+    // got the interrupt but didn't change state. Maybe a fast pulse
+    if (w->noise == 0) {
+      w->noise = 10;
+    }
+    return IRQ_HANDLED;
+  }
+
+  l->wasLow = isLow;
+
+  if (isLow) {
+    if (w->bitCount != 0) {
+      diff = diff_usec((struct timespec64 *)&(w->lastBitTs), &now);
+
+      if (diff < w->pulseIntervalMin_usec) {
+        // pulse too early
+        w->noise = 11;
+        goto noise;
+      }
+
+      if (diff > w->pulseIntervalMax_usec) {
+        w->data = 0;
+        w->bitCount = 0;
+      }
+    }
+
+    if (w->activeLine != NULL) {
+      // there's movement on both lines
+      w->noise = 12;
+      goto noise;
+    }
+
+    w->activeLine = l;
+
+    w->lastBitTs.tv_sec = now.tv_sec;
+    w->lastBitTs.tv_nsec = now.tv_nsec;
+
+  } else {
+    if (w->activeLine != l) {
+      // there's movement on both lines or previous noise
+      w->noise = 13;
+      goto noise;
+    }
+
+    w->activeLine = NULL;
+
+    if (w->bitCount >= WIEGAND_MAX_BITS) {
+      return IRQ_HANDLED;
+    }
+
+    diff = diff_usec((struct timespec64 *)&(w->lastBitTs), &now);
+    if (diff < w->pulseWidthMin_usec) {
+      // pulse too short
+      w->noise = 14;
+      goto noise;
+    }
+    if (diff > w->pulseWidthMax_usec) {
+      // pulse too long
+      w->noise = 15;
+      goto noise;
+    }
+
+    w->data <<= 1;
+    if (l == &w->d1) {
+      w->data |= 1;
+    }
+    w->bitCount++;
+
+    hrtimer_cancel(&w->timer);
+    hrtimer_start(&w->timer,
+                  ktime_set(0, (w->pulseIntervalMax_usec - diff) * 1000),
+                  HRTIMER_MODE_REL);
+  }
+
+  return IRQ_HANDLED;
+
+noise:
+  wiegandReset(w);
+  return IRQ_HANDLED;
+}
+
+ssize_t devAttrWiegandEnabled_show(struct device *dev,
+                                   struct device_attribute *attr, char *buf) {
+  struct WiegandBean *w;
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+  return sprintf(buf, w->enabled ? "1\n" : "0\n");
+}
+
+ssize_t devAttrWiegandEnabled_store(struct device *dev,
+                                    struct device_attribute *attr,
+                                    const char *buf, size_t count) {
+  struct WiegandBean *w;
+  bool enable;
+  int result = 0;
+
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+
+  if (buf[0] == '0') {
+    enable = false;
+  } else if (buf[0] == '1') {
+    enable = true;
+  } else {
+    return -EINVAL;
+  }
+
+  if (enable && !w->enabled) {
+    if (w->d0.gpio->owner != NULL || w->d1.gpio->owner != NULL) {
+      return -EBUSY;
+    }
+    w->d0.gpio->owner = w;
+    w->d1.gpio->owner = w;
+
+    w->d0.gpio->flags = GPIOD_IN;
+    w->d1.gpio->flags = GPIOD_IN;
+
+    result = gpioInit(w->d0.gpio);
+    if (!result) {
+      result = gpioInit(w->d1.gpio);
+    }
+
+    if (result) {
+      pr_err("error setting up wiegand GPIOs\n");
+      enable = false;
+    } else {
+      gpiod_set_debounce(w->d0.gpio->desc, 0);
+      gpiod_set_debounce(w->d1.gpio->desc, 0);
+
+      w->d0.irq = gpiod_to_irq(w->d0.gpio->desc);
+      w->d1.irq = gpiod_to_irq(w->d1.gpio->desc);
+
+      result = request_irq(w->d0.irq, wiegandDataIrqHandler,
+                           IRQF_TRIGGER_FALLING | IRQF_TRIGGER_RISING,
+                           w->d0.gpio->name, w);
+
+      if (result) {
+        pr_err("error registering wiegand D0 irq handler\n");
+        enable = false;
+      } else {
+        w->d0.irqRequested = true;
+
+        result = request_irq(w->d1.irq, wiegandDataIrqHandler,
+                             IRQF_TRIGGER_FALLING | IRQF_TRIGGER_RISING,
+                             w->d1.gpio->name, w);
+
+        if (result) {
+          pr_err("error registering wiegand D1 irq handler\n");
+          enable = false;
+        } else {
+          w->d1.irqRequested = true;
+        }
+      }
+    }
+  }
+
+  if (enable) {
+    w->noise = 0;
+    wiegandReset(w);
+  } else {
+    wiegandDisable(w);
+  }
+
+  if (result) {
+    return result;
+  }
+  return count;
+}
+
+ssize_t devAttrWiegandData_show(struct device *dev,
+                                struct device_attribute *attr, char *buf) {
+  struct timespec64 now;
+  unsigned long long diff;
+  struct WiegandBean *w;
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+
+  if (!w->enabled) {
+    return -ENODEV;
+  }
+
+  if (w->notifKn == NULL) {
+    w->notifKn = sysfs_get_dirent(dev->kobj.sd, attr->attr.name);
+  }
+
+  ktime_get_raw_ts64(&now);
+  diff = diff_usec((struct timespec64 *)&(w->lastBitTs), &now);
+  if (diff <= w->pulseIntervalMax_usec) {
+    return -EBUSY;
+  }
+
+  return sprintf(buf, "%llu %d %llu\n", to_usec(&w->lastBitTs), w->bitCount,
+                 w->data);
+}
+
+ssize_t devAttrWiegandNoise_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf) {
+  struct WiegandBean *w;
+  int noise;
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+  noise = w->noise;
+
+  w->noise = 0;
+
+  return sprintf(buf, "%d\n", noise);
+}
+
+ssize_t devAttrWiegandPulseIntervalMin_show(struct device *dev,
+                                            struct device_attribute *attr,
+                                            char *buf) {
+  struct WiegandBean *w;
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+
+  return sprintf(buf, "%lu\n", w->pulseIntervalMin_usec);
+}
+
+ssize_t devAttrWiegandPulseIntervalMin_store(struct device *dev,
+                                             struct device_attribute *attr,
+                                             const char *buf, size_t count) {
+  int ret;
+  unsigned long val;
+  struct WiegandBean *w;
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+
+  ret = kstrtol(buf, 10, &val);
+  if (ret < 0) {
+    return ret;
+  }
+
+  w->pulseIntervalMin_usec = val;
+
+  return count;
+}
+
+ssize_t devAttrWiegandPulseIntervalMax_show(struct device *dev,
+                                            struct device_attribute *attr,
+                                            char *buf) {
+  struct WiegandBean *w;
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+
+  return sprintf(buf, "%lu\n", w->pulseIntervalMax_usec);
+}
+
+ssize_t devAttrWiegandPulseIntervalMax_store(struct device *dev,
+                                             struct device_attribute *attr,
+                                             const char *buf, size_t count) {
+  int ret;
+  unsigned long val;
+  struct WiegandBean *w;
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+
+  ret = kstrtol(buf, 10, &val);
+  if (ret < 0) {
+    return ret;
+  }
+
+  w->pulseIntervalMax_usec = val;
+
+  return count;
+}
+
+ssize_t devAttrWiegandPulseWidthMin_show(struct device *dev,
+                                         struct device_attribute *attr,
+                                         char *buf) {
+  struct WiegandBean *w;
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+
+  return sprintf(buf, "%lu\n", w->pulseWidthMin_usec);
+}
+
+ssize_t devAttrWiegandPulseWidthMin_store(struct device *dev,
+                                          struct device_attribute *attr,
+                                          const char *buf, size_t count) {
+  int ret;
+  unsigned long val;
+  struct WiegandBean *w;
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+
+  ret = kstrtol(buf, 10, &val);
+  if (ret < 0) {
+    return ret;
+  }
+
+  w->pulseWidthMin_usec = val;
+
+  return count;
+}
+
+ssize_t devAttrWiegandPulseWidthMax_show(struct device *dev,
+                                         struct device_attribute *attr,
+                                         char *buf) {
+  struct WiegandBean *w;
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+
+  return sprintf(buf, "%lu\n", w->pulseWidthMax_usec);
+}
+
+ssize_t devAttrWiegandPulseWidthMax_store(struct device *dev,
+                                          struct device_attribute *attr,
+                                          const char *buf, size_t count) {
+  int ret;
+  unsigned long val;
+  struct WiegandBean *w;
+  w = wiegandGetBean(dev, attr);
+  if (w == NULL) {
+    return -EFAULT;
+  }
+
+  ret = kstrtol(buf, 10, &val);
+  if (ret < 0) {
+    return ret;
+  }
+
+  w->pulseWidthMax_usec = val;
+
+  return count;
+}

--- a/drivers/staging/sferalabs/commons/wiegand/wiegand.h
+++ b/drivers/staging/sferalabs/commons/wiegand/wiegand.h
@@ -1,0 +1,85 @@
+#ifndef _SL_WIEGAND_H
+#define _SL_WIEGAND_H
+
+#include <linux/device.h>
+
+#include "../gpio/gpio.h"
+
+struct WiegandLine {
+  struct GpioBean *gpio;
+  unsigned int irq;
+  bool irqRequested;
+  bool wasLow;
+};
+
+struct WiegandBean {
+  char id;
+  struct WiegandLine d0;
+  struct WiegandLine d1;
+  struct WiegandLine *activeLine;
+  unsigned long pulseIntervalMin_usec;
+  unsigned long pulseIntervalMax_usec;
+  unsigned long pulseWidthMin_usec;
+  unsigned long pulseWidthMax_usec;
+  bool enabled;
+  uint64_t data;
+  int bitCount;
+  int noise;
+  struct timespec64 lastBitTs;
+  struct hrtimer timer;
+  struct kernfs_node *notifKn;
+};
+
+void wiegandInit(struct WiegandBean *w);
+
+void wiegandDisable(struct WiegandBean *w);
+
+ssize_t devAttrWiegandEnabled_show(struct device *dev,
+                                   struct device_attribute *attr, char *buf);
+
+ssize_t devAttrWiegandEnabled_store(struct device *dev,
+                                    struct device_attribute *attr,
+                                    const char *buf, size_t count);
+
+ssize_t devAttrWiegandData_show(struct device *dev,
+                                struct device_attribute *attr, char *buf);
+
+ssize_t devAttrWiegandNoise_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf);
+
+ssize_t devAttrWiegandPulseIntervalMin_show(struct device *dev,
+                                            struct device_attribute *attr,
+                                            char *buf);
+
+ssize_t devAttrWiegandPulseIntervalMin_store(struct device *dev,
+                                             struct device_attribute *attr,
+                                             const char *buf, size_t count);
+
+ssize_t devAttrWiegandPulseIntervalMax_show(struct device *dev,
+                                            struct device_attribute *attr,
+                                            char *buf);
+
+ssize_t devAttrWiegandPulseIntervalMax_store(struct device *dev,
+                                             struct device_attribute *attr,
+                                             const char *buf, size_t count);
+
+ssize_t devAttrWiegandPulseWidthMin_show(struct device *dev,
+                                         struct device_attribute *attr,
+                                         char *buf);
+
+ssize_t devAttrWiegandPulseWidthMin_store(struct device *dev,
+                                          struct device_attribute *attr,
+                                          const char *buf, size_t count);
+
+ssize_t devAttrWiegandPulseWidthMax_show(struct device *dev,
+                                         struct device_attribute *attr,
+                                         char *buf);
+
+ssize_t devAttrWiegandPulseWidthMax_store(struct device *dev,
+                                          struct device_attribute *attr,
+                                          const char *buf, size_t count);
+
+struct WiegandBean *wiegandGetBean(struct device *dev,
+                                   struct device_attribute *attr);
+
+#endif

--- a/drivers/staging/sferalabs/ionopi-v3/Kconfig
+++ b/drivers/staging/sferalabs/ionopi-v3/Kconfig
@@ -1,0 +1,4 @@
+config IONO_PI_V3
+	tristate "Sfera Labs Iono Pi v3 support"
+	help
+	  Driver for the Sfera Labs Iono Pi v3 board.

--- a/drivers/staging/sferalabs/ionopi-v3/Makefile
+++ b/drivers/staging/sferalabs/ionopi-v3/Makefile
@@ -1,0 +1,8 @@
+obj-$(CONFIG_IONO_PI_V3) += ionopi-v3.o
+
+ionopi-v3-objs := module.o
+ionopi-v3-objs += ../commons/misc/misc.o
+ionopi-v3-objs += ../commons/gpio/gpio.o
+ionopi-v3-objs += ../commons/wiegand/wiegand.o
+ionopi-v3-objs += ../commons/atecc/atecc.o
+ionopi-v3-objs += pcf2131/pcf2131.o

--- a/drivers/staging/sferalabs/ionopi-v3/module.c
+++ b/drivers/staging/sferalabs/ionopi-v3/module.c
@@ -1,0 +1,2371 @@
+/*
+ * Iono Pi v3 kernel module
+ *
+ *     Copyright (C) 2024-2025 Sfera Labs S.r.l.
+ *
+ *     For information, visit https://www.sferalabs.cc
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * LICENSE.txt file for more details.
+ *
+ */
+
+#include <linux/delay.h>
+#include <linux/i2c.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/regulator/consumer.h>
+#include <linux/spi/spi.h>
+#include <linux/version.h>
+
+#include "../commons/atecc/atecc.h"
+#include "../commons/misc/misc.h"
+#include "../commons/gpio/gpio.h"
+#include "../commons/wiegand/wiegand.h"
+#include "pcf2131/pcf2131.h"
+
+#define MCP3462_CMD_DEV_ADDR 0b01000000
+
+#define MCP3462_CMD_READ_STATIC (MCP3462_CMD_DEV_ADDR | 0b00000001)
+#define MCP3462_CMD_WRITE_INCR (MCP3462_CMD_DEV_ADDR | 0b00000010)
+#define MCP3462_CMD_READ_INCR (MCP3462_CMD_DEV_ADDR | 0b00000011)
+#define MCP3462_CMD_CONV_START (MCP3462_CMD_DEV_ADDR | 0b00101000)
+
+#define MCP3462_STAT_DR_STATUS_MASK 0b00000100
+#define MCP3462_STAT_DEV_ADDR_MASK 0b00111000
+#define MCP3462_STAT_DEV_ADDR 0b00010000
+
+#define MCP3462_REG_ADDR_ADCDATA (0x0 << 2)
+#define MCP3462_REG_ADDR_CONFIG0 (0x1 << 2)
+#define MCP3462_REG_ADDR_CONFIG1 (0x2 << 2)
+#define MCP3462_REG_ADDR_CONFIG2 (0x3 << 2)
+#define MCP3462_REG_ADDR_CONFIG3 (0x4 << 2)
+#define MCP3462_REG_ADDR_MUX (0x6 << 2)
+
+#define MCP3462_CONFIG0_ADC_MODE 0b00000011  // Conversion mode
+#define MCP3462_CONFIG0_CS_SEL 0b00000000    // No current source
+#define MCP3462_CONFIG0_CLK_SEL 0b00100000   // Internal clock, no output
+#define MCP3462_CONFIG0_VREF_SEL 0b10000000  // Internal voltage reference
+#define MCP3462_CONFIG0                                 \
+  (MCP3462_CONFIG0_VREF_SEL | MCP3462_CONFIG0_CLK_SEL | \
+   MCP3462_CONFIG0_CS_SEL | MCP3462_CONFIG0_ADC_MODE)
+
+#define MCP3462_CONFIG1_PRE 0b00000000       // AMCLK = MCLK
+#define MCP3462_CONFIG1_RESERVED 0b00000000  // Always 00
+
+#define MCP3462_CONFIG2_RESERVED 0b00000001  // Always 1
+#define MCP3462_CONFIG2_AZ_REF \
+  0b00000010  // Auto-Zeroing Reference Buffer Setting enabled
+#define MCP3462_CONFIG2_GAIN 0b00001000   // Gain x 1
+#define MCP3462_CONFIG2_BOOST 0b10000000  // Current x 1
+
+#define MCP3462_CONFIG3_EN_GAINCAL 0b00000000   // Disabled
+#define MCP3462_CONFIG3_EN_OFFCAL 0b00000000    // Disabled
+#define MCP3462_CONFIG3_EN_CRCCOM 0b00000100    // Enabled
+#define MCP3462_CONFIG3_CRC_FORMAT 0b00000000   // 16 bit
+#define MCP3462_CONFIG3_DATA_FORMAT 0b00000000  // 16 bit
+#define MCP3462_CONFIG3_CONV_MODE 0b11000000    // Continuous
+#define MCP3462_CONFIG3                                      \
+  (MCP3462_CONFIG3_CONV_MODE | MCP3462_CONFIG3_DATA_FORMAT | \
+   MCP3462_CONFIG3_CRC_FORMAT | MCP3462_CONFIG3_EN_CRCCOM |  \
+   MCP3462_CONFIG3_EN_OFFCAL | MCP3462_CONFIG3_EN_GAINCAL)
+
+#define MCP3462_MUX_SE_CH0 0x08
+#define MCP3462_MUX_SE_CH1 0x18
+#define MCP3462_MUX_SE_CH2 0x28
+#define MCP3462_MUX_SE_CH3 0x38
+
+#define MCP3462_FACTOR_AV 1125
+#define MCP3462_FACTOR_AI 750
+#define MCP3462_DIVISOR 1024
+
+#define MCP3462_OSR_DEFAULT 0b0011
+#define MCP3462_AZ_MUX_DEFAULT 0b1
+
+#define LOG_TAG "ionopi: "
+
+struct DeviceAttrBean {
+  struct device_attribute devAttr;
+  void *data;
+};
+
+struct DeviceBean {
+  char *name;
+  struct device *pDevice;
+  struct DeviceAttrBean *devAttrBeans;
+};
+
+static struct class *pDeviceClass;
+
+static ssize_t devAttrMcp3462Osr_show(struct device *dev,
+                                      struct device_attribute *attr, char *buf);
+
+static ssize_t devAttrMcp3462Osr_store(struct device *dev,
+                                       struct device_attribute *attr,
+                                       const char *buf, size_t count);
+
+static ssize_t devAttrMcp3462AzMux_show(struct device *dev,
+                                        struct device_attribute *attr,
+                                        char *buf);
+
+static ssize_t devAttrMcp3462AzMux_store(struct device *dev,
+                                         struct device_attribute *attr,
+                                         const char *buf, size_t count);
+
+static ssize_t devAttrAv1Mv_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf);
+
+static ssize_t devAttrAv2Mv_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf);
+
+static ssize_t devAttrAi1Ua_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf);
+
+static ssize_t devAttrAi2Ua_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf);
+
+static ssize_t devAttrAv1Raw_show(struct device *dev,
+                                  struct device_attribute *attr, char *buf);
+
+static ssize_t devAttrAv2Raw_show(struct device *dev,
+                                  struct device_attribute *attr, char *buf);
+
+static ssize_t devAttrAi1Raw_show(struct device *dev,
+                                  struct device_attribute *attr, char *buf);
+
+static ssize_t devAttrAi2Raw_show(struct device *dev,
+                                  struct device_attribute *attr, char *buf);
+
+static ssize_t devAttrMax4896_show(struct device *dev,
+                                   struct device_attribute *attr, char *buf);
+
+static ssize_t devAttrMax4896_store(struct device *dev,
+                                    struct device_attribute *attr,
+                                    const char *buf, size_t count);
+
+enum dout_e {
+  DO_O1 = 0,
+  DO_O2,
+  DO_O3,
+  DO_O4,
+  DO_OC1,
+  DO_OC2,
+  DO_OC3,
+  DO_ALL,
+};
+
+struct max4896_out {
+  uint8_t mask;
+  uint8_t shift;
+};
+
+static struct max4896_out _max4896_outs[] = {
+    [DO_O1] =
+        {
+            .mask = 0b1,
+            .shift = 0,
+        },
+    [DO_O2] =
+        {
+            .mask = 0b1,
+            .shift = 1,
+        },
+    [DO_O3] =
+        {
+            .mask = 0b1,
+            .shift = 2,
+        },
+    [DO_O4] =
+        {
+            .mask = 0b1,
+            .shift = 3,
+        },
+    [DO_OC1] =
+        {
+            .mask = 0b1,
+            .shift = 4,
+        },
+    [DO_OC2] =
+        {
+            .mask = 0b1,
+            .shift = 5,
+        },
+    [DO_OC3] =
+        {
+            .mask = 0b1,
+            .shift = 6,
+        },
+    [DO_ALL] =
+        {
+            .mask = 0b1111111,
+            .shift = 0,
+        },
+};
+
+enum din_e {
+  DI1,
+  DI2,
+  DI3,
+  DI4,
+  DI5,
+  DI6,
+  DI_SIZE,
+};
+
+enum dt_e {
+  DT1,
+  DT2,
+  DT3,
+  DT4,
+};
+
+enum gpio_e {
+  LED,
+  DO_RESET,
+  DO_FLAG,
+  DO_PDCD,
+  DO_SPLD,
+  V5OF,
+  GPIO_SIZE,
+};
+
+static struct GpioBean _gpio[] = {
+    [LED] =
+        {
+            .name = "ionopi_led",
+            .flags = GPIOD_OUT_LOW,
+        },
+    [DO_RESET] =
+        {
+            .name = "ionopi_do_reset",
+            .invert = true,
+            .flags = GPIOD_OUT_HIGH,
+        },
+    [DO_FLAG] =
+        {
+            .name = "ionopi_do_flag",
+            .invert = true,
+            .flags = GPIOD_IN,
+        },
+    [DO_PDCD] =
+        {
+            .name = "ionopi_do_pdcd",
+            .invert = true,
+            .flags = GPIOD_OUT_HIGH,
+        },
+    [DO_SPLD] =
+        {
+            .name = "ionopi_do_spld",
+            .invert = true,
+            .flags = GPIOD_OUT_HIGH,
+        },
+    [V5OF] =
+        {
+            .name = "ionopi_v5of",
+            .flags = GPIOD_IN,
+            .invert = true,
+        },
+};
+
+static struct GpioBean _gpio_dt[] = {
+    [DT1] =
+        {
+            .name = "ionopi_dt1",
+        },
+    [DT2] =
+        {
+            .name = "ionopi_dt2",
+        },
+    [DT3] =
+        {
+            .name = "ionopi_dt3",
+        },
+    [DT4] =
+        {
+            .name = "ionopi_dt4",
+        },
+};
+
+static struct DebouncedGpioBean _gpio_din[] = {
+    [DI1] =
+        {
+            .gpio =
+                {
+                    .name = "ionopi_di1",
+                    .flags = GPIOD_IN,
+                },
+        },
+    [DI2] =
+        {
+            .gpio =
+                {
+                    .name = "ionopi_di2",
+                    .flags = GPIOD_IN,
+                },
+        },
+    [DI3] =
+        {
+            .gpio =
+                {
+                    .name = "ionopi_di3",
+                    .flags = GPIOD_IN,
+                },
+        },
+    [DI4] =
+        {
+            .gpio =
+                {
+                    .name = "ionopi_di4",
+                    .flags = GPIOD_IN,
+                },
+        },
+    [DI5] =
+        {
+            .gpio =
+                {
+                    .name = "ionopi_di5",
+                    .flags = GPIOD_IN,
+                },
+        },
+    [DI6] =
+        {
+            .gpio =
+                {
+                    .name = "ionopi_di6",
+                    .flags = GPIOD_IN,
+                },
+        },
+};
+
+static struct WiegandBean _w1 = {
+    .d0 =
+        {
+            .gpio = &_gpio_dt[DT1],
+        },
+    .d1 =
+        {
+            .gpio = &_gpio_dt[DT2],
+        },
+};
+
+static struct WiegandBean _w2 = {
+    .d0 =
+        {
+            .gpio = &_gpio_dt[DT3],
+        },
+    .d1 =
+        {
+            .gpio = &_gpio_dt[DT4],
+        },
+};
+
+static struct DeviceAttrBean devAttrBeansLed[] = {
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "status",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpio_show,
+                .store = devAttrGpio_store,
+            },
+        .data = &_gpio[LED],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "blink",
+                        .mode = 0220,
+                    },
+                .store = devAttrGpioBlink_store,
+            },
+        .data = &_gpio[LED],
+    },
+
+    {},
+};
+
+static struct DeviceAttrBean devAttrBeansDigitalIn[] = {
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di1",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpio_show,
+            },
+        .data = &_gpio_din[DI1].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di2",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpio_show,
+            },
+        .data = &_gpio_din[DI2].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di3",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpio_show,
+            },
+        .data = &_gpio_din[DI3].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di4",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpio_show,
+            },
+        .data = &_gpio_din[DI4].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di5",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpio_show,
+            },
+        .data = &_gpio_din[DI5].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di6",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpio_show,
+            },
+        .data = &_gpio_din[DI6].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di1_deb",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDeb_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI1].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di2_deb",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDeb_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI2].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di3_deb",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDeb_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI3].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di4_deb",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDeb_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI4].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di5_deb",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDeb_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI5].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di6_deb",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDeb_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI6].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di1_deb_on_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOn_show,
+                .store = devAttrGpioDebMsOn_store,
+            },
+        .data = &_gpio_din[DI1].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di1_deb_off_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOff_show,
+                .store = devAttrGpioDebMsOff_store,
+            },
+        .data = &_gpio_din[DI1].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di2_deb_on_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOn_show,
+                .store = devAttrGpioDebMsOn_store,
+            },
+        .data = &_gpio_din[DI2].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di2_deb_off_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOff_show,
+                .store = devAttrGpioDebMsOff_store,
+            },
+        .data = &_gpio_din[DI2].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di3_deb_on_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOn_show,
+                .store = devAttrGpioDebMsOn_store,
+            },
+        .data = &_gpio_din[DI3].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di3_deb_off_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOff_show,
+                .store = devAttrGpioDebMsOff_store,
+            },
+        .data = &_gpio_din[DI3].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di4_deb_on_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOn_show,
+                .store = devAttrGpioDebMsOn_store,
+            },
+        .data = &_gpio_din[DI4].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di4_deb_off_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOff_show,
+                .store = devAttrGpioDebMsOff_store,
+            },
+        .data = &_gpio_din[DI4].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di5_deb_on_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOn_show,
+                .store = devAttrGpioDebMsOn_store,
+            },
+        .data = &_gpio_din[DI5].gpio,
+    },
+
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di5_deb_off_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOff_show,
+                .store = devAttrGpioDebMsOff_store,
+            },
+        .data = &_gpio_din[DI5].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di6_deb_on_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOn_show,
+                .store = devAttrGpioDebMsOn_store,
+            },
+        .data = &_gpio_din[DI6].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di6_deb_off_ms",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioDebMsOff_show,
+                .store = devAttrGpioDebMsOff_store,
+            },
+        .data = &_gpio_din[DI6].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di1_deb_on_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOnCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI1].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di1_deb_off_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOffCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI1].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di2_deb_on_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOnCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI2].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di2_deb_off_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOffCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI2].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di3_deb_on_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOnCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI3].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di3_deb_off_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOffCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI3].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di4_deb_on_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOnCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI4].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di4_deb_off_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOffCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI4].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di5_deb_on_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOnCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI5].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di5_deb_off_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOffCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI5].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di6_deb_on_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOnCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI6].gpio,
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "di6_deb_off_cnt",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpioDebOffCnt_show,
+                .store = NULL,
+            },
+        .data = &_gpio_din[DI6].gpio,
+    },
+
+    {},
+};
+
+static struct DeviceAttrBean devAttrBeansDigitalIO[] = {
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "dt1_mode",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioMode_show,
+                .store = devAttrGpioMode_store,
+            },
+        .data = &_gpio_dt[DT1],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "dt2_mode",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioMode_show,
+                .store = devAttrGpioMode_store,
+            },
+        .data = &_gpio_dt[DT2],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "dt3_mode",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioMode_show,
+                .store = devAttrGpioMode_store,
+            },
+        .data = &_gpio_dt[DT3],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "dt4_mode",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpioMode_show,
+                .store = devAttrGpioMode_store,
+            },
+        .data = &_gpio_dt[DT4],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "dt1",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpio_show,
+                .store = devAttrGpio_store,
+            },
+        .data = &_gpio_dt[DT1],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "dt2",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpio_show,
+                .store = devAttrGpio_store,
+            },
+        .data = &_gpio_dt[DT2],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "dt3",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpio_show,
+                .store = devAttrGpio_store,
+            },
+        .data = &_gpio_dt[DT3],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "dt4",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpio_show,
+                .store = devAttrGpio_store,
+            },
+        .data = &_gpio_dt[DT4],
+    },
+
+    {},
+};
+
+static struct DeviceAttrBean devAttrBeansAnalogIn[] = {
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "osr",
+                        .mode = 0660,
+                    },
+                .show = devAttrMcp3462Osr_show,
+                .store = devAttrMcp3462Osr_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "az_mux",
+                        .mode = 0660,
+                    },
+                .show = devAttrMcp3462AzMux_show,
+                .store = devAttrMcp3462AzMux_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "av1_mv",
+                        .mode = 0440,
+                    },
+                .show = devAttrAv1Mv_show,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "av2_mv",
+                        .mode = 0440,
+                    },
+                .show = devAttrAv2Mv_show,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "ai1_ua",
+                        .mode = 0440,
+                    },
+                .show = devAttrAi1Ua_show,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "ai2_ua",
+                        .mode = 0440,
+                    },
+                .show = devAttrAi2Ua_show,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "av1_raw",
+                        .mode = 0440,
+                    },
+                .show = devAttrAv1Raw_show,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "av2_raw",
+                        .mode = 0440,
+                    },
+                .show = devAttrAv2Raw_show,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "ai1_raw",
+                        .mode = 0440,
+                    },
+                .show = devAttrAi1Raw_show,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "ai2_raw",
+                        .mode = 0440,
+                    },
+                .show = devAttrAi2Raw_show,
+            },
+    },
+
+    {},
+};
+
+static struct DeviceAttrBean devAttrBeansDigitalOut[] = {
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "pdc",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpio_show,
+                .store = devAttrGpio_store,
+            },
+        .data = &_gpio[DO_PDCD],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "spl",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpio_show,
+                .store = devAttrGpio_store,
+            },
+        .data = &_gpio[DO_SPLD],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "reset",
+                        .mode = 0660,
+                    },
+                .show = devAttrGpio_show,
+                .store = devAttrGpio_store,
+            },
+        .data = &_gpio[DO_RESET],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "flag",
+                        .mode = 0440,
+                    },
+                .show = devAttrGpio_show,
+                .store = NULL,
+            },
+        .data = &_gpio[DO_FLAG],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "o1",
+                        .mode = 0660,
+                    },
+                .show = devAttrMax4896_show,
+                .store = devAttrMax4896_store,
+            },
+        .data = &_max4896_outs[DO_O1],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "o2",
+                        .mode = 0660,
+                    },
+                .show = devAttrMax4896_show,
+                .store = devAttrMax4896_store,
+            },
+        .data = &_max4896_outs[DO_O2],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "o3",
+                        .mode = 0660,
+                    },
+                .show = devAttrMax4896_show,
+                .store = devAttrMax4896_store,
+            },
+        .data = &_max4896_outs[DO_O3],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "o4",
+                        .mode = 0660,
+                    },
+                .show = devAttrMax4896_show,
+                .store = devAttrMax4896_store,
+            },
+        .data = &_max4896_outs[DO_O4],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "oc1",
+                        .mode = 0660,
+                    },
+                .show = devAttrMax4896_show,
+                .store = devAttrMax4896_store,
+            },
+        .data = &_max4896_outs[DO_OC1],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "oc2",
+                        .mode = 0660,
+                    },
+                .show = devAttrMax4896_show,
+                .store = devAttrMax4896_store,
+            },
+        .data = &_max4896_outs[DO_OC2],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "oc3",
+                        .mode = 0660,
+                    },
+                .show = devAttrMax4896_show,
+                .store = devAttrMax4896_store,
+            },
+        .data = &_max4896_outs[DO_OC3],
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "outputs",
+                        .mode = 0660,
+                    },
+                .show = devAttrMax4896_show,
+                .store = devAttrMax4896_store,
+            },
+        .data = &_max4896_outs[DO_ALL],
+    },
+
+    {},
+};
+
+static struct DeviceAttrBean devAttrBeansWiegand[] = {
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w1_enabled",
+                        .mode = 0660,
+                    },
+                .show = devAttrWiegandEnabled_show,
+                .store = devAttrWiegandEnabled_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w1_data",
+                        .mode = 0440,
+                    },
+                .show = devAttrWiegandData_show,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w1_noise",
+                        .mode = 0440,
+                    },
+                .show = devAttrWiegandNoise_show,
+                .store = NULL,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w1_pulse_itvl_min",
+                        .mode = 0660,
+                    },
+                .show = devAttrWiegandPulseIntervalMin_show,
+                .store = devAttrWiegandPulseIntervalMin_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w1_pulse_itvl_max",
+                        .mode = 0660,
+                    },
+                .show = devAttrWiegandPulseIntervalMax_show,
+                .store = devAttrWiegandPulseIntervalMax_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w1_pulse_width_min",
+                        .mode = 0660,
+                    },
+                .show = devAttrWiegandPulseWidthMin_show,
+                .store = devAttrWiegandPulseWidthMin_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w1_pulse_width_max",
+                        .mode = 0660,
+                    },
+                .show = devAttrWiegandPulseWidthMax_show,
+                .store = devAttrWiegandPulseWidthMax_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w2_enabled",
+                        .mode = 0660,
+                    },
+                .show = devAttrWiegandEnabled_show,
+                .store = devAttrWiegandEnabled_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w2_data",
+                        .mode = 0440,
+                    },
+                .show = devAttrWiegandData_show,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w2_noise",
+                        .mode = 0440,
+                    },
+                .show = devAttrWiegandNoise_show,
+                .store = NULL,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w2_pulse_itvl_min",
+                        .mode = 0660,
+                    },
+                .show = devAttrWiegandPulseIntervalMin_show,
+                .store = devAttrWiegandPulseIntervalMin_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w2_pulse_itvl_max",
+                        .mode = 0660,
+                    },
+                .show = devAttrWiegandPulseIntervalMax_show,
+                .store = devAttrWiegandPulseIntervalMax_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w2_pulse_width_min",
+                        .mode = 0660,
+                    },
+                .show = devAttrWiegandPulseWidthMin_show,
+                .store = devAttrWiegandPulseWidthMin_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "w2_pulse_width_max",
+                        .mode = 0660,
+                    },
+                .show = devAttrWiegandPulseWidthMax_show,
+                .store = devAttrWiegandPulseWidthMax_store,
+            },
+    },
+
+    {},
+};
+
+static struct DeviceAttrBean devAttrBeansWatchdog[] = {
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "enabled",
+                        .mode = 0660,
+                    },
+                .show = devAttrWatchdogEnabled_show,
+                .store = devAttrWatchdogEnabled_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "heartbeat",
+                        .mode = 0220,
+                    },
+                .show = NULL,
+                .store = devAttrWatchdogHeartbeat_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "timeout",
+                        .mode = 0660,
+                    },
+                .show = devAttrWatchdogTimeout_show,
+                .store = devAttrWatchdogTimeout_store,
+            },
+    },
+
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "off_time",
+                        .mode = 0660,
+                    },
+                .show = devAttrWatchdogOffTime_show,
+                .store = devAttrWatchdogOffTime_store,
+            },
+    },
+
+    {},
+};
+
+static struct DeviceAttrBean devAttrBeansAtecc[] = {
+    {
+        .devAttr =
+            {
+                .attr =
+                    {
+                        .name = "serial_num",
+                        .mode = 0440,
+                    },
+                .show = devAttrAteccSerial_show,
+                .store = NULL,
+            },
+    },
+
+    {},
+};
+
+static struct DeviceBean devices[] = {
+    {
+        .name = "led",
+        .devAttrBeans = devAttrBeansLed,
+    },
+
+    {
+        .name = "digital_in",
+        .devAttrBeans = devAttrBeansDigitalIn,
+    },
+
+    {
+        .name = "digital_io",
+        .devAttrBeans = devAttrBeansDigitalIO,
+    },
+
+    {
+        .name = "analog_in",
+        .devAttrBeans = devAttrBeansAnalogIn,
+    },
+
+    {
+        .name = "digital_out",
+        .devAttrBeans = devAttrBeansDigitalOut,
+    },
+
+    {
+        .name = "wiegand",
+        .devAttrBeans = devAttrBeansWiegand,
+    },
+
+    {
+        .name = "watchdog",
+        .devAttrBeans = devAttrBeansWatchdog,
+    },
+
+    {
+        .name = "sec_elem",
+        .devAttrBeans = devAttrBeansAtecc,
+    },
+
+    {},
+};
+
+struct _ionopi_data_t {
+  struct mutex spi_lock;
+};
+
+struct _mcp3462_data_t {
+  uint8_t osr;
+  uint8_t az_mux;
+  struct spi_device *spi;
+  struct spi_message msg;
+  struct regulator *reg;
+  uint8_t curr_channel;
+  struct spi_transfer transfer[2];
+  u8 cmd_tx_buf[5] ____cacheline_aligned;
+  u8 cmd_rx_buf[5];
+  u8 resp_rx_buf[5];
+};
+
+struct _max4896_data_t {
+  struct spi_device *spi;
+  struct spi_message msg;
+  struct regulator *reg;
+  bool first;
+  struct spi_transfer transfer;
+  u8 cmd ____cacheline_aligned;
+  u8 state;
+};
+
+static struct _ionopi_data_t _ionopi_data;
+static struct _mcp3462_data_t _mcp3462_data;
+static struct _max4896_data_t _max4896_data;
+
+static void *dev_attr_get_data(struct device_attribute *attr) {
+  struct DeviceAttrBean *dab;
+  dab = container_of(attr, struct DeviceAttrBean, devAttr);
+  if (dab == NULL) {
+    return NULL;
+  }
+  return dab->data;
+}
+
+struct GpioBean *gpioGetBean(struct device *dev, struct device_attribute *attr,
+                             const char **vals) {
+  return (struct GpioBean *)dev_attr_get_data(attr);
+}
+
+struct WiegandBean *wiegandGetBean(struct device *dev,
+                                   struct device_attribute *attr) {
+  if (attr->attr.name[1] == '1') {
+    return &_w1;
+  } else {
+    return &_w2;
+  }
+}
+
+static int _spi_lock(void) {
+  int i, ret;
+  ret = -EBUSY;
+  for (i = 0; i < 40; i++) {
+    if (mutex_trylock(&_ionopi_data.spi_lock)) {
+      ret = 1;
+      break;
+    }
+    msleep(1);
+  }
+  return ret;
+}
+
+static void _spi_unlock(void) { mutex_unlock(&_ionopi_data.spi_lock); }
+
+static uint16_t mcp3462_crc(uint16_t crc, uint8_t dByte) {
+  uint8_t k;
+  crc ^= dByte << 8;
+  for (k = 0; k < 8; k++) crc = crc & 0x8000 ? (crc << 1) ^ 0x8005 : crc << 1;
+  return crc;
+}
+
+static int mcp3462_spi_msg(int cmdLen, int respLen) {
+  int ret, i, j;
+  uint16_t crc;
+
+  if (respLen > 0) {
+    respLen += 2;  // CRC bytes
+  }
+  _mcp3462_data.transfer[0].len = cmdLen;
+  _mcp3462_data.transfer[1].len = respLen;
+
+  spi_message_init_with_transfers(&_mcp3462_data.msg, _mcp3462_data.transfer,
+                                  respLen > 0 ? 2 : 1);
+
+  for (j = 0; j < 3; j++) {
+    memset(&_mcp3462_data.cmd_rx_buf, 0, cmdLen);
+    if (respLen > 0) {
+      memset(&_mcp3462_data.resp_rx_buf, 0, respLen);
+    }
+
+    ret = spi_sync(_mcp3462_data.spi, &_mcp3462_data.msg);
+    if (ret < 0) {
+      pr_alert(LOG_TAG "mcp3462 spi xfer error\n");
+      continue;
+    }
+
+    if ((_mcp3462_data.cmd_rx_buf[0] & MCP3462_STAT_DEV_ADDR_MASK) !=
+        MCP3462_STAT_DEV_ADDR) {
+      pr_alert(LOG_TAG "mcp3462 dev addr error\n");
+      ret = -EIO;
+      continue;
+    }
+
+    if (respLen > 0) {
+      crc = mcp3462_crc(0, _mcp3462_data.cmd_rx_buf[0]);
+      for (i = 0; i < respLen - 2; i++) {
+        crc = mcp3462_crc(crc, _mcp3462_data.resp_rx_buf[i]);
+      }
+      if (_mcp3462_data.resp_rx_buf[i] != ((crc >> 8) & 0xff) ||
+          _mcp3462_data.resp_rx_buf[i + 1] != (crc & 0xff)) {
+        pr_alert(LOG_TAG "mcp3462 CRC error\n");
+        ret = -EIO;
+        continue;
+      }
+    }
+
+    ret = 0;
+    break;
+  }
+
+  return ret;
+}
+
+static ssize_t devAttrMcp3462Osr_show(struct device *dev,
+                                      struct device_attribute *attr,
+                                      char *buf) {
+  return sprintf(buf, "%d\n", _mcp3462_data.osr);
+}
+
+static bool mcp3462_check_config(uint8_t addr, uint8_t val) {
+  int ret;
+  _mcp3462_data.cmd_tx_buf[0] = MCP3462_CMD_READ_STATIC | addr;
+  ret = mcp3462_spi_msg(1, 1);
+  if (ret < 0) {
+    return false;
+  }
+  if (_mcp3462_data.resp_rx_buf[0] != val) {
+    return false;
+  }
+  return true;
+}
+
+static int mcp3462_config(void) {
+  int ret;
+
+  u8 cfg1 = MCP3462_CONFIG1_RESERVED | ((_mcp3462_data.osr & 0xf) << 2) |
+            MCP3462_CONFIG1_PRE;
+  u8 cfg2 = MCP3462_CONFIG2_BOOST | MCP3462_CONFIG2_GAIN |
+            ((_mcp3462_data.az_mux & 0x1) << 2) | MCP3462_CONFIG2_AZ_REF |
+            MCP3462_CONFIG2_RESERVED;
+
+  // Write CONFIG1-3
+
+  _mcp3462_data.cmd_tx_buf[0] =
+      MCP3462_CMD_WRITE_INCR | MCP3462_REG_ADDR_CONFIG1;
+  _mcp3462_data.cmd_tx_buf[1] = cfg1;
+  _mcp3462_data.cmd_tx_buf[2] = cfg2;
+  _mcp3462_data.cmd_tx_buf[3] = MCP3462_CONFIG3;
+
+  ret = mcp3462_spi_msg(4, 0);
+  if (ret < 0) {
+    pr_alert(LOG_TAG "mcp3462 CONFIG1-3 write failed attempt\n");
+    return ret;
+  }
+
+  // Write CONFIG0 (start ADC conversion mode)
+
+  _mcp3462_data.cmd_tx_buf[0] =
+      MCP3462_CMD_WRITE_INCR | MCP3462_REG_ADDR_CONFIG0;
+  _mcp3462_data.cmd_tx_buf[1] = MCP3462_CONFIG0;
+
+  ret = mcp3462_spi_msg(2, 0);
+  if (ret < 0) {
+    pr_alert(LOG_TAG "mcp3462 CONFIG0 write failed attempt\n");
+    return ret;
+  }
+
+  // Check config
+  // (CONFIG0 checked last to give it more time to start)
+
+  if (!mcp3462_check_config(MCP3462_REG_ADDR_CONFIG1, cfg1) ||
+      !mcp3462_check_config(MCP3462_REG_ADDR_CONFIG2, cfg2) ||
+      !mcp3462_check_config(MCP3462_REG_ADDR_CONFIG3, MCP3462_CONFIG3) ||
+      !mcp3462_check_config(MCP3462_REG_ADDR_CONFIG0, MCP3462_CONFIG0)) {
+    pr_alert(LOG_TAG "mcp3462 config check failed attempt\n");
+    return -EIO;
+  }
+
+  pr_info(LOG_TAG "mcp3462 configured (osr=%d, az=%d)\n", _mcp3462_data.osr,
+          _mcp3462_data.az_mux);
+
+  return 0;
+}
+
+static ssize_t devAttrMcp3462Osr_store(struct device *dev,
+                                       struct device_attribute *attr,
+                                       const char *buf, size_t count) {
+  int ret;
+  unsigned long val;
+
+  ret = kstrtoul(buf, 10, &val);
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (val > 15) {
+    return -EINVAL;
+  }
+
+  _mcp3462_data.osr = val;
+
+  ret = mcp3462_config();
+  if (ret < 0) {
+    pr_err(LOG_TAG "mcp3462 failed to configure\n");
+    return ret;
+  }
+
+  return count;
+}
+
+static ssize_t devAttrMcp3462AzMux_show(struct device *dev,
+                                        struct device_attribute *attr,
+                                        char *buf) {
+  return sprintf(buf, "%d\n", _mcp3462_data.az_mux);
+}
+
+static ssize_t devAttrMcp3462AzMux_store(struct device *dev,
+                                         struct device_attribute *attr,
+                                         const char *buf, size_t count) {
+  int ret;
+  unsigned long val;
+
+  ret = kstrtoul(buf, 10, &val);
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (val > 1) {
+    return -EINVAL;
+  }
+
+  _mcp3462_data.az_mux = val;
+
+  ret = mcp3462_config();
+  if (ret < 0) {
+    pr_err(LOG_TAG "mcp3462 failed to configure\n");
+    return ret;
+  }
+
+  return count;
+}
+
+static ssize_t devAttrMcp3462_show(char *buf, uint8_t channel, int mult) {
+  int i, ret;
+
+  ret = _spi_lock();
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (_mcp3462_data.curr_channel != channel) {
+    _mcp3462_data.cmd_tx_buf[0] = MCP3462_CMD_WRITE_INCR | MCP3462_REG_ADDR_MUX;
+    _mcp3462_data.cmd_tx_buf[1] = channel;
+    ret = mcp3462_spi_msg(2, 0);
+    if (ret < 0) {
+      _mcp3462_data.curr_channel = 0;
+      _spi_unlock();
+      pr_alert(LOG_TAG "mcp3462 MUX write error\n");
+      return ret;
+    }
+
+    _mcp3462_data.cmd_tx_buf[0] = MCP3462_CMD_CONV_START;
+    ret = mcp3462_spi_msg(1, 0);
+    if (ret < 0) {
+      _mcp3462_data.curr_channel = 0;
+      _spi_unlock();
+      pr_alert(LOG_TAG "mcp3462 conversion restart error\n");
+      return ret;
+    }
+
+    _mcp3462_data.curr_channel = channel;
+  }
+
+  _mcp3462_data.cmd_tx_buf[0] =
+      MCP3462_CMD_READ_STATIC | MCP3462_REG_ADDR_ADCDATA;
+
+  for (i = 0; i < 150; i++) {
+    ret = mcp3462_spi_msg(1, 2);
+    if (ret < 0) {
+      _spi_unlock();
+      pr_alert(LOG_TAG "mcp3462 data read error\n");
+      return ret;
+    }
+
+    if ((_mcp3462_data.cmd_rx_buf[0] & MCP3462_STAT_DR_STATUS_MASK) != 0) {
+      ret = -EBUSY;
+      continue;
+    }
+
+    ret = 0;
+    break;
+  }
+
+  if (ret < 0) {
+    _spi_unlock();
+    pr_alert(LOG_TAG "mcp3462 data read timeout\n");
+    return ret;
+  }
+
+  ret = (int16_t)((_mcp3462_data.resp_rx_buf[0] << 8) |
+                  (_mcp3462_data.resp_rx_buf[1] & 0xff));
+
+  _spi_unlock();
+
+  if (mult > 0) {
+    ret = ret * mult /
+          MCP3462_DIVISOR;  // = (adc_data * 2.4V / 32768) * (AX_max_val) / 2.0V
+    if (ret < 0) {
+      ret = 0;
+    }
+  }
+
+  return sprintf(buf, "%d\n", ret);
+}
+
+static ssize_t devAttrAv1Mv_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf) {
+  return devAttrMcp3462_show(buf, MCP3462_MUX_SE_CH0, MCP3462_FACTOR_AV);
+}
+
+static ssize_t devAttrAv2Mv_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf) {
+  return devAttrMcp3462_show(buf, MCP3462_MUX_SE_CH1, MCP3462_FACTOR_AV);
+}
+
+static ssize_t devAttrAi1Ua_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf) {
+  return devAttrMcp3462_show(buf, MCP3462_MUX_SE_CH2, MCP3462_FACTOR_AI);
+}
+
+static ssize_t devAttrAi2Ua_show(struct device *dev,
+                                 struct device_attribute *attr, char *buf) {
+  return devAttrMcp3462_show(buf, MCP3462_MUX_SE_CH3, MCP3462_FACTOR_AI);
+}
+
+static ssize_t devAttrAv1Raw_show(struct device *dev,
+                                  struct device_attribute *attr, char *buf) {
+  return devAttrMcp3462_show(buf, MCP3462_MUX_SE_CH0, 0);
+}
+
+static ssize_t devAttrAv2Raw_show(struct device *dev,
+                                  struct device_attribute *attr, char *buf) {
+  return devAttrMcp3462_show(buf, MCP3462_MUX_SE_CH1, 0);
+}
+
+static ssize_t devAttrAi1Raw_show(struct device *dev,
+                                  struct device_attribute *attr, char *buf) {
+  return devAttrMcp3462_show(buf, MCP3462_MUX_SE_CH2, 0);
+}
+
+static ssize_t devAttrAi2Raw_show(struct device *dev,
+                                  struct device_attribute *attr, char *buf) {
+  return devAttrMcp3462_show(buf, MCP3462_MUX_SE_CH3, 0);
+}
+
+static int _mcp3462_spi_probe(struct spi_device *spi) {
+  int ret;
+
+  _mcp3462_data.spi = spi;
+  _mcp3462_data.reg = devm_regulator_get(&spi->dev, "vref");
+  if (IS_ERR(_mcp3462_data.reg)) {
+    pr_err(LOG_TAG "mcp3462 failed to get regulator\n");
+    return PTR_ERR(_mcp3462_data.reg);
+  }
+
+  ret = regulator_enable(_mcp3462_data.reg);
+  if (ret < 0) {
+    pr_err(LOG_TAG "mcp3462 failed to enable regulator\n");
+    return ret;
+  }
+
+  _mcp3462_data.transfer[0].tx_buf = _mcp3462_data.cmd_tx_buf;
+  _mcp3462_data.transfer[0].rx_buf = _mcp3462_data.cmd_rx_buf;
+  _mcp3462_data.transfer[1].tx_buf = NULL;
+  _mcp3462_data.transfer[1].rx_buf = _mcp3462_data.resp_rx_buf;
+
+  _mcp3462_data.osr = MCP3462_OSR_DEFAULT;
+  _mcp3462_data.az_mux = MCP3462_AZ_MUX_DEFAULT;
+
+  pr_info(LOG_TAG "mcp3462 probing ...\n");
+
+  ret = mcp3462_config();
+  if (ret < 0) {
+    pr_err(LOG_TAG "mcp3462 failed to configure\n");
+    return ret;
+  }
+
+  return 0;
+}
+
+static void _mcp3462_spi_remove(struct spi_device *spi) {
+  regulator_disable(_mcp3462_data.reg);
+  pr_info(LOG_TAG "mcp3462 removed\n");
+}
+
+const struct of_device_id _mcp3462_of_match[] = {
+    {.compatible = "sferalabs,ionopi-v3-mcp3462"},
+    {},
+};
+MODULE_DEVICE_TABLE(of, _mcp3462_of_match);
+
+static const struct spi_device_id _mcp3462_ids[] = {
+    {"ionopi-v3-mcp3462", 0},
+    {},
+};
+MODULE_DEVICE_TABLE(spi, _mcp3462_ids);
+
+static struct spi_driver _mcp3462_spi_driver = {
+    .driver =
+        {
+            .name = "ionopi-v3-mcp3462",
+            .owner = THIS_MODULE,
+            .of_match_table = of_match_ptr(_mcp3462_of_match),
+        },
+    .probe = _mcp3462_spi_probe,
+    .remove = _mcp3462_spi_remove,
+    .id_table = _mcp3462_ids,
+};
+
+static int _max4896_xfer(void) {
+  int ret, i;
+
+  ret = _spi_lock();
+  if (ret < 0) {
+    return ret;
+  }
+
+  for (i = 0; i < 3; i++) {
+    ret = spi_sync(_max4896_data.spi, &_max4896_data.msg);
+    if (ret < 0) {
+      pr_alert(LOG_TAG "max4896 spi xfer error\n");
+      continue;
+    }
+
+    ret = 0;
+    break;
+  }
+
+  _spi_unlock();
+
+  _max4896_data.first = false;
+
+  return ret;
+}
+
+static ssize_t devAttrMax4896_show(struct device *dev,
+                                   struct device_attribute *attr, char *buf) {
+  struct max4896_out *data;
+  uint8_t cmd, state, b, c, s;
+  int i, ret;
+  if (_max4896_data.first) {
+    return -EACCES;
+  }
+
+  data = (struct max4896_out *)dev_attr_get_data(attr);
+  if (data == NULL) {
+    return -EFAULT;
+  }
+
+  // Rewrite current cmd and read
+  ret = _max4896_xfer();
+  if (ret < 0) {
+    return ret;
+  }
+
+  cmd = (_max4896_data.cmd >> data->shift) & data->mask;
+  state = (_max4896_data.state >> data->shift) & data->mask;
+
+  b = 0;
+  for (i = (data->mask == 0b1 ? 0 : 6); i >= 0; i--) {
+    c = ((cmd >> i) & 1);
+    s = ((state >> i) & 1);
+    if (c ^ s) {
+      buf[b++] = c ? 'S' : 'F';
+    } else {
+      buf[b++] = c ? '1' : '0';
+    }
+  }
+  buf[b++] = '\n';
+
+  return b;
+}
+
+static ssize_t devAttrMax4896_store(struct device *dev,
+                                    struct device_attribute *attr,
+                                    const char *buf, size_t count) {
+  struct max4896_out *data;
+  uint8_t cmd, mask, len, i, b;
+  int ret;
+  data = (struct max4896_out *)dev_attr_get_data(attr);
+  if (data == NULL) {
+    return -EFAULT;
+  }
+
+  len = (data->mask == 0b1 ? 1 : 7);
+
+  if (count < len) {
+    return -EINVAL;
+  }
+
+  cmd = 0;
+  for (i = 0; i < len; i++) {
+    cmd <<= 1;
+    if (buf[i] == '1') {
+      cmd |= 1;
+    } else if (toUpper(buf[i]) == 'F') {
+      b = len - i + data->shift - 1;
+      cmd |= ~(_max4896_data.cmd >> b) & 1;
+    } else if (buf[i] != '0') {
+      return -EINVAL;
+    }
+  }
+
+  cmd <<= data->shift;
+  mask = data->mask << data->shift;
+
+  _max4896_data.cmd = (_max4896_data.cmd & ~mask) | (cmd & mask);
+
+  ret = _max4896_xfer();
+  if (ret < 0) {
+    return ret;
+  }
+
+  return count;
+}
+
+static int _max4896_spi_probe(struct spi_device *spi) {
+  int ret;
+
+  _max4896_data.spi = spi;
+  _max4896_data.reg = devm_regulator_get(&spi->dev, "vref");
+  if (IS_ERR(_max4896_data.reg)) {
+    pr_err(LOG_TAG "max4896 failed to get regulator\n");
+    return PTR_ERR(_max4896_data.reg);
+  }
+
+  ret = regulator_enable(_max4896_data.reg);
+  if (ret < 0) {
+    pr_err(LOG_TAG "max4896 failed to enable regulator\n");
+    return ret;
+  }
+
+  _max4896_data.transfer.tx_buf = &_max4896_data.cmd;
+  _max4896_data.transfer.rx_buf = &_max4896_data.state;
+  _max4896_data.transfer.len = 1;
+
+  spi_message_init_with_transfers(&_max4896_data.msg, &_max4896_data.transfer,
+                                  1);
+
+  _max4896_data.first = true;
+
+  pr_info(LOG_TAG "max4896 added\n");
+
+  return 0;
+}
+
+static void _max4896_spi_remove(struct spi_device *spi) {
+  regulator_disable(_max4896_data.reg);
+  pr_info(LOG_TAG "max4896 removed\n");
+}
+
+const struct of_device_id _max4896_of_match[] = {
+    {.compatible = "sferalabs,ionopi-v3-max4896"},
+    {},
+};
+MODULE_DEVICE_TABLE(of, _max4896_of_match);
+
+static const struct spi_device_id _max4896_ids[] = {
+    {"ionopi-v3-max4896", 0},
+    {},
+};
+MODULE_DEVICE_TABLE(spi, _max4896_ids);
+
+static struct spi_driver _max4896_spi_driver = {
+    .driver =
+        {
+            .name = "ionopi-v3-max4896",
+            .owner = THIS_MODULE,
+            .of_match_table = of_match_ptr(_max4896_of_match),
+        },
+    .probe = _max4896_spi_probe,
+    .remove = _max4896_spi_remove,
+    .id_table = _max4896_ids,
+};
+
+static void cleanup(struct platform_device *pdev) {
+  struct DeviceBean *db;
+  struct DeviceAttrBean *dab;
+  int i, di, ai;
+
+  spi_unregister_driver(&_mcp3462_spi_driver);
+
+  spi_unregister_driver(&_max4896_spi_driver);
+
+  pcf2131_i2c_unregister_driver();
+
+  di = 0;
+  while (devices[di].name != NULL) {
+    if (devices[di].pDevice && !IS_ERR(devices[di].pDevice)) {
+      db = &devices[di];
+      ai = 0;
+      while (db->devAttrBeans[ai].devAttr.attr.name != NULL) {
+        dab = &db->devAttrBeans[ai];
+        device_remove_file(db->pDevice, &dab->devAttr);
+        ai++;
+      }
+    }
+    device_destroy(pDeviceClass, 0);
+    di++;
+  }
+
+  if (!IS_ERR(pDeviceClass)) {
+    class_destroy(pDeviceClass);
+  }
+
+  wiegandDisable(&_w1);
+  wiegandDisable(&_w2);
+
+  for (i = 0; i < GPIO_SIZE; i++) {
+    gpioFree(&_gpio[i]);
+  }
+  for (i = 0; i < DI_SIZE; i++) {
+    gpioFreeDebounce(&_gpio_din[i]);
+  }
+
+  mutex_destroy(&_ionopi_data.spi_lock);
+}
+
+static int ionopi_init(struct platform_device *pdev) {
+  struct DeviceBean *db;
+  struct DeviceAttrBean *dab;
+  int i, di, ai;
+
+  pr_info(LOG_TAG "init\n");
+
+  mutex_init(&_ionopi_data.spi_lock);
+
+  gpioSetPlatformDev(pdev);
+
+  if (spi_register_driver(&_mcp3462_spi_driver)) {
+    pr_err(LOG_TAG "failed to register MCP3462 driver\n");
+    goto fail;
+  }
+
+  if (spi_register_driver(&_max4896_spi_driver)) {
+    pr_err(LOG_TAG "failed to register MAX4896 driver\n");
+    goto fail;
+  }
+
+  if (pcf2131_i2c_register_driver()) {
+    pr_err(LOG_TAG "failed to register PCF2131 driver\n");
+    goto fail;
+  }
+
+  for (i = 0; i < GPIO_SIZE; i++) {
+    if (gpioInit(&_gpio[i])) {
+      pr_err(LOG_TAG "error setting up GPIO %s\n", _gpio[i].name);
+      goto fail;
+    }
+  }
+  for (i = 0; i < DI_SIZE; i++) {
+    if (gpioInitDebounce(&_gpio_din[i])) {
+      pr_err(LOG_TAG "error setting up GPIO %s\n", _gpio_din[i].gpio.name);
+      goto fail;
+    }
+  }
+
+  wiegandInit(&_w1);
+  wiegandInit(&_w2);
+
+  pDeviceClass = class_create("ionopi");
+
+  if (IS_ERR(pDeviceClass)) {
+    pr_err(LOG_TAG "failed to create device class\n");
+    goto fail;
+  }
+
+  di = 0;
+  while (devices[di].name != NULL) {
+    db = &devices[di];
+    db->pDevice = device_create(pDeviceClass, NULL, 0, NULL, db->name);
+    if (IS_ERR(db->pDevice)) {
+      pr_err(LOG_TAG "failed to create device '%s'\n", db->name);
+      goto fail;
+    }
+
+    ai = 0;
+    while (db->devAttrBeans[ai].devAttr.attr.name != NULL) {
+      dab = &db->devAttrBeans[ai];
+      if (device_create_file(db->pDevice, &dab->devAttr)) {
+        pr_err(LOG_TAG "failed to create device file '%s/%s'\n", db->name,
+               dab->devAttr.attr.name);
+        goto fail;
+      }
+      ai++;
+    }
+    di++;
+  }
+
+  return 0;
+
+fail:
+  pr_err(LOG_TAG "init failed\n");
+  cleanup(pdev);
+  return -1;
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+static void ionopi_exit(struct platform_device *pdev) {
+#else
+static int ionopi_exit(struct platform_device *pdev) {
+#endif
+  cleanup(pdev);
+  pr_info(LOG_TAG "exit\n");
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+  return 0;
+#endif
+}
+
+const struct of_device_id _ionopi_of_match[] = {
+    {.compatible = "sferalabs,ionopi-v3"},
+    {},
+};
+MODULE_DEVICE_TABLE(of, _ionopi_of_match);
+
+static struct platform_driver ionopi_driver = {
+    .probe = ionopi_init,
+    .remove = ionopi_exit,
+    .driver =
+        {
+            .name = "ionopi-v3",
+            .owner = THIS_MODULE,
+            .of_match_table = _ionopi_of_match,
+        },
+};
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Sfera Labs - http://sferalabs.cc");
+MODULE_DESCRIPTION("Iono Pi v3 driver module");
+MODULE_VERSION("1.0");
+
+module_platform_driver(ionopi_driver);

--- a/drivers/staging/sferalabs/ionopi-v3/pcf2131/pcf2131.c
+++ b/drivers/staging/sferalabs/ionopi-v3/pcf2131/pcf2131.c
@@ -1,0 +1,1073 @@
+/*
+ * Based on:
+ *
+ * An I2C and SPI driver for the NXP PCF2127/29/31 RTC
+ * Copyright 2013 Til-Technologies
+ *
+ * Author: Renaud Cerrato <r.cerrato@til-technologies.fr>
+ *
+ * Watchdog and tamper functions
+ * Author: Bruno Thomsen <bruno.thomsen@gmail.com>
+ *
+ * PCF2131 support
+ * Author: Hugo Villeneuve <hvilleneuve@dimonoff.com>
+ */
+
+#include "pcf2131.h"
+
+#include <linux/bcd.h>
+#include <linux/i2c.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/of_irq.h>
+#include <linux/regmap.h>
+#include <linux/rtc.h>
+#include <linux/slab.h>
+#include <linux/spi/spi.h>
+#include <linux/watchdog.h>
+
+#define RTC_PCF21XX_DEBUG 0
+
+#if RTC_PCF21XX_DEBUG
+#undef dev_dbg
+#define dev_dbg dev_info
+#endif
+
+/* Control register 1 */
+#define PCF21XX_REG_CTRL1 0x00
+#define PCF21XX_BIT_CTRL1_SI BIT(0)
+#define PCF21XX_BIT_CTRL1_POR_OVRD BIT(3)
+#define PCF21XX_BIT_CTRL1_TSF1 BIT(4)
+#define PCF21XX_BIT_CTRL1_STOP BIT(5)
+/* Control register 2 */
+#define PCF21XX_REG_CTRL2 0x01
+#define PCF21XX_BIT_CTRL2_AIE BIT(1)
+#define PCF21XX_BIT_CTRL2_TSIE BIT(2)
+#define PCF21XX_BIT_CTRL2_AF BIT(4)
+#define PCF21XX_BIT_CTRL2_TSF2 BIT(5)
+#define PCF21XX_BIT_CTRL2_WDTF BIT(6)
+#define PCF21XX_BIT_CTRL2_MSF BIT(7)
+/* Control register 3 */
+#define PCF21XX_REG_CTRL3 0x02
+#define PCF21XX_BIT_CTRL3_BLIE BIT(0)
+#define PCF21XX_BIT_CTRL3_BIE BIT(1)
+#define PCF21XX_BIT_CTRL3_BLF BIT(2)
+#define PCF21XX_BIT_CTRL3_BF BIT(3)
+#define PCF21XX_BIT_CTRL3_BTSE BIT(4)
+#define PCF21XX_CTRL3_PWRMNG_MASK GENMASK(7, 5)
+/* Time and date registers */
+#define PCF21XX_REG_TIME_BASE 0x03
+#define PCF21XX_BIT_SC_OSF BIT(7)
+/* Alarm registers */
+#define PCF21XX_REG_ALARM_BASE 0x0A
+#define PCF21XX_BIT_ALARM_AE BIT(7)
+/* CLKOUT control register */
+#define PCF21XX_REG_CLKOUT 0x0f
+#define PCF21XX_BIT_CLKOUT_OTPR BIT(5)
+/* Watchdog registers */
+#define PCF21XX_REG_WD_CTL 0x10
+#define PCF21XX_BIT_WD_CTL_TF0 BIT(0)
+#define PCF21XX_BIT_WD_CTL_TF1 BIT(1)
+#define PCF21XX_BIT_WD_CTL_TI_TP BIT(5)
+#define PCF21XX_BIT_WD_CTL_CD0 BIT(6)
+#define PCF21XX_BIT_WD_CTL_CD1 BIT(7)
+#define PCF21XX_REG_WD_VAL 0x11
+/* Tamper timestamp1 registers */
+#define PCF21XX_REG_TS1_BASE 0x12
+#define PCF21XX_BIT_TS_CTRL_TSOFF BIT(6)
+#define PCF21XX_BIT_TS_CTRL_TSM BIT(7)
+/*
+ * RAM registers
+ * PCF2127 has 512 bytes general-purpose static RAM (SRAM) that is
+ * battery backed and can survive a power outage.
+ * PCF2129/31 doesn't have this feature.
+ */
+#define PCF21XX_REG_RAM_ADDR_MSB 0x1A
+#define PCF21XX_REG_RAM_WRT_CMD 0x1C
+#define PCF21XX_REG_RAM_RD_CMD 0x1D
+
+/* Watchdog timer value constants */
+#define PCF21XX_WD_VAL_STOP 0
+/* PCF2127/29 watchdog timer value constants */
+#define PCF21XX_WD_CLOCK_HZ_X1000 1000 /* 1Hz */
+#define PCF21XX_WD_MIN_HW_HEARTBEAT_MS 500
+/* PCF2131 watchdog timer value constants */
+#define PCF2131_WD_CLOCK_HZ_X1000 250 /* 1/4Hz */
+#define PCF2131_WD_MIN_HW_HEARTBEAT_MS 4000
+
+#define PCF21XX_WD_DEFAULT_TIMEOUT_S 60
+#define IONOPI_WD_DEFAULT_OFF_TIME_S 5
+
+/* Mask for currently enabled interrupts */
+#define PCF21XX_CTRL1_IRQ_MASK (PCF21XX_BIT_CTRL1_TSF1)
+#define PCF21XX_CTRL2_IRQ_MASK \
+  (PCF21XX_BIT_CTRL2_AF | PCF21XX_BIT_CTRL2_WDTF | PCF21XX_BIT_CTRL2_TSF2)
+
+#define PCF21XX_MAX_TS_SUPPORTED 4
+
+/* Control register 4 */
+#define PCF2131_REG_CTRL4 0x03
+#define PCF2131_BIT_CTRL4_TSF4 BIT(4)
+#define PCF2131_BIT_CTRL4_TSF3 BIT(5)
+#define PCF2131_BIT_CTRL4_TSF2 BIT(6)
+#define PCF2131_BIT_CTRL4_TSF1 BIT(7)
+/* Control register 5 */
+#define PCF2131_REG_CTRL5 0x04
+#define PCF2131_BIT_CTRL5_TSIE4 BIT(4)
+#define PCF2131_BIT_CTRL5_TSIE3 BIT(5)
+#define PCF2131_BIT_CTRL5_TSIE2 BIT(6)
+#define PCF2131_BIT_CTRL5_TSIE1 BIT(7)
+/* Software reset register */
+#define PCF2131_REG_SR_RESET 0x05
+#define PCF2131_SR_RESET_READ_PATTERN (BIT(2) | BIT(5))
+#define PCF2131_SR_RESET_CPR_CMD (PCF2131_SR_RESET_READ_PATTERN | BIT(7))
+/* Time and date registers */
+#define PCF2131_REG_TIME_BASE 0x07
+/* Alarm registers */
+#define PCF2131_REG_ALARM_BASE 0x0E
+/* CLKOUT control register */
+#define PCF2131_REG_CLKOUT 0x13
+/* Watchdog registers */
+#define PCF2131_REG_WD_CTL 0x35
+#define PCF2131_REG_WD_VAL 0x36
+/* Tamper timestamp1 registers */
+#define PCF2131_REG_TS1_BASE 0x14
+/* Tamper timestamp2 registers */
+#define PCF2131_REG_TS2_BASE 0x1B
+/* Tamper timestamp3 registers */
+#define PCF2131_REG_TS3_BASE 0x22
+/* Tamper timestamp4 registers */
+#define PCF2131_REG_TS4_BASE 0x29
+/* Interrupt mask registers */
+#define PCF2131_REG_INT_A_MASK1 0x31
+#define PCF2131_REG_INT_A_MASK2 0x32
+#define PCF2131_REG_INT_B_MASK1 0x33
+#define PCF2131_REG_INT_B_MASK2 0x34
+#define PCF2131_BIT_INT_BLIE BIT(0)
+#define PCF2131_BIT_INT_BIE BIT(1)
+#define PCF2131_BIT_INT_AIE BIT(2)
+#define PCF2131_BIT_INT_WD_CD BIT(3)
+#define PCF2131_BIT_INT_SI BIT(4)
+#define PCF2131_BIT_INT_MI BIT(5)
+#define PCF2131_CTRL2_IRQ_MASK (PCF21XX_BIT_CTRL2_AF | PCF21XX_BIT_CTRL2_WDTF)
+#define PCF2131_CTRL4_IRQ_MASK                                                \
+  (PCF2131_BIT_CTRL4_TSF4 | PCF2131_BIT_CTRL4_TSF3 | PCF2131_BIT_CTRL4_TSF2 | \
+   PCF2131_BIT_CTRL4_TSF1)
+
+enum pcf21xx_type { PCF2131, PCF21XX_LAST_ID };
+
+struct pcf21xx_ts_config {
+  u8 reg_base; /* Base register to read timestamp values. */
+
+  /*
+   * If the TS input pin is driven to GND, an interrupt can be generated
+   * (supported by all variants).
+   */
+  u8 gnd_detect_reg; /* Interrupt control register address. */
+  u8 gnd_detect_bit; /* Interrupt bit. */
+
+  /*
+   * If the TS input pin is driven to an intermediate level between GND
+   * and supply, an interrupt can be generated (optional feature depending
+   * on variant).
+   */
+  u8 inter_detect_reg; /* Interrupt control register address. */
+  u8 inter_detect_bit; /* Interrupt bit. */
+
+  u8 ie_reg; /* Interrupt enable control register. */
+  u8 ie_bit; /* Interrupt enable bit. */
+};
+
+struct pcf21xx_config {
+  int type; /* IC variant */
+  int max_register;
+  unsigned int has_nvmem : 1;
+  unsigned int has_bit_wd_ctl_cd0 : 1;
+  unsigned int
+      wd_val_reg_readable : 1;  /* If watchdog value register can be read. */
+  unsigned int has_int_a_b : 1; /* PCF2131 supports two interrupt outputs. */
+  u8 reg_time_base;             /* Time/date base register. */
+  u8 regs_alarm_base;           /* Alarm function base registers. */
+  u8 reg_wd_ctl;                /* Watchdog control register. */
+  u8 reg_wd_val;                /* Watchdog value register. */
+  u8 reg_clkout;                /* Clkout register. */
+  int wdd_clock_hz_x1000;       /* Watchdog clock in Hz multiplicated by 1000 */
+  int wdd_min_hw_heartbeat_ms;
+  struct attribute_group attribute_group;
+};
+
+struct pcf21xx {
+  struct rtc_device *rtc;
+  struct watchdog_device wdd;
+  struct regmap *regmap;
+  const struct pcf21xx_config *cfg;
+  bool irq_enabled;
+  int wdd_off_time_sec;
+};
+
+static struct pcf21xx *_instance;
+
+static int pcf21xx_rtc_set_alarm(struct device *dev, struct rtc_wkalrm *alrm);
+static int pcf21xx_wdt_ping(struct watchdog_device *wdd);
+static int pcf21xx_wdt_start(struct watchdog_device *wdd);
+static int pcf21xx_wdt_stop(struct watchdog_device *wdd);
+
+/*
+ * In the routines that deal directly with the hardware, we use
+ * rtc_time -- month 0-11, hour 0-23, yr = calendar year-epoch.
+ */
+static int pcf21xx_rtc_read_time_opt_check(struct device *dev,
+                                           struct rtc_time *tm,
+                                           bool check_osf) {
+  struct pcf21xx *pcf21xx = dev_get_drvdata(dev);
+  unsigned char buf[7];
+  int ret;
+
+  /*
+   * Avoid reading CTRL2 register as it causes WD_VAL register
+   * value to reset to 0 which means watchdog is stopped.
+   */
+  ret = regmap_bulk_read(pcf21xx->regmap, pcf21xx->cfg->reg_time_base, buf,
+                         sizeof(buf));
+  if (ret) {
+    dev_err(dev, "%s: read error\n", __func__);
+    return ret;
+  }
+
+  /* Clock integrity is not guaranteed when OSF flag is set. */
+  if (check_osf && (buf[0] & PCF21XX_BIT_SC_OSF)) {
+    /*
+     * no need clear the flag here,
+     * it will be cleared once the new date is saved
+     */
+    dev_warn(dev, "oscillator stop detected, date/time is not reliable\n");
+    return -EINVAL;
+  }
+
+  dev_dbg(dev,
+          "%s: raw data is sec=%02x, min=%02x, hr=%02x, "
+          "mday=%02x, wday=%02x, mon=%02x, year=%02x\n",
+          __func__, buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6]);
+
+  tm->tm_sec = bcd2bin(buf[0] & 0x7F);
+  tm->tm_min = bcd2bin(buf[1] & 0x7F);
+  tm->tm_hour = bcd2bin(buf[2] & 0x3F);
+  tm->tm_mday = bcd2bin(buf[3] & 0x3F);
+  tm->tm_wday = buf[4] & 0x07;
+  tm->tm_mon = bcd2bin(buf[5] & 0x1F) - 1;
+  tm->tm_year = bcd2bin(buf[6]);
+  tm->tm_year += 100;
+
+  dev_dbg(dev,
+          "%s: tm is secs=%d, mins=%d, hours=%d, "
+          "mday=%d, mon=%d, year=%d, wday=%d\n",
+          __func__, tm->tm_sec, tm->tm_min, tm->tm_hour, tm->tm_mday,
+          tm->tm_mon, tm->tm_year, tm->tm_wday);
+
+  return 0;
+}
+
+static int pcf21xx_rtc_read_time(struct device *dev, struct rtc_time *tm) {
+  return pcf21xx_rtc_read_time_opt_check(dev, tm, true);
+}
+
+static int pcf21xx_rtc_set_time(struct device *dev, struct rtc_time *tm) {
+  struct pcf21xx *pcf21xx = dev_get_drvdata(dev);
+  unsigned char buf[7];
+  int i = 0, err;
+  bool wd_active;
+
+  dev_dbg(dev,
+          "%s: secs=%d, mins=%d, hours=%d, "
+          "mday=%d, mon=%d, year=%d, wday=%d\n",
+          __func__, tm->tm_sec, tm->tm_min, tm->tm_hour, tm->tm_mday,
+          tm->tm_mon, tm->tm_year, tm->tm_wday);
+
+  /* hours, minutes and seconds */
+  buf[i++] = bin2bcd(tm->tm_sec); /* this will also clear OSF flag */
+  buf[i++] = bin2bcd(tm->tm_min);
+  buf[i++] = bin2bcd(tm->tm_hour);
+  buf[i++] = bin2bcd(tm->tm_mday);
+  buf[i++] = tm->tm_wday & 0x07;
+
+  /* month, 1 - 12 */
+  buf[i++] = bin2bcd(tm->tm_mon + 1);
+
+  /* year */
+  buf[i++] = bin2bcd(tm->tm_year - 100);
+
+  /* Write access to time registers:
+   * PCF2127/29: no special action required.
+   * PCF2131:    requires setting the STOP and CPR bits. STOP bit needs to
+   *             be cleared after time registers are updated.
+   */
+  if (pcf21xx->cfg->type == PCF2131) {
+    err = regmap_update_bits(pcf21xx->regmap, PCF21XX_REG_CTRL1,
+                             PCF21XX_BIT_CTRL1_STOP, PCF21XX_BIT_CTRL1_STOP);
+    if (err) {
+      dev_dbg(dev, "setting STOP bit failed\n");
+      return err;
+    }
+
+    err = regmap_write(pcf21xx->regmap, PCF2131_REG_SR_RESET,
+                       PCF2131_SR_RESET_CPR_CMD);
+    if (err) {
+      dev_dbg(dev, "sending CPR cmd failed\n");
+      return err;
+    }
+  }
+
+  wd_active = watchdog_active(&pcf21xx->wdd);
+
+  if (wd_active) {
+    err = pcf21xx_wdt_stop(&pcf21xx->wdd);
+    if (err) {
+      dev_dbg(dev, "watchdog stop failed\n");
+      return err;
+    }
+  }
+
+  /* write time register's data */
+  err = regmap_bulk_write(pcf21xx->regmap, pcf21xx->cfg->reg_time_base, buf, i);
+  if (err) {
+    dev_dbg(dev, "%s: err=%d", __func__, err);
+    return err;
+  }
+
+  if (pcf21xx->cfg->type == PCF2131) {
+    /* Clear STOP bit (PCF2131 only) after write is completed. */
+    err = regmap_update_bits(pcf21xx->regmap, PCF21XX_REG_CTRL1,
+                             PCF21XX_BIT_CTRL1_STOP, 0);
+    if (err) {
+      dev_dbg(dev, "clearing STOP bit failed\n");
+      return err;
+    }
+  }
+
+  if (wd_active) {
+    err = pcf21xx_wdt_start(&pcf21xx->wdd);
+    if (err) {
+      dev_dbg(dev, "watchdog restart failed\n");
+      return err;
+    }
+  }
+
+  return 0;
+}
+
+static int pcf21xx_rtc_ioctl(struct device *dev, unsigned int cmd,
+                             unsigned long arg) {
+  struct pcf21xx *pcf21xx = dev_get_drvdata(dev);
+  int val, touser = 0;
+  int ret;
+
+  switch (cmd) {
+    case RTC_VL_READ:
+      ret = regmap_read(pcf21xx->regmap, PCF21XX_REG_CTRL3, &val);
+      if (ret) return ret;
+
+      if (val & PCF21XX_BIT_CTRL3_BLF) touser |= RTC_VL_BACKUP_LOW;
+
+      if (val & PCF21XX_BIT_CTRL3_BF) touser |= RTC_VL_BACKUP_SWITCH;
+
+      return put_user(touser, (unsigned int __user *)arg);
+
+    case RTC_VL_CLR:
+      return regmap_update_bits(pcf21xx->regmap, PCF21XX_REG_CTRL3,
+                                PCF21XX_BIT_CTRL3_BF, 0);
+
+    default:
+      return -ENOIOCTLCMD;
+  }
+}
+
+/* watchdog driver */
+
+static int pcf21xx_wdt_update(struct watchdog_device *wdd) {
+  int wd_val;
+  struct pcf21xx *pcf21xx = watchdog_get_drvdata(wdd);
+
+  /*
+   * Compute counter value of WATCHDG_TIM_VAL to obtain desired period
+   * in seconds, depending on the source clock frequency.
+   */
+  wd_val = ((wdd->timeout * pcf21xx->cfg->wdd_clock_hz_x1000) / 1000) + 1;
+
+  return regmap_write(pcf21xx->regmap, pcf21xx->cfg->reg_wd_val, wd_val);
+}
+
+static int pcf21xx_wdt_ping(struct watchdog_device *wdd) {
+  int ret;
+  time64_t ts;
+  struct rtc_wkalrm alrm;
+  struct pcf21xx *pcf21xx = watchdog_get_drvdata(wdd);
+
+  dev_dbg(wdd->parent, "%s: active=%d\n", __func__, watchdog_active(wdd));
+
+  ret = pcf21xx_rtc_read_time_opt_check(wdd->parent, &alrm.time, false);
+  if (ret) return ret;
+
+  ts = rtc_tm_to_time64(&alrm.time);
+  ts += wdd->timeout + pcf21xx->wdd_off_time_sec;
+  rtc_time64_to_tm(ts, &alrm.time);
+  alrm.enabled = true;
+
+  ret = pcf21xx_rtc_set_alarm(wdd->parent, &alrm);
+  if (ret) return ret;
+
+  return pcf21xx_wdt_update(wdd);
+}
+
+/*
+ * Restart watchdog timer if feature is active.
+ *
+ * Note: Reading CTRL2 register causes watchdog to stop which is unfortunate,
+ * since register also contain control/status flags for other features.
+ * Always call this function after reading CTRL2 register.
+ *
+ * This does not seem to apply for PCF2131
+ */
+static int pcf21xx_wdt_active_ping(struct pcf21xx *pcf21xx) {
+  int ret = 0;
+
+  if (pcf21xx->cfg->type == PCF2131) {
+    return ret;
+  }
+
+  if (watchdog_active(&pcf21xx->wdd)) {
+    ret = pcf21xx_wdt_update(&pcf21xx->wdd);
+    if (ret)
+      dev_err(pcf21xx->wdd.parent, "%s: watchdog restart failed, ret=%d\n",
+              __func__, ret);
+  }
+
+  return ret;
+}
+
+static int pcf21xx_wdt_start(struct watchdog_device *wdd) {
+  struct pcf21xx *pcf21xx = watchdog_get_drvdata(wdd);
+  int ret = 0;
+
+  dev_dbg(wdd->parent, "%s\n", __func__);
+
+  ret = regmap_clear_bits(pcf21xx->regmap, PCF21XX_REG_CTRL1,
+                          PCF21XX_BIT_CTRL1_SI);
+  if (ret < 0) return ret;
+
+  ret = regmap_set_bits(pcf21xx->regmap, pcf21xx->cfg->reg_wd_ctl,
+                        PCF21XX_BIT_WD_CTL_CD1);
+  if (ret < 0) return ret;
+
+  return pcf21xx_wdt_ping(wdd);
+}
+
+static int pcf21xx_wdt_stop(struct watchdog_device *wdd) {
+  struct pcf21xx *pcf21xx = watchdog_get_drvdata(wdd);
+  int ret = 0;
+
+  dev_dbg(wdd->parent, "%s\n", __func__);
+
+  ret = regmap_clear_bits(pcf21xx->regmap, pcf21xx->cfg->reg_wd_ctl,
+                          PCF21XX_BIT_WD_CTL_CD1);
+  if (ret < 0) return ret;
+
+  ret =
+      regmap_set_bits(pcf21xx->regmap, PCF21XX_REG_CTRL1, PCF21XX_BIT_CTRL1_SI);
+  if (ret < 0) return ret;
+
+  ret = regmap_write(pcf21xx->regmap, pcf21xx->cfg->reg_wd_val,
+                     PCF21XX_WD_VAL_STOP);
+  if (ret) return ret;
+
+  clear_bit(WDOG_ACTIVE, &pcf21xx->wdd.status);
+  return ret;
+}
+
+static int pcf21xx_wdt_set_timeout(struct watchdog_device *wdd,
+                                   unsigned int new_timeout) {
+  dev_dbg(wdd->parent, "new watchdog timeout: %is (old: %is)\n", new_timeout,
+          wdd->timeout);
+
+  wdd->timeout = new_timeout;
+
+  if (watchdog_active(wdd)) {
+    return pcf21xx_wdt_ping(wdd);
+  }
+  return 0;
+}
+
+static const struct watchdog_info pcf21xx_wdt_info = {
+    .identity = "Iono Pi v3 Watchdog",
+    .options = WDIOF_KEEPALIVEPING | WDIOF_SETTIMEOUT,
+};
+
+static const struct watchdog_ops pcf21xx_watchdog_ops = {
+    .owner = THIS_MODULE,
+    .start = pcf21xx_wdt_start,
+    .stop = pcf21xx_wdt_stop,
+    .ping = pcf21xx_wdt_ping,
+    .set_timeout = pcf21xx_wdt_set_timeout,
+};
+
+/*
+ * Compute watchdog period, t, in seconds, from the WATCHDG_TIM_VAL register
+ * value, n, and the clock frequency, f1000, in Hz x 1000.
+ *
+ * The PCF2127/29 datasheet gives t as:
+ *   t = n / f
+ * The PCF2131 datasheet gives t as:
+ *   t = (n - 1) / f
+ * For both variants, the watchdog is triggered when the WATCHDG_TIM_VAL reaches
+ * the value 1, and not zero. Consequently, the equation from the PCF2131
+ * datasheet seems to be the correct one for both variants.
+ */
+static int pcf21xx_watchdog_get_period(int n, int f1000) {
+  return (1000 * (n - 1)) / f1000;
+}
+
+static int pcf21xx_watchdog_init(struct device *dev, struct pcf21xx *pcf21xx) {
+  int ret;
+  unsigned int wd_ctl, ctrl2;
+  bool wd_active;
+
+  if (!IS_ENABLED(CONFIG_WATCHDOG) ||
+      !device_property_read_bool(dev, "reset-source"))
+    return 0;
+
+  pcf21xx->wdd.parent = dev;
+  pcf21xx->wdd.info = &pcf21xx_wdt_info;
+  pcf21xx->wdd.ops = &pcf21xx_watchdog_ops;
+
+  pcf21xx->wdd.min_timeout =
+      1 + pcf21xx_watchdog_get_period(2, pcf21xx->cfg->wdd_clock_hz_x1000);
+  pcf21xx->wdd.max_timeout =
+      pcf21xx_watchdog_get_period(255, pcf21xx->cfg->wdd_clock_hz_x1000);
+  pcf21xx->wdd.timeout = PCF21XX_WD_DEFAULT_TIMEOUT_S;
+
+  dev_dbg(dev, "%s clock=%dHz/1000 min_timeout=%d max_timeout=%d\n", __func__,
+          pcf21xx->cfg->wdd_clock_hz_x1000, pcf21xx->wdd.min_timeout,
+          pcf21xx->wdd.max_timeout);
+
+  pcf21xx->wdd.min_hw_heartbeat_ms = pcf21xx->cfg->wdd_min_hw_heartbeat_ms;
+  pcf21xx->wdd.status = WATCHDOG_NOWAYOUT_INIT_STATUS;
+
+  pcf21xx->wdd_off_time_sec = IONOPI_WD_DEFAULT_OFF_TIME_S;
+
+  watchdog_set_drvdata(&pcf21xx->wdd, pcf21xx);
+
+  /* 1/4 Hz watchdog timer and permanent active signal when MSF is set */
+  ret = regmap_update_bits(pcf21xx->regmap, pcf21xx->cfg->reg_wd_ctl,
+                           PCF21XX_BIT_WD_CTL_TI_TP | PCF21XX_BIT_WD_CTL_TF1 |
+                               PCF21XX_BIT_WD_CTL_TF0,
+                           PCF21XX_BIT_WD_CTL_TF1);
+  if (ret) {
+    dev_err(dev, "%s: watchdog config (wd_ctl) failed\n", __func__);
+    return ret;
+  }
+
+  /* Check if watchdog is active */
+  ret = regmap_read(pcf21xx->regmap, pcf21xx->cfg->reg_wd_ctl, &wd_ctl);
+  if (ret) return ret;
+
+  ret = regmap_read(pcf21xx->regmap, PCF21XX_REG_CTRL2, &ctrl2);
+  if (ret) return ret;
+
+  if ((wd_ctl & PCF21XX_BIT_WD_CTL_CD1) && !(ctrl2 & PCF21XX_BIT_CTRL2_WDTF)) {
+    set_bit(WDOG_HW_RUNNING, &pcf21xx->wdd.status);
+    ret = pcf21xx_wdt_start(&pcf21xx->wdd);
+    wd_active = true;
+  } else {
+    ret = pcf21xx_wdt_stop(&pcf21xx->wdd);
+    wd_active = false;
+  }
+  if (ret) return ret;
+
+  if (wd_active)
+    set_bit(WDOG_ACTIVE, &pcf21xx->wdd.status);
+  else
+    clear_bit(WDOG_ACTIVE, &pcf21xx->wdd.status);
+
+  return devm_watchdog_register_device(dev, &pcf21xx->wdd);
+}
+
+/* Alarm */
+
+static int pcf21xx_rtc_alarm_irq_enable(struct device *dev, u32 enable) {
+  struct pcf21xx *pcf21xx = dev_get_drvdata(dev);
+  int ret;
+
+  ret = regmap_update_bits(pcf21xx->regmap, PCF21XX_REG_CTRL2,
+                           PCF21XX_BIT_CTRL2_AIE,
+                           enable ? PCF21XX_BIT_CTRL2_AIE : 0);
+  if (ret) return ret;
+
+  return pcf21xx_wdt_active_ping(pcf21xx);
+}
+
+static int pcf21xx_rtc_set_alarm(struct device *dev, struct rtc_wkalrm *alrm) {
+  struct pcf21xx *pcf21xx = dev_get_drvdata(dev);
+  uint8_t buf[5];
+  int ret;
+
+  ret = regmap_clear_bits(
+      pcf21xx->regmap, PCF21XX_REG_CTRL2,
+      PCF21XX_BIT_CTRL2_AF | PCF21XX_BIT_CTRL2_WDTF | PCF21XX_BIT_CTRL2_MSF);
+  if (ret < 0) return ret;
+
+  ret = pcf21xx_wdt_active_ping(pcf21xx);
+  if (ret) return ret;
+
+  buf[0] = bin2bcd(alrm->time.tm_sec);
+  buf[1] = bin2bcd(alrm->time.tm_min);
+  buf[2] = bin2bcd(alrm->time.tm_hour);
+  buf[3] = PCF21XX_BIT_ALARM_AE; /* Do not match on day */
+  buf[4] = PCF21XX_BIT_ALARM_AE; /* Do not match on week day */
+
+  ret = regmap_bulk_write(pcf21xx->regmap, pcf21xx->cfg->regs_alarm_base, buf,
+                          sizeof(buf));
+  if (ret) return ret;
+
+  return pcf21xx_rtc_alarm_irq_enable(dev, alrm->enabled);
+}
+
+static const struct rtc_class_ops pcf21xx_rtc_ops = {
+    .ioctl = pcf21xx_rtc_ioctl,
+    .read_time = pcf21xx_rtc_read_time,
+    .set_time = pcf21xx_rtc_set_time,
+};
+
+/* sysfs interface */
+
+static ssize_t battery_low_show(struct device *dev,
+                                struct device_attribute *attr, char *buf) {
+  struct pcf21xx *pcf21xx = dev_get_drvdata(dev->parent);
+  unsigned int ctrl3;
+  int ret;
+
+  ret = regmap_read(pcf21xx->regmap, PCF21XX_REG_CTRL3, &ctrl3);
+  if (ret) return ret;
+
+  return sprintf(buf, "%d\n", (ctrl3 & PCF21XX_BIT_CTRL3_BLF) ? 1 : 0);
+};
+
+static DEVICE_ATTR_RO(battery_low);
+
+static struct attribute *pcf2131_attrs[] = {
+    &dev_attr_battery_low.attr,
+    NULL,
+};
+
+static struct pcf21xx_config pcf21xx_cfg[] = {
+    [PCF2131] =
+        {
+            .type = PCF2131,
+            .max_register = 0x36,
+            .has_nvmem = 0,
+            .has_bit_wd_ctl_cd0 = 0,
+            .wd_val_reg_readable = 0,
+            .has_int_a_b = 1,
+            .reg_time_base = PCF2131_REG_TIME_BASE,
+            .regs_alarm_base = PCF2131_REG_ALARM_BASE,
+            .reg_wd_ctl = PCF2131_REG_WD_CTL,
+            .reg_wd_val = PCF2131_REG_WD_VAL,
+            .reg_clkout = PCF2131_REG_CLKOUT,
+            .wdd_clock_hz_x1000 = PCF2131_WD_CLOCK_HZ_X1000,
+            .wdd_min_hw_heartbeat_ms = PCF2131_WD_MIN_HW_HEARTBEAT_MS,
+            .attribute_group =
+                {
+                    .attrs = pcf2131_attrs,
+                },
+        },
+};
+
+/*
+ * Route alarm and seconds interrupts to INT A pin
+ * and watchdog interrupt to INT B
+ */
+static int pcf21xx_configure_interrupt_pins(struct device *dev) {
+  struct pcf21xx *pcf21xx = dev_get_drvdata(dev);
+  int ret;
+
+  /* Mask bits need to be cleared to enable corresponding
+   * interrupt source.
+   */
+  ret = regmap_write(pcf21xx->regmap, PCF2131_REG_INT_A_MASK1,
+                     ~(PCF2131_BIT_INT_AIE | PCF2131_BIT_INT_SI) & 0x3f);
+  if (ret) return ret;
+
+  ret = regmap_write(pcf21xx->regmap, PCF2131_REG_INT_A_MASK2, 0x0f);
+  if (ret) return ret;
+
+  ret = regmap_write(pcf21xx->regmap, PCF2131_REG_INT_B_MASK1,
+                     ~PCF2131_BIT_INT_WD_CD & 0x3f);
+  if (ret) return ret;
+
+  ret = regmap_write(pcf21xx->regmap, PCF2131_REG_INT_B_MASK2, 0x0f);
+  if (ret) return ret;
+
+  return ret;
+}
+
+static int pcf21xx_probe(struct device *dev, struct regmap *regmap,
+                         int alarm_irq, const struct pcf21xx_config *config) {
+  struct pcf21xx *pcf21xx;
+  int ret = 0;
+  unsigned int val;
+
+  dev_dbg(dev, "%s\n", __func__);
+
+  pcf21xx = devm_kzalloc(dev, sizeof(*pcf21xx), GFP_KERNEL);
+  if (!pcf21xx) return -ENOMEM;
+
+  pcf21xx->regmap = regmap;
+  pcf21xx->cfg = config;
+
+  dev_set_drvdata(dev, pcf21xx);
+
+  pcf21xx->rtc = devm_rtc_allocate_device(dev);
+  if (IS_ERR(pcf21xx->rtc)) return PTR_ERR(pcf21xx->rtc);
+
+  pcf21xx->rtc->ops = &pcf21xx_rtc_ops;
+  pcf21xx->rtc->range_min = RTC_TIMESTAMP_BEGIN_2000;
+  pcf21xx->rtc->range_max = RTC_TIMESTAMP_END_2099;
+  pcf21xx->rtc->set_start_time = true; /* Sets actual start to 1970 */
+
+  clear_bit(RTC_FEATURE_ALARM, pcf21xx->rtc->features);
+
+  if (pcf21xx->cfg->has_int_a_b) {
+    /* Configure int A/B pins, independently of alarm_irq. */
+    ret = pcf21xx_configure_interrupt_pins(dev);
+    if (ret) {
+      dev_err(dev, "failed to configure interrupt pins\n");
+      return ret;
+    }
+  }
+
+  /*
+   * The "Power-On Reset Override" facility prevents the RTC to do a reset
+   * after power on. For normal operation the PORO must be disabled.
+   */
+  ret = regmap_clear_bits(pcf21xx->regmap, PCF21XX_REG_CTRL1,
+                          PCF21XX_BIT_CTRL1_POR_OVRD);
+  if (ret < 0) return ret;
+
+  /* Make sure PWRMNG[2:0] is set to 000b. This is the default for
+   * PCF2127/29, but not for PCF2131 (default of 111b).
+   *
+   * PWRMNG[2:0]  = 000b:
+   *   battery switch-over function is enabled in standard mode;
+   *   battery low detection function is enabled
+   */
+  ret = regmap_clear_bits(pcf21xx->regmap, PCF21XX_REG_CTRL3,
+                          PCF21XX_CTRL3_PWRMNG_MASK);
+  if (ret < 0) {
+    dev_err(dev, "PWRMNG config failed\n");
+    return ret;
+  }
+
+  ret = regmap_read(pcf21xx->regmap, pcf21xx->cfg->reg_clkout, &val);
+  if (ret < 0) return ret;
+
+  if (!(val & PCF21XX_BIT_CLKOUT_OTPR)) {
+    ret = regmap_set_bits(pcf21xx->regmap, pcf21xx->cfg->reg_clkout,
+                          PCF21XX_BIT_CLKOUT_OTPR);
+    if (ret < 0) return ret;
+
+    msleep(100);
+  }
+
+  pcf21xx_watchdog_init(dev, pcf21xx);
+
+  /*
+   * Disable battery low/switch-over timestamp and interrupts.
+   * Clear battery interrupt flags which can block new trigger events.
+   * Note: This is the default chip behaviour but added to ensure
+   * correct tamper timestamp and interrupt function.
+   */
+  ret = regmap_update_bits(
+      pcf21xx->regmap, PCF21XX_REG_CTRL3,
+      PCF21XX_BIT_CTRL3_BTSE | PCF21XX_BIT_CTRL3_BIE | PCF21XX_BIT_CTRL3_BLIE,
+      0);
+  if (ret) {
+    dev_err(dev, "%s: interrupt config (ctrl3) failed\n", __func__);
+    return ret;
+  }
+
+  ret = rtc_add_group(pcf21xx->rtc, &pcf21xx->cfg->attribute_group);
+  if (ret) {
+    dev_err(dev, "%s: tamper sysfs registering failed\n", __func__);
+    return ret;
+  }
+
+  ret = devm_rtc_register_device(pcf21xx->rtc);
+  if (ret) return ret;
+
+  _instance = pcf21xx;
+
+  return 0;
+}
+
+static const struct of_device_id pcf21xx_of_match[] = {
+    {
+        .compatible = "sferalabs,ionopi-v3-pcf2131",
+        .data = &pcf21xx_cfg[PCF2131],
+    },
+    {},
+};
+MODULE_DEVICE_TABLE(of, pcf21xx_of_match);
+
+static int pcf21xx_i2c_write(void *context, const void *data, size_t count) {
+  struct device *dev = context;
+  struct i2c_client *client = to_i2c_client(dev);
+  int ret;
+
+  ret = i2c_master_send(client, data, count);
+  if (ret != count) return ret < 0 ? ret : -EIO;
+
+  return 0;
+}
+
+static int pcf21xx_i2c_gather_write(void *context, const void *reg,
+                                    size_t reg_size, const void *val,
+                                    size_t val_size) {
+  struct device *dev = context;
+  struct i2c_client *client = to_i2c_client(dev);
+  int ret;
+  void *buf;
+
+  if (WARN_ON(reg_size != 1)) return -EINVAL;
+
+  buf = kmalloc(val_size + 1, GFP_KERNEL);
+  if (!buf) return -ENOMEM;
+
+  memcpy(buf, reg, 1);
+  memcpy(buf + 1, val, val_size);
+
+  ret = i2c_master_send(client, buf, val_size + 1);
+
+  kfree(buf);
+
+  if (ret != val_size + 1) return ret < 0 ? ret : -EIO;
+
+  return 0;
+}
+
+static int pcf21xx_i2c_read(void *context, const void *reg, size_t reg_size,
+                            void *val, size_t val_size) {
+  struct device *dev = context;
+  struct i2c_client *client = to_i2c_client(dev);
+  int ret;
+
+  if (WARN_ON(reg_size != 1)) return -EINVAL;
+
+  ret = i2c_master_send(client, reg, 1);
+  if (ret != 1) return ret < 0 ? ret : -EIO;
+
+  ret = i2c_master_recv(client, val, val_size);
+  if (ret != val_size) return ret < 0 ? ret : -EIO;
+
+  return 0;
+}
+
+/*
+ * The reason we need this custom regmap_bus instead of using regmap_init_i2c()
+ * is that the STOP condition is required between set register address and
+ * read register data when reading from registers.
+ */
+static const struct regmap_bus pcf21xx_i2c_regmap = {
+    .write = pcf21xx_i2c_write,
+    .gather_write = pcf21xx_i2c_gather_write,
+    .read = pcf21xx_i2c_read,
+};
+
+static const struct i2c_device_id pcf21xx_i2c_id[] = {
+    {"ionopi-v3-pcf2131", PCF2131},
+    {},
+};
+MODULE_DEVICE_TABLE(i2c, pcf21xx_i2c_id);
+
+static int pcf21xx_i2c_probe(struct i2c_client *client) {
+  struct regmap *regmap;
+  static struct regmap_config config = {
+      .reg_bits = 8,
+      .val_bits = 8,
+  };
+  const struct pcf21xx_config *variant;
+
+  if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C)) return -ENODEV;
+
+  if (client->dev.of_node) {
+    variant = of_device_get_match_data(&client->dev);
+    if (!variant) return -ENODEV;
+  } else {
+    enum pcf21xx_type type = i2c_match_id(pcf21xx_i2c_id, client)->driver_data;
+
+    if (type >= PCF21XX_LAST_ID) return -ENODEV;
+    variant = &pcf21xx_cfg[type];
+  }
+
+  config.max_register = variant->max_register,
+
+  regmap = devm_regmap_init(&client->dev, &pcf21xx_i2c_regmap, &client->dev,
+                            &config);
+  if (IS_ERR(regmap)) {
+    dev_err(&client->dev, "%s: regmap allocation failed: %ld\n", __func__,
+            PTR_ERR(regmap));
+    return PTR_ERR(regmap);
+  }
+
+  return pcf21xx_probe(&client->dev, regmap, client->irq, variant);
+}
+
+static struct i2c_driver pcf21xx_i2c_driver = {
+    .driver =
+        {
+            .name = "ionopi-v3-pcf2131",
+            .of_match_table = of_match_ptr(pcf21xx_of_match),
+        },
+    .probe = pcf21xx_i2c_probe,
+    .id_table = pcf21xx_i2c_id,
+};
+
+int pcf2131_i2c_register_driver(void) {
+  return i2c_add_driver(&pcf21xx_i2c_driver);
+}
+
+void pcf2131_i2c_unregister_driver(void) {
+  i2c_del_driver(&pcf21xx_i2c_driver);
+}
+
+ssize_t devAttrWatchdogEnabled_show(struct device *dev,
+                                    struct device_attribute *attr, char *buf) {
+  if (_instance == NULL) {
+    return -ENODEV;
+  }
+  return sprintf(buf, "%d\n", watchdog_active(&_instance->wdd));
+}
+
+ssize_t devAttrWatchdogEnabled_store(struct device *dev,
+                                     struct device_attribute *attr,
+                                     const char *buf, size_t count) {
+  int ret;
+  bool enable;
+  if (_instance == NULL) {
+    return -ENODEV;
+  }
+
+  if (buf[0] == '0') {
+    enable = false;
+  } else if (buf[0] == '1') {
+    enable = true;
+  } else {
+    return -EINVAL;
+  }
+
+  if (enable) {
+    ret = pcf21xx_wdt_start(&_instance->wdd);
+  } else {
+    ret = pcf21xx_wdt_stop(&_instance->wdd);
+  }
+
+  if (ret) return ret;
+
+  if (enable) {
+    set_bit(WDOG_ACTIVE, &_instance->wdd.status);
+  } else {
+    clear_bit(WDOG_ACTIVE, &_instance->wdd.status);
+  }
+
+  return count;
+}
+
+ssize_t devAttrWatchdogHeartbeat_store(struct device *dev,
+                                       struct device_attribute *attr,
+                                       const char *buf, size_t count) {
+  int ret;
+  if (_instance == NULL) {
+    return -ENODEV;
+  }
+
+  if (!watchdog_active(&_instance->wdd)) {
+    return -EPERM;
+  }
+
+  ret = pcf21xx_wdt_ping(&_instance->wdd);
+  if (ret) {
+    return ret;
+  }
+
+  return count;
+}
+
+ssize_t devAttrWatchdogTimeout_show(struct device *dev,
+                                    struct device_attribute *attr, char *buf) {
+  if (_instance == NULL) {
+    return -ENODEV;
+  }
+  return sprintf(buf, "%d\n", _instance->wdd.timeout);
+}
+
+ssize_t devAttrWatchdogTimeout_store(struct device *dev,
+                                     struct device_attribute *attr,
+                                     const char *buf, size_t count) {
+  int ret;
+  unsigned long val;
+  if (_instance == NULL) {
+    return -ENODEV;
+  }
+
+  ret = kstrtoul(buf, 10, &val);
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (val < _instance->wdd.min_timeout || val > _instance->wdd.max_timeout) {
+    return -EINVAL;
+  }
+
+  ret = pcf21xx_wdt_set_timeout(&_instance->wdd, val);
+  if (ret) {
+    return ret;
+  }
+
+  return count;
+}
+
+ssize_t devAttrWatchdogOffTime_show(struct device *dev,
+                                    struct device_attribute *attr, char *buf) {
+  if (_instance == NULL) {
+    return -ENODEV;
+  }
+  return sprintf(buf, "%d\n", _instance->wdd_off_time_sec);
+}
+
+ssize_t devAttrWatchdogOffTime_store(struct device *dev,
+                                     struct device_attribute *attr,
+                                     const char *buf, size_t count) {
+  int ret;
+  unsigned long val;
+  if (_instance == NULL) {
+    return -ENODEV;
+  }
+
+  ret = kstrtoul(buf, 10, &val);
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (val < 5 || val > (86400 - _instance->wdd.timeout - 1)) {
+    return -EINVAL;
+  }
+
+  _instance->wdd_off_time_sec = val;
+
+  if (watchdog_active(&_instance->wdd)) {
+    ret = pcf21xx_wdt_ping(&_instance->wdd);
+    if (ret) {
+      return ret;
+    }
+  }
+
+  return count;
+}

--- a/drivers/staging/sferalabs/ionopi-v3/pcf2131/pcf2131.h
+++ b/drivers/staging/sferalabs/ionopi-v3/pcf2131/pcf2131.h
@@ -1,0 +1,28 @@
+#ifndef _SL_PCF2131_H
+#define _SL_PCF2131_H
+
+#include <linux/device.h>
+
+int pcf2131_i2c_register_driver(void);
+void pcf2131_i2c_unregister_driver(void);
+
+ssize_t devAttrWatchdogEnabled_show(struct device *dev,
+                                    struct device_attribute *attr, char *buf);
+ssize_t devAttrWatchdogEnabled_store(struct device *dev,
+                                     struct device_attribute *attr,
+                                     const char *buf, size_t count);
+ssize_t devAttrWatchdogHeartbeat_store(struct device *dev,
+                                       struct device_attribute *attr,
+                                       const char *buf, size_t count);
+ssize_t devAttrWatchdogTimeout_show(struct device *dev,
+                                    struct device_attribute *attr, char *buf);
+ssize_t devAttrWatchdogTimeout_store(struct device *dev,
+                                     struct device_attribute *attr,
+                                     const char *buf, size_t count);
+ssize_t devAttrWatchdogOffTime_show(struct device *dev,
+                                    struct device_attribute *attr, char *buf);
+ssize_t devAttrWatchdogOffTime_store(struct device *dev,
+                                     struct device_attribute *attr,
+                                     const char *buf, size_t count);
+
+#endif


### PR DESCRIPTION
Hi,

This pull request represents an initial step toward integrating drivers for our boards and modules directly into the kernel, with the goal of improving distribution and long-term maintainability.

I'm fully aware this is not the ideal or final structure, but I wanted to get the conversation started with something concrete to gather feedback and suggestions on how best to proceed.

Our devices combine multiple functionalities, which makes it difficult to fit them under existing driver categories. To bootstrap the discussion, I've added a new `drivers/staging/sferalabs` directory.

In this first commit:
- I've included the driver for an upcoming product, *Iono Pi v3*.
- I've added a `commons` directory with shared components that will be reused across future drivers.

All drivers expose a `sysfs` interface to access the board/module functionalities. The Iono Pi v3 driver also registers RTC and Watchdog device nodes.

For reference, the driver (distributed as an out-of-tree kernel module) of the current Iono Pi version can be found here:  
https://github.com/sfera-labs/iono-pi-kernel-module

Before diving into formatting and implementation specifics, I'd really appreciate your thoughts on whether this structure and general approach would be acceptable.

Looking forward to your feedback!

Thank you,    
Giampiero