### PR TITLE
overlays: sc16is75x: Disable spidev0 first

### DIFF
--- a/arch/arm/boot/dts/overlays/sc16is750-spi0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is750-spi0-overlay.dts
@@ -5,6 +5,13 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
 		target = <&spi0>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -23,13 +30,6 @@
 				#gpio-cells = <2>;
 				spi-max-frequency = <4000000>;
 			};
-		};
-	};
-
-	fragment@1 {
-		target = <&spidev0>;
-		__overlay__ {
-			status = "disabled";
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/sc16is752-spi0-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is752-spi0-overlay.dts
@@ -5,6 +5,13 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
 		target = <&spi0>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -23,13 +30,6 @@
 				#gpio-cells = <2>;
 				spi-max-frequency = <4000000>;
 			};
-		};
-	};
-
-	fragment@1 {
-		target = <&spidev0>;
-		__overlay__ {
-			status = "disabled";
 		};
 	};
 


### PR DESCRIPTION
Ensure spidev is disabled before the cs pin is referenced. Otherwise the overlay will fail when loaded during runtime with
"spi spi0.0: chipselect 0 already in use"