### PR TITLE
workflows: Use native arm64 runners

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         include:
@@ -56,17 +56,13 @@ jobs:
             kernel: kernel_2712
 
     steps:
-    - name: Update install
-      run:
+    - name: Install armhf crossbuild toolchain
+      if: matrix.arch == 'arm'
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
         sudo apt-get update
-
-    - name: Install toolchain
-      run:
-        if [[ "${{matrix.arch}}" == "arm64" ]]; then
-          sudo apt-get install gcc-aarch64-linux-gnu;
-        else
-          sudo apt-get install gcc-arm-linux-gnueabihf;
-        fi
+        sudo apt-get install -y gcc-arm-linux-gnueabihf
       timeout-minutes: 15
 
     - uses: actions/checkout@v4
@@ -79,7 +75,6 @@ jobs:
         mkdir ${{github.workspace}}/build
         export ARCH=${{matrix.arch}}
         if [[ "$ARCH" == "arm64" ]]; then
-          export CROSS_COMPILE=aarch64-linux-gnu-
           export DTS_SUBDIR=broadcom
           export IMAGE=Image.gz
         else


### PR DESCRIPTION
Use native arm64 runners to speed up build process. Cross compile is still used for arm targets, but also benefit from the arm64 runner architecture. Overall build time will be reduced by 25 to 30 minutes by this.

For comparison:

| arch | defconfig | time x86_x64 | time arm64 |
| ---- | --------- | ------------ | ---------- |
| arm | bcm2835 | 10:59 | 6:13 |
| arm | bcmrpi | 31:27 | 18:25 |
| arm | bcm2709 | 33:13 | 18:35 |
| arm64 | arm64 | 40:10 | 20:04 |
| arm64 | bcm2711 | 53:42 | 21:56 |
| arm64 | bcm2711_rt | 42:07 | 22:55 |
| arm64 | bcm2712 | 42:54 | 22:46 |

x86_64: https://github.com/raspberrypi/linux/actions/runs/17582418198/job/49949837669 (total 53:48)

arm64: https://github.com/RevolutionPi/linux-raspberrypi/actions/runs/17626854174 (total 23:01)