### PR TITLE
spi: rp2040-gpio-bridge: Add CRYPTO_HASH2 dependency

### DIFF
--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -875,7 +875,7 @@ config SPI_RB4XX
 
 config SPI_RP2040_GPIO_BRIDGE
 	tristate "Raspberry Pi RP2040 GPIO Bridge"
-	depends on I2C && SPI && GPIOLIB
+	depends on I2C && SPI && GPIOLIB && CRYPTO_HASH2
 	help
 	  Support for the Raspberry Pi RP2040 GPIO bridge.
 


### PR DESCRIPTION
The driver uses a couple of `crypto_shash_*` functions, which are not always available, potentially leading to build errors:

```
arm-linux-ld: drivers/spi/spi-rp2040-gpio-bridge.o: in function `rp2040_gbdg_block_hash':
spi-rp2040-gpio-bridge.c:(.text+0x274): undefined reference to `crypto_shash_update'
spi-rp2040-gpio-bridge.c:(.text+0x2c4): undefined reference to `crypto_shash_update'
spi-rp2040-gpio-bridge.c:(.text+0x2e4): undefined reference to `crypto_shash_final'
spi-rp2040-gpio-bridge.c:(.text+0x2ec): undefined reference to `crypto_shash_digest'
spi-rp2040-gpio-bridge.c:(.text+0x2fc): undefined reference to `crypto_shash_update'
arm-linux-ld: drivers/spi/spi-rp2040-gpio-bridge.o: in function `rp2040_gbdg_probe':
spi-rp2040-gpio-bridge.c:(.text+0x510): undefined reference to `crypto_alloc_shash'
```

Fixes: fe24eda35d31 ("spi: Add a driver for the RPI RP2040 GPIO bridge")