### PR TITLE
Side-port dwc_otg fixes to dwc2

### DIFF
--- a/drivers/usb/dwc2/hcd.c
+++ b/drivers/usb/dwc2/hcd.c
@@ -676,7 +676,19 @@ static void dwc2_hc_init(struct dwc2_hsotg *hsotg, struct dwc2_host_chan *chan)
 		hcchar |= HCCHAR_EPDIR;
 	if (chan->speed == USB_SPEED_LOW)
 		hcchar |= HCCHAR_LSPDDEV;
-	hcchar |= chan->ep_type << HCCHAR_EPTYPE_SHIFT & HCCHAR_EPTYPE_MASK;
+
+	/*
+	 * Masquerading Interrupt split transfers as Control puts the transfer
+	 * into the non-periodic handler in the hub. This stops the hub
+	 * dropping complete-split data in the microframe after a CSPLIT
+	 * should have arrived, improving resilience to host IRQ latency.
+	 * Devices are none the wiser - the handshake tokens are the same.
+	 */
+	if (chan->do_split && chan->ep_type == USB_ENDPOINT_XFER_INT)
+		hcchar |= USB_ENDPOINT_XFER_CONTROL << HCCHAR_EPTYPE_SHIFT & HCCHAR_EPTYPE_MASK;
+	else
+		hcchar |= chan->ep_type << HCCHAR_EPTYPE_SHIFT & HCCHAR_EPTYPE_MASK;
+
 	hcchar |= chan->max_packet << HCCHAR_MPS_SHIFT & HCCHAR_MPS_MASK;
 	dwc2_writel(hsotg, hcchar, HCCHAR(hc_num));
 	if (dbg_hc(chan)) {

--- a/drivers/usb/dwc2/hcd.c
+++ b/drivers/usb/dwc2/hcd.c
@@ -2646,6 +2646,10 @@ static int dwc2_assign_and_init_hc(struct dwc2_hsotg *hsotg, struct dwc2_qh *qh)
 	else
 		chan->do_split = 0;
 
+	/* Limit split IN transfers to the remaining buffer space */
+	if (qh->do_split && chan->ep_is_in)
+		chan->max_packet = min_t(u32, chan->max_packet, chan->xfer_len);
+
 	/* Set the transfer attributes */
 	dwc2_hc_init_xfer(hsotg, chan, qtd);
 

--- a/drivers/usb/dwc2/hcd.c
+++ b/drivers/usb/dwc2/hcd.c
@@ -3800,12 +3800,17 @@ static int dwc2_hcd_is_status_changed(struct dwc2_hsotg *hsotg, int port)
 int dwc2_hcd_get_frame_number(struct dwc2_hsotg *hsotg)
 {
 	u32 hfnum = dwc2_readl(hsotg, HFNUM);
+	u32 hprt0 = dwc2_readl(hsotg, HPRT0);
 
 #ifdef DWC2_DEBUG_SOF
 	dev_vdbg(hsotg->dev, "DWC OTG HCD GET FRAME NUMBER %d\n",
 		 (hfnum & HFNUM_FRNUM_MASK) >> HFNUM_FRNUM_SHIFT);
 #endif
-	return (hfnum & HFNUM_FRNUM_MASK) >> HFNUM_FRNUM_SHIFT;
+	/* HS root port counts microframes, not frames */
+	if ((hprt0 & HPRT0_SPD_MASK) >> HPRT0_SPD_SHIFT == HPRT0_SPD_HIGH_SPEED)
+		return (hfnum & HFNUM_FRNUM_MASK) >> (3 + HFNUM_FRNUM_SHIFT);
+	else
+		return (hfnum & HFNUM_FRNUM_MASK) >> HFNUM_FRNUM_SHIFT;
 }
 
 int dwc2_hcd_get_future_frame_number(struct dwc2_hsotg *hsotg, int us)


### PR DESCRIPTION
This is a grab-bag of commits accumulated as a result of fixing things in dwc_otg and not dwc2. As dwc2 was derived from some variant of dwc_otg far in the past, the codebases have diverged.

With the recent emphasis on moving more platforms to dwc2, it's time to remove these inherited bugs. Or at least the ones that are obvious from the dwc_otg commit history.