### PR TITLE
gpio: pwm: Fix return type of pwm_gpio_set

### DIFF
--- a/drivers/gpio/gpio-pwm.c
+++ b/drivers/gpio/gpio-pwm.c
@@ -27,14 +27,14 @@ static int pwm_gpio_get_direction(struct gpio_chip *gc, unsigned int off)
 	return GPIO_LINE_DIRECTION_OUT;
 }
 
-static void pwm_gpio_set(struct gpio_chip *gc, unsigned int off, int val)
+static int pwm_gpio_set(struct gpio_chip *gc, unsigned int off, int val)
 {
 	struct pwm_gpio *pwm_gpio = gpiochip_get_data(gc);
 	struct pwm_state state;
 
 	pwm_get_state(pwm_gpio->pwm[off], &state);
 	state.duty_cycle = val ? state.period : 0;
-	pwm_apply_might_sleep(pwm_gpio->pwm[off], &state);
+	return pwm_apply_might_sleep(pwm_gpio->pwm[off], &state);
 }
 
 static int pwm_gpio_parse_dt(struct pwm_gpio *pwm_gpio,


### PR DESCRIPTION
Fixes the following build failure:

drivers/gpio/gpio-pwm.c:108:26: error: assignment to 'int (*)(struct gpio_chip *, unsigned int,  int)' from incompatible pointer type 'void (*)(struct gpio_chip *, unsigned int,  int)' [-Wincompatible-pointer-types]
  108 |         pwm_gpio->gc.set = pwm_gpio_set;
      |                          ^
drivers/gpio/gpio-pwm.c:30:13: note: 'pwm_gpio_set' declared here
   30 | static void pwm_gpio_set(struct gpio_chip *gc, unsigned int off, int val)
      |             ^~~~~~~~~~~~

Fixes: 8b95d76cd44e ("drivers/gpio: Add a driver that wraps the PWM API as a GPIO controller")