### PR TITLE
brcmfmac: Add power_save_disable module parameter

### DIFF
--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
@@ -3300,6 +3300,8 @@ brcmf_cfg80211_set_power_mgmt(struct wiphy *wiphy, struct net_device *ndev,
 
 	brcmf_dbg(TRACE, "Enter\n");
 
+	enabled &= !brcmf_power_save_disable;
+
 	/*
 	 * Powersave enable/disable request is coming from the
 	 * cfg80211 even before the interface is up. In that

--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.c
@@ -44,6 +44,10 @@ int brcmf_msg_level;
 module_param_named(debug, brcmf_msg_level, int, 0600);
 MODULE_PARM_DESC(debug, "Level of debug output");
 
+bool brcmf_power_save_disable;
+module_param_named(power_save_disable, brcmf_power_save_disable, bool, 0600);
+MODULE_PARM_DESC(power_save, "Disable WiFi power management");
+
 static int brcmf_p2p_enable;
 module_param_named(p2pon, brcmf_p2p_enable, int, 0);
 MODULE_PARM_DESC(p2pon, "Enable legacy p2p management functionality");

--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.h
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.h
@@ -30,6 +30,8 @@ struct brcmf_mp_global_t {
 
 extern struct brcmf_mp_global_t brcmf_mp_global;
 
+extern bool brcmf_power_save_disable;
+
 /**
  * struct brcmf_mp_device - Device module paramaters.
  *


### PR DESCRIPTION
The power_save_disable module parameter allows power management to be disabled from start of day, e.g. from a .conf file, without needing to run any commands from e.g. a systemd service. It also prevents any subsequent modifications unless the parameter is changed at runtime.

N.B. With power management disabled in this way, commands such as "iw wlan0 get power_save" may indicated that it is enabled, but the output in the kernel log says otherwise:

    brcmfmac: brcmf_cfg80211_set_power_mgmt: power save disabled

See: https://github.com/RPi-Distro/raspi-config/issues/282