### PR TITLE
staging: vc04_services: vc-sm-cma: fix integer overflow in vc_sm_cma_…

### DIFF
--- a/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
+++ b/drivers/staging/vc04_services/vc-sm-cma/vc_sm.c
@@ -40,6 +40,7 @@
 #include <linux/module.h>
 #include <linux/mm.h>
 #include <linux/of_device.h>
+#include <linux/overflow.h>
 #include <linux/platform_device.h>
 #include <linux/proc_fs.h>
 #include <linux/slab.h>
@@ -1263,6 +1264,8 @@ static int clean_invalid_contig_2d(const void __user *addr,
 				   const unsigned int cache_op)
 {
 	size_t i;
+	size_t last_block_offset;
+	size_t total_range;
 	void (*op_fn)(const void *start, const void *end);
 
 	if (!block_size) {
@@ -1270,11 +1273,27 @@ static int clean_invalid_contig_2d(const void __user *addr,
 		return -EINVAL;
 	}
 
+	if (!block_count)
+		return 0;
+
 	op_fn = cache_op_to_func(cache_op);
 	if (!op_fn)
 		return -EINVAL;
 
-	for (i = 0; i < block_count; i ++, addr += stride)
+	/*
+	 * Validate that the entire user-supplied address range falls
+	 * within userspace. Without this check, an attacker could
+	 * invoke cache maintenance operations on kernel addresses.
+	 */
+	if (check_mul_overflow((size_t)(block_count - 1), stride,
+			       &last_block_offset))
+		return -EOVERFLOW;
+	if (check_add_overflow(last_block_offset, block_size, &total_range))
+		return -EOVERFLOW;
+	if (!access_ok(addr, total_range))
+		return -EFAULT;
+
+	for (i = 0; i < block_count; i++, addr += stride)
 		op_fn(addr, addr + block_size);
 
 	return 0;
@@ -1292,9 +1311,13 @@ static int vc_sm_cma_clean_invalid2(unsigned int cmdnr, unsigned long arg)
 		       __func__, cmdnr);
 		return -EFAULT;
 	}
-	block = kmalloc(ioparam.op_count * sizeof(*block), GFP_KERNEL);
+
+	if (!ioparam.op_count)
+		return 0;
+
+	block = kmalloc_array(ioparam.op_count, sizeof(*block), GFP_KERNEL);
 	if (!block)
-		return -EFAULT;
+		return -ENOMEM;
 
 	if (copy_from_user(block, (void *)(arg + sizeof(ioparam)),
 			   ioparam.op_count * sizeof(*block)) != 0) {


### PR DESCRIPTION
This PR fixes two security issues in the VideoCore shared memory CMA
driver (vc-sm-cma), accessible via /dev/vc-sm-cma which is created
with mode 0666 (world-accessible, no authentication required).

Both bugs are in vc_sm_cma_clean_invalid2(), reachable via the
VC_SM_CMA_CMD_CLEAN_INVALID2 ioctl on 32-bit ARM kernels.

**Fix 1: Integer overflow in kmalloc size computation**
ioparam.op_count (user-controlled __u32) is multiplied by sizeof(*block)
without overflow protection. On 32-bit ARM this wraps, causing a small
heap allocation followed by out-of-bounds heap reads. Fixed by switching
to kmalloc_array().

**Fix 2: Missing address validation in cache maintenance operations**
clean_invalid_contig_2d() performs dmac_inv_range/dmac_clean_range/
dmac_flush_range on a user-supplied virtual address without access_ok()
validation. An unprivileged user can perform cache maintenance on
arbitrary kernel virtual addresses. Fixed by adding access_ok() with
overflow-safe range computation.

Both issues affect 32-bit Raspberry Pi kernels (RPi 1/2/3/Zero and
32-bit RPi 4/5 configurations).

Found through manual source code auditing.

Reported-by: Sebastián Alba Vives <sebasjosue84@gmail.com>
Signed-off-by: Sebastián Alba Vives <sebasjosue84@gmail.com>