### PR TITLE
hwmon: aht10: Fix AHT20 initialization

### DIFF
--- a/drivers/hwmon/aht10.c
+++ b/drivers/hwmon/aht10.c
@@ -37,6 +37,8 @@
 #define AHT10_CMD_MEAS	0b10101100
 #define AHT10_CMD_RST	0b10111010
 
+#define AHT20_CMD_INIT	0b10111110
+
 /*
  * Flags in the answer byte/command
  */
@@ -59,6 +61,7 @@ MODULE_DEVICE_TABLE(i2c, aht10_id);
 
 static const struct of_device_id aht10_of_id[] = {
 	{ .compatible = "aosong,aht10", },
+	{ .compatible = "aosong,aht20", },
 	{ }
 };
 MODULE_DEVICE_TABLE(of, aht10_of_id);
@@ -107,8 +110,13 @@ struct aht10_data {
  */
 static int aht10_init(struct aht10_data *data)
 {
-	const u8 cmd_init[] = {AHT10_CMD_INIT, AHT10_CAL_ENABLED | AHT10_MODE_CYC,
-			       0x00};
+	u8 cmd_init[] = {AHT10_CMD_INIT, AHT10_CAL_ENABLED | AHT10_MODE_CYC, 0x00};
+
+	if (data->crc8) { /* AHT20 */
+		cmd_init[0] = AHT20_CMD_INIT;
+		cmd_init[1] = AHT10_CAL_ENABLED;
+	}
+
 	int res;
 	u8 status;
 	struct i2c_client *client = data->client;


### PR DESCRIPTION
The existing driver claims AHT20 support in i2c_device_id, but fails to:
1. Use the correct init command (0xBE for AHT20 vs 0xE1 for AHT10)
2. Omit AHT10_MODE_CYC which AHT20 doesn't support/require

This patch adds the proper initialization sequence and includes "aosong,aht20" in the device tree match table to fully support the AHT20.

AHT20 data sheet: http://www.aosong.com/uploadfiles/2025/04/20250417112732054.pdf

Tested on Raspberry Pi 3B+ and Zero 2 W.