### PR TITLE
ARM: dts: Select the PL011 platform driver

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm270x.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm270x.dtsi
@@ -239,6 +239,7 @@
 };
 
 &uart0 {
+	compatible = "arm,pl011-axi";
 	/* Enable CTS bug workaround */
 	cts-event-workaround;
 };

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
@@ -509,22 +509,30 @@ i2c_vc: &i2c0 {};
 	pinctrl-names = "default";
 };
 
+&uart0 {
+	compatible = "arm,pl011-axi";
+};
+
 &uart2 {
+	compatible = "arm,pl011-axi";
 	pinctrl-0 = <&uart2_pins>;
 	pinctrl-names = "default";
 };
 
 &uart3 {
+	compatible = "arm,pl011-axi";
 	pinctrl-0 = <&uart3_pins>;
 	pinctrl-names = "default";
 };
 
 &uart4 {
+	compatible = "arm,pl011-axi";
 	pinctrl-0 = <&uart4_pins>;
 	pinctrl-names = "default";
 };
 
 &uart5 {
+	compatible = "arm,pl011-axi";
 	pinctrl-0 = <&uart5_pins>;
 	pinctrl-names = "default";
 };

--- a/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
@@ -429,7 +429,7 @@
 };
 
 &uart10 {
-	arm,primecell-periphid = <0x00341011>;
+	compatible = "arm,pl011-axi";
 };
 
 &aon_intr {


### PR DESCRIPTION
The PL011 driver in this downstream kernel tree supports an extra compatible string - arm,pl011-axi - for use by RP1. This registers as a platform driver, not an AMBA driver, and has the advantage of responding to dynamic Device Tree changes such as loading one of the "uart<n>" overlays.

Change all of the downstream Raspberry Pi dts files to use the new compatible string. At the same time, remove the override of the periphid as the upstream code now has the correct value.

See: https://github.com/raspberrypi/linux/issues/7019