### PR TITLE
Cleanup downstream lan78xx

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b-plus.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b-plus.dts
@@ -258,8 +258,6 @@
 };
 
 &eth_phy {
-	microchip,eee-enabled;
-	microchip,tx-lpi-timer = <600>; /* non-aggressive*/
 	microchip,downshift-after = <2>;
 };
 
@@ -285,8 +283,8 @@ i2c_csi_dsi0: &i2c0 {
 		pwr_led_activelow = <&led_pwr>,"gpios:8";
 		pwr_led_trigger = <&led_pwr>,"linux,default-trigger";
 
-		eee = <&eth_phy>,"microchip,eee-enabled?";
-		tx_lpi_timer = <&eth_phy>,"microchip,tx-lpi-timer:0";
+		eee = <&eth_phy>,"eee-broken-1000t!",
+		      <&eth_phy>,"eee-broken-100tx!";
 		eth_led0 = <&eth_phy>,"microchip,led-modes:0";
 		eth_led1 = <&eth_phy>,"microchip,led-modes:4";
 		eth_downshift_after = <&eth_phy>,"microchip,downshift-after:0";

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -233,8 +233,8 @@ Params:
         drm_fb2_vc4             Assign /dev/fb2 to the vc4 outputs
 
         eee                     Enable Energy Efficient Ethernet support for
-                                compatible devices (default "on"). See also
-                                "tx_lpi_timer". Pi3B+, Pi4, CM4, Pi5 and CM5.
+                                compatible devices (default "on").
+                                Pi3B+, Pi4, CM4, Pi5 and CM5.
 
         enable_eeprom           Set to "on" to enable the onboard bootloader
                                 EEPROM by driving GPIO 57 low
@@ -454,10 +454,6 @@ Params:
 
         suspend                 Make the power button trigger a suspend rather
                                 than a power-off (2712 only, default "off")
-
-        tx_lpi_timer            Set the delay in microseconds between going idle
-                                and entering the low power state (default 600).
-                                Requires EEE to be enabled - see "eee".
 
         uart0                   Set to "off" to disable uart0 (default "on")
 

--- a/drivers/net/usb/lan78xx.c
+++ b/drivers/net/usb/lan78xx.c
@@ -1960,7 +1960,6 @@ static const struct ethtool_ops lan78xx_ethtool_ops = {
 	.set_link_ksettings = lan78xx_set_link_ksettings,
 	.get_regs_len	= lan78xx_get_regs_len,
 	.get_regs	= lan78xx_get_regs,
-	.get_ts_info    = ethtool_op_get_ts_info,
 };
 
 static int lan78xx_init_mac_address(struct lan78xx_net *dev)

--- a/drivers/net/usb/lan78xx.c
+++ b/drivers/net/usb/lan78xx.c
@@ -2897,29 +2897,6 @@ static int lan78xx_phy_init(struct lan78xx_net *dev)
 		goto phylink_uninit;
 	}
 
-	if (of_property_read_bool(phydev->mdio.dev.of_node,
-				  "microchip,eee-enabled")) {
-		struct ethtool_keee edata;
-		memset(&edata, 0, sizeof(edata));
-
-		linkmode_set_bit(ETHTOOL_LINK_MODE_1000baseT_Full_BIT,
-			edata.advertised);
-		linkmode_set_bit(ETHTOOL_LINK_MODE_100baseT_Full_BIT,
-			edata.advertised);
-
-		edata.eee_enabled = true;
-		edata.tx_lpi_enabled = true;
-		if (of_property_read_u32(phydev->mdio.dev.of_node,
-					 "microchip,tx-lpi-timer",
-					 &edata.tx_lpi_timer))
-			edata.tx_lpi_timer = 600; /* non-aggressive */
-		rtnl_lock();
-		(void)lan78xx_set_eee(dev->net, &edata);
-		rtnl_unlock();
-
-		phy_support_eee(phydev);
-	}
-
 	ret = lan78xx_configure_leds_from_dt(dev, phydev);
 	if (ret < 0)
 		goto phylink_uninit;

--- a/drivers/net/usb/lan78xx.c
+++ b/drivers/net/usb/lan78xx.c
@@ -1818,34 +1818,15 @@ exit_pm_put:
 static int lan78xx_get_eee(struct net_device *net, struct ethtool_keee *edata)
 {
 	struct lan78xx_net *dev = netdev_priv(net);
-	u32 buf;
-	int ret;
 
-	ret = phylink_ethtool_get_eee(dev->phylink, edata);
-	if (ret < 0)
-		return ret;
-
-	ret = lan78xx_read_reg(dev, EEE_TX_LPI_REQ_DLY, &buf);
-	if (ret >= 0)
-		edata->tx_lpi_timer = buf;
-	else
-		edata->tx_lpi_timer = 0;
-
-	return 0;
+	return phylink_ethtool_get_eee(dev->phylink, edata);
 }
 
 static int lan78xx_set_eee(struct net_device *net, struct ethtool_keee *edata)
 {
 	struct lan78xx_net *dev = netdev_priv(net);
-	u32 buf;
-	int ret;
 
-	ret = phylink_ethtool_set_eee(dev->phylink, edata);
-	if (ret < 0)
-		return ret;
-
-	buf = (u32)edata->tx_lpi_timer;
-	return lan78xx_write_reg(dev, EEE_TX_LPI_REQ_DLY, buf);
+	return phylink_ethtool_set_eee(dev->phylink, edata);
 }
 
 static void lan78xx_get_drvinfo(struct net_device *net,


### PR DESCRIPTION
The downstream `microchip,eee-enabled` and `microchip,tx-lpi-timer` DT properties and the corresponding driver-side get/set_eee changes are superseded by Oleksij Rempel's proper phylink LPI integration that landed in 6.17 (673d455bbb1d). That series adds `mac_enable_tx_lpi/mac_disable_tx_lpi` callbacks, sets `eee_enabled_default = true` and `lpi_timer_default = 50`, so EEE works out of the box without any downstream driver patches.

This reverts both downstream driver patches and converts the DT to use standard `eee-broken-*` PHY properties (same approach as the genet EEE cleanup in 54a9cd7e22b8), keeping the dtparam=eee=off` override working for users who need to disable EEE.

Also reverts the downstream `SOF_TIMESTAMPING_TX_SOFTWARE` patch which added a duplicate `get_ts_info` entry - the same fix was upstreamed independently in v6.0 (33e6b1674f33), leaving a harmless but confusing duplicate in the ethtool_ops struct.

8633b35f34d0 ("lan78xx: Ack pending PHY ints when resetting") is also a candidate for revert, as the phylink refactoring reworked the IRQ ack path. @pelwell, thoughts?