### PR TITLE
mfd: rp1: depends on PCI_MSI

### DIFF
--- a/drivers/mfd/Kconfig
+++ b/drivers/mfd/Kconfig
@@ -2387,6 +2387,7 @@ config MFD_INTEL_M10_BMC_PMCI
 config MFD_RP1
 	tristate "RP1 MFD driver"
 	depends on PCI
+	depends on PCI_MSI
 	select MFD_CORE
 	help
 	  Support for the RP1 peripheral chip.


### PR DESCRIPTION
rpi1.c depends on symbol [CONFIG_PCI_MSI to define the pci_msi_* methods](https://github.com/raspberrypi/linux/blob/rpi-6.12.y/include/linux/msi.h#L643-L661):
```c
/* PCI specific interfaces */
#ifdef CONFIG_PCI_MSI
struct pci_dev *msi_desc_to_pci_dev(struct msi_desc *desc);
void pci_write_msi_msg(unsigned int irq, struct msi_msg *msg);
void __pci_read_msi_msg(struct msi_desc *entry, struct msi_msg *msg);
void __pci_write_msi_msg(struct msi_desc *entry, struct msi_msg *msg);
void pci_msi_mask_irq(struct irq_data *data);
void pci_msi_unmask_irq(struct irq_data *data);
struct irq_domain *pci_msi_create_irq_domain(struct fwnode_handle *fwnode,
					     struct msi_domain_info *info,
					     struct irq_domain *parent);
u32 pci_msi_domain_get_msi_rid(struct irq_domain *domain, struct pci_dev *pdev);
struct irq_domain *pci_msi_get_device_domain(struct pci_dev *pdev);
#else /* CONFIG_PCI_MSI */
static inline struct irq_domain *pci_msi_get_device_domain(struct pci_dev *pdev)
{
	return NULL;
}
static inline void pci_write_msi_msg(unsigned int irq, struct msi_msg *msg) { }
#endif /* !CONFIG_PCI_MSI */
```

such as [pci_msi_mask_irq](https://github.com/raspberrypi/linux/blob/rpi-6.12.y/drivers/mfd/rp1.c#L109C2-L109C30):
```c
static void rp1_mask_irq(struct irq_data *irqd)
{
	struct rp1_dev *rp1 = irqd->domain->host_data;
	struct irq_data *pcie_irqd = rp1->pcie_irqds[irqd->hwirq];

	pci_msi_mask_irq(pcie_irqd);
}
```
[But never sets so in the Kconfig](https://github.com/raspberrypi/linux/blob/rpi-6.12.y/drivers/mfd/Kconfig#L2387-L2396):
```kconfig
config MFD_RP1
	tristate "RP1 MFD driver"
	depends on PCI
	select MFD_CORE
        [...]
```
Therefore, set it.

The motivation is mostly CI, be able to infer dependencies and compile without relying on a particular defconfig.