### PR TITLE
ARM: dts: watchdog param creates early-watchdog

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm270x-rpi.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm270x-rpi.dtsi
@@ -85,7 +85,7 @@
 		i2c_arm_baudrate = <&i2c1>,"clock-frequency:0";
 		i2c_vc_baudrate = <&i2c0if>,"clock-frequency:0";
 
-		watchdog = <&watchdog>,"status";
+		watchdog = <&watchdog>,"early-watchdog?";
 		random = <&random>,"status";
 		sd_overclock = <&sdhost>,"brcm,overclock-50:0";
 		sd_force_pio = <&sdhost>,"brcm,force-pio?";

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -95,6 +95,8 @@ pio: &rp1_pio {
 	status = "okay";
 };
 
+watchdog: &pm {};
+
 / {
 	chosen: chosen {
 		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe cgroup_disable=memory numa_policy=interleave nvme.max_host_mem_size_mb=0";
@@ -149,6 +151,7 @@ pio: &rp1_pio {
 		uart4 = &uart4;
 		usb0 = &rp1_usb0;
 		usb1 = &rp1_usb1;
+		watchdog = &watchdog;
 		wifi0 = &wifi;
 	};
 
@@ -225,6 +228,7 @@ pio: &rp1_pio {
 			    <&uart0>,"dmas:8=",<&rp1_dma>,
 			    <&uart0>,"dmas:12=",<RP1_DMA_UART0_RX>,
 			    <&uart0>,"dma-names[=747800727800"; // "tx", "rx"
+		watchdog = <&watchdog>, "early-watchdog?";
 		wifiaddr = <&wifi>, "local-mac-address[";
 
 		cam0_reg = <&cam0_reg>,"status";


### PR DESCRIPTION
The firmware change correcting the implementation of dtoverlay_is_enabled had the unintended consequence of causing the firmware to enable the watchdog even though the user had not explicitly requested it. This is harmless on Linux because the watchdog driver takes over and disarms it, but on other operating systems this can lead to a reboot.

An upcoming change to the firmware will avoid this problem by also requiring the presence of a new property, "early-watchdog". It's also the case that disabling the watchdog driver in Device Tree also disables important power management functionality. Therefore, change the dtparam=watchdog implementation to only add the new property (or not), leaving the container node enabled.

See: https://github.com/raspberrypi/firmware/issues/1980