### PR TITLE
Add dtparm to enable bootloader eeprom on CM4S

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
@@ -243,6 +243,13 @@
 		brcm,pins = <>;
 		brcm,function = <>;
 	};
+
+	enable_eeprom_hog: enable_eeprom_hog {
+		gpio-hog;
+		gpios = <57 GPIO_ACTIVE_HIGH>;
+		output-low;
+		status = "disabled";
+	};
 };
 
 /* Permanently disable HDMI1 */
@@ -289,5 +296,7 @@ i2c_csi_dsi0: &i2c0 {
 		act_led_gpio = <&led_act>,"gpios:4";
 		act_led_activelow = <&led_act>,"gpios:8";
 		act_led_trigger = <&led_act>,"linux,default-trigger";
+
+		enable_eeprom = <&enable_eeprom_hog>,"status";
 	};
 };

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -236,6 +236,10 @@ Params:
                                 compatible devices (default "on"). See also
                                 "tx_lpi_timer". Pi3B+ only.
 
+        enable_eeprom           Set to "on" to enable the onboard bootloader
+                                EEPROM by driving GPIO 57 low
+                                (default "off"). CM4S only.
+
         eth_downshift_after     Set the number of auto-negotiation failures
                                 after which the 1000Mbps modes are disabled.
                                 Legal values are 2, 3, 4, 5 and 0, where


### PR DESCRIPTION
In order to make rpi-eeprom-update work on CM4S too, the eeprom needs to be enabled, besides the CM4 specific extras (already outlined by rpi-eeprom-update).

Add a GPIO hog on GPIO 57 (active high, output-low) to enable the onboard bootloader EEPROM on CM4S. The hog is disabled by default and can be activated via dtparam=enable_eeprom=on in config.txt.

Patch for rpi-eeprom-update: https://github.com/raspberrypi/rpi-eeprom/pull/806
