### PR TITLE
Update tpm-slb9673-overlay.dts

### DIFF
--- a/arch/arm/boot/dts/overlays/tpm-slb9673-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tpm-slb9673-overlay.dts
@@ -28,6 +28,7 @@
 				gpios = <&gpio 2 6>, /* SDA GPIO_OPEN_DRAIN */
 				     	<&gpio 3 6>; /* CLK GPIO_OPEN_DRAIN */
 				clock-frequency = <400000>;
+  				i2c-gpio,delay-us = <0x01>;
 				status = "okay";
 			};
 		};

--- a/arch/arm/boot/dts/overlays/tpm-slb9673-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tpm-slb9673-overlay.dts
@@ -28,7 +28,7 @@
 				gpios = <&gpio 2 6>, /* SDA GPIO_OPEN_DRAIN */
 				     	<&gpio 3 6>; /* CLK GPIO_OPEN_DRAIN */
 				clock-frequency = <400000>;
-  				i2c-gpio,delay-us = <0x01>;
+				i2c-gpio,delay-us = <0x01>;
 				status = "okay";
 			};
 		};


### PR DESCRIPTION
Add 'i2c-gpio,delay-us = <0x01>' to increase communication speed with tpm-slb9673 drastically

 Signed-off-by: @PaulKissinger 