### PR TITLE
firmware/raspberrypi: raise timeout to 3s

### DIFF
--- a/drivers/firmware/raspberrypi.c
+++ b/drivers/firmware/raspberrypi.c
@@ -61,7 +61,7 @@ rpi_firmware_transaction(struct rpi_firmware *fw, u32 chan, u32 data)
 	reinit_completion(&fw->c);
 	ret = mbox_send_message(fw->chan, &message);
 	if (ret >= 0) {
-		if (wait_for_completion_timeout(&fw->c, HZ)) {
+		if (wait_for_completion_timeout(&fw->c, 3*HZ)) {
 			ret = 0;
 		} else {
 			ret = -ETIMEDOUT;


### PR DESCRIPTION
This patch was submitted upstream. It's not been accepted yet, but it's such a simple patch that they can't demand too many changes. The existing 1 second timeout is a bit too short for comfort, and when timeouts do happen things don't recover well.