### PR TITLE
drm/v3d: Increase the autosuspend delay

### DIFF
--- a/drivers/gpu/drm/v3d/v3d_drv.c
+++ b/drivers/gpu/drm/v3d/v3d_drv.c
@@ -423,7 +423,7 @@ static int v3d_platform_drm_probe(struct platform_device *pdev)
 
 	v3d_init_hw_state(v3d);
 
-	pm_runtime_set_autosuspend_delay(dev, 50);
+	pm_runtime_set_autosuspend_delay(dev, 100);
 	pm_runtime_use_autosuspend(dev);
 
 	ret = drm_dev_register(drm, 0);


### PR DESCRIPTION
The downstream implementation of power management for v3d used a 100ms delay and it has been tested for many years with success. Use the same delay with the runtime PM implementation.

Although the shorter 50ms delay is not problematic in RPi 5, it can cause occasional GPU resets on RPi 4 during intensive workloads, due to the overhead of negotiating with the ASB bridge during frequent power domain transitions.

---

I observed this issue while running some high definition traces in RPi 4. Considering that the downstream implementation used to use a 100ms delay, I believe it would be safer to keep the delay that was already widely tested. With a 100ms delay, I wasn't able to reproduce the GPU resets anymore.