### PR TITLE
RP1 Video Out: Hack for 50fps/60fps buffer-flips in interlaced modes

### DIFF
--- a/drivers/gpu/drm/rp1/rp1-vec/rp1_vec.c
+++ b/drivers/gpu/drm/rp1/rp1-vec/rp1_vec.c
@@ -358,7 +358,9 @@ static int rp1vec_connector_get_modes(struct drm_connector *connector)
 				mode->vdisplay	  >>= 1;
 				mode->vsync_start >>= 1;
 				mode->vsync_end	  >>= 1;
-				mode->vtotal	  >>= 1;
+				mode->vtotal      >>= 1;
+				if (mode->vtotal == 262 && tvstd < DRM_MODE_TV_MODE_PAL)
+					mode->vtotal++;
 			} else if (mode->hdisplay == 704 && mode->vtotal == preferred_lines) {
 				mode->type |= DRM_MODE_TYPE_PREFERRED;
 			}
@@ -468,6 +470,7 @@ static int rp1vec_platform_probe(struct platform_device *pdev)
 		return ret;
 	}
 	vec->pdev = pdev;
+	spin_lock_init(&vec->hw_lock);
 
 	for (i = 0; i < RP1VEC_NUM_HW_BLOCKS; i++) {
 		vec->hw_base[i] =

--- a/drivers/gpu/drm/rp1/rp1-vec/rp1_vec.h
+++ b/drivers/gpu/drm/rp1/rp1-vec/rp1_vec.h
@@ -50,6 +50,12 @@ struct rp1_vec {
 	u32 cur_fmt;
 	bool fake_31khz, vec_running, pipe_enabled;
 	struct completion finished;
+
+	spinlock_t hw_lock; /* the following are used in line-match ISR */
+	dma_addr_t last_dma_addr;
+	u32 last_stride;
+	bool field_flip;
+	bool lower_field_flag;
 };
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
By avoiding VEC's built-in interlaced DMA modes, and sending individual fields (adapting the "field wobble" trick from the DPI driver), it looks like we can get VEC to update at full field rate.

This changes the pattern of VSync pulses on the VEC's FE->BE interface. Some jiggery-pokery with the NTSC vertical settings was required before the BE would tolerate this (my guess is that the offset between "frame datum" and VSync, which is nonzero in conventional NTSC line numbering, made it more sensitive to FE VSync timings?)

Needs more testing to ensure it's reliable in all modes (including the "vintage" ones). Unlike the DPI case we can't use PIO to infer correct field polarity. If it  ever gets out of step, it won't recover!

To clarify: The first of these two commits relates to _progressive_ modes, and is unrelated.