### PR TITLE
6.17 RP1 DRM fixups

### DIFF
--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-ili9881-7inch-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-ili9881-7inch-overlay.dts
@@ -19,10 +19,11 @@
 
 			display_mcu: display_mcu@45
 			{
-				compatible = "raspberrypi,v2-touchscreen-panel-regulator";
+				compatible = "raspberrypi,touchscreen-panel-regulator-v2";
 				reg = <0x45>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				#pwm-cells = <3>;
 			};
 
 			gt911: gt911@5d {
@@ -54,7 +55,7 @@
 				reg = <0>;
 				compatible = "raspberrypi,dsi-7inch";
 				reset-gpio = <&display_mcu 0 GPIO_ACTIVE_LOW>;
-				backlight = <&display_mcu>;
+				backlight = <&backlight>;
 
 				port {
 					panel_in: endpoint {
@@ -90,6 +91,14 @@
 				startup-delay-us = <50000>;
 				enable-active-high;
 			};
+
+			backlight: panel_backlight@1 {
+				compatible = "pwm-backlight";
+				brightness-levels = <0 31>;
+				num-interpolated-steps = <31>;
+				default-brightness-level = <15>;
+				pwms = <&display_mcu 0 200000 0>;
+			};
 		};
 	};
 
@@ -111,7 +120,8 @@
 		dsi0 = <&dsi_frag>, "target:0=",<&dsi0>,
 		       <&i2c_frag>, "target:0=",<&i2c_csi_dsi0>,
 		       <&touch_reg>, "reg:0=0",
-		       <&touch_reg>, "regulator-name=touch_reg_0";
+		       <&touch_reg>, "regulator-name=touch_reg_0",
+		       <&backlight>, "reg:0=0";
 		sizex = <&gt911>,"touchscreen-size-x:0";
 		sizey = <&gt911>,"touchscreen-size-y:0";
 		invx = <0>, "+10";

--- a/drivers/gpu/drm/rp1/rp1-dpi/Kconfig
+++ b/drivers/gpu/drm/rp1/rp1-dpi/Kconfig
@@ -5,9 +5,6 @@ config DRM_RP1_DPI
 	select DRM_CLIENT_SELECTION
 	select DRM_GEM_DMA_HELPER
 	select DRM_KMS_HELPER
-	select DRM_VRAM_HELPER
-	select DRM_TTM
-	select DRM_TTM_HELPER
 	depends on RP1_PIO || !RP1_PIO
 	help
 	  Choose this option to enable DPI output on Raspberry Pi RP1

--- a/drivers/gpu/drm/rp1/rp1-dsi/Kconfig
+++ b/drivers/gpu/drm/rp1/rp1-dsi/Kconfig
@@ -6,9 +6,6 @@ config DRM_RP1_DSI
 	select DRM_GEM_DMA_HELPER
 	select DRM_KMS_HELPER
 	select DRM_MIPI_DSI
-	select DRM_VRAM_HELPER
-	select DRM_TTM
-	select DRM_TTM_HELPER
 	select GENERIC_PHY
 	select GENERIC_PHY_MIPI_DPHY
 	help

--- a/drivers/gpu/drm/rp1/rp1-dsi/rp1_dsi.c
+++ b/drivers/gpu/drm/rp1/rp1-dsi/rp1_dsi.c
@@ -430,7 +430,7 @@ static int rp1dsi_platform_probe(struct platform_device *pdev)
 		ret = PTR_ERR(drm);
 		return ret;
 	}
-	dsi = drmm_kzalloc(drm, sizeof(*dsi), GFP_KERNEL);
+	dsi = devm_drm_bridge_alloc(dev, struct rp1_dsi, bridge, &rp1_dsi_bridge_funcs);
 	if (!dsi) {
 		ret = -ENOMEM;
 		goto err_free_drm;
@@ -441,7 +441,6 @@ static int rp1dsi_platform_probe(struct platform_device *pdev)
 	drm->dev_private = dsi;
 	platform_set_drvdata(pdev, drm);
 
-	dsi->bridge.funcs = &rp1_dsi_bridge_funcs;
 	dsi->bridge.of_node = dev->of_node;
 	dsi->bridge.type = DRM_MODE_CONNECTOR_DSI;
 

--- a/drivers/gpu/drm/rp1/rp1-vec/Kconfig
+++ b/drivers/gpu/drm/rp1/rp1-vec/Kconfig
@@ -5,8 +5,5 @@ config DRM_RP1_VEC
 	select DRM_CLIENT_SELECTION
 	select DRM_GEM_DMA_HELPER
 	select DRM_KMS_HELPER
-	select DRM_VRAM_HELPER
-	select DRM_TTM
-	select DRM_TTM_HELPER
 	help
 	  Choose this option to enable Video Out on RP1


### PR DESCRIPTION
Found whilst testing 6.18, but was broken in 6.17 as well.