### PR TITLE
overlays: Fix the rs485 support in uart[2345]

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5325,6 +5325,8 @@ Params: ctsrts                  Enable CTS/RTS on GPIOs 2-3 (default off)
                                 drive the OE pin of an RS485 transceiver (i.e.
                                 MAX3078E); also enables the UARTx ctsrts
                                 parameter, as RTS is required (default off).
+        rs485_full_duplex       When RS485 mode is enabled, enables receiving of
+                                data while sending data (default off)
         rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
                                 line from active-high (default) to active-low.
         rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
@@ -5349,6 +5351,8 @@ Params: ctsrts                  Enable CTS/RTS on GPIOs 6-7 (default off)
                                 drive the OE pin of an RS485 transceiver (i.e.
                                 MAX3078E); also enables the UARTx ctsrts
                                 parameter, as RTS is required (default off).
+        rs485_full_duplex       When RS485 mode is enabled, enables receiving of
+                                data while sending data (default off)
         rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
                                 line from active-high (default) to active-low.
         rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
@@ -5373,6 +5377,8 @@ Params: ctsrts                  Enable CTS/RTS on GPIOs 10-11 (default off)
                                 drive the OE pin of an RS485 transceiver (i.e.
                                 MAX3078E); also enables the UARTx ctsrts
                                 parameter, as RTS is required (default off).
+        rs485_full_duplex       When RS485 mode is enabled, enables receiving of
+                                data while sending data (default off)
         rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
                                 line from active-high (default) to active-low.
         rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
@@ -5397,6 +5403,8 @@ Params: ctsrts                  Enable CTS/RTS on GPIOs 14-15 (default off)
                                 drive the OE pin of an RS485 transceiver (i.e.
                                 MAX3078E); also enables the UARTx ctsrts
                                 parameter, as RTS is required (default off).
+        rs485_full_duplex       When RS485 mode is enabled, enables receiving of
+                                data while sending data (default off)
         rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
                                 line from active-high (default) to active-low.
         rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in

--- a/arch/arm/boot/dts/overlays/uart2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart2-overlay.dts
@@ -19,9 +19,9 @@
 		};
 	};
 
-	rs485: fragment@2 {
+	fragment@2 {
 		target = <&uart2>;
-		__dormant__ {
+		rs485: __dormant__ {
 			linux,rs485-enabled-at-boot-time;
 			rs485-rts-delay = <0 0>;
 		};
@@ -30,7 +30,7 @@
 	__overrides__ {
 		ctsrts = <0>,"=1";
 		rs485 = <0>,"=1=2";
-		rs485_invert_rts = <&rs485>,"rs485-rts-active-low";
+		rs485_invert_rts = <&rs485>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
 		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";
 	};

--- a/arch/arm/boot/dts/overlays/uart2-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart2-overlay.dts
@@ -30,6 +30,7 @@
 	__overrides__ {
 		ctsrts = <0>,"=1";
 		rs485 = <0>,"=1=2";
+		rs485_full_duplex = <&rs485>,"rs485-rx-during-tx?";
 		rs485_invert_rts = <&rs485>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
 		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";

--- a/arch/arm/boot/dts/overlays/uart3-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart3-overlay.dts
@@ -19,9 +19,9 @@
 		};
 	};
 
-	rs485: fragment@2 {
+	fragment@2 {
 		target = <&uart3>;
-		__dormant__ {
+		rs485: __dormant__ {
 			linux,rs485-enabled-at-boot-time;
 			rs485-rts-delay = <0 0>;
 		};
@@ -30,7 +30,7 @@
 	__overrides__ {
 		ctsrts = <0>,"=1";
 		rs485 = <0>,"=1=2";
-		rs485_invert_rts = <&rs485>,"rs485-rts-active-low";
+		rs485_invert_rts = <&rs485>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
 		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";
 	};

--- a/arch/arm/boot/dts/overlays/uart3-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart3-overlay.dts
@@ -30,6 +30,7 @@
 	__overrides__ {
 		ctsrts = <0>,"=1";
 		rs485 = <0>,"=1=2";
+		rs485_full_duplex = <&rs485>,"rs485-rx-during-tx?";
 		rs485_invert_rts = <&rs485>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
 		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";

--- a/arch/arm/boot/dts/overlays/uart4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart4-overlay.dts
@@ -30,6 +30,7 @@
 	__overrides__ {
 		ctsrts = <0>,"=1";
 		rs485 = <0>,"=1=2";
+		rs485_full_duplex = <&rs485>,"rs485-rx-during-tx?";
 		rs485_invert_rts = <&rs485>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
 		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";

--- a/arch/arm/boot/dts/overlays/uart4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart4-overlay.dts
@@ -19,9 +19,9 @@
 		};
 	};
 
-	rs485: fragment@2 {
+	fragment@2 {
 		target = <&uart4>;
-		__dormant__ {
+		rs485: __dormant__ {
 			linux,rs485-enabled-at-boot-time;
 			rs485-rts-delay = <0 0>;
 		};
@@ -30,7 +30,7 @@
 	__overrides__ {
 		ctsrts = <0>,"=1";
 		rs485 = <0>,"=1=2";
-		rs485_invert_rts = <&rs485>,"rs485-rts-active-low";
+		rs485_invert_rts = <&rs485>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
 		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";
 	};

--- a/arch/arm/boot/dts/overlays/uart5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart5-overlay.dts
@@ -19,9 +19,9 @@
 		};
 	};
 
-	rs485: fragment@2 {
+	fragment@2 {
 		target = <&uart5>;
-		__dormant__ {
+		rs485: __dormant__ {
 			linux,rs485-enabled-at-boot-time;
 			rs485-rts-delay = <0 0>;
 		};
@@ -30,7 +30,7 @@
 	__overrides__ {
 		ctsrts = <0>,"=1";
 		rs485 = <0>,"=1=2";
-		rs485_invert_rts = <&rs485>,"rs485-rts-active-low";
+		rs485_invert_rts = <&rs485>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
 		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";
 	};

--- a/arch/arm/boot/dts/overlays/uart5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart5-overlay.dts
@@ -30,6 +30,7 @@
 	__overrides__ {
 		ctsrts = <0>,"=1";
 		rs485 = <0>,"=1=2";
+		rs485_full_duplex = <&rs485>,"rs485-rx-during-tx?";
 		rs485_invert_rts = <&rs485>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&rs485>, "rs485-rts-delay:0";
 		rs485_rts_off_delay = <&rs485>, "rs485-rts-delay:4";


### PR DESCRIPTION
Errors in the uart{2,3,4,5} overlays cause some parameters to have no effect. Fix the problem by moving the rs485 label and by declaring rs485-rts-active-low as a boolean.

See: https://forums.raspberrypi.com/viewtopic.php?p=2353808
See: #6820
Fixes: 9d79fae257c7 ("Add RS485 mode support for UART2, UART3, UART4, and UART5.")