### PR TITLE
Add RS485 mode support for UART2, UART3, UART4, and UART5.

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5181,6 +5181,19 @@ Name:   uart2
 Info:   Enable uart 2 on GPIOs 0-3. BCM2711 only.
 Load:   dtoverlay=uart2,<param>
 Params: ctsrts                  Enable CTS/RTS on GPIOs 2-3 (default off)
+        rs485                   Enable RS485 mode for using the RTS line to
+                                drive the OE pin of an RS485 transceiver (i.e.
+                                MAX3078E); also enables the UARTx ctsrts
+                                parameter, as RTS is required (default off).
+        rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
+                                line from active-high (default) to active-low
+                                (default off).
+        rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission starting
+                                and the RTS line being asserted (default 0).
+        rs485_rts_off_delay     When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission ending
+                                and the RTS line being deasserted (default 0).
 
 
 Name:   uart2-pi5
@@ -5193,6 +5206,19 @@ Name:   uart3
 Info:   Enable uart 3 on GPIOs 4-7. BCM2711 only.
 Load:   dtoverlay=uart3,<param>
 Params: ctsrts                  Enable CTS/RTS on GPIOs 6-7 (default off)
+        rs485                   Enable RS485 mode for using the RTS line to
+                                drive the OE pin of an RS485 transceiver (i.e.
+                                MAX3078E); also enables the UARTx ctsrts
+                                parameter, as RTS is required (default off).
+        rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
+                                line from active-high (default) to active-low
+                                (default off).
+        rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission starting
+                                and the RTS line being asserted (default 0).
+        rs485_rts_off_delay     When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission ending
+                                and the RTS line being deasserted (default 0).
 
 
 Name:   uart3-pi5
@@ -5205,6 +5231,19 @@ Name:   uart4
 Info:   Enable uart 4 on GPIOs 8-11. BCM2711 only.
 Load:   dtoverlay=uart4,<param>
 Params: ctsrts                  Enable CTS/RTS on GPIOs 10-11 (default off)
+        rs485                   Enable RS485 mode for using the RTS line to
+                                drive the OE pin of an RS485 transceiver (i.e.
+                                MAX3078E); also enables the UARTx ctsrts
+                                parameter, as RTS is required (default off).
+        rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
+                                line from active-high (default) to active-low
+                                (default off).
+        rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission starting
+                                and the RTS line being asserted (default 0).
+        rs485_rts_off_delay     When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission ending
+                                and the RTS line being deasserted (default 0).
 
 
 Name:   uart4-pi5
@@ -5217,6 +5256,19 @@ Name:   uart5
 Info:   Enable uart 5 on GPIOs 12-15. BCM2711 only.
 Load:   dtoverlay=uart5,<param>
 Params: ctsrts                  Enable CTS/RTS on GPIOs 14-15 (default off)
+        rs485                   Enable RS485 mode for using the RTS line to
+                                drive the OE pin of an RS485 transceiver (i.e.
+                                MAX3078E); also enables the UARTx ctsrts
+                                parameter, as RTS is required (default off).
+        rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
+                                line from active-high (default) to active-low
+                                (default off).
+        rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission starting
+                                and the RTS line being asserted (default 0).
+        rs485_rts_off_delay     When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission ending
+                                and the RTS line being deasserted (default 0).
 
 
 Name:   udrc

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5186,8 +5186,7 @@ Params: ctsrts                  Enable CTS/RTS on GPIOs 2-3 (default off)
                                 MAX3078E); also enables the UARTx ctsrts
                                 parameter, as RTS is required (default off).
         rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
-                                line from active-high (default) to active-low
-                                (default off).
+                                line from active-high (default) to active-low.
         rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
                                 milliseconds) between data transmission starting
                                 and the RTS line being asserted (default 0).
@@ -5211,8 +5210,7 @@ Params: ctsrts                  Enable CTS/RTS on GPIOs 6-7 (default off)
                                 MAX3078E); also enables the UARTx ctsrts
                                 parameter, as RTS is required (default off).
         rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
-                                line from active-high (default) to active-low
-                                (default off).
+                                line from active-high (default) to active-low.
         rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
                                 milliseconds) between data transmission starting
                                 and the RTS line being asserted (default 0).
@@ -5236,8 +5234,7 @@ Params: ctsrts                  Enable CTS/RTS on GPIOs 10-11 (default off)
                                 MAX3078E); also enables the UARTx ctsrts
                                 parameter, as RTS is required (default off).
         rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
-                                line from active-high (default) to active-low
-                                (default off).
+                                line from active-high (default) to active-low.
         rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
                                 milliseconds) between data transmission starting
                                 and the RTS line being asserted (default 0).
@@ -5261,8 +5258,7 @@ Params: ctsrts                  Enable CTS/RTS on GPIOs 14-15 (default off)
                                 MAX3078E); also enables the UARTx ctsrts
                                 parameter, as RTS is required (default off).
         rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
-                                line from active-high (default) to active-low
-                                (default off).
+                                line from active-high (default) to active-low.
         rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
                                 milliseconds) between data transmission starting
                                 and the RTS line being asserted (default 0).

--- a/arch/arm/boot/dts/overlays/uart2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart2-overlay.dts
@@ -19,7 +19,19 @@
 		};
 	};
 
+	rs485: fragment@2 {
+		target = <&uart2>;
+		__dormant__ {
+			linux,rs485-enabled-at-boot-time;
+			rs485-rts-delay = <0 0>;
+		};
+	};
+
 	__overrides__ {
 		ctsrts = <0>,"=1";
+		rs485 = <0>,"=1=2";
+		rs485_invert_rts = <&rs485>,"rs485-rts-active-low";
+		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
+		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/uart3-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart3-overlay.dts
@@ -19,7 +19,19 @@
 		};
 	};
 
+	rs485: fragment@2 {
+		target = <&uart3>;
+		__dormant__ {
+			linux,rs485-enabled-at-boot-time;
+			rs485-rts-delay = <0 0>;
+		};
+	};
+
 	__overrides__ {
 		ctsrts = <0>,"=1";
+		rs485 = <0>,"=1=2";
+		rs485_invert_rts = <&rs485>,"rs485-rts-active-low";
+		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
+		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/uart4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart4-overlay.dts
@@ -19,7 +19,19 @@
 		};
 	};
 
+	rs485: fragment@2 {
+		target = <&uart4>;
+		__dormant__ {
+			linux,rs485-enabled-at-boot-time;
+			rs485-rts-delay = <0 0>;
+		};
+	};
+
 	__overrides__ {
 		ctsrts = <0>,"=1";
+		rs485 = <0>,"=1=2";
+		rs485_invert_rts = <&rs485>,"rs485-rts-active-low";
+		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
+		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/uart5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart5-overlay.dts
@@ -19,7 +19,19 @@
 		};
 	};
 
+	rs485: fragment@2 {
+		target = <&uart5>;
+		__dormant__ {
+			linux,rs485-enabled-at-boot-time;
+			rs485-rts-delay = <0 0>;
+		};
+	};
+
 	__overrides__ {
 		ctsrts = <0>,"=1";
+		rs485 = <0>,"=1=2";
+		rs485_invert_rts = <&rs485>,"rs485-rts-active-low";
+		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
+		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";
 	};
 };


### PR DESCRIPTION
This patch adds RS485 mode support for UART2/3/4/5.
This allows the RTS line to be used to drive the OE pin of an RS485 transceiver (i.e. MAX3078E).
I needed this for a project & it would be useful to have in-tree.

The "ctsrts" override is automatically activated, as this is required to enable the RTS line; there are also overrides to invert the RTS signal, and to set the RTS on and off delays to change the RTS timing around data transmission.

I haven't made changes to uart0-overlay.dts or uart1-overlay.dts as the syntax is quite different, I'm guessing this is legacy.
I also haven't made changes to uartX-pi5-overlay.dts as I'm unable to test these due to them being Pi5-only.

Tested and working OK on a CM4 with a pair of MAX3078E transceivers, overrides in /boot/firmware/config.txt as follows:
`dtoverlay=uart3,rs485`
`dtoverlay=uart4,rs485`

Credit to 6by9 for pretty much all of the device tree modifications here.
The associated forum thread is available here:
https://forums.raspberrypi.com/viewtopic.php?p=2311800