### PR TITLE
serial: pl011: Initialise the hrtimers for RS485 on pl011_axi

### DIFF
--- a/drivers/tty/serial/amba-pl011.c
+++ b/drivers/tty/serial/amba-pl011.c
@@ -3148,6 +3148,11 @@ static int pl011_axi_probe(struct platform_device *pdev)
 
 	r = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 
+	hrtimer_setup(&uap->trigger_start_tx, pl011_trigger_start_tx, CLOCK_MONOTONIC,
+		      HRTIMER_MODE_REL);
+	hrtimer_setup(&uap->trigger_stop_tx, pl011_trigger_stop_tx, CLOCK_MONOTONIC,
+		      HRTIMER_MODE_REL);
+
 	ret = pl011_setup_port(&pdev->dev, uap, r, portnr);
 	if (ret)
 		return ret;


### PR DESCRIPTION
pl011_axi_probe was missing the equivlent hrtimer initialisation from commit 2c1fd53af21b ("serial: amba-pl011: Fix RTS handling in RS485 mode") and commit 8cb44188b986 ("serial: amba-pl011: Switch to use hrtimer_setup()") resulting in the kernel blowing up as soon as pl011_rs485_stop_tx tried to use them.

Add the hrtimer initialisation.

Fixes: 120c89e1051a ("serial: pl011: rp1 uart support")