### PR TITLE
drivers: media: cfe: Workaround for 16-bit mismatch in the hardware

### DIFF
--- a/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
@@ -851,8 +851,11 @@ static void cfe_start_channel(struct cfe_node *node)
 		width = source_fmt->width;
 		height = source_fmt->height;
 
-		/* Must have a valid CSI2 datatype. */
-		WARN_ON(!fmt->csi_dt);
+		/*
+		 * Must have a valid CSI2 datatype, but it will be 0 for 16-bit
+		 * formats to work-around the HW mismatch.
+		 */
+		WARN_ON(fmt->depth != 16 && !fmt->csi_dt);
 
 		/*
 		 * Start the associated CSI2 Channel as well.

--- a/drivers/media/platform/raspberrypi/rp1_cfe/cfe_fmts.h
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/cfe_fmts.h
@@ -197,7 +197,7 @@ static const struct cfe_fmt formats[] = {
 		.fourcc = V4L2_PIX_FMT_SBGGR16,
 		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
 		.depth = 16,
-		.csi_dt = MIPI_CSI2_DT_RAW16,
+		.csi_dt = 0, /* Avoid RP1 HW mismatch for 16-bit modes. */
 		.flags = CFE_FORMAT_FLAG_FE_OUT,
 		.remap = { V4L2_PIX_FMT_SBGGR16, V4L2_PIX_FMT_PISP_COMP1_BGGR },
 	},
@@ -205,7 +205,7 @@ static const struct cfe_fmt formats[] = {
 		.fourcc = V4L2_PIX_FMT_SGBRG16,
 		.code = MEDIA_BUS_FMT_SGBRG16_1X16,
 		.depth = 16,
-		.csi_dt = MIPI_CSI2_DT_RAW16,
+		.csi_dt = 0, /* Avoid RP1 HW mismatch for 16-bit modes. */
 		.flags = CFE_FORMAT_FLAG_FE_OUT,
 		.remap = { V4L2_PIX_FMT_SGBRG16, V4L2_PIX_FMT_PISP_COMP1_GBRG },
 	},
@@ -213,7 +213,7 @@ static const struct cfe_fmt formats[] = {
 		.fourcc = V4L2_PIX_FMT_SGRBG16,
 		.code = MEDIA_BUS_FMT_SGRBG16_1X16,
 		.depth = 16,
-		.csi_dt = MIPI_CSI2_DT_RAW16,
+		.csi_dt = 0, /* Avoid RP1 HW mismatch for 16-bit modes. */
 		.flags = CFE_FORMAT_FLAG_FE_OUT,
 		.remap = { V4L2_PIX_FMT_SGRBG16, V4L2_PIX_FMT_PISP_COMP1_GRBG },
 	},
@@ -221,7 +221,7 @@ static const struct cfe_fmt formats[] = {
 		.fourcc = V4L2_PIX_FMT_SRGGB16,
 		.code = MEDIA_BUS_FMT_SRGGB16_1X16,
 		.depth = 16,
-		.csi_dt = MIPI_CSI2_DT_RAW16,
+		.csi_dt = 0, /* Avoid RP1 HW mismatch for 16-bit modes. */
 		.flags = CFE_FORMAT_FLAG_FE_OUT,
 		.remap = { V4L2_PIX_FMT_SRGGB16, V4L2_PIX_FMT_PISP_COMP1_RGGB },
 	},


### PR DESCRIPTION
Set the data type for 16-bit modes to 0 (wildcard) to workarond the 16-bit mismatch in hardware.

We also need to supress the warning about DT == 0 on start stream in these cases.