### PR TITLE
overlays: mcp2515: Add support for spi3 and spi5

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3393,9 +3393,9 @@ Params: s08-spi<n>-<m>-present  4-bit integer, bitmap indicating MCP23S08
 
 
 Name:   mcp2515
-Info:   Configures the MCP2515 CAN controller on spi0/1/2
-        For devices on spi1 or spi2, the interfaces should be enabled
-        with one of the spi1-1/2/3cs and/or spi2-1/2/3cs overlays.
+Info:   Configures the MCP2515 CAN controller on spi0/1/2/3/5
+        For devices on spi1, spi2, spi3 or spi5, the interfaces should be enabled
+        with one of the spi<n>-1/2/3cs overlays.
 Load:   dtoverlay=mcp2515,<param>=<val>
 Params: spi<n>-<m>              Configure device at spi<n>, cs<m>
                                 (boolean, required)

--- a/arch/arm/boot/dts/overlays/mcp2515-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp2515-overlay.dts
@@ -67,6 +67,34 @@
 	};
 
 	fragment@8 {
+		target-path = "spi3/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@9 {
+		target-path = "spi3/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@10 {
+		target-path = "spi5/spidev@0";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@11 {
+		target-path = "spi5/spidev@1";
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@12 {
 		target = <&gpio>;
 		__overlay__ {
 			mcp2515_pins: mcp2515_pins {
@@ -76,7 +104,7 @@
 		};
 	};
 
-	fragment@9 {
+	fragment@13 {
 		target-path = "/clocks";
 		__overlay__ {
 			clk_mcp2515_osc: mcp2515-osc {
@@ -87,7 +115,7 @@
 		};
 	};
 
-	mcp2515_frag: fragment@10 {
+	mcp2515_frag: fragment@14 {
 		target = <&spi0>;
 		__overlay__ {
 			status = "okay";
@@ -118,6 +146,7 @@
 			<&mcp2515>, "reg:0=1",
 			<&mcp2515_pins>, "name=mcp2515_spi0_1_pins",
 			<&clk_mcp2515_osc>, "name=mcp2515-spi0-1-osc";
+
 		spi1-0 = <0>, "+2",
 			<&mcp2515_frag>, "target:0=", <&spi1>,
 			<&mcp2515>, "reg:0=0",
@@ -133,6 +162,7 @@
 			<&mcp2515>, "reg:0=2",
 			<&mcp2515_pins>, "name=mcp2515_spi1_2_pins",
 			<&clk_mcp2515_osc>, "name=mcp2515-spi1-2-osc";
+
 		spi2-0 = <0>, "+5",
 			<&mcp2515_frag>, "target:0=", <&spi2>,
 			<&mcp2515>, "reg:0=0",
@@ -148,6 +178,29 @@
 			<&mcp2515>, "reg:0=2",
 			<&mcp2515_pins>, "name=mcp2515_spi2_2_pins",
 			<&clk_mcp2515_osc>, "name=mcp2515-spi2-2-osc";
+
+		spi3-0 = <0>, "+8",
+			<&mcp2515_frag>, "target:0=", <&spi3>,
+			<&mcp2515>, "reg:0=0",
+			<&mcp2515_pins>, "name=mcp2515_spi3_0_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi3-0-osc";
+		spi3-1 = <0>, "+9",
+			<&mcp2515_frag>, "target:0=", <&spi3>,
+			<&mcp2515>, "reg:0=1",
+			<&mcp2515_pins>, "name=mcp2515_spi3_1_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi3-1-osc";
+
+		spi5-0 = <0>, "+10",
+			<&mcp2515_frag>, "target:0=", <&spi5>,
+			<&mcp2515>, "reg:0=0",
+			<&mcp2515_pins>, "name=mcp2515_spi5_0_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi5-0-osc";
+		spi5-1 = <0>, "+11",
+			<&mcp2515_frag>, "target:0=", <&spi5>,
+			<&mcp2515>, "reg:0=1",
+			<&mcp2515_pins>, "name=mcp2515_spi5_1_pins",
+			<&clk_mcp2515_osc>, "name=mcp2515-spi5-1-osc";
+
 		oscillator = <&clk_mcp2515_osc>, "clock-frequency:0";
 		speed = <&mcp2515>, "spi-max-frequency:0";
 		interrupt = <&mcp2515_pins>, "brcm,pins:0",


### PR DESCRIPTION
This PR extends the `mcp2515` overlay to support the `spi3` and `spi5` buses, which are available on newer Raspberry Pi models like the Pi 4 and Pi 5.

Previously, the overlay was hardcoded to only support SPI0, SPI1, and SPI2. This update:
- Adds the necessary `__dormant__` fragments to disable the default user-space `spidev` drivers on buses 3 and 5.
- Updates the `__overrides__` routing logic so the MCP2515 can be easily targeted via `config.txt` (e.g., `dtoverlay=mcp2515,spi3-0,interrupt=25`).
- Updates the README to reflect the newly available parameters.

Tested and verified working on a Raspberry Pi 5.