### PR TITLE
Cleanup downstream genet patches

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-4-b.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-4-b.dts
@@ -213,6 +213,7 @@
 	phy1: ethernet-phy@1 {
 		/* No PHY interrupt */
 		reg = <0x1>;
+		brcm,powerdown-enable;
 
 		leds {
 			#address-cells = <1>;

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts
@@ -216,6 +216,7 @@
 	phy1: ethernet-phy@0 {
 		/* No PHY interrupt */
 		reg = <0x0>;
+		brcm,powerdown-enable;
 	};
 };
 

--- a/drivers/net/ethernet/broadcom/genet/bcmgenet.c
+++ b/drivers/net/ethernet/broadcom/genet/bcmgenet.c
@@ -68,9 +68,6 @@ static void bcmgenet_set_rx_mode(struct net_device *dev);
 static bool skip_umac_reset = false;
 module_param(skip_umac_reset, bool, 0444);
 MODULE_PARM_DESC(skip_umac_reset, "Skip UMAC reset step");
-static bool eee = true;
-module_param(eee, bool, 0444);
-MODULE_PARM_DESC(eee, "Enable EEE (default Y)");
 
 static inline void bcmgenet_writel(u32 value, void __iomem *offset)
 {
@@ -3366,17 +3363,6 @@ static int bcmgenet_open(struct net_device *dev)
 	}
 
 	bcmgenet_phy_pause_set(dev, priv->rx_pause, priv->tx_pause);
-
-	if (!eee) {
-		struct ethtool_keee eee_data;
-
-		ret = bcmgenet_get_eee(dev, &eee_data);
-		if (ret == 0) {
-			eee_data.eee_enabled = 0;
-			bcmgenet_set_eee(dev, &eee_data);
-			netdev_warn(dev, "EEE disabled\n");
-		}
-	}
 
 	bcmgenet_netif_start(dev);
 

--- a/drivers/net/ethernet/broadcom/genet/bcmgenet.c
+++ b/drivers/net/ethernet/broadcom/genet/bcmgenet.c
@@ -65,9 +65,6 @@
 
 /* Forward declarations */
 static void bcmgenet_set_rx_mode(struct net_device *dev);
-static bool skip_umac_reset = true;
-module_param(skip_umac_reset, bool, 0444);
-MODULE_PARM_DESC(skip_umac_reset, "Skip UMAC reset step");
 
 static inline void bcmgenet_writel(u32 value, void __iomem *offset)
 {
@@ -2561,11 +2558,6 @@ static void reset_umac(struct bcmgenet_priv *priv)
 	/* 7358a0/7552a0: bad default in RBUF_FLUSH_CTRL.umac_sw_rst */
 	bcmgenet_rbuf_ctrl_set(priv, 0);
 	udelay(10);
-
-	if (skip_umac_reset) {
-		pr_warn("Skipping UMAC reset\n");
-		return;
-	}
 
 	/* issue soft reset and disable MAC while updating its registers */
 	spin_lock_bh(&priv->reg_lock);

--- a/drivers/net/ethernet/broadcom/genet/bcmgenet.c
+++ b/drivers/net/ethernet/broadcom/genet/bcmgenet.c
@@ -65,7 +65,7 @@
 
 /* Forward declarations */
 static void bcmgenet_set_rx_mode(struct net_device *dev);
-static bool skip_umac_reset = false;
+static bool skip_umac_reset = true;
 module_param(skip_umac_reset, bool, 0444);
 MODULE_PARM_DESC(skip_umac_reset, "Skip UMAC reset step");
 

--- a/drivers/net/ethernet/broadcom/genet/bcmmii.c
+++ b/drivers/net/ethernet/broadcom/genet/bcmmii.c
@@ -312,8 +312,6 @@ int bcmgenet_mii_probe(struct net_device *dev)
 	/* Communicate the integrated PHY revision */
 	if (priv->internal_phy)
 		phy_flags = priv->gphy_rev;
-	else
-		phy_flags = PHY_BRCM_AUTO_PWRDWN_ENABLE;
 
 	/* This is an ugly quirk but we have not been correctly interpreting
 	 * the phy_interface values and we have done that across different


### PR DESCRIPTION
Spring cleaning part 2 - genet driver:

Reverted:
- 712989f8e002 `("net: bcmgenet: Add 'eee' module parameter")` - the `genet.eee=N` bootarg is superseded by `eee-broken-*` DT properties (54a9cd7e22b8) and upstream phylib-managed EEE (908c344d5cfa, net-next, backported in #7270).
- 09d1901497ce `("bcmgenet: Disable skip_umac_reset by default")` and dfad8d6677d4 `("net: bcmgenet: Workaround #2 for Pi4 Ethernet fail")` - the skip_umac_reset workaround and its default toggle are both superseded by upstream 88f6c8bf1aae (`"net: bcmgenet: keep MAC in reset until PHY is up"`, v6.0).
- bd61974c6611 `("net: genet: enable link energy detect powerdown for external PHYs")` - replaced by adding `brcm,powerdown-enable` to the Pi 4B and CM4 PHY nodes in device tree, matching what Pi 5 and CM5 already do.