### PR TITLE
Added device tree overlays for the rpi-power HAT.

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -247,6 +247,8 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-fw-uart.dtbo \
 	rpi-poe.dtbo \
 	rpi-poe-plus.dtbo \
+	rpi-power-hat-b.dtbo \
+	rpi-power-hat-t.dtbo \
 	rpi-sense.dtbo \
 	rpi-sense-v2.dtbo \
 	rpi-tv.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4461,6 +4461,18 @@ Params: poe_fan_temp0           Temperature (in millicelcius) at which the fan
                                 the firmware.
 
 
+Name:   rpi-power-hat-b
+Info:   Raspberry Pi Power HAT Bottom
+Load:   dtoverlay=rpi-power-hat-b
+Params: <None>
+
+
+Name:   rpi-power-hat-t
+Info:   Raspberry Pi Power HAT Top
+Load:   dtoverlay=rpi-power-hat-t
+Params: <None>
+
+
 Name:   rpi-proto
 Info:   This overlay has been renamed to proto-codec.
 Load:   <Deprecated>

--- a/arch/arm/boot/dts/overlays/rpi-power-hat-b-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-power-hat-b-overlay.dts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/dts-v1/;
+/plugin/;
+
+// Overlay for the Raspberry Pi Power Hat.
+// 1 of 2 overlays required for top/bottom interchangeability
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c1>;
+		__overlay__ {
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			power_control: fxl6408@43 {
+				reg = <0x43>;
+				compatible = "fcs,fxl6408";
+				gpio-controller;
+				#gpio-cells = <2>;
+				gpio-line-names =
+					"B1_PWR",
+					"B2_PWR",
+					"B3",
+					"B4",
+					"B5",
+					"B6",
+					"B7",
+					"B8";
+			};
+
+			pwr1_monitor: ina260@42 {
+				reg = <0x42>;
+				compatible = "ti,ina260";
+			};
+
+			pwr2_monitor: ina260@4c {
+				reg = <0x4c>;
+				compatible = "ti,ina260";
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			rpi_power_hat_b: rpi-power-hat-b {
+				compatible = "raspberrypi,rpi-power-hat-b";
+
+				// References to the I2C devices
+				power-controller = <&power_control>;
+				power1-monitor = <&pwr1_monitor>;
+				power2-monitor = <&pwr2_monitor>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-power-hat-t-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-power-hat-t-overlay.dts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/dts-v1/;
+/plugin/;
+
+// Overlay for the Raspberry Pi Power Hat.
+// 2 of 2 overlays required for top/bottom interchangeability
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c1>;
+		__overlay__ {
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			power_control: fxl6408@44 {
+				reg = <0x44>;
+				compatible = "fcs,fxl6408";
+				gpio-controller;
+				#gpio-cells = <2>;
+				gpio-line-names =
+					"T1_PWR",
+					"T2_PWR",
+					"T3",
+					"T4",
+					"T5",
+					"T6",
+					"T7",
+					"T8";
+			};
+
+			pwr1_monitor: ina260@46 {
+				reg = <0x46>;
+				compatible = "ti,ina260";
+			};
+
+			pwr2_monitor: ina260@4d {
+				reg = <0x4d>;
+				compatible = "ti,ina260";
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			rpi_power_hat_t: rpi-power-hat-t {
+				compatible = "raspberrypi,rpi-power-hat-t";
+
+				// References to the I2C devices
+				power-controller = <&power_control>;
+				power1-monitor = <&pwr1_monitor>;
+				power2-monitor = <&pwr2_monitor>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Added 2 device tree overlays for the rpi-control-hat. One for 'bottom' mode and one for 'top' mode. 