### PR TITLE
drm/vc4: txp: fix writeback dimension checks and normalize rotation

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_drv.h
+++ b/drivers/gpu/drm/vc4/vc4_drv.h
@@ -1087,6 +1087,7 @@ extern struct platform_driver vc4_vec_driver;
 
 /* vc4_txp.c */
 extern struct platform_driver vc4_txp_driver;
+void vc4_txp_connector_reset(struct drm_connector *connector);
 
 /* vc4_irq.c */
 void vc4_irq_enable(struct drm_device *dev);

--- a/drivers/gpu/drm/vc4/vc4_txp.c
+++ b/drivers/gpu/drm/vc4/vc4_txp.c
@@ -390,11 +390,27 @@ vc4_txp_connector_detect(struct drm_connector *connector, bool force)
 	return connector_status_connected;
 }
 
+void vc4_txp_connector_reset(struct drm_connector *connector)
+{
+	uint64_t rotation = DRM_MODE_ROTATE_0;
+
+	drm_atomic_helper_connector_reset(connector);
+
+	if (connector->state) {
+		if (connector->rotation_property)
+			drm_object_property_get_default_value(&connector->base,
+							      connector->rotation_property,
+							      &rotation);
+
+		connector->state->rotation = rotation;
+	}
+}
+
 static const struct drm_connector_funcs vc4_txp_connector_funcs = {
 	.detect = vc4_txp_connector_detect,
 	.fill_modes = drm_helper_probe_single_connector_modes,
 	.destroy = drm_connector_cleanup,
-	.reset = drm_atomic_helper_connector_reset,
+	.reset = vc4_txp_connector_reset,
 	.atomic_duplicate_state = drm_atomic_helper_connector_duplicate_state,
 	.atomic_destroy_state = drm_atomic_helper_connector_destroy_state,
 };

--- a/drivers/gpu/drm/vc4/vc4_txp.c
+++ b/drivers/gpu/drm/vc4/vc4_txp.c
@@ -261,11 +261,11 @@ static int vc4_txp_connector_atomic_check(struct drm_connector *conn,
 
 	fb = conn_state->writeback_job->fb;
 	if ((conn_state->rotation == DRM_MODE_ROTATE_0 &&
-	     fb->width != crtc_state->mode.hdisplay &&
-	     fb->height != crtc_state->mode.vdisplay) ||
+	    (fb->width != crtc_state->mode.hdisplay ||
+	     fb->height != crtc_state->mode.vdisplay)) ||
 	    (conn_state->rotation == (DRM_MODE_ROTATE_0 | DRM_MODE_TRANSPOSE) &&
-	     fb->width != crtc_state->mode.vdisplay &&
-	     fb->height != crtc_state->mode.hdisplay)) {
+	    (fb->width != crtc_state->mode.vdisplay ||
+	     fb->height != crtc_state->mode.hdisplay))) {
 		DRM_DEBUG_KMS("Invalid framebuffer size %ux%u vs mode %ux%u\n",
 			      fb->width, fb->height,
 			      crtc_state->mode.hdisplay, crtc_state->mode.vdisplay);


### PR DESCRIPTION
If the rotation value is 0, it can be compared to an accurate bitmask, thereby bypassing size validation; furthermore, frame buffer size validation is so inadequate that it cannot reliably filter out write buffers that are too small.

This results in a DMA OOB vulnerability on Raspberry Pi models prior to the 5 that lack an IOMMU, and I have successfully reproduced this vulnerability.

I tested this immediately by installing the Raspberry Pi OS 64-bit on a Raspberry Pi 4 Model B rev 1.2 using Imager.

This issue occurs on Raspberry Pi without IOMMU, and DMA OOB can be easily reproduced in any kernel version where vulnerable code exists, in addition to the kernel version I reproduced.



https://github.com/user-attachments/assets/afe597b1-a149-4546-9ce4-fe06337251a1



