### PR TITLE
iommu: bcm2712-iommu: Allocate tables on demand; add OF properties

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
@@ -285,6 +285,7 @@
 		compatible = "brcm,bcm2712-iommu";
 		reg = <0x10 0x5100  0x0 0x80>;
 		cache = <&iommuc>;
+		aperture-size = <0x1 0x00000000>; // Increase IOVA aperture size to 4GBytes
 		#iommu-cells = <0>;
 	};
 

--- a/drivers/iommu/bcm2712-iommu.h
+++ b/drivers/iommu/bcm2712-iommu.h
@@ -2,7 +2,7 @@
 /*
  * IOMMU driver for BCM2712
  *
- * Copyright (c) 2023 Raspberry Pi Ltd.
+ * Copyright (c) 2023-2025 Raspberry Pi Ltd.
  */
 
 #ifndef _BCM2712_IOMMU_H
@@ -25,16 +25,18 @@ struct bcm2712_iommu {
 	struct iommu_group *group;
 	struct bcm2712_iommu_domain *domain;
 	char const *name;
-	struct sg_table *sgt; /* allocated memory for page tables */
-	u32 *tables;          /* kernel mapping for page tables */
+	u64 dma_iova_offset;  /* Hack for IOMMU attached to PCIe RC, included below */
+	u64 aperture_base;    /* Base of IOVA region as passed to DMA peripherals */
+	u64 aperture_end;     /* End of IOVA region as passed to DMA peripherals */
+	u32 **tables;         /* For each Linux page of L2 tables, kernel virtual address */
+	u32 *top_table;       /* Top-level table holding IOMMU page-numbers of L2 tables */
+	u32 *default_page;    /* Page used to trap illegal reads and writes */
 	struct bcm2712_iommu_cache *cache;
 	spinlock_t hw_lock;   /* to protect HW registers */
 	void __iomem *reg_base;
-	u64 dma_iova_offset; /* Hack for IOMMU attached to PCIe RC */
 	u32 bigpage_mask;
 	u32 superpage_mask;
 	unsigned int nmapped_pages;
-	bool dirty; /* true when tables are oriented towards CPU */
 };
 
 struct bcm2712_iommu_domain {


### PR DESCRIPTION
Allocate space for level-2 IOMMU translation tables on demand. This should save memory in most cases but means that map_pages() can now fail with -ENOMEM. Unused pages are retained for re-use.

Add OF properties to override the default aperture size (2GB) and base address (40GB); this doesn't include any dma-iova-offset.

Various tidy-ups. The internal representation of aperture limits *does* include dma_iova_offset, as that is more commonly useful. Clarify the distinction between Linux pages and IOMMU table pages. Fix wrong definition of MMMU_CTRL_PT_INVALID_EN flag.