### PR TITLE
Overlays: rpi-power-hat i2c_arm enable

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-power-hat-b-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-power-hat-b-overlay.dts
@@ -9,11 +9,12 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c1>;
+		target = <&i2c_arm>;
 		__overlay__ {
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+			status = "okay";
 
 			power_control: fxl6408@43 {
 				reg = <0x43>;

--- a/arch/arm/boot/dts/overlays/rpi-power-hat-t-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-power-hat-t-overlay.dts
@@ -9,11 +9,12 @@
 	compatible = "brcm,bcm2835";
 
 	fragment@0 {
-		target = <&i2c1>;
+		target = <&i2c_arm>;
 		__overlay__ {
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+			status = "okay";
 
 			power_control: fxl6408@44 {
 				reg = <0x44>;


### PR DESCRIPTION
Updated rpi-power-hat device tree overlays to enable i2c_arm