### PR TITLE
arm64: dts: bcm2712-rpi: Add uart0_dma parameter

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -460,6 +460,9 @@ Params:
                                 6, 8 and 10 of the 40-way header (2712 only,
                                 default "off")
 
+        uart0_dma               Enable DMA usage on UART0 (2712 only, default
+                                "off")
+
         uart1                   Set to "on" or "off" to enable or disable uart1
                                 (default varies)
 

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -220,6 +220,11 @@ pio: &rp1_pio {
 		suspend = <&pwr_key>, "linux,code:0=205";
 		uart0 = <&uart0>, "status";
 		uart0_console = <&uart0>,"status", <&aliases>, "console=",&uart0;
+		uart0_dma = <&uart0>,"dmas:0=",<&rp1_dma>,
+			    <&uart0>,"dmas:4=",<RP1_DMA_UART0_TX>,
+			    <&uart0>,"dmas:8=",<&rp1_dma>,
+			    <&uart0>,"dmas:12=",<RP1_DMA_UART0_RX>,
+			    <&uart0>,"dma-names[=747800727800"; // "tx", "rx"
 		wifiaddr = <&wifi>, "local-mac-address[";
 
 		cam0_reg = <&cam0_reg>,"status";


### PR DESCRIPTION
It seems that some applications don't work with UART DMA enabled, while others don't work without it. No DMA seems to be the safer default choice, but add a dtparam - uart0_dma - to re-enable it.

See: https://github.com/raspberrypi/linux/issues/6365