### PR TITLE
Select internal MSI target for 32-bit DMA on Pi 5 PCIe

### DIFF
--- a/arch/arm/boot/dts/overlays/pcie-32bit-dma-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pcie-32bit-dma-pi5-overlay.dts
@@ -19,21 +19,8 @@
 			#address-cells = <3>;
 			#size-cells = <2>;
 			dma-ranges = <0x02000000 0x0 0x00000000 0x0 0x00000000
-				      0x0 0x80000000>,
-				     <0x02000000 0x00 0xfffff000 0x10 0x00131000
-				      0x00 0x00001000>;
+				      0x0 0x80000000>;
 		};
 	};
 
-	fragment@1 {
-		target = <&mip1>;
-		__overlay__ {
-			/*
-			 * The MIP driver uses the reg property to derive the target
-			 * address for MSI writes - place this below 4GB.
-			 */
-			reg = <0x10 0x00131000 0x00 0xc0>,
-			      <0x00 0xfffff000 0x00 0x1000>;
-		};
-	};
 };

--- a/arch/arm/boot/dts/overlays/pcie-32bit-dma-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pcie-32bit-dma-pi5-overlay.dts
@@ -18,6 +18,7 @@
 			 */
 			#address-cells = <3>;
 			#size-cells = <2>;
+			msi-parent = <&pciex1>;
 			dma-ranges = <0x02000000 0x0 0x00000000 0x0 0x00000000
 				      0x0 0x80000000>;
 		};


### PR DESCRIPTION
Revert #7049 as this broke #7046 - the cause is not understood, but there is a prudent workaround.