### PR TITLE
dtoverlays: adjust inbound windows for MIP1 on Pi 5 with 32-bit PCIe DMA

### DIFF
--- a/arch/arm/boot/dts/overlays/pcie-32bit-dma-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pcie-32bit-dma-pi5-overlay.dts
@@ -19,8 +19,21 @@
 			#address-cells = <3>;
 			#size-cells = <2>;
 			dma-ranges = <0x02000000 0x0 0x00000000 0x0 0x00000000
-				      0x0 0x80000000>;
+				      0x0 0x80000000>,
+				     <0x02000000 0x00 0xfffff000 0x10 0x00131000
+				      0x00 0x00001000>;
 		};
 	};
 
+	fragment@1 {
+		target = <&mip1>;
+		__overlay__ {
+			/*
+			 * The MIP driver uses the reg property to derive the target
+			 * address for MSI writes - place this below 4GB.
+			 */
+			reg = <0x10 0x00131000 0x00 0xc0>,
+			      <0x00 0xfffff000 0x00 0x1000>;
+		};
+	};
 };


### PR DESCRIPTION
see #7046 

Note that trying this with an NVMe drive as a test will result in swiotlb exhaustion - compiling with CONFIG_SWIOTLB_DYNAMIC fixed this but the vc4 driver won't link - which is a separate issue.

