### PR TITLE
media: imx477: Increase IMX477_VBLANK_MIN due to image corruption

### DIFF
--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -72,7 +72,7 @@ MODULE_PARM_DESC(fstrobe_delay, "Set fstrobe delay from end all lines starting t
 
 /* V_TIMING internal */
 #define IMX477_REG_FRAME_LENGTH		CCI_REG16(0x0340)
-#define IMX477_VBLANK_MIN		4
+#define IMX477_VBLANK_MIN		48
 #define IMX477_FRAME_LENGTH_MAX		0xffdc
 
 /* H_TIMING internal */


### PR DESCRIPTION
The 4056x3040 mode appears to need more vertical blanking lines than any other, leaving a black bar at the bottom of the image.

Increase IMX477_VBLANK_MIN from 4 to 48 to compensate. (It may be possible to reduce it slightly further, but fix the regression for now).

https://github.com/raspberrypi/linux/issues/7109