### PR TITLE
Improve PIO DMA performance

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -2,6 +2,9 @@
 
 #include <dt-bindings/power/raspberrypi-power.h>
 
+#define DMA_SEL_WANTHEAVY       (1 << 8)
+#define DMA_SEL_ONLYHEAVY       (1 << 9)
+
 &soc {
 	firmware: firmware {
 		compatible = "raspberrypi,bcm2835-firmware", "simple-mfd";
@@ -91,7 +94,21 @@
 	};
 };
 
+&rp1_dma {
+	snps,sel-require =  <DMA_SEL_WANTHEAVY DMA_SEL_WANTHEAVY 0 0 0 0 0 0>;
+	snps,sel-preclude = <0 0 DMA_SEL_ONLYHEAVY DMA_SEL_ONLYHEAVY DMA_SEL_ONLYHEAVY
+			     DMA_SEL_ONLYHEAVY DMA_SEL_ONLYHEAVY DMA_SEL_ONLYHEAVY>;
+};
+
 pio: &rp1_pio {
+	dmas = <&rp1_dma (RP1_DMA_PIO_CH0_TX | DMA_SEL_WANTHEAVY)>,
+			<&rp1_dma (RP1_DMA_PIO_CH0_RX | DMA_SEL_WANTHEAVY)>,
+			<&rp1_dma (RP1_DMA_PIO_CH1_TX | DMA_SEL_WANTHEAVY)>,
+			<&rp1_dma (RP1_DMA_PIO_CH1_RX | DMA_SEL_WANTHEAVY)>,
+			<&rp1_dma (RP1_DMA_PIO_CH2_TX | DMA_SEL_WANTHEAVY)>,
+			<&rp1_dma (RP1_DMA_PIO_CH2_RX | DMA_SEL_WANTHEAVY)>,
+			<&rp1_dma (RP1_DMA_PIO_CH3_TX | DMA_SEL_WANTHEAVY)>,
+			<&rp1_dma (RP1_DMA_PIO_CH3_RX | DMA_SEL_WANTHEAVY)>;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
+++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
@@ -1111,7 +1111,7 @@
 			snps,data-width = <4>; // (8 << 4) == 128 bits
 			snps,block-size = <0x40000 0x40000 0x40000 0x40000 0x40000 0x40000 0x40000 0x40000>;
 			snps,priority = <0 1 2 3 4 5 6 7>;
-			snps,axi-max-burst-len = <4>;
+			snps,axi-max-burst-len = <8 8 4 4 4 4 4 4>;
 			status = "disabled";
 		};
 

--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac.h
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac.h
@@ -29,7 +29,7 @@ struct dw_axi_dma_hcfg {
 	u32	block_size[DMAC_MAX_CHANNELS];
 	u32	priority[DMAC_MAX_CHANNELS];
 	/* maximum supported axi burst length */
-	u32	axi_rw_burst_len;
+	u32	axi_rw_burst_len[DMAC_MAX_CHANNELS];
 	/* Register map for DMAX_NUM_CHANNELS <= 8 */
 	bool	reg_map_8_channels;
 	bool	restrict_axi_burst_len;

--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac.h
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac.h
@@ -58,6 +58,8 @@ struct dw_axi_dma {
 	struct dma_device	dma;
 	struct dw_axi_dma_hcfg	*hdata;
 	struct device_dma_parameters	dma_parms;
+	u32	sel_required[DMAC_MAX_CHANNELS];
+	u32	sel_precluded[DMAC_MAX_CHANNELS];
 
 	/* channels */
 	struct axi_dma_chan	*chan;

--- a/drivers/misc/rp1-pio.c
+++ b/drivers/misc/rp1-pio.c
@@ -50,7 +50,7 @@
 #define RP1_PIO_FIFO_RX2	0x18
 #define RP1_PIO_FIFO_RX3	0x1c
 
-#define RP1_PIO_DMACTRL_DEFAULT	0x80000104
+#define RP1_PIO_DMACTRL_DEFAULT	0x80000108
 
 #define HANDLER(_n, _f) \
 	[_IOC_NR(PIO_IOC_ ## _n)] = { #_n, rp1_pio_ ## _f, _IOC_SIZE(PIO_IOC_ ## _n) }
@@ -676,6 +676,10 @@ static int rp1_pio_sm_config_xfer_internal(struct rp1_pio_client *client, uint s
 	config.src_addr = fifo_addr;
 	config.dst_addr = fifo_addr;
 	config.direction = (dir == RP1_PIO_DIR_TO_SM) ? DMA_MEM_TO_DEV : DMA_DEV_TO_MEM;
+	if (dir == RP1_PIO_DIR_TO_SM)
+		config.dst_maxburst = 8;
+	else
+		config.src_maxburst = 8;
 
 	ret = dmaengine_slave_config(dma->chan, &config);
 	if (ret)

--- a/drivers/misc/rp1-pio.c
+++ b/drivers/misc/rp1-pio.c
@@ -648,8 +648,10 @@ static int rp1_pio_sm_config_xfer_internal(struct rp1_pio_client *client, uint s
 	chan_name[3] = '\0';
 
 	dma->chan = dma_request_chan(dev, chan_name);
-	if (IS_ERR(dma->chan))
-		return PTR_ERR(dma->chan);
+	if (IS_ERR(dma->chan)) {
+		ret = PTR_ERR(dma->chan);
+		goto err_unclaim;
+	}
 
 	/* Alloc and map bounce buffers */
 	for (dma->buf_count = 0; dma->buf_count < buf_count; dma->buf_count++) {
@@ -694,6 +696,7 @@ static int rp1_pio_sm_config_xfer_internal(struct rp1_pio_client *client, uint s
 err_dma_free:
 	rp1_pio_sm_dma_free(dev, dma);
 
+err_unclaim:
 	spin_lock(&pio->lock);
 	client->claimed_dmas &= ~dma_mask;
 	pio->claimed_dmas &= ~dma_mask;


### PR DESCRIPTION
The RP1 DMA controller configuration makes channels 1 and 2 more capable than the others. Add a mechanism to reserve those channels for the PIO block. There may be other ways to improve the DMA bandwidth when talking to the PIO block, but this alone more than doubles the throughput.