### PR TITLE
dtoverlay: Add autorepeat option to gpio-key overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1592,6 +1592,7 @@ Params: gpio                    GPIO pin to trigger on (default 3)
                                 (GPIO3) has an external pullup
         label                   Set a label for the key
         keycode                 Set the key code for the button
+        autorepeat              Set the key to autorepeat
 
 
 

--- a/arch/arm/boot/dts/overlays/gpio-key-overlay.dts
+++ b/arch/arm/boot/dts/overlays/gpio-key-overlay.dts
@@ -43,6 +43,7 @@
 		keycode =    <&key>,"linux,code:0";
 		gpio_pull =  <&pin_state>,"brcm,pull:0";
 		active_low = <&key>,"gpios:8";
+		autorepeat = <&button>,"autorepeat?";
 	};
 
 };


### PR DESCRIPTION
It's a standard option of the gpio_keys driver, so add an override for it in the overlay.