### PR TITLE
arm64/dma-mapping: Fix arch_sync_dma_for_device to respect dir parameter

### DIFF
--- a/arch/arm64/mm/dma-mapping.c
+++ b/arch/arm64/mm/dma-mapping.c
@@ -16,8 +16,22 @@ void arch_sync_dma_for_device(phys_addr_t paddr, size_t size,
 			      enum dma_data_direction dir)
 {
 	unsigned long start = (unsigned long)phys_to_virt(paddr);
+	unsigned long end = start + size;
 
-	dcache_clean_poc(start, start + size);
+	switch (dir) {
+	case DMA_BIDIRECTIONAL:
+		dcache_clean_inval_poc(start, end);
+		break;
+	case DMA_TO_DEVICE:
+		dcache_clean_poc(start, end);
+		break;
+	case DMA_FROM_DEVICE:
+		dcache_inval_poc(start, end);
+		break;
+	case DMA_NONE:
+	default:
+		break;
+	}
 }
 
 void arch_sync_dma_for_cpu(phys_addr_t paddr, size_t size,


### PR DESCRIPTION
All other architectures do different cache operations depending on the dir parameter. Fix arm64 to do the same.

This fixes udmabuf operations when syncing for read e.g. when the CPU reads back a V4L2 decoded frame buffer.

I suspect it also fixes less common dma_heap/system issues too. It can be argued that these problems should be fixed in udmabuf & dma_heap but fixing here also works around any other hidden bugs in other drivers. This fix does not preclude fixing the other drivers as well.