### PR TITLE
drm/vc4: plane: Fix incorrect handling of GEN_6_D in vc4_plane_async_…

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -2373,7 +2373,7 @@ void vc4_plane_async_set_fb(struct drm_plane *plane, struct drm_framebuffer *fb)
 	 */
 	WARN_ON_ONCE(plane->state->crtc_x < 0 || plane->state->crtc_y < 0);
 
-	if (vc4->gen == VC4_GEN_6_C) {
+	if (vc4->gen >= VC4_GEN_6_C) {
 		u32 value;
 
 		value = vc4_state->dlist[vc4_state->ptr0_offset[0]] &


### PR DESCRIPTION
…set_fb

A conditional had been left as == GEN_6_C, when it also applied to GEN_6_D, resulting in an invalid change to the dlist on async updates.

Fixes: b7b14b31c886 ("drm/vc4: plane: Add support for 2712 D-step.")