### PR TITLE
Mulligan for #6392

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
@@ -488,6 +488,11 @@
 &pcie1 {
 	brcm,fifo-qos-map = /bits/ 8 <3 3 3 3>;
 	status = "disabled";
+	ranges =
+		/* 2GiB, 32-bit, non-prefetchable at PCIe 00_80000000 */
+		<0x02000000 0x00 0x80000000 0x1b 0x80000000 0x00 0x80000000>,
+		/* 14GiB, 64-bit, prefetchable at PCIe 04_00000000 */
+		<0x43000000 0x04 0x00000000 0x18 0x00000000 0x03 0x80000000>;
 };
 
 &pcie2 {


### PR DESCRIPTION
Upstream's base dts exposes a full-range 32bit MMIO window starting at a PCI bus address of 0. This causes sufficient interop annoyance to be worth permanently applying the mmio-hi property of the pciex1-compat-pi5 overlay to the downstream dts.