### PR TITLE
Fix Clang 22 warnings

### DIFF
--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
@@ -1499,7 +1499,7 @@ static struct dma_chan *dw_axi_dma_of_xlate(struct of_phandle_args *dma_spec,
 {
 	struct dw_axi_dma *dw = ofdma->of_dma_data;
 	struct axi_dma_chan *chan;
-	uint32_t chan_flags_all;
+	uint32_t chan_flags_all = 0;
 	uint32_t busy_channels;
 	struct dma_chan *dchan;
 	dma_cap_mask_t mask;

--- a/drivers/gpu/drm/vc4/vc4_plane.c
+++ b/drivers/gpu/drm/vc4/vc4_plane.c
@@ -2817,7 +2817,7 @@ int vc4_plane_create_additional_planes(struct drm_device *drm)
 	struct drm_plane *cursor_plane;
 	struct drm_crtc *crtc;
 	unsigned int i;
-	struct drm_crtc *txp_crtc;
+	struct drm_crtc *txp_crtc = NULL;
 	uint32_t non_txp_crtc_mask;
 
 	drm_for_each_crtc(crtc, drm) {

--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/fweh.h
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/fweh.h
@@ -310,7 +310,7 @@ struct eventmsgs_ext {
 	u8	command;
 	u8	len;
 	u8	maxgetsize;
-	u8	mask[1];
+	u8	mask[];
 };
 
 typedef int (*brcmf_fweh_handler_t)(struct brcmf_if *ifp,

--- a/drivers/pci/controller/pcie-brcmstb.c
+++ b/drivers/pci/controller/pcie-brcmstb.c
@@ -1575,7 +1575,7 @@ static void brcm_config_clkreq(struct brcm_pcie *pcie)
 {
 	static const char err_msg[] = "invalid 'brcm,clkreq-mode' DT string\n";
 	const char *mode = "default";
-	u32 clkreq_cntl;
+	u32 clkreq_cntl = 0;
 	int ret, tmp;
 
 	ret = of_property_read_string(pcie->np, "brcm,clkreq-mode", &mode);

--- a/sound/drivers/Kconfig
+++ b/sound/drivers/Kconfig
@@ -265,8 +265,9 @@ config SND_AC97_POWER_SAVE_DEFAULT
 
 config SND_PIMIDI
 	tristate "Pimidi driver"
-	depends on SND_SEQUENCER && CRC8
+	depends on SND_SEQUENCER
 	select SND_RAWMIDI
+	select CRC8
 	help
 	  Say Y here to include support for Blokas Pimidi.
 
@@ -275,7 +276,8 @@ config SND_PIMIDI
 
 config SND_PISOUND_MICRO
 	tristate "Pisound Micro driver"
-	depends on SND_SEQUENCER && CRC8
+	depends on SND_SEQUENCER
+	select CRC8
 	help
 	  Say Y here to include support for Blokas Pisound Micro.
 

--- a/sound/drivers/upisnd/upisnd_codec.c
+++ b/sound/drivers/upisnd/upisnd_codec.c
@@ -736,7 +736,7 @@ static int adau1961_add_routes(struct snd_soc_component *component)
 {
 	struct snd_soc_dapm_context *dapm = snd_soc_component_get_dapm(component);
 	struct adau *adau = snd_soc_component_get_drvdata(component);
-	int ret;
+	int ret = 0;
 
 	if (adau->clk_src != ADAU1961_CLK_SRC_MCLK)
 		ret = snd_soc_dapm_add_routes(dapm, &adau1961_dapm_pll_route, 1);

--- a/sound/soc/bcm/hifiberry_studio_dac8x.c
+++ b/sound/soc/bcm/hifiberry_studio_dac8x.c
@@ -767,7 +767,7 @@ static int hb_uni_read_card_info(struct platform_device *pdev)
 			return -EINVAL;
 		}
 	} else {
-		if ((priv->card_info.card_clk_options == 0x02)) {
+		if (priv->card_info.card_clk_options == 0x02) {
 			dev_err(&pdev->dev,
 				"Card cannot run as i2s clock consumer\n");
 			return -EINVAL;


### PR DESCRIPTION
This patch set fixes build warnings with Clang. These issues were observed when compiling code merged from this repository as part of Android kernel which is compiled using Clang 22 and `CONFIG_WERROR=y` set.

I also reproduced that these issues are present and resolved with this patch set when compiling the kernel from this repository (`rpi-6.18.y` branch) with Clang 22 both cross-compiling on Ubuntu host as well as natively on Raspberry Pi 5 using Raspberry Pi OS.

```
# Install Raspberry Pi OS (2025-12-04-raspios-trixie-arm64.img.xz) and update
$ sudo apt update
$ sudo apt full-upgrade

# Install build dependecies (https://www.raspberrypi.com/documentation/computers/linux_kernel.html#natively-build-a-kernel)
$ sudo apt install bc bison flex libssl-dev make

# Install Clang 22 (https://apt.llvm.org/)
$ wget https://apt.llvm.org/llvm.sh
$ chmod +x llvm.sh
$ sudo ./llvm.sh 22

# Download kernel source code (shallow clone to save time)
$ git clone https://github.com/raspberrypi/linux -b rpi-6.18.y --depth=1
$ cd linux

# Compile using Clang 22 with CONFIG_WERROR=y set
$ export LLVM=-22 CC=clang-22 KERNEL=kernel_2712
$ make bcm2712_defconfig
$ scripts/config --file .config --set-val CONFIG_WERROR y
$ make Image.gz modules dtbs -j$(nproc)
```

Also fixed minor issue that `SND_PIMIDI` and `SND_PISOUND_MICRO` should rather select `CRC8` than depend on it. This likely works here as some other drivers already selects `CRC8`. I generally don't compile the Android kernel with `SND_PISOUND_MICRO` enabled but it doesn't get set in defconfig as there's also no `CRC8` set otherwise.