### PR TITLE
drivers: media: i2c: imx335: Fix frame size enumeration

### DIFF
--- a/drivers/media/i2c/imx335.c
+++ b/drivers/media/i2c/imx335.c
@@ -718,7 +718,8 @@ static int imx335_enum_frame_size(struct v4l2_subdev *sd,
 	struct imx335 *imx335 = to_imx335(sd);
 	u32 code;
 
-	if (fsize->index > ARRAY_SIZE(imx335_mbus_codes))
+	/* Only a single supported_mode available. */
+	if (fsize->index > 0)
 		return -EINVAL;
 
 	code = imx335_get_format_code(imx335, fsize->code);


### PR DESCRIPTION
In commit cfa49ff0558a ("media: i2c: imx335: Support 2592x1940 10-bit mode") the IMX335 driver was extended to support multiple output modes.

This incorrectly extended the frame size enumeration to check against the supported mbus_codes array instead of the supported mode/frame array. This has the unwanted side effect of reporting the currently supported frame size 2592x1944 three times.

Fix the check accordingly to report a frame size for each supported size, which is presently only a single entry.

Fixes: cfa49ff0558a ("media: i2c: imx335: Support 2592x1940 10-bit mode")
Upstream: https://lore.kernel.org/linux-media/20250430073649.1986018-1-kieran.bingham@ideasonboard.com/T/#u