### PR TITLE
fixup! ARM: dts: Select the PL011 platform driver

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm270x.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm270x.dtsi
@@ -239,7 +239,7 @@
 };
 
 &uart0 {
-	compatible = "arm,pl011-axi";
+	compatible = "arm,pl011-axi", "arm,pl011", "arm,primecell";
 	/* Enable CTS bug workaround */
 	cts-event-workaround;
 };

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
@@ -510,29 +510,29 @@ i2c_vc: &i2c0 {};
 };
 
 &uart0 {
-	compatible = "arm,pl011-axi";
+	compatible = "arm,pl011-axi", "arm,pl011", "arm,primecell";
 };
 
 &uart2 {
-	compatible = "arm,pl011-axi";
+	compatible = "arm,pl011-axi", "arm,pl011", "arm,primecell";
 	pinctrl-0 = <&uart2_pins>;
 	pinctrl-names = "default";
 };
 
 &uart3 {
-	compatible = "arm,pl011-axi";
+	compatible = "arm,pl011-axi", "arm,pl011", "arm,primecell";
 	pinctrl-0 = <&uart3_pins>;
 	pinctrl-names = "default";
 };
 
 &uart4 {
-	compatible = "arm,pl011-axi";
+	compatible = "arm,pl011-axi", "arm,pl011", "arm,primecell";
 	pinctrl-0 = <&uart4_pins>;
 	pinctrl-names = "default";
 };
 
 &uart5 {
-	compatible = "arm,pl011-axi";
+	compatible = "arm,pl011-axi", "arm,pl011", "arm,primecell";
 	pinctrl-0 = <&uart5_pins>;
 	pinctrl-names = "default";
 };

--- a/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
@@ -430,7 +430,7 @@
 };
 
 &uart10 {
-	compatible = "arm,pl011-axi";
+	compatible = "arm,pl011-axi", "arm,pl011", "arm,primecell";
 };
 
 &aon_intr {


### PR DESCRIPTION
Retain the original compatible strings as fallbacks.

See: https://github.com/raspberrypi/linux/pull/7023