### PR TITLE
Suggest `raspinfo | pastebinit` in bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,8 +72,8 @@ body:
   attributes:
     label: System
     description: |
-      Copy and paste the results of `raspinfo | pastebinit` in to this section.
-      Alternatively, copy and paste a pastebin link, or add answers to the following questions:
+      Copy and paste the URL returned from `raspinfo | pastebinit` into this section.
+      Alternatively, add answers to the following questions:
       * Which OS and version (`cat /etc/rpi-issue`)?
       * Which firmware version (`vcgencmd version`)?
       * Which kernel version (`uname -a`)?

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,6 +53,7 @@ body:
       - Raspberry Pi 400
       - Raspberry Pi 5
       - Raspberry Pi 500
+      - Raspberry Pi 500+
       - Raspberry Pi CM1
       - Raspberry Pi CM3
       - Raspberry Pi CM3 Lite
@@ -71,7 +72,7 @@ body:
   attributes:
     label: System
     description: |
-      Copy and paste the results of the raspinfo command in to this section.
+      Copy and paste the results of `raspinfo | pastebinit` in to this section.
       Alternatively, copy and paste a pastebin link, or add answers to the following questions:
       * Which OS and version (`cat /etc/rpi-issue`)?
       * Which firmware version (`vcgencmd version`)?

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,6 +54,7 @@ body:
       - Raspberry Pi 5
       - Raspberry Pi 500
       - Raspberry Pi 500+
+      - Raspberry Pi CM0
       - Raspberry Pi CM1
       - Raspberry Pi CM3
       - Raspberry Pi CM3 Lite


### PR DESCRIPTION
Output of `raspinfo` is now over 65,000 characters, which is more than GitHub allows in a single form field! Also adds Pi 500+ to list of models.