### PR TITLE
drivers: media: pisp_be: Fix for job queue removal in stop_streaming()

### DIFF
--- a/drivers/media/platform/raspberrypi/pisp_be/pisp_be.c
+++ b/drivers/media/platform/raspberrypi/pisp_be/pisp_be.c
@@ -594,9 +594,7 @@ err_return_buffers:
 	return -ENODEV;
 }
 
-static void pispbe_schedule(struct pispbe_dev *pispbe,
-			    struct pispbe_node_group *node_group,
-			    bool clear_hw_busy)
+static void pispbe_schedule(struct pispbe_dev *pispbe, bool clear_hw_busy)
 {
 	struct pispbe_job_descriptor *job;
 
@@ -612,9 +610,6 @@ static void pispbe_schedule(struct pispbe_dev *pispbe,
 					       queue);
 		if (!job)
 			return;
-
-		if (node_group && job->node_group != node_group)
-			continue;
 
 		list_del(&job->queue);
 
@@ -703,7 +698,7 @@ static irqreturn_t pispbe_isr(int irq, void *dev)
 	}
 
 	/* check if there's more to do before going to sleep */
-	pispbe_schedule(pispbe, NULL, can_queue_another);
+	pispbe_schedule(pispbe, can_queue_another);
 
 	return IRQ_HANDLED;
 }
@@ -894,7 +889,7 @@ static void pispbe_node_buffer_queue(struct vb2_buffer *buf)
 	 * to do, but only for this client.
 	 */
 	if (!pispbe_prepare_job(node_group))
-		pispbe_schedule(pispbe, node_group, false);
+		pispbe_schedule(pispbe, false);
 }
 
 static int pispbe_node_start_streaming(struct vb2_queue *q, unsigned int count)
@@ -921,7 +916,7 @@ static int pispbe_node_start_streaming(struct vb2_queue *q, unsigned int count)
 
 	/* Maybe we're ready to run. */
 	if (!pispbe_prepare_job(node_group))
-		pispbe_schedule(pispbe, node_group, false);
+		pispbe_schedule(pispbe, false);
 
 	return 0;
 


### PR DESCRIPTION
The existing code unconditionally removes jobs from the job_queue list when all the nodes in a node group have stopped streaming. This will also remove jobs for any other node groups as the job_queue is a common list. Fix this by only conditionally deleting jobs that belong to the current node group.

Additionally, delete jobs as soon as the first node in the node group stops streaming. Running a job with an incomplete set of active nodes is invalid.

Fixes: 880153e0d0a9 ("media: pisp_be: Split jobs creation and scheduling")