### PR TITLE
staging: vc-sm-cma: Fix field-spanning write warning

### DIFF
--- a/drivers/staging/vc04_services/vc-sm-cma/vc_sm_defs.h
+++ b/drivers/staging/vc04_services/vc-sm-cma/vc_sm_defs.h
@@ -92,8 +92,7 @@ enum vc_sm_alloc_type_t {
 struct vc_sm_msg_hdr_t {
 	u32 type;
 	u32 trans_id;
-	u8 body[0];
-
+	u8 body[];
 };
 
 /* Request to allocate memory (HOST->VC) */


### PR DESCRIPTION
Replace one-element array with flexible-array member to fix:

[   11.725017] ------------[ cut here ]------------
[   11.725038] memcpy: detected field-spanning write (size 4) of single field "hdr->body" at drivers/staging/vc04_services/vc-sm-cma/vc_sm_cma_vchi.c:130 (size 0)
[   11.725113] WARNING: CPU: 3 PID: 455 at drivers/staging/vc04_services/vc-sm-cma/vc_sm_cma_vchi.c:130 vc_vchi_cmd_create+0x1a8/0x1d0 [vc_sm_cma]