### PR TITLE
drm/panel: st7701: Add missing bus_flags configuration for HyperPixel2.1 Round

### DIFF
--- a/drivers/gpu/drm/panel/panel-sitronix-st7701.c
+++ b/drivers/gpu/drm/panel/panel-sitronix-st7701.c
@@ -109,6 +109,7 @@ struct st7701_panel_desc {
 	enum mipi_dsi_pixel_format format;
 	u32 mediabus_format;
 	unsigned int panel_sleep_delay;
+	u32 bus_flags;
 
 	/* TFT matrix driver configuration, panel specific. */
 	const u8	pv_gamma[16];	/* Positive voltage gamma control */
@@ -706,6 +707,7 @@ static int st7701_get_modes(struct drm_panel *panel,
 
 	connector->display_info.width_mm = desc_mode->width_mm;
 	connector->display_info.height_mm = desc_mode->height_mm;
+	connector->display_info.bus_flags = st7701->desc->bus_flags;
 
 	/*
 	 * TODO: Remove once all drm drivers call
@@ -1312,6 +1314,7 @@ static const struct st7701_panel_desc txw210001b0_desc = {
 		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC255_MASK, 0x1d)
 	},
 	.gip_sequence = txw210001b0_gip_sequence,
+	.bus_flags = DRM_BUS_FLAG_PIXDATA_DRIVE_NEGEDGE,
 };
 
 static const struct st7701_panel_desc hyperpixel2r_desc = {
@@ -1376,6 +1379,7 @@ static const struct st7701_panel_desc hyperpixel2r_desc = {
 		CFIELD_PREP(ST7701_CMD2_BK0_GAMCTRL_VC255_MASK, 0x1d)
 	},
 	.gip_sequence = txw210001b0_gip_sequence,
+	.bus_flags = DRM_BUS_FLAG_PIXDATA_DRIVE_NEGEDGE,
 };
 
 static void st7701_cleanup(void *data)


### PR DESCRIPTION
Fix #7194.

Porting the bus_flags configuration from the kernel 6.6 code resolves the noise issue that was occurring with the Pimoroni HyperPixel 2.1 Round.