### PR TITLE
drm/vc4: plane: Increase UPM allocation size for YUV444

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -851,6 +851,9 @@ static size_t vc6_upm_size(const struct drm_plane_state *state,
 		else
 			stride = ALIGN(state->fb->width, 128);
 	}
+	if (!plane && (state->fb->format->format == DRM_FORMAT_YUV444 ||
+		       state->fb->format->format == DRM_FORMAT_YVU444))
+		stride <<= 1;
 	/*
 	 * TODO: This only works for raster formats, and is sub-optimal
 	 * for buffers with a stride aligned on 32 bytes.

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -1857,6 +1857,24 @@ static int vc6_plane_mode_set(struct drm_plane *plane,
 	if (ret)
 		return ret;
 
+	if (state->fb->format->format == DRM_FORMAT_YUV444 ||
+	    state->fb->format->format == DRM_FORMAT_YVU444) {
+		/* Similar to YUV422 requiring the chroma scaler to always be
+		 * enabled that is handled in vc4_plane_setup_clipping_and_scaling,
+		 * GEN6 requires the scaler for the luma channel to be enabled
+		 * for YUV444.
+		 */
+		if (vc4_state->x_scaling[0] == VC4_SCALING_NONE) {
+			vc4_state->x_scaling[0] = VC4_SCALING_PPF;
+			vc4_state->is_unity = false;
+		}
+
+		if (vc4_state->y_scaling[0] == VC4_SCALING_NONE) {
+			vc4_state->y_scaling[0] = VC4_SCALING_PPF;
+			vc4_state->is_unity = false;
+		}
+	}
+
 	if (!vc4_state->src_w[0] || !vc4_state->src_h[0] ||
 	    !vc4_state->crtc_w || !vc4_state->crtc_h) {
 		/* 0 source size probably means the plane is offscreen.


### PR DESCRIPTION
YUV444 support isn't officially supported by the hardware, but worked if you told it the image was YUV422 with double the width and altered chroma scaling.

Adding BCM2712 support gained a fetcher memory (UPM). The code handling UPM allocations didn't have a case for YUV444, so only allocated based on the base width, and therefore underflowed.

Increase the UPM allocation size for the luma plane of YUV444 to match.

Fixes: 076eedaf762f ("drm/vc4: hvs: Add support for BCM2712 HVS")