### PR TITLE
media: pisp_be: Add support for the NV12MT_10_COL128 format

### DIFF
--- a/drivers/media/platform/raspberrypi/pisp_be/pisp_be.c
+++ b/drivers/media/platform/raspberrypi/pisp_be/pisp_be.c
@@ -1103,8 +1103,9 @@ static void pispbe_set_plane_params(struct v4l2_format *f,
 		 */
 		const unsigned int align =
 			p->bytesperline ? fmt->min_align : fmt->opt_align;
+		unsigned int pixel_grouping = fmt->pixel_grouping ?: 1;
 
-		bpl = (f->fmt.pix_mp.width * fmt->bit_depth) >> 3;
+		bpl = ((f->fmt.pix_mp.width / pixel_grouping) * fmt->bit_depth) >> 3;
 		bpl = ALIGN(max(p->bytesperline, bpl), align);
 
 		plane_size = bpl * f->fmt.pix_mp.height *

--- a/drivers/media/platform/raspberrypi/pisp_be/pisp_be_formats.h
+++ b/drivers/media/platform/raspberrypi/pisp_be/pisp_be_formats.h
@@ -19,6 +19,7 @@ struct pisp_be_format {
 	unsigned int opt_align;
 	unsigned int min_align;
 	unsigned int bit_depth;
+	unsigned int pixel_grouping;
 	/* 0P3 factor for plane sizing */
 	unsigned int plane_factor[PISPBE_MAX_PLANES];
 	unsigned int num_planes;
@@ -237,6 +238,18 @@ static const struct pisp_be_format supported_formats[] = {
 		.bit_depth	    = 8,
 		.plane_factor	    = { P3(1), P3(1), P3(1) },
 		.num_planes	    = 3,
+		.colorspace_mask    = V4L2_COLORSPACE_MASK_ALL_SRGB,
+		.colorspace_default = V4L2_COLORSPACE_SMPTE170M,
+	},
+	{
+		.fourcc		    = V4L2_PIX_FMT_NV12MT_10_COL128,
+		.opt_align	    = 128,
+		.min_align	    = 128,
+		/* 3 pixels packed into 32bits */
+		.bit_depth	    = 32,
+		.pixel_grouping	    = 3,
+		.plane_factor	    = { P3(1), P3(0.5) },
+		.num_planes	    = 2,
 		.colorspace_mask    = V4L2_COLORSPACE_MASK_ALL_SRGB,
 		.colorspace_default = V4L2_COLORSPACE_SMPTE170M,
 	},


### PR DESCRIPTION
The 10bit column format from the HEVC codec is supported by the PISP BE, so add the configuration.
It requires some additional handling as it packs 3 10bit samples into 32 bits, with 2 bits of padding. Alignment and calculating strides is therefore not quite as straightforward.