### PR TITLE
Fixup c91c9f257db9 ("fbdev: Allow client to request a particular /dev…

### DIFF
--- a/drivers/video/fbdev/core/fbmem.c
+++ b/drivers/video/fbdev/core/fbmem.c
@@ -446,6 +446,7 @@ static int do_register_framebuffer(struct fb_info *fb_info)
 	if (num_registered_fb == FB_MAX)
 		return -ENXIO;
 
+	i = fb_info->node;
 	if (!fb_info->custom_fb_num || fb_info->node >= FB_MAX || registered_fb[fb_info->node]) {
 		for (i = min_dynamic_fb ; i < FB_MAX; i++)
 			if (!registered_fb[i])
@@ -463,6 +464,7 @@ static int do_register_framebuffer(struct fb_info *fb_info)
 	if (err < 0)
 		return err;
 
+	fb_info->node = i;
 	refcount_set(&fb_info->count, 1);
 	mutex_init(&fb_info->lock);
 	mutex_init(&fb_info->mm_lock);


### PR DESCRIPTION
…/fbN node")

We lost a line in the forward port, which meant that it always used /dev/fb0, and complained that the sysfs nodes already existed.

Fixes: c91c9f257db9 ("fbdev: Allow client to request a particular /dev/fbN node")

This also applies to 6.18.