### PR TITLE
drm/v3d: Add module parameter to enable MMU error logging

### DIFF
--- a/drivers/gpu/drm/v3d/v3d_drv.c
+++ b/drivers/gpu/drm/v3d/v3d_drv.c
@@ -47,6 +47,10 @@ module_param_named(super_pages, super_pages, bool, 0400);
 MODULE_PARM_DESC(super_pages, "Enable/Disable Super Pages support.");
 #endif
 
+bool debug_mmu;
+module_param(debug_mmu, bool, 0644);
+MODULE_PARM_DESC(debug_mmu, "Enable/Disable MMU error logging");
+
 static int v3d_get_param_ioctl(struct drm_device *dev, void *data,
 			       struct drm_file *file_priv)
 {

--- a/drivers/gpu/drm/v3d/v3d_drv.h
+++ b/drivers/gpu/drm/v3d/v3d_drv.h
@@ -589,6 +589,7 @@ int v3d_submit_cpu_ioctl(struct drm_device *dev, void *data,
 			 struct drm_file *file_priv);
 
 /* v3d_irq.c */
+extern bool debug_mmu;
 int v3d_irq_init(struct v3d_dev *v3d);
 void v3d_irq_enable(struct v3d_dev *v3d);
 void v3d_irq_disable(struct v3d_dev *v3d);

--- a/drivers/gpu/drm/v3d/v3d_irq.c
+++ b/drivers/gpu/drm/v3d/v3d_irq.c
@@ -183,7 +183,7 @@ v3d_hub_irq(int irq, void *arg)
 			"GMP",
 		};
 		const char *client = "?";
-		static int logged_error;
+		static bool logged_error;
 
 		V3D_WRITE(V3D_MMU_CTL, V3D_READ(V3D_MMU_CTL));
 
@@ -193,16 +193,18 @@ v3d_hub_irq(int irq, void *arg)
 				client = v3d41_axi_ids[axi_id];
 		}
 
-		if (!logged_error)
-		dev_err(v3d->drm.dev, "MMU error from client %s (%d) at 0x%llx%s%s%s\n",
-			client, axi_id, (long long)vio_addr,
-			((intsts & V3D_HUB_INT_MMU_WRV) ?
-			 ", write violation" : ""),
-			((intsts & V3D_HUB_INT_MMU_PTI) ?
-			 ", pte invalid" : ""),
-			((intsts & V3D_HUB_INT_MMU_CAP) ?
-			 ", cap exceeded" : ""));
-		logged_error = 1;
+		if (!logged_error || debug_mmu) {
+			dev_err(v3d->drm.dev, "MMU error from client %s (%d) at 0x%llx%s%s%s\n",
+				client, axi_id, (long long)vio_addr,
+				((intsts & V3D_HUB_INT_MMU_WRV) ?
+				 ", write violation" : ""),
+				((intsts & V3D_HUB_INT_MMU_PTI) ?
+				 ", pte invalid" : ""),
+				((intsts & V3D_HUB_INT_MMU_CAP) ?
+				 ", cap exceeded" : ""));
+		}
+		logged_error = true;
+
 		status = IRQ_HANDLED;
 	}
 


### PR DESCRIPTION
Currently, downstream carries a commit that suppresses all but the first MMU error. While this avoids excessive logging, MMU error messages are often valuable for developers during debugging. At the moment, getting this information requires rebuilding the kernel with that commit reverted.

This PR proposes adding a new module parameter (downstream-only) to allow MMU error logging to be enabled on demand, avoiding the need to recompile the kernel.

As an alternative, we could simply revert the commit “drm/v3d: Suppress all but the first MMU error”, since MMU errors are no longer as frequent as they once were.

I'd appreciate to hear your thoughts about the preferred approach.