### PR TITLE
dtoverlays: Add rgb666 option to mipi-dbi-spi

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3607,6 +3607,7 @@ Params:
 
         width                   Panel width in pixels (required)
         height                  Panel height in pixels (required)
+        rgb666                  Drive the display as RGB666 instead of RGB565.
         width-mm                Panel width in mm
         height-mm               Panel height in mm
         x-offset                Panel x-offset in controller RAM

--- a/arch/arm/boot/dts/overlays/mipi-dbi-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mipi-dbi-spi-overlay.dts
@@ -149,6 +149,7 @@
 
 		width         = <&timing>, "hactive:0";
 		height        = <&timing>, "vactive:0";
+		rgb666        = <&panel>, "format=b6x2g6x2r6x2";
 		x-offset      = <&timing>, "hback-porch:0";
 		y-offset      = <&timing>, "vback-porch:0";
 		clock-frequency = <&timing>, "clock-frequency:0";


### PR DESCRIPTION
The option to drive RGB666 displays was added in 6.11 with commit aa61186951cc ("drm/tiny: panel-mipi-dbi: Support the pixel format property")

Add the option to the overlay (the default remains rgb565)