### PR TITLE
Change crop struct to match height for 16 by 9 mode. Addresses #7321

### DIFF
--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -884,7 +884,7 @@ static const struct imx477_mode supported_modes[] = {
 			.left = IMX477_PIXEL_ARRAY_LEFT,
 			.top = IMX477_PIXEL_ARRAY_TOP + 440,
 			.width = 4056,
-			.height = 3040,
+			.height = 2160,
 		},
 		.frm_length_default = 10,
 		.reg_list = {


### PR DESCRIPTION
Proposed correction to the struct definition of the full resolution 16:9 cropped modes  to reflect the actual cropped height.

Tested and resolves both the issue of offset and distorted ScalerCrop images in Picamera2, and the crop definitions returned by rpi-cam apps --list-cameras.