### PR TITLE
media: i2c: imx477: Fix crop description in 12Mpix 16:9 modes

### DIFF
--- a/drivers/media/i2c/imx477.c
+++ b/drivers/media/i2c/imx477.c
@@ -884,7 +884,7 @@ static const struct imx477_mode supported_modes[] = {
 			.left = IMX477_PIXEL_ARRAY_LEFT,
 			.top = IMX477_PIXEL_ARRAY_TOP + 440,
 			.width = 4056,
-			.height = 3040,
+			.height = 2160,
 		},
 		.frm_length_default = 10,
 		.reg_list = {


### PR DESCRIPTION
Repeat of #7328 but against  rpi-6.18.y
Amends the crop description to match the generated crop size.

Fixes problem with Picamera2 ScalerCrop returning distorted images in the affected modes. Also corrects rpicam-apps ---list-cameras inconsistencies.