### PR TITLE
FIXUP: "fbdev: Allow client to request a particular /dev/fbdevN node"

### DIFF
--- a/drivers/video/fbdev/core/fbmem.c
+++ b/drivers/video/fbdev/core/fbmem.c
@@ -446,12 +446,12 @@ static int do_register_framebuffer(struct fb_info *fb_info)
 	if (num_registered_fb == FB_MAX)
 		return -ENXIO;
 
-	i = fb_info->node;
 	if (!fb_info->custom_fb_num || fb_info->node >= FB_MAX || registered_fb[fb_info->node]) {
 		for (i = min_dynamic_fb ; i < FB_MAX; i++)
 			if (!registered_fb[i])
 				break;
 	}
+
 	if (!fb_info->modelist.prev || !fb_info->modelist.next)
 		INIT_LIST_HEAD(&fb_info->modelist);
 
@@ -460,7 +460,6 @@ static int do_register_framebuffer(struct fb_info *fb_info)
 	if (err < 0)
 		return err;
 
-	fb_info->node = i;
 	refcount_set(&fb_info->count, 1);
 	mutex_init(&fb_info->lock);
 	mutex_init(&fb_info->mm_lock);


### PR DESCRIPTION
Fixes up forward port to 6.16
Squash in (currently) ee76d8549ca02d29a5add4f2596659a61b89a2bc.