### PR TITLE
method add to retrieve pio data via DMA

### DIFF
--- a/drivers/misc/rp1-pio.c
+++ b/drivers/misc/rp1-pio.c
@@ -971,6 +971,24 @@ int rp1_pio_sm_xfer_data(struct rp1_pio_client *client, uint sm, uint dir,
 }
 EXPORT_SYMBOL_GPL(rp1_pio_sm_xfer_data);
 
+void *rp1_pio_sm_buffer_virt(struct rp1_pio_client *client,
+                             unsigned sm, unsigned dir, int index)
+{
+    struct rp1_pio_device *pio = client->pio;
+    struct dma_info *dma;
+
+    if (sm >= RP1_PIO_SMS_COUNT || dir >= RP1_PIO_DIR_COUNT)
+        return NULL;
+
+    dma = &pio->dma_configs[sm][dir];
+
+    if (index >= dma->buf_count)
+        return NULL;
+
+    return dma->bufs[index].buf;
+}
+EXPORT_SYMBOL_GPL(rp1_pio_sm_buffer_virt);
+
 struct handler_info {
 	const char *name;
 	int (*func)(struct rp1_pio_client *client, void *param);

--- a/include/linux/pio_rp1.h
+++ b/include/linux/pio_rp1.h
@@ -190,6 +190,7 @@ int rp1_pio_sm_config_xfer(struct rp1_pio_client *client, uint sm, uint dir,
 int rp1_pio_sm_xfer_data(struct rp1_pio_client *client, uint sm, uint dir,
 			 uint data_bytes, void *data, dma_addr_t dma_addr,
 			 void (*callback)(void *param), void *param);
+void *rp1_pio_sm_buffer_virt(struct rp1_pio_client *client, unsigned sm, unsigned dir, int index);
 
 int rp1_pio_can_add_program(struct rp1_pio_client *client, void *param);
 int rp1_pio_add_program(struct rp1_pio_client *client, void *param);


### PR DESCRIPTION
Iam using the rp1-pio driver in a driver iam developing.

Using DMA for retrieving data from the PIO i need an additonal method for getting the data in the virtual memory.. so i decided to simply adding a method.

I think this method is relevant also for others.