### PR TITLE
drm/vc4: plane: Use nearest neighbour filter with YUV444 workaround

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -475,6 +475,10 @@ struct vc4_plane_state {
 	enum vc4_scaling_mode x_scaling[2], y_scaling[2];
 	bool is_unity;
 	bool is_yuv;
+	/* Allows use of nearest neighbour scaling filter when doing unity YUV444
+	 * workaround
+	 */
+	bool is_yuv444_unity;
 
 	/* Our allocation in LBM for temporary storage during scaling. */
 	unsigned int lbm_handle;


### PR DESCRIPTION
As a follow-up to commit ef79eea9e4b8 ("drm/vc4: plane: Enable scaler for YUV444 on GEN6"), the image looks a little soft when rendering at 1:1 due to the scaling filter being enabled.

Switch to using the nearest neighbour filter automatically when not scaling in YUV444 to compensate.