### PR TITLE
mmc: Relax the 50MHz overclock check

### DIFF
--- a/drivers/mmc/host/bcm2835-mmc.c
+++ b/drivers/mmc/host/bcm2835-mmc.c
@@ -1068,7 +1068,7 @@ static void bcm2835_mmc_set_clock(struct bcm2835_host *host, unsigned int clock)
 	unsigned long timeout;
 	unsigned int input_clock = clock;
 
-	if (host->overclock_50 && (clock == 50000000))
+	if (host->overclock_50 && (clock >= 50000000))
 		clock = host->overclock_50 * 1000000 + 999999;
 
 	host->mmc->actual_clock = 0;

--- a/drivers/mmc/host/bcm2835-sdhost.c
+++ b/drivers/mmc/host/bcm2835-sdhost.c
@@ -1541,7 +1541,7 @@ static void bcm2835_sdhost_set_clock(struct bcm2835_host *host, unsigned int clo
 	if (host->debug)
 		pr_info("%s: set_clock(%d)\n", mmc_hostname(host->mmc), clock);
 
-	if (host->overclock_50 && (clock == 50*MHZ))
+	if (host->overclock_50 && (clock >= 50*MHZ))
 		clock = host->overclock_50 * MHZ + (MHZ - 1);
 
 	/* The SDCDIV register has 11 bits, and holds (div - 2).

--- a/drivers/mmc/host/bcm2835.c
+++ b/drivers/mmc/host/bcm2835.c
@@ -1127,7 +1127,7 @@ static void bcm2835_set_clock(struct bcm2835_host *host, unsigned int clock)
 	const unsigned int MHZ = 1000000;
 	int div;
 
-	if (host->overclock_50 && (clock == 50*MHZ))
+	if (host->overclock_50 && (clock >= 50*MHZ))
 		clock = host->overclock_50 * MHZ + (MHZ - 1);
 
 	/* The SDCDIV register has 11 bits, and holds (div - 2).  But


### PR DESCRIPTION
EMMC clock speeds are based around divisions of 52Mhz, not the 50MHz
used by SD. As such, relax the "full speed" check (intended to stop
any overclock whenever an operation has to be retried) so that any
requested speed of 50MHz or higher will be overclocked.

See: https://github.com/raspberrypi/linux/issues/7120
