### PR TITLE
overlays: Add vec-gpio-pi5-overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -345,6 +345,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	vc4-kms-v3d-pi4.dtbo \
 	vc4-kms-v3d-pi5.dtbo \
 	vc4-kms-vga666.dtbo \
+	vec-gpio-pi5.dtbo \
 	vga666.dtbo \
 	vl805.dtbo \
 	w1-gpio.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5832,12 +5832,21 @@ Info:   See vc4-kms-v3d-pi4 (this is the Pi 5 version)
 
 
 Name:   vc4-kms-vga666
-Info:   Enable the VGA666 (resistor ladder ADC) for the vc4-kms-v3d driver.
+Info:   Enable the VGA666 (resistor ladder DAC) for the vc4-kms-v3d driver.
         Requires vc4-kms-v3d to be loaded.
 Load:   dtoverlay=vc4-kms-vga666,<param>
 Params: ddc                     Enables GPIOs 0&1 as the I2C to read the EDID
                                 from the display. NB These are NOT 5V tolerant
                                 GPIOs, therefore level shifters are required.
+
+
+Name:   vec-gpio-pi5
+Info:   Overlay to output composite video as an 8-bit digital code over GPIO
+        pins 4-11, for Raspberry Pi 5 series only. Requires composite video
+        to be enabled; incompatible with any use of DPI or VGA666.
+Load:   dtoverlay=vec-gpio-pi5,<param>
+Params: clk                     Enable GPIO 0 (clock, 108 MHz)
+        gpio27                  Enable GPIO 27 (duplicate MSB)
 
 
 Name:   vga666

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -518,6 +518,14 @@
 		bcm2712;
 	};
 
+	vec-gpio {
+		bcm2712 = "vec-gpio-pi5";
+	};
+
+	vec-gpio-pi5 {
+		bcm2712;
+	};
+
 	vl805 {
 		bcm2711;
 	};

--- a/arch/arm/boot/dts/overlays/vec-gpio-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vec-gpio-pi5-overlay.dts
@@ -1,0 +1,48 @@
+/*
+ * vec-gpio-pi5-overlay.dts
+ */
+
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2712";
+
+	fragment@0 {
+		target = <&rp1_vec>;
+		rp1vec_overlay: __overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&rp1vec_ch0pins>, <&rp1vec_ch0pins>;
+		};
+	};
+
+	fragment@1 {
+		   target = <&gpio>;
+		   __overlay__ {
+			rp1vec_ch0pins: rp1vec_ch0pins {
+				function = "dpi";
+				pins = "gpio4", "gpio5", "gpio6", "gpio7",
+					"gpio8", "gpio9", "gpio10", "gpio11";
+				bias-disable;
+				drive-strength = <12>;
+			};
+			rp1vec_pin27: rp1vec_pin27 {
+				function = "dpi";
+				pins = "gpio27";
+				bias-disable;
+				drive-strength = <12>;
+			};
+			rp1vec_clkpin: rp1vec_clkpin {
+				function = "dpi";
+				pins = "gpio0";
+				bias-disable;
+				drive-strength = <12>;
+			};
+		};
+	};
+
+	__overrides__ {
+		gpio27 = <&rp1vec_overlay>, "pinctrl-0:4=", <&rp1vec_pin27>;
+		clk = <&rp1vec_overlay>, "pinctrl-0:8=", <&rp1vec_clkpin>;
+	};
+};


### PR DESCRIPTION
Add an overlay to allow composite video to be output on GPIOs 4-11 on Raspberry Pi 5, 500, 500+ or CM5 only, with an optional 108 MHz clock on GPIO 0 and duplicate MSB on GPIO 27.

Requires composite video to be enabled and DPI to be disabled.