### PR TITLE
Correcting GT928 GPIO configuration for CFA050-PI-M touchscreen

### DIFF
--- a/arch/arm/boot/dts/overlays/crystalfontz-cfa050_pi_m-overlay.dts
+++ b/arch/arm/boot/dts/overlays/crystalfontz-cfa050_pi_m-overlay.dts
@@ -109,6 +109,8 @@
 			gt928: gt928@5d {
 				compatible = "goodix,gt928";
 				reg = <0x5d>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&gt928intpins>;
 				interrupt-parent = <&gpio>;
 				interrupts = <26 2>; //gpio 26, 2=high-to-low trigger
 				irq-gpios = <&gpio 26 0>; //gpio 26, 0=active-high


### PR DESCRIPTION
Added missing pinctrl configuration lines which enable pull-up on GPIO26.