### PR TITLE
Overlays: add overlay for rak-6421 WisBlock hat

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -234,6 +234,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	pwm1.dtbo \
 	qca7000.dtbo \
 	qca7000-uart0.dtbo \
+	rak-6421.dtbo \
 	ramoops.dtbo \
 	ramoops-pi4.dtbo \
 	rootmaster.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4273,6 +4273,15 @@ Params: baudrate                Set the baudrate for the UART (default
                                 "115200")
 
 
+Name:   rak-6421
+Info:   RAK6421 Meshtastic WisHat
+        This board allows connecting RAK WisBlock radios and sensors to
+        the Raspberry Pi. Consists of two SPI radio ports and 4 i2c
+        sensor slots.
+Load:   dtoverlay=rak-6421
+Params: <None>
+
+
 Name:   ramoops
 Info:   Enable the preservation of crash logs across a reboot. With
         systemd-pstore enabled (as it is on Raspberry Pi OS) the crash logs

--- a/arch/arm/boot/dts/overlays/rak-6421-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rak-6421-overlay.dts
@@ -1,0 +1,33 @@
+/*
+ * Device Tree overlay for RAK 6421 Meshtastic HAT+
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+
+	i2c_frag: fragment@0 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+	fragment@1 {
+		target = <&spi0_cs_pins>;
+		frag1: __overlay__ {
+			brcm,pins = <8 7>;
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		frag2: __overlay__ {
+			cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
The RAK 6421 is a new HAT+ device for Meshtastic, that adds support for the WisBlock ecosystem on the Raspberry Pi. This overlay will usually be loaded via the HAT+ eeprom.