### PR TITLE
rpi-6.18: overlays: pcf857x: Add support for pca857x, pca967x and max732x

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3860,10 +3860,19 @@ Params: addr                    I2C address of expander. Default
                                 depends on model selected.
         i2c-bus                 Supports all the standard I2C bus selection
                                 parameters - see "dtoverlay -h i2c-bus"
+        max7328                 Select the Maxim MAX7328 (8 bit)
+        max7329                 Select the Maxim MAX7329 (8 bit)
         pcf8574                 Select the NXP PCF8574 (8 bit)
         pcf8574a                Select the NXP PCF8574A (8 bit)
         pcf8575                 Select the NXP PCF8575 (16 bit)
         pca8574                 Select the NXP PCA8574 (8 bit)
+        pca8575                 Select the NXP PCA8575 (16 bit)
+        pca9670                 Select the NXP PCA9670 (8 bit)
+        pca9671                 Select the NXP PCA9671 (16 bit)
+        pca9672                 Select the NXP PCA9672 (8 bit)
+        pca9673                 Select the NXP PCA9673 (16 bit)
+        pca9674                 Select the NXP PCA9674 (8 bit)
+        pca9675                 Select the NXP PCA9675 (16 bit)
 
 
 Name:   pcie-32bit-dma

--- a/arch/arm/boot/dts/overlays/pcf857x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pcf857x-overlay.dts
@@ -25,10 +25,19 @@
 	};
 
 	__overrides__ {
+		max7328  = <&pcf857x>,"compatible=maxim,max7328",  <&pcf857x>,"reg:0=0x20";
+		max7329  = <&pcf857x>,"compatible=maxim,max7329",  <&pcf857x>,"reg:0=0x38";
 		pcf8574  = <&pcf857x>,"compatible=nxp,pcf8574",  <&pcf857x>,"reg:0=0x20";
 		pcf8574a = <&pcf857x>,"compatible=nxp,pcf8574a", <&pcf857x>,"reg:0=0x38";
 		pcf8575  = <&pcf857x>,"compatible=nxp,pcf8575",  <&pcf857x>,"reg:0=0x20";
 		pca8574  = <&pcf857x>,"compatible=nxp,pca8574",  <&pcf857x>,"reg:0=0x20";
+		pca8575  = <&pcf857x>,"compatible=nxp,pca8575",  <&pcf857x>,"reg:0=0x20";
+		pca9670  = <&pcf857x>,"compatible=nxp,pca9670",  <&pcf857x>,"reg:0=0x20";
+		pca9671  = <&pcf857x>,"compatible=nxp,pca9671",  <&pcf857x>,"reg:0=0x20";
+		pca9672  = <&pcf857x>,"compatible=nxp,pca9672",  <&pcf857x>,"reg:0=0x20";
+		pca9673  = <&pcf857x>,"compatible=nxp,pca9673",  <&pcf857x>,"reg:0=0x28";
+		pca9674  = <&pcf857x>,"compatible=nxp,pca9674",  <&pcf857x>,"reg:0=0x20";
+		pca9675  = <&pcf857x>,"compatible=nxp,pca9675",  <&pcf857x>,"reg:0=0x20";
 		addr = <&pcf857x>,"reg:0";
 	};
 };


### PR DESCRIPTION
Extend the pcf857x overlay to support all the chipsets, which are also compatible.