### PR TITLE
mm/mempolicy: Remove CONFIG_TMPFS from mpol_parse_str in headers

### DIFF
--- a/include/linux/mempolicy.h
+++ b/include/linux/mempolicy.h
@@ -160,10 +160,7 @@ static inline void check_highest_zone(enum zone_type k)
 int do_migrate_pages(struct mm_struct *mm, const nodemask_t *from,
 		     const nodemask_t *to, int flags);
 
-
-#ifdef CONFIG_TMPFS
 extern int mpol_parse_str(char *str, struct mempolicy **mpol);
-#endif
 
 extern void mpol_to_str(char *buffer, int maxlen, struct mempolicy *pol);
 


### PR DESCRIPTION
Commit 24993d71a571 ("mm/numa: Allow override of kernel's default NUMA policy") removed the #ifdef CONFIG_TMPFS guard from the function definition for mpol_parse_str, but not for the prototype. This lead to build errors/ warnings should CONFIG_TMPFS be disabled.

Fixes: 24993d71a571 ("mm/numa: Allow override of kernel's default NUMA policy")

See report in https://forums.raspberrypi.com/viewtopic.php?t=396256