### PR TITLE
overlays: Add rs485 support to uart[0-4]-pi5

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5367,6 +5367,20 @@ Name:   uart0-pi5
 Info:   Enable uart 0 on GPIOs 14-15. Pi 5 only.
 Load:   dtoverlay=uart0-pi5,<param>
 Params: ctsrts                  Enable CTS/RTS on GPIOs 16-17 (default off)
+        rs485                   Enable RS485 mode for using the RTS line to
+                                drive the OE pin of an RS485 transceiver (i.e.
+                                MAX3078E); also enables the UARTx ctsrts
+                                parameter, as RTS is required (default off).
+        rs485_full_duplex       When RS485 mode is enabled, enables receiving of
+                                data while sending data (default off)
+        rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
+                                line from active-high (default) to active-low.
+        rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission starting
+                                and the RTS line being asserted (default 0).
+        rs485_rts_off_delay     When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission ending
+                                and the RTS line being deasserted (default 0).
 
 
 Name:   uart1
@@ -5381,6 +5395,20 @@ Name:   uart1-pi5
 Info:   Enable uart 1 on GPIOs 0-1. Pi 5 only.
 Load:   dtoverlay=uart1-pi5,<param>
 Params: ctsrts                  Enable CTS/RTS on GPIOs 2-3 (default off)
+        rs485                   Enable RS485 mode for using the RTS line to
+                                drive the OE pin of an RS485 transceiver (i.e.
+                                MAX3078E); also enables the UARTx ctsrts
+                                parameter, as RTS is required (default off).
+        rs485_full_duplex       When RS485 mode is enabled, enables receiving of
+                                data while sending data (default off)
+        rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
+                                line from active-high (default) to active-low.
+        rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission starting
+                                and the RTS line being asserted (default 0).
+        rs485_rts_off_delay     When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission ending
+                                and the RTS line being deasserted (default 0).
 
 
 Name:   uart2
@@ -5407,6 +5435,20 @@ Name:   uart2-pi5
 Info:   Enable uart 2 on GPIOs 4-5. Pi 5 only.
 Load:   dtoverlay=uart2-pi5,<param>
 Params: ctsrts                  Enable CTS/RTS on GPIOs 6-7 (default off)
+        rs485                   Enable RS485 mode for using the RTS line to
+                                drive the OE pin of an RS485 transceiver (i.e.
+                                MAX3078E); also enables the UARTx ctsrts
+                                parameter, as RTS is required (default off).
+        rs485_full_duplex       When RS485 mode is enabled, enables receiving of
+                                data while sending data (default off)
+        rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
+                                line from active-high (default) to active-low.
+        rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission starting
+                                and the RTS line being asserted (default 0).
+        rs485_rts_off_delay     When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission ending
+                                and the RTS line being deasserted (default 0).
 
 
 Name:   uart3
@@ -5433,6 +5475,20 @@ Name:   uart3-pi5
 Info:   Enable uart 3 on GPIOs 8-9. Pi 5 only.
 Load:   dtoverlay=uart3-pi5,<param>
 Params: ctsrts                  Enable CTS/RTS on GPIOs 10-11 (default off)
+        rs485                   Enable RS485 mode for using the RTS line to
+                                drive the OE pin of an RS485 transceiver (i.e.
+                                MAX3078E); also enables the UARTx ctsrts
+                                parameter, as RTS is required (default off).
+        rs485_full_duplex       When RS485 mode is enabled, enables receiving of
+                                data while sending data (default off)
+        rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
+                                line from active-high (default) to active-low.
+        rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission starting
+                                and the RTS line being asserted (default 0).
+        rs485_rts_off_delay     When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission ending
+                                and the RTS line being deasserted (default 0).
 
 
 Name:   uart4
@@ -5459,6 +5515,20 @@ Name:   uart4-pi5
 Info:   Enable uart 4 on GPIOs 12-13. Pi 5 only.
 Load:   dtoverlay=uart4-pi5,<param>
 Params: ctsrts                  Enable CTS/RTS on GPIOs 14-15 (default off)
+        rs485                   Enable RS485 mode for using the RTS line to
+                                drive the OE pin of an RS485 transceiver (i.e.
+                                MAX3078E); also enables the UARTx ctsrts
+                                parameter, as RTS is required (default off).
+        rs485_full_duplex       When RS485 mode is enabled, enables receiving of
+                                data while sending data (default off)
+        rs485_invert_rts        When RS485 mode is enabled, inverts the RTS
+                                line from active-high (default) to active-low.
+        rs485_rts_on_delay      When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission starting
+                                and the RTS line being asserted (default 0).
+        rs485_rts_off_delay     When RS485 mode is enabled, sets the delay (in
+                                milliseconds) between data transmission ending
+                                and the RTS line being deasserted (default 0).
 
 
 Name:   uart5

--- a/arch/arm/boot/dts/overlays/uart0-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart0-pi5-overlay.dts
@@ -15,7 +15,8 @@
 
 	__overrides__ {
 		ctsrts = <&frag0>,"pinctrl-0:4=",<&uart0_ctsrts_pins>;
-		rs485 = <&frag0>,"pinctrl-0:4=",<&uart0_ctsrts_pins>, <&frag0>,"linux,rs485-enabled-at-boot-time?";
+		rs485 = <&frag0>,"pinctrl-0:4=",<&uart0_ctsrts_pins>,
+				<&frag0>,"linux,rs485-enabled-at-boot-time?";
 		rs485_full_duplex = <&frag0>,"rs485-rx-during-tx?";
 		rs485_invert_rts = <&frag0>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&frag0>,"rs485-rts-delay:0";

--- a/arch/arm/boot/dts/overlays/uart0-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart0-pi5-overlay.dts
@@ -9,10 +9,16 @@
 		frag0: __overlay__ {
 			status = "okay";
 			pinctrl-0 = <&uart0_pins>;
+			rs485-rts-delay = <0 0>;
 		};
 	};
 
 	__overrides__ {
 		ctsrts = <&frag0>,"pinctrl-0:4=",<&uart0_ctsrts_pins>;
+		rs485 = <&frag0>,"pinctrl-0:4=",<&uart0_ctsrts_pins>, <&frag0>,"linux,rs485-enabled-at-boot-time?";
+		rs485_full_duplex = <&frag0>,"rs485-rx-during-tx?";
+		rs485_invert_rts = <&frag0>,"rs485-rts-active-low?";
+		rs485_rts_on_delay = <&frag0>,"rs485-rts-delay:0";
+		rs485_rts_off_delay = <&frag0>,"rs485-rts-delay:4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/uart1-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart1-pi5-overlay.dts
@@ -15,7 +15,8 @@
 
 	__overrides__ {
 		ctsrts = <&frag0>,"pinctrl-0:4=",<&uart1_ctsrts_pins>;
-		rs485 = <&frag0>,"pinctrl-0:4=",<&uart1_ctsrts_pins>, <&frag0>,"linux,rs485-enabled-at-boot-time?";
+		rs485 = <&frag0>,"pinctrl-0:4=",<&uart1_ctsrts_pins>,
+				<&frag0>,"linux,rs485-enabled-at-boot-time?";
 		rs485_full_duplex = <&frag0>,"rs485-rx-during-tx?";
 		rs485_invert_rts = <&frag0>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&frag0>,"rs485-rts-delay:0";

--- a/arch/arm/boot/dts/overlays/uart1-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart1-pi5-overlay.dts
@@ -9,10 +9,16 @@
 		frag0: __overlay__ {
 			status = "okay";
 			pinctrl-0 = <&uart1_pins>;
+			rs485-rts-delay = <0 0>;
 		};
 	};
 
 	__overrides__ {
 		ctsrts = <&frag0>,"pinctrl-0:4=",<&uart1_ctsrts_pins>;
+		rs485 = <&frag0>,"pinctrl-0:4=",<&uart1_ctsrts_pins>, <&frag0>,"linux,rs485-enabled-at-boot-time?";
+		rs485_full_duplex = <&frag0>,"rs485-rx-during-tx?";
+		rs485_invert_rts = <&frag0>,"rs485-rts-active-low?";
+		rs485_rts_on_delay = <&frag0>,"rs485-rts-delay:0";
+		rs485_rts_off_delay = <&frag0>,"rs485-rts-delay:4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/uart2-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart2-pi5-overlay.dts
@@ -15,7 +15,8 @@
 
 	__overrides__ {
 		ctsrts = <&frag0>,"pinctrl-0:4=",<&uart2_ctsrts_pins>;
-		rs485 = <&frag0>,"pinctrl-0:4=",<&uart2_ctsrts_pins>, <&frag0>,"linux,rs485-enabled-at-boot-time?";
+		rs485 = <&frag0>,"pinctrl-0:4=",<&uart2_ctsrts_pins>,
+				<&frag0>,"linux,rs485-enabled-at-boot-time?";
 		rs485_full_duplex = <&frag0>,"rs485-rx-during-tx?";
 		rs485_invert_rts = <&frag0>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&frag0>,"rs485-rts-delay:0";

--- a/arch/arm/boot/dts/overlays/uart2-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart2-pi5-overlay.dts
@@ -9,10 +9,16 @@
 		frag0: __overlay__ {
 			status = "okay";
 			pinctrl-0 = <&uart2_pins>;
+			rs485-rts-delay = <0 0>;
 		};
 	};
 
 	__overrides__ {
 		ctsrts = <&frag0>,"pinctrl-0:4=",<&uart2_ctsrts_pins>;
+		rs485 = <&frag0>,"pinctrl-0:4=",<&uart2_ctsrts_pins>, <&frag0>,"linux,rs485-enabled-at-boot-time?";
+		rs485_full_duplex = <&frag0>,"rs485-rx-during-tx?";
+		rs485_invert_rts = <&frag0>,"rs485-rts-active-low?";
+		rs485_rts_on_delay = <&frag0>,"rs485-rts-delay:0";
+		rs485_rts_off_delay = <&frag0>,"rs485-rts-delay:4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/uart3-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart3-pi5-overlay.dts
@@ -9,10 +9,16 @@
 		frag0: __overlay__ {
 			status = "okay";
 			pinctrl-0 = <&uart3_pins>;
+			rs485-rts-delay = <0 0>;
 		};
 	};
 
 	__overrides__ {
 		ctsrts = <&frag0>,"pinctrl-0:4=",<&uart3_ctsrts_pins>;
+		rs485 = <&frag0>,"pinctrl-0:4=",<&uart3_ctsrts_pins>, <&frag0>,"linux,rs485-enabled-at-boot-time?";
+		rs485_full_duplex = <&frag0>,"rs485-rx-during-tx?";
+		rs485_invert_rts = <&frag0>,"rs485-rts-active-low?";
+		rs485_rts_on_delay = <&frag0>,"rs485-rts-delay:0";
+		rs485_rts_off_delay = <&frag0>,"rs485-rts-delay:4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/uart3-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart3-pi5-overlay.dts
@@ -15,7 +15,8 @@
 
 	__overrides__ {
 		ctsrts = <&frag0>,"pinctrl-0:4=",<&uart3_ctsrts_pins>;
-		rs485 = <&frag0>,"pinctrl-0:4=",<&uart3_ctsrts_pins>, <&frag0>,"linux,rs485-enabled-at-boot-time?";
+		rs485 = <&frag0>,"pinctrl-0:4=",<&uart3_ctsrts_pins>,
+				<&frag0>,"linux,rs485-enabled-at-boot-time?";
 		rs485_full_duplex = <&frag0>,"rs485-rx-during-tx?";
 		rs485_invert_rts = <&frag0>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&frag0>,"rs485-rts-delay:0";

--- a/arch/arm/boot/dts/overlays/uart4-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart4-pi5-overlay.dts
@@ -15,7 +15,8 @@
 
 	__overrides__ {
 		ctsrts = <&frag0>,"pinctrl-0:4=",<&uart4_ctsrts_pins>;
-		rs485 = <&frag0>,"pinctrl-0:4=",<&uart4_ctsrts_pins>, <&frag0>,"linux,rs485-enabled-at-boot-time?";
+		rs485 = <&frag0>,"pinctrl-0:4=",<&uart4_ctsrts_pins>,
+				<&frag0>,"linux,rs485-enabled-at-boot-time?";
 		rs485_full_duplex = <&frag0>,"rs485-rx-during-tx?";
 		rs485_invert_rts = <&frag0>,"rs485-rts-active-low?";
 		rs485_rts_on_delay = <&frag0>,"rs485-rts-delay:0";

--- a/arch/arm/boot/dts/overlays/uart4-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/uart4-pi5-overlay.dts
@@ -9,10 +9,16 @@
 		frag0: __overlay__ {
 			status = "okay";
 			pinctrl-0 = <&uart4_pins>;
+			rs485-rts-delay = <0 0>;
 		};
 	};
 
 	__overrides__ {
 		ctsrts = <&frag0>,"pinctrl-0:4=",<&uart4_ctsrts_pins>;
+		rs485 = <&frag0>,"pinctrl-0:4=",<&uart4_ctsrts_pins>, <&frag0>,"linux,rs485-enabled-at-boot-time?";
+		rs485_full_duplex = <&frag0>,"rs485-rx-during-tx?";
+		rs485_invert_rts = <&frag0>,"rs485-rts-active-low?";
+		rs485_rts_on_delay = <&frag0>,"rs485-rts-delay:0";
+		rs485_rts_off_delay = <&frag0>,"rs485-rts-delay:4";
 	};
 };


### PR DESCRIPTION
Add RS-485 support to UARTs 0 to 4 of Pi 5.