### PR TITLE
misc: ws2812-pio-rp1: Allow gamma to be disabled

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5980,8 +5980,10 @@ Params: brightness              Set the initial brightness for the LEDs. The
                                 a single byte to offset 0 of the device. Note
                                 that brightness is a multiplier for the pixel
                                 values, and only white pixels can reach the
-                                maximum visible brightness. (range 0-255,
-                                default 255)
+                                maximum visible brightness. N.B. Setting
+                                brightness to 0 acctivates pass-through mode,
+                                disabling all brightness and gamma processing.
+                                (range 0-255, default 255)
         dev_name                The name for the /dev/ device entry. Note that
                                 if the name includes '%d' it will be replaced
                                 by the instance number. (default 'leds%d')

--- a/drivers/misc/ws2812-pio-rp1.c
+++ b/drivers/misc/ws2812-pio-rp1.c
@@ -142,8 +142,8 @@ static uint8_t ws2812_apply_gamma(uint8_t brightness, uint8_t val)
 {
 	int bright;
 
-	if (!val)
-		return 0;
+	if (!val || !brightness)
+		return val;
 	bright = (val * brightness) / 255;
 	return ws2812_gamma[bright];
 }


### PR DESCRIPTION
Modify the gamma logic such that setting the brightness in DT to zero causes the supplied pixel values to be passed through unmodified.

See: https://github.com/raspberrypi/linux/issues/7108