### PR TITLE
overlays: sc16is75x: Fix spi1 cs-gpios

### DIFF
--- a/arch/arm/boot/dts/overlays/sc16is75x-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is75x-spi-overlay.dts
@@ -61,6 +61,13 @@
 		};
 	};
 
+	spi_cs_fixup: fragment@100 {
+		target = <&spi1>;
+		__dormant__ {
+			cs-gpios = <&gpio 18 1>;
+		};
+	};
+
 	__overrides__ {
 		sc16is750 = <&sc16is75x>,"compatible=nxp,sc16is750",
 			<&sc16is75x>, "name=sc16is750@0";
@@ -79,7 +86,8 @@
 			<&sc16is75x_pins>, "name=sc16is75x_spi0_1_pins";
 		spi1-0 = <0>, "-0",
 			<&sc16is75x_frag>, "target:0=", <&spi1>,
-			<&sc16is75x_pins>, "name=sc16is75x_spi1_0_pins";
+			<&sc16is75x_pins>, "name=sc16is75x_spi1_0_pins",
+			<0>,"+100";
 		spi1-1 = <0>, "-0",
 			<&sc16is75x_frag>, "target:0=", <&spi1>,
 			<&sc16is75x>, "reg:0=1",


### PR DESCRIPTION
Native cs is somewhat broken on spi1 (see [1]), so re-add the explicit cs-gpios definition, as was done before in sc16is752-spi1-overlay.

Fixes https://github.com/raspberrypi/linux/issues/6962

[1] https://github.com/torvalds/linux/commit/519f2c22a6c71a9fefed1166c36d48246e010514