### PR TITLE
dt: Add eth_max_speed override for CM4, Pi4, and Pi400

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -67,7 +67,7 @@ jobs:
         else
           sudo apt-get install gcc-arm-linux-gnueabihf;
         fi
-      timeout-minutes: 5
+      timeout-minutes: 15
 
     - uses: actions/checkout@v4
       with:

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-4-b.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-4-b.dts
@@ -506,5 +506,6 @@ i2c_csi_dsi0: &i2c0 {
 
 		eth_led0 = <&phy1>,"led-modes:0";
 		eth_led1 = <&phy1>,"led-modes:4";
+		eth_max_speed = <&phy1>,"max-speed:0";
 	};
 };

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-400.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-400.dts
@@ -81,6 +81,7 @@ cam0_reg: &cam_dummy_reg {
 			       <&led_act>,"status=okay";
 		act_led_activelow = <&led_act>,"gpios:8";
 		act_led_trigger = <&led_act>,"linux,default-trigger";
+		eth_max_speed = <&phy1>,"max-speed:0";
 		pwr_led_gpio = <&led_pwr>,"gpios:4";
 		pwr_led_activelow = <&led_pwr>,"gpios:8";
 		pwr_led_trigger = <&led_pwr>,"linux,default-trigger";

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts
@@ -476,6 +476,7 @@ i2c_csi_dsi0: &i2c0 {
 
 		eth_led0 = <&phy1>,"led-modes:0";
 		eth_led1 = <&phy1>,"led-modes:4";
+		eth_max_speed = <&phy1>,"max-speed:0";
 
 		ant1 =  <&ant1>,"output-high?=on",
 			<&ant1>, "output-low?=off",

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -266,7 +266,8 @@ Params:
 
         eth_max_speed           Set the maximum speed a link is allowed
                                 to negotiate. Legal values are 10, 100 and
-                                1000 (default 1000). Pi3B+ only.
+                                1000 (default set by the platform).
+                                Pi3B+, Pi4, Pi400, and CM4 only.
 
         fan_temp0               Temperature threshold (in millicelcius) for
                                 1st cooling level (default 50000). Pi5 only.

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -266,8 +266,8 @@ Params:
 
         eth_max_speed           Set the maximum speed a link is allowed
                                 to negotiate. Legal values are 10, 100 and
-                                1000 (default set by the platform).
-                                Pi3B+, Pi4, Pi400, and CM4 only.
+                                1000 (default set by the platform). Pi3B+,
+                                Pi4, Pi400, CM4, Pi5, Pi500, and CM5 only.
 
         fan_temp0               Temperature threshold (in millicelcius) for
                                 1st cooling level (default 50000). Pi5 only.

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -194,6 +194,7 @@ watchdog: &pm {};
 		drm_fb2_vc4 = <&aliases>, "drm-fb2=",&vc4;
 		eth_led0 = <&phy1>,"led-modes:0";
 		eth_led1 = <&phy1>,"led-modes:4";
+		eth_max_speed = <&phy1>,"max-speed:0";
 		fan_temp0 = <&cpu_tepid>,"temperature:0";
 		fan_temp0_hyst = <&cpu_tepid>,"hysteresis:0";
 		fan_temp0_speed = <&fan>, "cooling-levels:4";


### PR DESCRIPTION
max-speed is a generic property for ethernet PHYs, so should be supported by the PHY on CM4/Pi4/Pi400.

Add the override and update the documentation accordingly.