### PR TITLE
Improve the RP1 DMA channel allocation scheme

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -2,8 +2,7 @@
 
 #include <dt-bindings/power/raspberrypi-power.h>
 
-#define DMA_SEL_WANTHEAVY       (1 << 8)
-#define DMA_SEL_ONLYHEAVY       (1 << 9)
+#define DMA_FLAG_HEAVY       (1 << 8)
 
 &soc {
 	firmware: firmware {
@@ -95,20 +94,18 @@
 };
 
 &rp1_dma {
-	snps,sel-require =  <DMA_SEL_WANTHEAVY DMA_SEL_WANTHEAVY 0 0 0 0 0 0>;
-	snps,sel-preclude = <0 0 DMA_SEL_ONLYHEAVY DMA_SEL_ONLYHEAVY DMA_SEL_ONLYHEAVY
-			     DMA_SEL_ONLYHEAVY DMA_SEL_ONLYHEAVY DMA_SEL_ONLYHEAVY>;
+	snps,chan-flags = <DMA_FLAG_HEAVY DMA_FLAG_HEAVY 0 0 0 0 0 0>;
 };
 
 pio: &rp1_pio {
-	dmas = <&rp1_dma (RP1_DMA_PIO_CH0_TX | DMA_SEL_WANTHEAVY)>,
-			<&rp1_dma (RP1_DMA_PIO_CH0_RX | DMA_SEL_WANTHEAVY)>,
-			<&rp1_dma (RP1_DMA_PIO_CH1_TX | DMA_SEL_WANTHEAVY)>,
-			<&rp1_dma (RP1_DMA_PIO_CH1_RX | DMA_SEL_WANTHEAVY)>,
-			<&rp1_dma (RP1_DMA_PIO_CH2_TX | DMA_SEL_WANTHEAVY)>,
-			<&rp1_dma (RP1_DMA_PIO_CH2_RX | DMA_SEL_WANTHEAVY)>,
-			<&rp1_dma (RP1_DMA_PIO_CH3_TX | DMA_SEL_WANTHEAVY)>,
-			<&rp1_dma (RP1_DMA_PIO_CH3_RX | DMA_SEL_WANTHEAVY)>;
+	dmas = <&rp1_dma (RP1_DMA_PIO_CH0_TX | DMA_FLAG_HEAVY)>,
+		<&rp1_dma (RP1_DMA_PIO_CH0_RX | DMA_FLAG_HEAVY)>,
+		<&rp1_dma (RP1_DMA_PIO_CH1_TX | DMA_FLAG_HEAVY)>,
+		<&rp1_dma (RP1_DMA_PIO_CH1_RX | DMA_FLAG_HEAVY)>,
+		<&rp1_dma (RP1_DMA_PIO_CH2_TX | DMA_FLAG_HEAVY)>,
+		<&rp1_dma (RP1_DMA_PIO_CH2_RX | DMA_FLAG_HEAVY)>,
+		<&rp1_dma (RP1_DMA_PIO_CH3_TX | DMA_FLAG_HEAVY)>,
+		<&rp1_dma (RP1_DMA_PIO_CH3_RX | DMA_FLAG_HEAVY)>;
 	status = "okay";
 };
 

--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac.h
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac.h
@@ -58,8 +58,7 @@ struct dw_axi_dma {
 	struct dma_device	dma;
 	struct dw_axi_dma_hcfg	*hdata;
 	struct device_dma_parameters	dma_parms;
-	u32	sel_required[DMAC_MAX_CHANNELS];
-	u32	sel_precluded[DMAC_MAX_CHANNELS];
+	u32	chan_flags[DMAC_MAX_CHANNELS];
 
 	/* channels */
 	struct axi_dma_chan	*chan;

--- a/drivers/misc/rp1-pio.c
+++ b/drivers/misc/rp1-pio.c
@@ -611,6 +611,7 @@ static int rp1_pio_sm_config_xfer_internal(struct rp1_pio_client *client, uint s
 	struct platform_device *pdev = pio->pdev;
 	struct device *dev = &pdev->dev;
 	struct dma_slave_config config = {};
+	struct dma_slave_caps dma_caps;
 	phys_addr_t fifo_addr;
 	struct dma_info *dma;
 	uint32_t dma_mask;
@@ -676,10 +677,12 @@ static int rp1_pio_sm_config_xfer_internal(struct rp1_pio_client *client, uint s
 	config.src_addr = fifo_addr;
 	config.dst_addr = fifo_addr;
 	config.direction = (dir == RP1_PIO_DIR_TO_SM) ? DMA_MEM_TO_DEV : DMA_DEV_TO_MEM;
+	dma_caps.max_burst = 4;
+	dma_get_slave_caps(dma->chan, &dma_caps);
 	if (dir == RP1_PIO_DIR_TO_SM)
-		config.dst_maxburst = 8;
+		config.dst_maxburst = dma_caps.max_burst;
 	else
-		config.src_maxburst = 8;
+		config.src_maxburst = dma_caps.max_burst;
 
 	ret = dmaengine_slave_config(dma->chan, &config);
 	if (ret)


### PR DESCRIPTION
As well as being bugged (#7078), the previous RP1 DMA channel allocation scheme would not make optimal use of the channels in the event that many were required. The new scheme gives each channel a score as to how well it matches the client's requirements, but when availability is low even low-scoring channels are eventually allocated.

Despite the improved functionality, the DT declaration is simpler. The driver should also behave the same with old-style DTBs.

See: https://github.com/raspberrypi/linux/issues/7078