### PR TITLE
staging: vc04_services: vc-sm-cma: Fix smatch warnings

### DIFF
--- a/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
+++ b/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
@@ -393,6 +393,7 @@ static int vc_sm_dma_buf_attach(struct dma_buf *dmabuf,
 	ret = sg_alloc_table(sgt, buf->alloc.sg_table->orig_nents, GFP_KERNEL);
 	if (ret) {
 		kfree(a);
+		mutex_unlock(&buf->lock);
 		return -ENOMEM;
 	}
 
@@ -1223,7 +1224,7 @@ error:
 		dma_buf_put(dmabuf);
 	} else {
 		/* No dmabuf, therefore just free the buffer here */
-		if (buffer->cookie)
+		if (buffer && buffer->cookie)
 			dma_free_coherent(&sm_state->device->dev, buffer->size,
 					  buffer->cookie, buffer->dma_addr);
 		kfree(buffer);


### PR DESCRIPTION
Fix these two smatch warnings for the vc-sm-cma driver, rest were false positives:

../vc-sm-cma/vc_sm.c:413
vc_sm_dma_buf_attach() warn: inconsistent returns '&buf->lock'.
  Locked on  : 396
  Unlocked on: 413
../vc-sm-cma/vc_sm.c:1225
vc_sm_cma_ioctl_alloc() error: we previously assumed 'buffer' could be null (see line 1113)

This change is also posted upstream, squashed into the commit introducing support for vc-sm-cma driver:
https://lore.kernel.org/all/20251031-b4-vc-sm-cma-v1-0-0dd5c0ec3f5c@ideasonboard.com/T/#t