### PR TITLE
pwm: rp1: Silently correct illegal values

### DIFF
--- a/drivers/pwm/pwm-pio-rp1.c
+++ b/drivers/pwm/pwm-pio-rp1.c
@@ -83,7 +83,7 @@ static inline void pwm_program_init(PIO pio, uint sm, uint offset, uint pin)
 /* Write `period` to the input shift register - must be disabled */
 static void pio_pwm_set_period(PIO pio, uint sm, uint32_t period)
 {
-	pio_sm_put_blocking(pio, sm, period);
+	pio_sm_put_blocking(pio, sm, period - 1);
 	pio_sm_exec(pio, sm, pio_encode_pull(false, false));
 	pio_sm_exec(pio, sm, pio_encode_out(pio_isr, 32));
 }


### PR DESCRIPTION
Remove the need for the user to know the limitations of this PWM
implementation by adjusting configuration requests to be the closest
acceptable value. Add a get_state method so that the actual values can
be queried.

Also, correct the set_period method to pass (period - 1), as required by the
PIO state machine.

See: #7131
