### PR TITLE
fixup! mmc: sdhci-of-dwcmshc: define sdio timeout clocks

### DIFF
--- a/drivers/mmc/host/sdhci-of-dwcmshc.c
+++ b/drivers/mmc/host/sdhci-of-dwcmshc.c
@@ -1221,13 +1221,15 @@ static const struct dwcmshc_pltfm_data sdhci_dwcmshc_bf3_pdata = {
 };
 #endif
 
-static const struct sdhci_pltfm_data sdhci_dwcmshc_rp1_pdata = {
-	.ops = &sdhci_dwcmshc_ops,
-	.quirks = SDHCI_QUIRK_CAP_CLOCK_BASE_BROKEN |
-		  SDHCI_QUIRK_BROKEN_CARD_DETECTION,
-	.quirks2 = SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
-		   SDHCI_QUIRK2_BROKEN_HS200 |
-		   SDHCI_QUIRK2_SPURIOUS_INT_RESP,
+static const struct dwcmshc_pltfm_data sdhci_dwcmshc_rp1_pdata = {
+	.pdata = {
+		.ops = &sdhci_dwcmshc_ops,
+		.quirks = SDHCI_QUIRK_CAP_CLOCK_BASE_BROKEN |
+			  SDHCI_QUIRK_BROKEN_CARD_DETECTION,
+		.quirks2 = SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			   SDHCI_QUIRK2_BROKEN_HS200 |
+			   SDHCI_QUIRK2_SPURIOUS_INT_RESP,
+	}
 };
 
 static const struct dwcmshc_pltfm_data sdhci_dwcmshc_rk35xx_pdata = {


### PR DESCRIPTION
The usage of the .data field of the of_device_id array changed with the move to kernel 6.11, but because it holds a void pointer there were no warnings that the sdhci_dwcmshc_rp1_data was now the wrong type.

Convert sdhci_dwcmshc_rp1_data to a dwcmshc_pltfm_data to avoid a crash when one of RP1's SDIO interfaces is enabled.

See: https://github.com/raspberrypi/linux/issues/6778