### PR TITLE
drm/probe-helper: Ensure cmdline mode matches interlace mode

### DIFF
--- a/drivers/gpu/drm/drm_probe_helper.c
+++ b/drivers/gpu/drm/drm_probe_helper.c
@@ -163,6 +163,10 @@ static int drm_helper_probe_add_cmdline_mode(struct drm_connector *connector)
 				continue;
 		}
 
+		if (cmdline_mode->interlace !=
+		    !!(mode->flags & DRM_MODE_FLAG_INTERLACE))
+			continue;
+
 		/* Mark the matching mode as being preferred by the user */
 		mode->type |= DRM_MODE_TYPE_USERDEF;
 		return 0;


### PR DESCRIPTION
drm_helper_probe_add_cmdline_mode was looking for a match for the width, height, and refresh rate within the EDID modes, but didn't check the interlacing flag. That meant that with video=1920x1080@50i would match any 1920x1080@50 mode that was found.
The converse would be possible too if an interlaced mode with matching resolution & refresh rate was found first.

Check the interlacing flag as well.

https://github.com/raspberrypi/bookworm-feedback/issues/422