### PR TITLE
drivers: media: rpi: cfe: Avoid unpack operation for 16-bit formats

### DIFF
--- a/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
@@ -884,7 +884,9 @@ static void cfe_start_channel(struct cfe_node *node)
 			width = source_fmt->width;
 			height = source_fmt->height;
 
-			if (node->vid_fmt.fmt.pix.pixelformat ==
+			/* We don't need to repack in the case of 16-bit output. */
+			if (fmt->depth != 16 &&
+			    node->vid_fmt.fmt.pix.pixelformat ==
 					fmt->remap[CFE_REMAP_16BIT])
 				mode = CSI2_MODE_REMAP;
 			else if (node->vid_fmt.fmt.pix.pixelformat ==


### PR DESCRIPTION
The unpack operation is redundant for 16-bit sensor formats, don't set the hardware to do it in these cases.