### PR TITLE
drm/vc4: plane: Swap Cb/Cr offsets for YVU formats

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -2174,9 +2174,10 @@ static int vc6_plane_mode_set(struct drm_plane *plane,
 	 * TODO: This only covers Raster Scan Order planes
 	 */
 	for (i = 0; i < num_planes; i++) {
+		int idx = vc6_get_plane_idx(format, i);
 		struct drm_gem_dma_object *bo =
-			drm_fb_dma_get_gem_obj(fb, vc6_get_plane_idx(format, i));
-		dma_addr_t paddr = bo->dma_addr + fb->offsets[i] + offsets[i];
+			drm_fb_dma_get_gem_obj(fb, idx);
+		dma_addr_t paddr = bo->dma_addr + fb->offsets[idx] + offsets[idx];
 
 		/* Pointer Word 0 */
 		vc4_state->ptr0_offset[i] = vc4_state->dlist_count;


### PR DESCRIPTION
Follow up to "drm/vc4: plane: Swap Cb/Cr pointers for YVU formats" Swap the offsets as well as the buffer objects for YVU formats.

Draft as I want to double check the async update path too.