### PR TITLE
dtoverlays: Switch ssd1306 to use the DRM driver

### DIFF
--- a/arch/arm/boot/dts/overlays/ssd1306-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ssd1306-overlay.dts
@@ -14,7 +14,7 @@
 	    #size-cells = <0>;
 
 	    ssd1306: oled@3c{
-		compatible = "solomon,ssd1306fb-i2c";
+		compatible = "solomon,ssd1306";
 		reg = <0x3c>;
 		solomon,width = <128>;
 		solomon,height = <64>;


### PR DESCRIPTION
Both drivers/gpu/drm/solomon/ssd130x-i2c.c and
drivers/video/fbdev/ssd1307fb.c were registering the compatible "solomon,ssd1306fb-i2c", so bringing ambiguity as to which one got loaded.

fbdev is largely deprecated, so adopt the updated compatible for the drm driver.

Fixes #7012 as this doesn't fail during shutdown.