### PR TITLE
media: i2c: imx219: fix binning and rate_factor for 480p and 1232p

### DIFF
--- a/drivers/media/i2c/imx219.c
+++ b/drivers/media/i2c/imx219.c
@@ -148,12 +148,6 @@
 #define IMX219_PIXEL_ARRAY_WIDTH	3280U
 #define IMX219_PIXEL_ARRAY_HEIGHT	2464U
 
-enum binning_mode {
-	BINNING_NONE = IMX219_BINNING_NONE,
-	BINNING_X2 = IMX219_BINNING_X2,
-	BINNING_ANALOG_X2 = IMX219_BINNING_X2_ANALOG,
-};
-
 /* Mode : resolution and related config&values */
 struct imx219_mode {
 	/* Frame width */
@@ -409,8 +403,8 @@ static u32 imx219_get_format_bpp(const struct v4l2_mbus_framefmt *format)
 	}
 }
 
-static enum binning_mode imx219_get_binning(struct imx219 *imx219, u8 *bin_h,
-					    u8 *bin_v)
+static unsigned int imx219_get_binning(struct imx219 *imx219, u8 *bin_h,
+				       u8 *bin_v)
 {
 	struct v4l2_subdev_state *state =
 		v4l2_subdev_get_locked_active_state(&imx219->sd);
@@ -422,23 +416,23 @@ static enum binning_mode imx219_get_binning(struct imx219 *imx219, u8 *bin_h,
 	*bin_v = crop->height / format->height;
 
 	if (*bin_h == 2 && *bin_v == 2)
-		return BINNING_ANALOG_X2;
+		return IMX219_BINNING_X2_ANALOG;
 	else if (*bin_h == 2 || *bin_v == 2)
 		/*
 		 * Don't use analog binning if only one dimension
 		 * is binned, as it crops the other dimension
 		 */
-		return BINNING_X2;
+		return IMX219_BINNING_X2;
 	else
-		return BINNING_NONE;
+		return IMX219_BINNING_NONE;
 }
 
 static inline u32 imx219_get_rate_factor(struct imx219 *imx219)
 {
 	u8 bin_h, bin_v;
-	enum binning_mode binning = imx219_get_binning(imx219, &bin_h, &bin_v);
+	unsigned int binning = imx219_get_binning(imx219, &bin_h, &bin_v);
 
-	if (binning == BINNING_ANALOG_X2)
+	if (binning == IMX219_BINNING_X2_ANALOG)
 		return 2;
 
 	return 1;
@@ -674,7 +668,7 @@ static int imx219_set_framefmt(struct imx219 *imx219,
 {
 	const struct v4l2_mbus_framefmt *format;
 	const struct v4l2_rect *crop;
-	enum binning_mode binning;
+	unsigned int binning;
 	u8 bin_h, bin_v;
 	u32 bpp;
 	int ret = 0;
@@ -694,9 +688,9 @@ static int imx219_set_framefmt(struct imx219 *imx219,
 
 	binning = imx219_get_binning(imx219, &bin_h, &bin_v);
 	cci_write(imx219->regmap, IMX219_REG_BINNING_MODE_H,
-		  (bin_h == 2) ? binning : BINNING_NONE, &ret);
+		  (bin_h == 2) ? binning : IMX219_BINNING_NONE, &ret);
 	cci_write(imx219->regmap, IMX219_REG_BINNING_MODE_V,
-		  (bin_v == 2) ? binning : BINNING_NONE, &ret);
+		  (bin_v == 2) ? binning : IMX219_BINNING_NONE, &ret);
 
 	cci_write(imx219->regmap, IMX219_REG_X_OUTPUT_SIZE,
 		  format->width, &ret);


### PR DESCRIPTION
At a high FPS with RAW10, there is frame corruption for 480p because the rate_factor of 2 is used with the normal 2x2 bining [1]. This commit ties the rate_factor to the selected binning mode. For the 480p mode, analog 2x2 binning mode with a rate_factor of 2 is always used. For the 1232p mode the normal 2x2 binning mode is used for RAW10 while analog 2x2 binning mode is used for RAW8.

[1] raspberrypi#5493




Reworked due to upstream changes