### PR TITLE
Update stmpe.c accept chip ID 0x80 for STMPE610 variants

### DIFF
--- a/drivers/mfd/stmpe.c
+++ b/drivers/mfd/stmpe.c
@@ -1245,8 +1245,10 @@ static int stmpe_chip_init(struct stmpe *stmpe)
 		return ret;
 
 	id = (data[0] << 8) | data[1];
-	if ((id & variant->id_mask) != variant->id_val) {
-		dev_err(stmpe->dev, "unknown chip id: %#x\n", id);
+	if (((id & variant->id_mask) != variant->id_val) && id != 0x80) {
+		dev_err(stmpe->dev,
+			"unknown chip id: %#x (expected %#x or 0x80)\n",
+			id, variant->id_val);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Some third-party STMPE610 clones (such as those used on Duinotech XC9022 2.8" TFT HATs sold by Jaycar Electronics) report a chip ID value of 0x80 instead of the expected 0x81. The current stmpe driver rejects these devices with:

    stmpe-spi spi0.1: unknown chip id: 0x80
    probe with driver stmpe-spi failed with error -22

This prevents the touchscreen sub-driver (stmpe-ts) from binding, leaving the resistive touch panel non-functional even though the hardware is otherwise compatible.

The fix is trivial: relax the ID check in stmpe_probe_id() to also accept 0x80 as a valid chip ID. With this change applied, the touchscreen initialises correctly and delivers input events as expected. Tested on a Raspberry Pi 5 running Raspberry Pi OS Bookworm with an XC9022 HAT.

This quirk should not impact other STMPE variants which continue to report 0x81.