### PR TITLE
fixup! gpiolib: Override gpiochip numbers with DT aliases

### DIFF
--- a/drivers/gpio/gpiolib.c
+++ b/drivers/gpio/gpiolib.c
@@ -1092,7 +1092,7 @@ int gpiochip_add_data_with_key(struct gpio_chip *gc, void *data,
 		first_dynamic_gpiochip_num = (id >= 0) ? (id + 1) : 0;
 	}
 
-	id = of_alias_get_id(gdev->dev.of_node, "gpiochip");
+	id = of_alias_get_id(to_of_node(gpiochip_choose_fwnode(gc)), "gpiochip");
 	if (id < 0)
 		id = first_dynamic_gpiochip_num;
 


### PR DESCRIPTION
Commit [1] shuffled the initialisation of gpiochips, breaking the downstream patch that sets the chip numbers based on DT aliases.

Fix the downstream patch by determining the of_node on the fly, rather than assuming it has already been set. This does result in more calls to gpiochip_choose_fwnode() than are necessary, but it reduces the scope of the patch and makes it more resilient.

Signed-off-by: Phil Elwell <phil@raspberrypi.com>

[1] 16fdabe143fc ("gpio: Fix resource leaks on errors in
    gpiochip_add_data_with_key()")