### PR TITLE
drm/vc4: plane: TPZ scaling modes cannot reduce lbm size when alpha-less 

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -812,11 +812,8 @@ static unsigned int vc4_lbm_channel_size(const struct drm_plane_state *state,
 					 unsigned int channel)
 {
 	const struct drm_format_info *info = state->fb->format;
-	const struct vc4_plane_state *vc4_state = to_vc4_plane_state(state);
-	unsigned int channels_scaled = 0;
 	unsigned int components, words, wpc;
 	unsigned int width, lines;
-	unsigned int i;
 
 	/* LBM is meant to use the smaller of source or dest width, but there
 	 * is a issue with UV scaling that the size required for the second
@@ -842,13 +839,6 @@ static unsigned int vc4_lbm_channel_size(const struct drm_plane_state *state,
 	words = width * wpc * components;
 
 	lines = DIV_ROUND_UP(words, 128 / info->hsub);
-
-	for (i = 0; i < 2; i++)
-		if (vc4_state->y_scaling[channel] != VC4_SCALING_NONE)
-			channels_scaled++;
-
-	if (channels_scaled == 1)
-		lines = lines / 2;
 
 	return lines;
 }

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -802,7 +802,10 @@ static unsigned int vc4_lbm_components(const struct drm_plane_state *state,
 	if (info->is_yuv)
 		return channel ? 2 : 1;
 
-	if (info->has_alpha)
+	if (vc4_state->y_scaling[channel] == VC4_SCALING_TPZ)
+		return 4;
+
+	if (info->has_alpha && state->alpha == DRM_BLEND_ALPHA_OPAQUE)
 		return 4;
 
 	return 3;
@@ -832,9 +835,6 @@ static unsigned int vc4_lbm_channel_size(const struct drm_plane_state *state,
 	components = vc4_lbm_components(state, channel);
 	if (!components)
 		return 0;
-
-	if (state->alpha != DRM_BLEND_ALPHA_OPAQUE && info->has_alpha)
-		components -= 1;
 
 	words = width * wpc * components;
 


### PR DESCRIPTION
Spec says "Note that there is not an extra mode to save memory for alpha-less formats" in the TPZ section.

Curently, if first plane is RGB888 and scaled down (TPZ) a second plane will corrupt the LBM and result in garbage

I've also folded in the modification to components to the function as it seems misplaced
