### PR TITLE
usbnet: limit max_mtu based on device's hard_mtu

### DIFF
--- a/drivers/net/usb/usbnet.c
+++ b/drivers/net/usb/usbnet.c
@@ -1797,9 +1797,12 @@ usbnet_probe (struct usb_interface *udev, const struct usb_device_id *prod)
 		if ((dev->driver_info->flags & FLAG_NOARP) != 0)
 			net->flags |= IFF_NOARP;
 
-		/* maybe the remote can't receive an Ethernet MTU */
-		if (net->mtu > (dev->hard_mtu - net->hard_header_len))
-			net->mtu = dev->hard_mtu - net->hard_header_len;
+		if (net->max_mtu > (dev->hard_mtu - net->hard_header_len))
+			net->max_mtu = dev->hard_mtu - net->hard_header_len;
+
+		if (net->mtu > net->max_mtu)
+			net->mtu = net->max_mtu;
+
 	} else if (!info->in || !info->out)
 		status = usbnet_get_endpoints (dev, udev);
 	else {


### PR DESCRIPTION
This backport of https://git.kernel.org/netdev/net/c/c7159e960f14 will allow running Raspberry Pi OS kernel in QEMU using passt usb networking, without requiring throttling.

The initial problem is described at https://gitlab.com/qemu-project/qemu/-/issues/3268 and https://bugs.passt.top/attachment.cgi?bugid=189.

-----

From: Laurent Vivier \<lvivier working in redhat.com\>
Date: Mon, 19 Jan 2026 08:55:18 +0100

The usbnet driver initializes net->max_mtu to ETH_MAX_MTU before calling the device's bind() callback. When the bind() callback sets dev->hard_mtu based the device's actual capability (from CDC Ethernet's wMaxSegmentSize descriptor), max_mtu is never updated to reflect this hardware limitation).

This allows userspace (DHCP or IPv6 RA) to configure MTU larger than the device can handle, leading to silent packet drops when the backend sends packet exceeding the device's buffer size.

Fix this by limiting net->max_mtu to the device's hard_mtu after the bind callback returns.

See https://gitlab.com/qemu-project/qemu/-/issues/3268 and
    https://bugs.passt.top/attachment.cgi?bugid=189

Fixes: f77f0aee4da4 ("net: use core MTU range checking in USB NIC drivers")

Link: https://bugs.passt.top/show_bug.cgi?id=189
Reviewed-by: Stefano Brivio \<sbrivio working in redhat.com\>
Link: https://patch.msgid.link/20260119075518.2774373-1-lvivier@redhat.com