### PR TITLE
usb: dwc2: masquerade split-interrupt transfers

### DIFF
--- a/drivers/usb/dwc2/hcd.c
+++ b/drivers/usb/dwc2/hcd.c
@@ -676,6 +676,18 @@ static void dwc2_hc_init(struct dwc2_hsotg *hsotg, struct dwc2_host_chan *chan)
 		hcchar |= HCCHAR_EPDIR;
 	if (chan->speed == USB_SPEED_LOW)
 		hcchar |= HCCHAR_LSPDDEV;
+
+	/*
+	 * Masquerading Interrupt split transfers as Control puts the transfer
+	 * into the non-periodic handler in the hub. This stops the hub
+	 * dropping complete-split data in the microframe after a CSPLIT
+	 * should have arrived, improving resilience to host IRQ latency.
+	 * Devices are none the wiser - the handshake tokens are the same.
+	 * The fakery is undone in dwc2_hc_n_intr().
+	 */
+	if (chan->do_split && chan->ep_type == USB_ENDPOINT_XFER_INT)
+		chan->ep_type = USB_ENDPOINT_XFER_CONTROL;
+
 	hcchar |= chan->ep_type << HCCHAR_EPTYPE_SHIFT & HCCHAR_EPTYPE_MASK;
 	hcchar |= chan->max_packet << HCCHAR_MPS_SHIFT & HCCHAR_MPS_MASK;
 	dwc2_writel(hsotg, hcchar, HCCHAR(hc_num));

--- a/drivers/usb/dwc2/hcd.c
+++ b/drivers/usb/dwc2/hcd.c
@@ -2350,6 +2350,7 @@ static void dwc2_hc_init_xfer(struct dwc2_hsotg *hsotg,
 			else
 				chan->xfer_buf = urb->setup_packet;
 			chan->xfer_len = 8;
+			chan->max_packet = 8;
 			break;
 
 		case DWC2_CONTROL_DATA:

--- a/drivers/usb/dwc2/hcd_intr.c
+++ b/drivers/usb/dwc2/hcd_intr.c
@@ -2048,6 +2048,9 @@ static void dwc2_hc_n_intr(struct dwc2_hsotg *hsotg, int chnum)
 
 	chan->hcint = hcintraw;
 
+	/* Un-masquerade the transfer type */
+	if (chan->do_split)
+		chan->ep_type = chan->qh->ep_type;
 	/*
 	 * If the channel was halted due to a dequeue, the qtd list might
 	 * be empty or at least the first entry will not be the active qtd.


### PR DESCRIPTION
Second attempt at porting the dwc_otg hack to avoid dropped split transactions.

Transactions now "look OK" on the bus analyser but this needs more soak testing with different hub implementations.