### PR TITLE
arm64: dts: Remove the Pi5 FIRMWARE_UPDATED guards

### DIFF
--- a/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
@@ -4,25 +4,6 @@
 #include "bcm2712.dtsi"
 
 / {
-#ifndef FIRMWARE_UPDATED
-	#size-cells = <1>;
-
-	reserved-memory {
-		ranges;
-		#address-cells = <2>;
-		#size-cells = <1>;
-
-		atf@0 {
-			reg = <0x0 0x0 0x80000>;
-		};
-
-		linux,cma {
-			size = <0x4000000>; /* 64MB */
-			alloc-ranges = <0x0 0x00000000 0x40000000>;
-		};
-	};
-#endif
-
 	arm-pmu {
 		compatible = "arm,cortex-a76-pmu";
 		interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL_HIGH>,

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
@@ -17,11 +17,7 @@
 	/* Will be filled by the bootloader */
 	memory@0 {
 		device_type = "memory";
-#ifndef FIRMWARE_UPDATED
-		reg = <0 0 0x28000000>;
-#else
 		reg = <0 0 0 0x28000000>;
-#endif
 	};
 
 	leds: leds {

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
@@ -16,11 +16,7 @@
 	/* Will be filled by the bootloader */
 	memory@0 {
 		device_type = "memory";
-#ifndef FIRMWARE_UPDATED
-		reg = <0 0 0x28000000>;
-#else
 		reg = <0 0 0 0x28000000>;
-#endif
 	};
 
 	leds: leds {

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -297,11 +297,7 @@ pciex4: &pcie2 { };
 		compatible = "raspberrypi,bootloader-config", "nvmem-rmem";
 		#address-cells = <1>;
 		#size-cells = <1>;
-#ifndef FIRMWARE_UPDATED
-		reg = <0x0 0x0 0x0>;
-#else
 		reg = <0x0 0x0 0x0 0x0>;
-#endif
 		no-map;
 		status = "disabled";
 	};
@@ -313,11 +309,7 @@ pciex4: &pcie2 { };
 		compatible = "raspberrypi,bootloader-public-key", "nvmem-rmem";
 		#address-cells = <1>;
 		#size-cells = <1>;
-#ifndef FIRMWARE_UPDATED
-		reg = <0x0 0x0 0x0>;
-#else
 		reg = <0x0 0x0 0x0 0x0>;
-#endif
 		no-map;
 		status = "disabled";
 	};

--- a/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
@@ -608,11 +608,7 @@
 
 	hvs: hvs@107c580000 {
 		compatible = "brcm,bcm2712-hvs";
-#ifndef FIRMWARE_UPDATED
-		reg = <0x10 0x7c580000 0x1a000>;
-#else
 		reg = <0x10 0x7c580000 0x0 0x1a000>;
-#endif
 		interrupt-parent = <&disp_intr>;
 		interrupts = <2>, <9>, <16>;
 		interrupt-names = "ch0-eof", "ch1-eof", "ch2-eof";


### PR DESCRIPTION
The Raspberry Pi firmware has assumed that top level #size-cells value in dtb files is 1. As a result, the dts source files have had to use 32-bit sizes, making it awkward to declare memory regions of 4GB or larger, requiring them to be split into chunks. This primarily affects Pi 5, where the dts source has made use of conditional compilation to choose either 64-bit or 32-bit sizes, based on the presence or absence of the defined cpp symbol FIRMWARE_UPDATED.

As of EEPROM release pieeprom-2025-02-11, the firmware has read and made use of the actual #size-cells value declared in the dtb, allowing the use of 64-bit sizes. Remove the conditional sections, retaining the 64-bit size values.