### PR TITLE
workflows: Ignore checkpatch UNKNOWN_COMMIT_ID

### DIFF
--- a/.github/workflows/ci_checkpatch.conf
+++ b/.github/workflows/ci_checkpatch.conf
@@ -2,3 +2,4 @@
 --ignore FILE_PATH_CHANGES
 --ignore GIT_COMMIT_ID
 --ignore SPDX_LICENSE_TAG
+--ignore UNKNOWN_COMMIT_ID


### PR DESCRIPTION
As we do a shallow clone of the repo, Fixes: tags
generally don't have the matching commit available to lookup, and checkpatch logs it.

Ignore this error.

Addresses the issue noted by Nick H earlier - https://github.com/raspberrypi/linux/pull/6999#issuecomment-3187583910