### PR TITLE
Updates to support CM5 on the Crystalfontz CFA050-PI-M

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1081,11 +1081,12 @@ Params: cma-512                 CMA is 512MB (needs 1GB)
 
 Name:   crystalfontz-cfa050_pi_m
 Info:   Configures the Crystalfontz CFA050-PI-M series of Raspberry Pi CM4
-        based modules using the CFA7201280A0_050Tx 7" TFT LCD displays,
+        and CM5 based modules using the CFA7201280A0_050Tx 7" TFT LCD displays,
         with or without capacitive touch screen.
         Requires use of vc4-kms-v3d.
 Load:   dtoverlay=crystalfontz-cfa050_pi_m,<param>=<val>
 Params: captouch                Enable capacitive touch display
+        cm5                     Enable support for the Raspberry Pi CM5
 
 
 Name:   cutiepi-panel

--- a/arch/arm/boot/dts/overlays/crystalfontz-cfa050_pi_m-overlay.dts
+++ b/arch/arm/boot/dts/overlays/crystalfontz-cfa050_pi_m-overlay.dts
@@ -9,7 +9,7 @@
 // RaspberryPi CM4
 	compatible = "brcm,bcm2835";
 // PCF8574 I2C GPIO EXPANDER
-	fragment@0 {
+	frag0: fragment@0 {
 		target = <&i2c_csi_dsi>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -27,7 +27,7 @@
 		};
 	};
 // LM3630a BACKLIGHT LED CONTROLLER
-	fragment@1 {
+	frag1: fragment@1 {
 		target = <&i2c_csi_dsi>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -42,14 +42,28 @@
 					reg = <0>;
 					led-sources = <0 1>;
 					label = "lcd-backlight";
-					default-brightness = <128>;
+					default-brightness = <255>;
 					max-brightness = <255>;
 				};
 			};
 		};
 	};
+// PCF85063A RTC on I2C
+	frag2: fragment@2 {
+		target = <&i2c_csi_dsi>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+			pcf85063a@51 {
+				compatible = "nxp,pcf85063a";
+				reg = <0x51>;
+			};
+		};
+	};
+
 // CFAF7201280A0_050Tx TFT DSI PANEL
-	fragment@2 {
+	fragment@3 {
 		target = <&dsi1>;
 		__overlay__  {
 			#address-cells = <1>;
@@ -75,50 +89,43 @@
 		};
 	};
 // rPI GPIO INPUT FOR TOUCH IC IRQ
-	fragment@3 {
+	fragment@4 {
 		target = <&gpio>;
 		__dormant__ {
 			gt928intpins: gt928intpins {
-				brcm,pins = <26>;
-				brcm,function = <0>;
-				brcm,pull = <1>;
+				brcm,pins = <26>; //gpio pin
+				brcm,function = <0>; //input
+				brcm,pull = <2>; //2=pull-up
 			};
 		};
 	};
 // GT928 TOUCH CONTROLLER IC
-	fragment@4 {
+	frag5: fragment@5 {
 		target = <&i2c_csi_dsi>;
 		__dormant__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
-			gt928@5d {
+			gt928: gt928@5d {
 				compatible = "goodix,gt928";
 				reg = <0x5d>;
 				interrupt-parent = <&gpio>;
-				interrupts = <26 2>;
-				irq-gpios = <&gpio 26 0>;
+				interrupts = <26 2>; //gpio 26, 2=high-to-low trigger
+				irq-gpios = <&gpio 26 0>; //gpio 26, 0=active-high
 				reset-gpios = <&pcf8574a 1 1>;
 				touchscreen-inverted-x;
 				touchscreen-inverted-y;
 			};
 		};
 	};
-// PCF85063A RTC on I2C
-	fragment@5 {
-		target = <&i2c_csi_dsi>;
-		__overlay__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
-			status = "okay";
-			pcf85063a@51 {
-				compatible = "nxp,pcf85063a";
-				reg = <0x51>;
-			};
-		};
-	};
-// CAPACITIVE TOUCH OPTION FOR TFT PANEL
+//OVERLAY OPTIONS
 	__overrides__ {
-		captouch = <0>,"+3+4";
+		//enables captouch
+		captouch = <0>,"+4+5";
+		//changes options to support CM5 (default is CM4)
+		cm5 = <&frag0>, "target:0=",<&i2c_csi_dsi0>,
+			<&frag1>, "target:0=",<&i2c_csi_dsi0>,
+			<&frag2>, "target:0=",<&i2c_csi_dsi0>,
+			<&frag5>, "target:0=",<&i2c_csi_dsi0>;
 	};
 };

--- a/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c
+++ b/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c
@@ -2296,17 +2296,21 @@ static const struct drm_display_mode nwe080_default_mode = {
 };
 
 static const struct drm_display_mode cfaf7201280a0_050tx_default_mode = {
-	.clock		= 72830,
-	.hdisplay	= 720,
-	.hsync_start	= 720 + 87,
-	.hsync_end	= 720 + 87 + 20,
-	.htotal		= 720 + 87 + 20 + 87,
-	.vdisplay	= 1280,
-	.vsync_start	= 1280 + 16,
-	.vsync_end	= 1280 + 16 + 8,
-	.vtotal		= 1280 + 16 + 8 + 16,
-	.width_mm	= 62,
-	.height_mm	= 110,
+	/* 
+ 	 * These timings are a compromise so the panel will work with
+ 	 * both the CM4 and CM5.
+  	 */
+	.clock          = 78000,
+	.hdisplay       = 720,
+	.hsync_start    = 720 + 120,
+	.hsync_end      = 720 + 120 + 2,
+	.htotal         = 720 + 120 + 2 + 80,
+	.vdisplay       = 1280,
+	.vsync_start    = 1280 + 60,
+	.vsync_end      = 1280 + 60 + 2,
+	.vtotal         = 1280 + 60 + 2 + 90,
+	.width_mm       = 62,
+	.height_mm      = 110,
 };
 
 static const struct drm_display_mode rpi_5inch_default_mode = {


### PR DESCRIPTION
Updates to the ILI9881c panel driver and crystalfontz-cfa050_pi_m dt overlay to add support for Raspberry Pi Compute Module 5.

Signed-off-by: Mark Williams <mark@crystalfontz.com>