### PR TITLE
overlays: Ensure that defined pin groups are used

### DIFF
--- a/arch/arm/boot/dts/overlays/at86rf233-overlay.dts
+++ b/arch/arm/boot/dts/overlays/at86rf233-overlay.dts
@@ -34,23 +34,10 @@
 		};
 	};
 
-	fragment@2 {
-		target = <&gpio>;
-		__overlay__ {
-			lowpan0_pins: lowpan0_pins {
-				brcm,pins = <23 24 25>;
-				brcm,function = <0 1 1>; /* in out out */
-			};
-		};
-	};
-
 	__overrides__ {
-		interrupt = <&lowpan0>, "interrupts:0",
-			<&lowpan0_pins>, "brcm,pins:0";
-		reset     = <&lowpan0>, "reset-gpio:4",
-			<&lowpan0_pins>, "brcm,pins:4";
-		sleep     = <&lowpan0>, "sleep-gpio:4",
-			<&lowpan0_pins>, "brcm,pins:8";
+		interrupt = <&lowpan0>, "interrupts:0";
+		reset     = <&lowpan0>, "reset-gpio:4";
+		sleep     = <&lowpan0>, "sleep-gpio:4";
 		speed     = <&lowpan0>, "spi-max-frequency:0";
 		trim      = <&lowpan0>, "xtal-trim.0";
 	};

--- a/arch/arm/boot/dts/overlays/audiosense-pi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/audiosense-pi-overlay.dts
@@ -34,16 +34,6 @@
 		};
 	};
 
-	fragment@2 {
-		target = <&gpio>;
-		__overlay__ {
-			codec_rst: codec-rst {
-				brcm,pins = <26>;
-				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
-			};
-		};
-	};
-
 	fragment@3 {
 		target = <&i2c1>;
 		__overlay__ {

--- a/arch/arm/boot/dts/overlays/chipcap2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/chipcap2-overlay.dts
@@ -30,16 +30,6 @@
 	};
 
 	fragment@1 {
-		target = <&gpio>;
-		__overlay__ {
-			chipcap2_pins: chipcap2_pins {
-				brcm,pins = <4 5 6 26>;
-				brcm,function = <0 0 0 1>;
-			};
-		};
-	};
-
-	fragment@2 {
 		target-path = "/";
 		__overlay__ {
 			chipcap2_reg: chipcap2_reg {
@@ -54,13 +44,9 @@
 	};
 
 	__overrides__ {
-		ready_pin = <&chipcap2>, "interrupts:0",
-			    <&chipcap2_pins>, "brcm,pins:0";
-		low_pin = <&chipcap2>, "interrupts:8",
-			  <&chipcap2_pins>, "brcm,pins:4";
-		high_pin = <&chipcap2>, "interrupts:16",
-			   <&chipcap2_pins>, "brcm,pins:8";
-		reg_pin = <&chipcap2_reg>, "gpio:4",
-			  <&chipcap2_pins>, "brcm,pins:12";
+		ready_pin = <&chipcap2>, "interrupts:0";
+		low_pin = <&chipcap2>, "interrupts:8";
+		high_pin = <&chipcap2>, "interrupts:16";
+		reg_pin = <&chipcap2_reg>, "gpio:4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/dacberry400-overlay.dts
+++ b/arch/arm/boot/dts/overlays/dacberry400-overlay.dts
@@ -25,16 +25,6 @@
 	};
 
 	fragment@2 {
-		target = <&gpio>;
-		__overlay__ {
-			codec_rst: codec-rst {
-				brcm,pins = <26>;
-				brcm,function = <1>;
-			};
-		};
-	};
-
-	fragment@3 {
 		target = <&i2c1>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -58,7 +48,7 @@
 		};
 	};
 
-	fragment@4 {
+	fragment@3 {
 		target = <&sound>;
 		__overlay__ {
 			compatible = "osaelectronics,dacberry400";

--- a/arch/arm/boot/dts/overlays/draws-overlay.dts
+++ b/arch/arm/boot/dts/overlays/draws-overlay.dts
@@ -176,10 +176,6 @@
                 brcm,pull = <1>;
             };
 
-            aic3204_gpio: aic3204_gpio {
-                brcm,pins = <26>;
-            };
-
             sc16is752_irq: sc16is752_irq {
                 brcm,pins = <17>;
                 brcm,function = <0>;

--- a/arch/arm/boot/dts/overlays/gpio-poweroff-overlay.dts
+++ b/arch/arm/boot/dts/overlays/gpio-poweroff-overlay.dts
@@ -16,19 +16,8 @@
 		};
 	};
 
-	fragment@1 {
-		target = <&gpio>;
-		__overlay__ {
-			power_ctrl_pins: power_ctrl_pins {
-				brcm,pins = <26>;
-				brcm,function = <1>; // out
-			};
-		};
-	};
-
 	__overrides__ {
-		gpiopin =       <&power_ctrl>,"gpios:4",
-				<&power_ctrl_pins>,"brcm,pins:0";
+		gpiopin =       <&power_ctrl>,"gpios:4";
 		active_low =    <&power_ctrl>,"gpios:8";
 		input =         <&power_ctrl>,"input?";
 		export =        <&power_ctrl>,"export?";

--- a/arch/arm/boot/dts/overlays/mcp23s17-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp23s17-overlay.dts
@@ -103,6 +103,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi0-0-int-gpio parameter */
+				pinctrl-0 = <&spi0_0_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -124,6 +126,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi0-1-int-gpio parameter */
+				pinctrl-0 = <&spi0_1_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -145,6 +149,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi1-0-int-gpio parameter */
+				pinctrl-0 = <&spi1_0_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -166,6 +172,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi1-1-int-gpio parameter */
+				pinctrl-0 = <&spi1_1_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -187,6 +195,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi1-2-int-gpio parameter */
+				pinctrl-0 = <&spi1_2_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -208,6 +218,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi2-0-int-gpio parameter */
+				pinctrl-0 = <&spi2_0_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -229,6 +241,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi2-1-int-gpio parameter */
+				pinctrl-0 = <&spi2_1_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -250,6 +264,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi2-2-int-gpio parameter */
+				pinctrl-0 = <&spi2_2_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -271,6 +287,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi0-0-int-gpio parameter */
+				pinctrl-0 = <&spi0_0_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -292,6 +310,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi0-1-int-gpio parameter */
+				pinctrl-0 = <&spi0_1_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -313,6 +333,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi1-0-int-gpio parameter */
+				pinctrl-0 = <&spi1_0_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -334,6 +356,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi1-1-int-gpio parameter */
+				pinctrl-0 = <&spi1_1_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -355,6 +379,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi1-2-int-gpio parameter */
+				pinctrl-0 = <&spi1_2_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -376,6 +402,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi2-0-int-gpio parameter */
+				pinctrl-0 = <&spi2_0_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -397,6 +425,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi2-1-int-gpio parameter */
+				pinctrl-0 = <&spi2_1_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};
@@ -418,6 +448,8 @@
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi2-2-int-gpio parameter */
+				pinctrl-0 = <&spi2_2_int_pins>;
+				pinctrl-names = "default";
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/mcp23s17-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp23s17-overlay.dts
@@ -91,15 +91,15 @@
 		target = <&spi0>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s08_00: mcp23s08@0 {
 				compatible = "microchip,mcp23s08";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi0-0-present parameter */
-     				reg = <0>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi0-0-present parameter */
+				reg = <0>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi0-0-int-gpio parameter */
@@ -112,15 +112,15 @@
 		target = <&spi0>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s08_01: mcp23s08@1 {
 				compatible = "microchip,mcp23s08";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi0-1-present parameter */
-     				reg = <1>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi0-1-present parameter */
+				reg = <1>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi0-1-int-gpio parameter */
@@ -133,15 +133,15 @@
 		target = <&spi1>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s08_10: mcp23s08@0 {
 				compatible = "microchip,mcp23s08";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi1-0-present parameter */
-     				reg = <0>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi1-0-present parameter */
+				reg = <0>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi1-0-int-gpio parameter */
@@ -154,15 +154,15 @@
 		target = <&spi1>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s08_11: mcp23s08@1 {
 				compatible = "microchip,mcp23s08";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi1-1-present parameter */
-     				reg = <1>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi1-1-present parameter */
+				reg = <1>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi1-1-int-gpio parameter */
@@ -175,15 +175,15 @@
 		target = <&spi1>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s08_12: mcp23s08@2 {
 				compatible = "microchip,mcp23s08";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi1-2-present parameter */
-     				reg = <2>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi1-2-present parameter */
+				reg = <2>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi1-2-int-gpio parameter */
@@ -196,15 +196,15 @@
 		target = <&spi2>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s08_20: mcp23s08@0 {
 				compatible = "microchip,mcp23s08";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi2-0-present parameter */
-     				reg = <0>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi2-0-present parameter */
+				reg = <0>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi2-0-int-gpio parameter */
@@ -217,15 +217,15 @@
 		target = <&spi2>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s08_21: mcp23s08@1 {
 				compatible = "microchip,mcp23s08";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi2-1-present parameter */
-     				reg = <1>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi2-1-present parameter */
+				reg = <1>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi2-1-int-gpio parameter */
@@ -238,15 +238,15 @@
 		target = <&spi2>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s08_22: mcp23s08@2 {
 				compatible = "microchip,mcp23s08";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi2-2-present parameter */
-     				reg = <2>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi2-2-present parameter */
+				reg = <2>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s08-spi2-2-int-gpio parameter */
@@ -259,15 +259,15 @@
 		target = <&spi0>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s17_00: mcp23s17@0 {
 				compatible = "microchip,mcp23s17";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi0-0-present parameter */
-     				reg = <0>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi0-0-present parameter */
+				reg = <0>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi0-0-int-gpio parameter */
@@ -280,15 +280,15 @@
 		target = <&spi0>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s17_01: mcp23s17@1 {
 				compatible = "microchip,mcp23s17";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi0-1-present parameter */
-     				reg = <1>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi0-1-present parameter */
+				reg = <1>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi0-1-int-gpio parameter */
@@ -301,15 +301,15 @@
 		target = <&spi1>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s17_10: mcp23s17@0 {
 				compatible = "microchip,mcp23s17";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi1-0-present parameter */
-     				reg = <0>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi1-0-present parameter */
+				reg = <0>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi1-0-int-gpio parameter */
@@ -322,15 +322,15 @@
 		target = <&spi1>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s17_11: mcp23s17@1 {
 				compatible = "microchip,mcp23s17";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi1-1-present parameter */
-     				reg = <1>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi1-1-present parameter */
+				reg = <1>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi1-1-int-gpio parameter */
@@ -343,15 +343,15 @@
 		target = <&spi1>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s17_12: mcp23s17@2 {
 				compatible = "microchip,mcp23s17";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi1-2-present parameter */
-     				reg = <2>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi1-2-present parameter */
+				reg = <2>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi1-2-int-gpio parameter */
@@ -364,15 +364,15 @@
 		target = <&spi2>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s17_20: mcp23s17@0 {
 				compatible = "microchip,mcp23s17";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi2-0-present parameter */
-     				reg = <0>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi2-0-present parameter */
+				reg = <0>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi2-0-int-gpio parameter */
@@ -385,15 +385,15 @@
 		target = <&spi2>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s17_21: mcp23s17@1 {
 				compatible = "microchip,mcp23s17";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi2-1-present parameter */
-     				reg = <1>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi2-1-present parameter */
+				reg = <1>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi2-1-int-gpio parameter */
@@ -406,15 +406,15 @@
 		target = <&spi2>;
 		__dormant__ {
 			status = "okay";
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			mcp23s17_22: mcp23s17@2 {
 				compatible = "microchip,mcp23s17";
-  				gpio-controller;
-  				#gpio-cells = <2>;
-    				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi2-2-present parameter */
-     				reg = <2>;
-    				spi-max-frequency = <500000>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi2-2-present parameter */
+				reg = <2>;
+				spi-max-frequency = <500000>;
 				status = "okay";
 				#interrupt-cells=<2>;
 				interrupts = <0 2>;  /* 1st word overwritten by mcp23s17-spi2-2-int-gpio parameter */

--- a/arch/arm/boot/dts/overlays/sunfounder-pipower3-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sunfounder-pipower3-overlay.dts
@@ -28,17 +28,7 @@
 			};
 		};
 	};
-	fragment@3 {
-		target = <&gpio>;
-		__overlay__ {
-			power_ctrl_pins: power_ctrl_pins {
-				brcm,pins = <26>;
-				brcm,function = <1>; // out
-			};
-		};
-	};
 	__overrides__ {
-		poweroff_pin =	<&power_ctrl>,"gpios:4",
-						<&power_ctrl_pins>,"brcm,pins:0";
+		poweroff_pin =	<&power_ctrl>,"gpios:4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/tinylcd35-overlay.dts
+++ b/arch/arm/boot/dts/overlays/tinylcd35-overlay.dts
@@ -50,14 +50,6 @@
 	fragment@3 {
 		target = <&gpio>;
 		__overlay__ {
-			tinylcd35_pins: tinylcd35_pins {
-				brcm,pins = <25 24 18>;
-				brcm,function = <1>; /* out */
-			};
-			tinylcd35_ts_pins: tinylcd35_ts_pins {
-				brcm,pins = <5>;
-				brcm,function = <0>; /* in */
-			};
 			keypad_pins: keypad_pins {
 				brcm,pins = <4 17 22 23 27>;
 				brcm,function = <0>; /* in */
@@ -76,10 +68,6 @@
 			tinylcd35: tinylcd35@0{
 				compatible = "neosec,tinylcd";
 				reg = <0>;
-				pinctrl-names = "default";
-				pinctrl-0 = <&tinylcd35_pins>,
-					    <&tinylcd35_ts_pins>;
-
 				spi-max-frequency = <48000000>;
 				rotate = <270>;
 				fps = <20>;
@@ -211,8 +199,7 @@
 		fps =        <&tinylcd35>,"fps:0";
 		debug =      <&tinylcd35>,"debug:0";
 		touch =      <&tinylcd35_ts>,"status";
-		touchgpio =  <&tinylcd35_ts_pins>,"brcm,pins:0",
-			     <&tinylcd35_ts>,"interrupts:0",
+		touchgpio =  <&tinylcd35_ts>,"interrupts:0",
 			     <&tinylcd35_ts>,"pendown-gpio:4";
 		xohms =      <&tinylcd35_ts>,"ti,x-plate-ohms;0";
 		rtc-pcf =    <0>,"=5";

--- a/arch/arm/boot/dts/overlays/udrc-overlay.dts
+++ b/arch/arm/boot/dts/overlays/udrc-overlay.dts
@@ -115,10 +115,6 @@
                 brcm,function = <1>;
                 brcm,pull = <1>;
             };
-
-            aic3204_gpio: aic3204_gpio {
-                brcm,pins = <26>;
-            };
         };
     };
 

--- a/arch/arm/boot/dts/overlays/vc4-kms-dsi-lt070me05000-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dsi-lt070me05000-overlay.dts
@@ -32,6 +32,8 @@
 				compatible    = "jdi,lt070me05000";
 				status        = "okay";
 				reg           = <0>;
+				pinctrl-0     = <&lt070me05000_pins>;
+				pinctrl-names = "default";
 				reset-gpios   = <&gpio 17 1>;   // LCD RST
 				enable-gpios  = <&gpio 4 0>;    // LCD Enable
 				dcdc-en-gpios = <&gpio 5 0>;    // LCD DC-DC Enable

--- a/arch/arm/boot/dts/overlays/vec-gpio-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vec-gpio-pi5-overlay.dts
@@ -12,7 +12,7 @@
 		target = <&rp1_vec>;
 		rp1vec_overlay: __overlay__ {
 			pinctrl-names = "default";
-			pinctrl-0 = <&rp1vec_ch0pins>, <&rp1vec_ch0pins>;
+			pinctrl-0 = <&rp1vec_ch0pins &rp1vec_ch0pins>;
 		};
 	};
 


### PR DESCRIPTION
In order to prevent confusing problems where pin configuration is not
be applied, an upcoming change to the overlaycheck utility will add a
check that all added pin groups are in some way referenced by the
overlay. Before that can be done, it is necessary to ensure that all
existing overlays pass that test.

This patch modifies some overlays by adding the required "pinctrl-0"
properties, but for others that are just setting GPIOs to inputs and
outputs, where those same GPIOs are declared by <name>-gpios properties,
it is better to drop the pin groups and let the GPIO subsystem set up
the GPIOs as required. Removing this duplication may be helpful in the
future should we ever decide to enable the exclusive GPIO vs pinctrl
locking (.strict in struct pinmux_ops).

See: https://forums.raspberrypi.com/viewtopic.php?t=393742