### PR TITLE
pwm: rp1: use pwmchip_get_drvdata() instead of container_of()

### DIFF
--- a/drivers/pwm/pwm-pio-rp1.c
+++ b/drivers/pwm/pwm-pio-rp1.c
@@ -22,7 +22,6 @@
 #include <linux/pwm.h>
 
 struct pwm_pio_rp1 {
-	struct pwm_chip chip;
 	struct device *dev;
 	struct gpio_desc *gpiod;
 	struct mutex mutex;
@@ -98,7 +97,7 @@ static void pio_pwm_set_level(PIO pio, uint sm, uint32_t level)
 static int pwm_pio_rp1_apply(struct pwm_chip *chip, struct pwm_device *pwm,
 			  const struct pwm_state *state)
 {
-	struct pwm_pio_rp1 *ppwm = container_of(chip, struct pwm_pio_rp1, chip);
+	struct pwm_pio_rp1 *ppwm = pwmchip_get_drvdata(chip);
 	uint32_t new_duty_cycle;
 	uint32_t new_period;
 


### PR DESCRIPTION
The PWM framework may not embed struct pwm_chip within the driver’s private data. Using container_of() can result in accessing invalid memory or NULL pointers, especially after recent kernel changes.

Switch to pwmchip_get_drvdata() to reliably access the driver data. This resolves kernel warnings and probe failures seen after updating from kernel 6.12.28 to 6.12.34 [1]

[1] https://github.com/raspberrypi/linux/issues/6971