### PR TITLE
media: ov9282: Add external trigger mode support

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3718,6 +3718,10 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
         clk-continuous          Switch to continuous mode on the CSI clock lane,
                                 which increases the maximum frame rate slightly.
                                 Appears not to work on Pi3.
+        trigger-mode            Enable external trigger mode (0 = normal,
+                                1 = triggered). In this mode, the sensor outputs
+                                a frame only when triggered by a rising edge
+                                on the FSIN input pin.
 
 
 Name:   papirus

--- a/arch/arm/boot/dts/overlays/ov9281-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ov9281-overlay.dts
@@ -96,6 +96,7 @@
 		       <&reg_frag>, "target:0=",<&cam0_reg>;
 		arducam = <0>, "+6";
 		clk-continuous = <0>, "-7-8";
+		trigger-mode = <&cam_node>, "trigger-mode:0";
 	};
 };
 

--- a/arch/arm/boot/dts/overlays/ov9281.dtsi
+++ b/arch/arm/boot/dts/overlays/ov9281.dtsi
@@ -14,6 +14,7 @@ cam_node: ov9281@60 {
 
 	rotation = <0>;
 	orientation = <2>;
+	trigger-mode = <0>;
 
 	port {
 		cam_endpoint: endpoint {


### PR DESCRIPTION
Adds DT property `trigger-mode` to enable FSIN-triggered frame capture. Includes overlay and README update for ov9281_trig.

https://github.com/raspberrypi/linux/issues/5349#issuecomment-3058162605