### PR TITLE
Add support for phy interrupts on BCM54213PE

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -159,10 +159,10 @@ rp1_target: &pcie2 {
 	phy-reset-gpios = <&rp1_gpio 32 GPIO_ACTIVE_LOW>;
 	phy-reset-duration = <5>;
 
-	phy1: ethernet-phy@1 {
-		reg = <0x1>;
+	phy1: ethernet-phy@0 {
+		reg = <0x0>;
 		brcm,powerdown-enable;
-		interrupt-parent = <&gpio>;
+		interrupt-parent = <&rp1_gpio>;
 		interrupts = <37 IRQ_TYPE_LEVEL_LOW>;
 		eee-broken-1000t;
 		eee-broken-100tx;

--- a/drivers/net/phy/broadcom.c
+++ b/drivers/net/phy/broadcom.c
@@ -1484,6 +1484,8 @@ static struct phy_driver broadcom_drivers[] = {
 	.probe		= bcm54xx_phy_probe,
 	.config_init	= bcm54xx_config_init,
 	.config_intr	= bcm_phy_config_intr,
+	.handle_interrupt = bcm_phy_handle_interrupt,
+	.link_change_notify	= bcm54xx_link_change_notify,
 	.suspend	= bcm54xx_suspend,
 	.resume		= bcm54xx_resume,
 }, {


### PR DESCRIPTION
While working on the eee support for rp1's macb driver, I noticed that CM5 defines a phy interrupt, but it isn't used at all.  It's caused by missing pointers in the ops struct of BCM54213PE. Also the mdio address differes from pi5 (probably different strapping on the board?), which is fixed by this series.

Before:
```
[    3.501498] macb 1f00100000.ethernet eth0: PHY [1f00100000.ethernet-ffffffff:00] driver [Broadcom BCM54213PE] (irq=POLL)
```

After:
```
[    3.597582] macb 1f00100000.ethernet eth0: PHY [1f00100000.ethernet-ffffffff:00] driver [Broadcom BCM54213PE] (irq=168)
```

```
$ cat /proc/interrupts | grep 1f00100000.ethernet-ffffffff:00
168:     701264          0          0          0  pinctrl-rp1  37 Level     1f00100000.ethernet-ffffffff:00
```