### PR TITLE
overlays: Add a pins_none parameter to audremap

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -875,6 +875,8 @@ Params: swap_lr                 Reverse the channel allocation, which will also
                                 for other purposes)
         pins_40_45              Select GPIOs 40 & 45 (don't use on BCM2711 - the
                                 pins are on different controllers)
+        pins_none               Effectively disable audio, useful if the pins
+                                are needed for something else.
 
 
 Name:   audremap-pi5

--- a/arch/arm/boot/dts/overlays/audremap-overlay.dts
+++ b/arch/arm/boot/dts/overlays/audremap-overlay.dts
@@ -34,5 +34,8 @@
 		pins_40_45 = <&frag0>,"brcm,pins:0=40",
 		             <&frag0>,"brcm,pins:4=45",
 			     <&frag0>,"brcm,function:0=4";
+		pins_none =  <0>,"-1",
+			     <&frag0>,"brcm,pins?=1",
+			     <&frag0>,"brcm,function?=1";
 	};
 };


### PR DESCRIPTION
Add the option to release the audio pins, effectively disabling audio usage.

See: https://github.com/raspberrypi/rpi-eeprom/issues/801