### PR TITLE
media: i2c: imx477: Fix uninitialized bug when restarting camera

### DIFF
--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -1599,8 +1599,8 @@ static int imx477_start_streaming(struct imx477 *imx477)
 
 	/* Apply default values of current mode */
 	reg_list = &imx477->mode->reg_list;
-	cci_multi_reg_write(imx477->regmap, reg_list->regs,
-			    reg_list->num_of_regs, &ret);
+	ret = cci_multi_reg_write(imx477->regmap, reg_list->regs,
+				  reg_list->num_of_regs, NULL);
 	if (ret) {
 		dev_err(&client->dev, "%s failed to set mode\n", __func__);
 		return ret;


### PR DESCRIPTION
In imx477_start_streaming, when restarting before the auto-suspend timeout (5s) so that the common register config write was skipped, "ret" was used uninitialized, leading to intermittent failure.

(Since return values are fully checked after the common write, there is anyway no need to propagate ret to mode-specific write.)