### PR TITLE
Enable interrupts on CM5 ethernet phy (again)

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -158,6 +158,8 @@ rp1_target: &pcie2 {
 	phy-handle = <&phy1>;
 	phy-reset-gpios = <&rp1_gpio 32 GPIO_ACTIVE_LOW>;
 	phy-reset-duration = <5>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth0_irq_pins>;
 
 	phy1: ethernet-phy@0 {
 		reg = <0x0>;
@@ -702,6 +704,14 @@ spi10_cs_pins: &spi10_cs_gpio1 {};
 		gpio-hog;
 		gpios = <48 GPIO_ACTIVE_HIGH>;
 		output-high;
+	};
+
+	eth0_irq_pins: eth0_irq_pins {
+		pins = "gpio37";
+		function = "gpio";
+		// workaround missing hardware PU
+		bias-pull-up;
+		input-enable;
 	};
 };
 

--- a/drivers/net/phy/broadcom.c
+++ b/drivers/net/phy/broadcom.c
@@ -444,13 +444,9 @@ static int bcm54xx_config_init(struct phy_device *phydev)
 	if (reg < 0)
 		return reg;
 
-	/* Mask interrupts globally.  */
-	reg |= MII_BCM54XX_ECR_IM;
-	err = phy_write(phydev, MII_BCM54XX_ECR, reg);
-	if (err < 0)
-		return err;
-
-	/* Unmask events we are interested in.  */
+	/* Initially all interrupts are masked in IMR, so unmask events
+	 * we are interested in.
+	 */
 	reg = ~(MII_BCM54XX_INT_DUPLEX |
 		MII_BCM54XX_INT_SPEED |
 		MII_BCM54XX_INT_LINK);

--- a/drivers/net/phy/broadcom.c
+++ b/drivers/net/phy/broadcom.c
@@ -516,10 +516,14 @@ static int bcm54xx_config_init(struct phy_device *phydev)
 			BCM54XX_SHD_LEDS1_LED3(BCM_LED_SRC_MULTICOLOR1);
 		bcm_phy_write_shadow(phydev, BCM54XX_SHD_LEDS1, val);
 		/* BCM54210PE controls two extra LEDs with the next register.
-		 * Make them shadow the first pair of LEDs - useful on CM4 which
-		 * uses LED3 for ETH_LEDY instead of LED1.
+		 * Make LED3 shadow LED1, but preserve LED4 as is - useful on
+		 * CM4/CM5 which use LED3 for ETH_LEDY instead of LED1. LED4
+		 * is either unused or configured as INT pin on CM5.
 		 */
-		bcm_phy_write_shadow(phydev, BCM54XX_SHD_LEDS1 + 1, val);
+		reg = bcm_phy_read_shadow(phydev, BCM54XX_SHD_LEDS2);
+		reg &= ~(0xf << 0);
+		reg |= BCM54XX_SHD_LEDS1_LED1(BCM_LED_SRC_MULTICOLOR1);
+		bcm_phy_write_shadow(phydev, BCM54XX_SHD_LEDS2, reg);
 
 		val = BCM_LED_MULTICOLOR_IN_PHASE |
 			BCM54XX_SHD_LEDS1_LED1(led_modes[0]) |

--- a/drivers/net/phy/broadcom.c
+++ b/drivers/net/phy/broadcom.c
@@ -1501,6 +1501,8 @@ static struct phy_driver broadcom_drivers[] = {
 	.probe		= bcm54xx_phy_probe,
 	.config_init	= bcm54xx_config_init,
 	.config_intr	= bcm_phy_config_intr,
+	.handle_interrupt = bcm_phy_handle_interrupt,
+	.link_change_notify	= bcm54xx_link_change_notify,
 	.suspend	= bcm54xx_suspend,
 	.resume		= bcm54xx_resume,
 }, {


### PR DESCRIPTION
Second attempt to enable interrupts on CM5's ethernet phy (see https://github.com/raspberrypi/linux/issues/6953). Took me some time, but I think I finally sorted it out:

- Interrupt seems to be attached to LED4/INT_N, but was previously overridden by the led shadow patch (magically worked on my machine as I had a led_modes config which had link status on LED4 ...)
- Interrupts were disable in ECR, but never re-enabled
- Active low GPIO is missing a pull up, so just use the bias pull up in rp1 

Happy for feedback and also some tests, so we won't missing anything out.
