### PR TITLE
overlays: Fix sc16is752-spi1 emulation

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4543,7 +4543,7 @@ Load:   <Deprecated>
 
 Name:   sc16is752-spi1
 Info:   This overlay is now deprecated. Use
-        "dtoverlay=sc16is75x-spi,sc16is752,spi1-0,..." instead.
+        "dtoverlay=sc16is75x-spi,sc16is752,spi1-1cs,spi1-0,..." instead.
 Load:   <Deprecated>
 
 
@@ -4558,6 +4558,8 @@ Params: sc16is750               Device is a SC16IS750 UART (default on)
                                 (boolean, required)
         int_pin                 GPIO used for IRQ (default 24)
         xtal                    On-board crystal frequency (default 14745600)
+        spi1-1cs                A special case to support sc16is752-spi1. Not
+                                intended for general use.
 
 
 Name:   sdhost

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -292,16 +292,12 @@
 		renamed = "sc16is75x-spi,sc16is750,spi0-0";
 	};
 
-	sc16is750-spi1 {
-		renamed = "sc16is75x-spi,sc16is750,spi1-0";
-	};
-
 	sc16is752-spi0 {
 		renamed = "sc16is75x-spi,sc16is752,spi0-0";
 	};
 
 	sc16is752-spi1 {
-		renamed = "sc16is75x-spi,sc16is752,spi1-0";
+		renamed = "sc16is75x-spi,sc16is752,spi1-1cs,spi1-0";
 	};
 
 	sdhost {

--- a/arch/arm/boot/dts/overlays/sc16is75x-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sc16is75x-spi-overlay.dts
@@ -53,11 +53,45 @@
 	fragment@3 {
 		target = <&gpio>;
 		__overlay__ {
-			sc16is75x_pins: sc16is75x_pins@24 {
+			sc16is75x_pins: sc16is75x_pins@18 {
 				brcm,pins = <24>;
 				brcm,function = <BCM2835_FSEL_GPIO_IN>;
 				brcm,pull = <BCM2835_PUD_OFF>;
 			};
+		};
+	};
+
+	fragment@4 {
+		target = <&gpio>;
+		__dormant__ {
+			spi1_pins: spi1_pins {
+				brcm,pins = <19 20 21>;
+				brcm,function = <3>; /* alt4 */
+			};
+
+			spi1_cs_pins: spi1_cs_pins {
+				brcm,pins = <18>;
+				brcm,function = <1>; /* output */
+			};
+		};
+	};
+
+	fragment@5 {
+		target = <&spi1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi1_pins &spi1_cs_pins>;
+			cs-gpios = <&gpio 18 1>;
+			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target = <&aux>;
+		__dormant__ {
+			status = "okay";
 		};
 	};
 
@@ -80,6 +114,7 @@
 		spi1-0 = <0>, "-0",
 			<&sc16is75x_frag>, "target:0=", <&spi1>,
 			<&sc16is75x_pins>, "name=sc16is75x_spi1_0_pins";
+		spi1-1cs = <0>,"+4+5+6";
 		spi1-1 = <0>, "-0",
 			<&sc16is75x_frag>, "target:0=", <&spi1>,
 			<&sc16is75x>, "reg:0=1",


### PR DESCRIPTION
[1] Removed the sc16is752-spi1 overlay, replacing it with an entry in overlay_map.dts that invokes sc16is75x-spi with specific parameters. This does not work because it fails to configure the SPI1 interface. Most such overlays would require the respective SPI interface to have already been configured using one of the spi<n>-<m> overlays, but it is not possible to do that using overlay_map, and it is unreasonable to suddenly impose that requirement on users.

Work around that specific problem by adding an extra parameter to sc16is75x to configure SPI1. It's not ideal, but better than a complete dedicated overlay.

Link: https://github.com/raspberrypi/linux/issues/6962
Fixes: ce20a8fdbf58 ("overlays: sc16is75x: Add generic SPI overlay")
Signed-off-by: Phil Elwell <phil@raspberrypi.com>

[1] commit ce20a8fdbf58 ("overlays: sc16is75x: Add generic SPI overlay")