### PR TITLE
mfd: rp1: Fix device links when modules disabled

### DIFF
--- a/drivers/mfd/rp1.c
+++ b/drivers/mfd/rp1.c
@@ -340,9 +340,8 @@ static int rp1_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 					rp1_chained_handle_irq);
 	}
 
-	if (rp1_node)
-		of_platform_populate(rp1_node, NULL, NULL, &pcie_pdev->dev);
-
+	of_node_to_fwnode(rp1_node)->dev = rp1->dev;
+	of_platform_populate(rp1_node, NULL, NULL, &pcie_pdev->dev);
 	of_node_put(rp1_node);
 
 	return 0;


### PR DESCRIPTION
Device links are used to keep track of suppliers and consumers of resources, adding some control over the ordering of device probes other than returning -EPROBE_DEFER. The way the RP1 device is created breaks this mechanism in the rare case that the use of modules has been completely disabled, thanks to some opimisations within the device link code.

Fix this glitch by giving the corresponding fwnode a pointer to the device, taking the opportunity to remove a pointless check on the validity of the rp1_node pointer.

See: https://github.com/raspberrypi/linux/issues/7018