### PR TITLE
drivers: media: pisp_be: Fix alignment for V4L2_PIX_FMT_SRGGB8

### DIFF
--- a/drivers/media/platform/raspberrypi/pisp_be/pisp_be_formats.h
+++ b/drivers/media/platform/raspberrypi/pisp_be/pisp_be_formats.h
@@ -295,8 +295,8 @@ static const struct pisp_be_format supported_formats[] = {
 	{
 		.fourcc		    = V4L2_PIX_FMT_SRGGB8,
 		.bit_depth	    = 8,
-		.opt_align	    = 16,
-		.min_align	    = 32,
+		.opt_align	    = 32,
+		.min_align	    = 16,
 		.plane_factor	    = { P3(1.0) },
 		.num_planes	    = 1,
 		.colorspace_mask    = V4L2_COLORSPACE_MASK_RAW,
@@ -305,8 +305,8 @@ static const struct pisp_be_format supported_formats[] = {
 	{
 		.fourcc		    = V4L2_PIX_FMT_SBGGR8,
 		.bit_depth	    = 8,
-		.opt_align	    = 16,
-		.min_align	    = 32,
+		.opt_align	    = 32,
+		.min_align	    = 16,
 		.plane_factor	    = { P3(1.0) },
 		.num_planes	    = 1,
 		.colorspace_mask    = V4L2_COLORSPACE_MASK_RAW,


### PR DESCRIPTION
The opt_align and min_align field values got swapped, fix this.

Fixes: 7e86e8f0 ("drivers: media: pisp_be: Add minimal alinment to the format structure")