### PR TITLE
drm/vc4: tests: Patch up the vc4 kunit tests

### DIFF
--- a/drivers/gpu/drm/vc4/tests/vc4_test_lbm_size.c
+++ b/drivers/gpu/drm/vc4/tests/vc4_test_lbm_size.c
@@ -279,7 +279,7 @@ static struct kunit_case vc4_lbm_size_tests[] = {
 
 static int vc4_lbm_size_test_init(struct kunit *test)
 {
-	struct drm_modeset_acquire_ctx *ctx;
+	static struct drm_modeset_acquire_ctx ctx;
 	struct vc4_lbm_size_priv *priv;
 	struct drm_device *drm;
 	struct vc4_dev *vc4;
@@ -295,12 +295,14 @@ static int vc4_lbm_size_test_init(struct kunit *test)
 	priv->file = drm_file_alloc(priv->vc4->base.primary);
 	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, priv->file);
 
-	ctx = drm_kunit_helper_acquire_ctx_alloc(test);
-	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, ctx);
+	drm_modeset_acquire_init(&ctx, 0);
 
 	drm = &vc4->base;
-	priv->state = drm_kunit_helper_atomic_state_alloc(test, drm, ctx);
+	priv->state = drm_kunit_helper_atomic_state_alloc(test, drm, &ctx);
 	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, priv->state);
+
+	drm_modeset_drop_locks(&ctx);
+	drm_modeset_acquire_fini(&ctx);
 
 	return 0;
 }

--- a/drivers/gpu/drm/vc4/tests/vc4_test_pv_muxing.c
+++ b/drivers/gpu/drm/vc4/tests/vc4_test_pv_muxing.c
@@ -807,7 +807,7 @@ static void drm_vc4_test_pv_muxing_invalid(struct kunit *test)
 static int vc4_pv_muxing_test_init(struct kunit *test)
 {
 	const struct pv_muxing_param *params = test->param_value;
-	struct drm_modeset_acquire_ctx ctx;
+	static struct drm_modeset_acquire_ctx ctx;
 	struct pv_muxing_priv *priv;
 	struct drm_device *drm;
 	struct vc4_dev *vc4;


### PR DESCRIPTION
Commit [1] removed the dynamic allocation of drm_modeset_acquire_ctx structures, with clients expected to allocate them by other means, such as on the stack. This usage model works less well when tests are split into separate initialisation and run phases, because a ctx allocated on the stack in the init function will go out of scope and likely be overwritten by the run function(s).

As kunit tests seem to be single threaded, make ctx static to avoid the issue.

[1] commit 30188df0c387 ("drm/tests: Drop drm_kunit_helper_acquire_ctx_alloc()")