### PR TITLE
drm/panel: ilitek-ili9881c: Restore missing lanes configuration for nwe080 panel

### DIFF
--- a/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c
+++ b/drivers/gpu/drm/panel/panel-ilitek-ili9881c.c
@@ -2512,6 +2512,7 @@ static const struct ili9881c_desc nwe080_desc = {
 	.init_length = ARRAY_SIZE(nwe080_init),
 	.mode = &nwe080_default_mode,
 	.mode_flags = MIPI_DSI_MODE_VIDEO_SYNC_PULSE | MIPI_DSI_MODE_VIDEO,
+	.lanes = 4,
 };
 
 static const struct ili9881c_desc cfaf7201280a0_050tx_desc = {


### PR DESCRIPTION
drm/panel: ilitek-ili9881c: Restore missing lanes configuration for nwe080

This config was missing with the forward porting of the rasp pi kernel to 6.12. Refer to https://github.com/raspberrypi/linux/issues/6856

I have tested this fix on my panel hardware. Previously it worked well with the nwe080 panel desc on rpi kernel 6.6. After updating to rpi 6.12, the panel stopped working. After I made this fix and recompiled the driver, the panel worked again.

I couldn't see any other panels with missing "lanes" parameter which were missed in the forward port from 6.6 to 6.12.