### PR TITLE
overlays: README: add Pi4 and CM4 to eee dtparam description

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -234,7 +234,7 @@ Params:
 
         eee                     Enable Energy Efficient Ethernet support for
                                 compatible devices (default "on"). See also
-                                "tx_lpi_timer". Pi3B+ only.
+                                "tx_lpi_timer". Pi3B+, Pi4 and CM4 only.
 
         enable_eeprom           Set to "on" to enable the onboard bootloader
                                 EEPROM by driving GPIO 57 low


### PR DESCRIPTION
The eee dtparam is also available on Pi4 and CM4 via the __overrides__ in bcm2711-rpi-ds.dtsi. Update the description accordingly.