### PR TITLE
dtoverlays: tc358743: Update legacy compatible frag with cam0 override

### DIFF
--- a/arch/arm/boot/dts/overlays/tc358743-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tc358743-overlay.dts
@@ -8,7 +8,7 @@
 / {
 	compatible = "brcm,bcm2835";
 
-	fragment@100 {
+	legacy_frag: fragment@100 {
 		target = <&csi1>;
 		__overlay__ {
 			compatible = "brcm,bcm2835-unicam-legacy";
@@ -17,5 +17,12 @@
 
 	__overrides__ {
 		media-controller = <0>,"!100";
+		// Overwrites the cam0 override from tc358743.dtsi as we need to
+		// update legacy_frag.
+		cam0 = <&i2c_frag>, "target:0=",<&i2c_csi_dsi0>,
+		       <&csi_frag>, "target:0=",<&csi0>,
+		       <&clk_frag>, "target:0=",<&cam0_clk>,
+		       <&tc358743>, "clocks:0=",<&cam0_clk>,
+		       <&legacy_frag>, "target:0=",<&csi0>;
 	};
 };


### PR DESCRIPTION
The non-pi5 variant of tc358743 needs to update the compatible of csi0 rather than csi1 if the cam0 override is used, otherwise it gets loaded in Media Controller mode.

https://forums.raspberrypi.com/viewtopic.php?t=393755

(If there's a cleaner way to add to the `cam0` override then I'm happy to adopt it. Just creating the `cam0` override in tc358743-overlay.dts appeared to overwrite that from tc358743.dtsi).