### PR TITLE
nvme-pci: Re-enable NVME Host Memory Block (HMB) support 

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
@@ -3,7 +3,7 @@
 
 / {
 	chosen {
-		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0 cgroup_disable=memory numa_policy=interleave";
+		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0 cgroup_disable=memory numa_policy=interleave nvme.max_host_mem_size_mb=0";
 	};
 
 	__overrides__ {

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -97,7 +97,7 @@ pio: &rp1_pio {
 
 / {
 	chosen: chosen {
-		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe cgroup_disable=memory numa_policy=interleave";
+		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe cgroup_disable=memory numa_policy=interleave nvme.max_host_mem_size_mb=0";
 		stdout-path = "serial10:115200n8";
 	};
 

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -2081,7 +2081,6 @@ static void nvme_free_host_mem(struct nvme_dev *dev)
 	dev->nr_host_mem_descs = 0;
 }
 
-#if 0
 static int __nvme_alloc_host_mem(struct nvme_dev *dev, u64 preferred,
 		u32 chunk_size)
 {
@@ -2150,11 +2149,9 @@ out:
 	dev->host_mem_descs = NULL;
 	return -ENOMEM;
 }
-#endif
 
 static int nvme_alloc_host_mem(struct nvme_dev *dev, u64 min, u64 preferred)
 {
-#if 0
 	u64 min_chunk = min_t(u64, preferred, PAGE_SIZE * MAX_ORDER_NR_PAGES);
 	u64 hmminds = max_t(u32, dev->ctrl.hmminds * 4096, PAGE_SIZE * 2);
 	u64 chunk_size;
@@ -2167,7 +2164,6 @@ static int nvme_alloc_host_mem(struct nvme_dev *dev, u64 min, u64 preferred)
 			nvme_free_host_mem(dev);
 		}
 	}
-#endif
 
 	return -ENOMEM;
 }


### PR DESCRIPTION
This pull request restores the NVME Host Memory Block (HMB) support that was disabled in RPi kernel in December 2024.
Instead, the default kernel command line is changed for RPi 4/5 to set maximum allowed HBM size to 0.

This preserves current kernel functionality, but gives the user possibility to manually enable HMB in `cmdline.txt` file by adding `nvme.max_host_mem_size_mb=<size>` parameter. 

Optionally the user can increase the default CMA size in `config.txt` by adding/changing the 
`dtoverlay=vc4-kms-v3d,cma-<size>` line
