### PR TITLE
Update temperature units from millicelcius to millidegree Celsius

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -273,27 +273,27 @@ Params:
                                 1000 (default set by the platform). Pi3B+,
                                 Pi4, Pi400, CM4, Pi5, Pi500, and CM5 only.
 
-        fan_temp0               Temperature threshold (in millicelcius) for
+        fan_temp0               Temperature threshold (in millidegree Celsius) for
                                 1st cooling level (default 50000). Pi5 only.
-        fan_temp0_hyst          Temperature hysteresis (in millicelcius) for
+        fan_temp0_hyst          Temperature hysteresis (in millidegree Celsius) for
                                 1st cooling level (default 5000). Pi5 only.
         fan_temp0_speed         Fan PWM setting for 1st cooling level (0-255,
                                 default 75). Pi5 only.
-        fan_temp1               Temperature threshold (in millicelcius) for
+        fan_temp1               Temperature threshold (in millidegree Celsius) for
                                 2nd cooling level (default 60000). Pi5 only.
-        fan_temp1_hyst          Temperature hysteresis (in millicelcius) for
+        fan_temp1_hyst          Temperature hysteresis (in millidegree Celsius) for
                                 2nd cooling level (default 5000). Pi5 only.
         fan_temp1_speed         Fan PWM setting for 2nd cooling level (0-255,
                                 default 125). Pi5 only.
-        fan_temp2               Temperature threshold (in millicelcius) for
+        fan_temp2               Temperature threshold (in millidegree Celsius) for
                                 3rd cooling level (default 67500). Pi5 only.
-        fan_temp2_hyst          Temperature hysteresis (in millicelcius) for
+        fan_temp2_hyst          Temperature hysteresis (in millidegree Celsius) for
                                 3rd cooling level (default 5000). Pi5 only.
         fan_temp2_speed         Fan PWM setting for 3rd cooling level (0-255,
                                 default 175). Pi5 only.
-        fan_temp3               Temperature threshold (in millicelcius) for
+        fan_temp3               Temperature threshold (in millidegree Celsius) for
                                 4th cooling level (default 75000). Pi5 only.
-        fan_temp3_hyst          Temperature hysteresis (in millicelcius) for
+        fan_temp3_hyst          Temperature hysteresis (in millidegree Celsius) for
                                 4th cooling level (default 5000). Pi5 only.
         fan_temp3_speed         Fan PWM setting for 4th cooling level (0-255,
                                 default 250). Pi5 only.
@@ -1532,8 +1532,8 @@ Info:   Configure a GPIO pin to control a cooling fan.
 Load:   dtoverlay=gpio-fan,<param>=<val>
 Params: gpiopin                 GPIO used to control the fan (default 12)
         temp                    Temperature at which the fan switches on, in
-                                millicelcius (default 55000)
-        hyst                    Temperature delta (in millicelcius) below
+                                millidegree Celsius (default 55000)
+        hyst                    Temperature delta (in millidegree Celsius) below
                                 temp at which the fan will drop to minrpm
                                 (default 10000)
 
@@ -2194,17 +2194,17 @@ Params: addr                    Sets the address for the fan controller. Note
                                 mintemp (range 0-255. default 0)
         maxpwm                  PWM setting for the fan when the SoC is above
                                 maxtemp (range 0-255. default 255)
-        midtemp                 Temperature (in millicelcius) at which the fan
+        midtemp                 Temperature (in millidegree Celsius) at which the fan
                                 begins to speed up (default 50000)
 
-        midtemp_hyst            Temperature delta (in millicelcius) below
+        midtemp_hyst            Temperature delta (in millidegree Celsius) below
                                 mintemp at which the fan will drop to minrpm
                                 (default 2000)
 
-        maxtemp                 Temperature (in millicelcius) at which the fan
+        maxtemp                 Temperature (in millidegree Celsius) at which the fan
                                 will be held at maxrpm (default 70000)
 
-        maxtemp_hyst            Temperature delta (in millicelcius) below
+        maxtemp_hyst            Temperature delta (in millidegree Celsius) below
                                 maxtemp at which the fan begins to slow down
                                 (default 2000)
 
@@ -4285,28 +4285,28 @@ Load:   dtoverlay=pwm-gpio-fan,<param>=<val>
 Params: fan_gpio                BCM number of the pin driving the fan,
                                 default 18 (GPIO 18)
         fan_temp0               CPU temperature at which fan is started with
-                                low speed in millicelsius,
+                                low speed in millidegree Celsius,
                                 default 55000 (55 °C)
         fan_temp1               CPU temperature at which fan is switched
-                                to medium speed in millicelsius,
+                                to medium speed in millidegree Celsius,
                                 default 60000 (60 °C)
         fan_temp2               CPU temperature at which fan is switched
-                                to high speed in millicelsius,
+                                to high speed in millidegree Celsius,
                                 default 67500 (67.5 °C)
         fan_temp3               CPU temperature at which fan is switched
-                                to max speed in millicelsius,
+                                to max speed in millidegree Celsius,
                                 default 75000 (75 °C)
-        fan_temp0_hyst          Temperature hysteris at which fan is stopped
-                                in millicelsius,default 5000 (resulting
-                                in 50 °C)
-        fan_temp1_hyst          Temperature hysteris at which fan is switched
-                                back to low speed in millicelsius,
+        fan_temp0_hyst          Temperature hysteresis at which fan is stopped
+                                in millidegree Celsius,
+                                default 5000 (resulting in 50 °C)
+        fan_temp1_hyst          Temperature hysteresis at which fan is switched
+                                back to low speed in millidegree Celsius,
                                 default 5000 (resulting in 55 °C)
-        fan_temp2_hyst          Temperature hysteris at which fan is switched
-                                back to medium speed in millicelsius,
+        fan_temp2_hyst          Temperature hysteresis at which fan is switched
+                                back to medium speed in millidegree Celsius,
                                 default 5000 (resulting in 62.5 °C)
-        fan_temp3_hyst          Temperature hysteris at which fan is switched
-                                back to high speed in millicelsius,
+        fan_temp3_hyst          Temperature hysteresis at which fan is switched
+                                back to high speed in millidegree Celsius,
                                 default 5000 (resulting in 70 °C)
         fan_temp0_speed         Fan speed for low cooling state in range
                                 0 to 255, default 114 (45% PWM duty cycle)
@@ -4560,21 +4560,21 @@ Params: txd0_pin                GPIO pin for TXD0 (any free - default 20)
 Name:   rpi-poe
 Info:   Raspberry Pi PoE HAT fan
 Load:   dtoverlay=rpi-poe,<param>[=<val>]
-Params: poe_fan_temp0           Temperature (in millicelcius) at which the fan
+Params: poe_fan_temp0           Temperature (in millidegree Celsius) at which the fan
                                 turns on (default 40000)
-        poe_fan_temp0_hyst      Temperature delta (in millicelcius) at which
+        poe_fan_temp0_hyst      Temperature delta (in millidegree Celsius) at which
                                 the fan turns off (default 2000)
-        poe_fan_temp1           Temperature (in millicelcius) at which the fan
+        poe_fan_temp1           Temperature (in millidegree Celsius) at which the fan
                                 speeds up (default 45000)
-        poe_fan_temp1_hyst      Temperature delta (in millicelcius) at which
+        poe_fan_temp1_hyst      Temperature delta (in millidegree Celsius) at which
                                 the fan slows down (default 2000)
-        poe_fan_temp2           Temperature (in millicelcius) at which the fan
+        poe_fan_temp2           Temperature (in millidegree Celsius) at which the fan
                                 speeds up (default 50000)
-        poe_fan_temp2_hyst      Temperature delta (in millicelcius) at which
+        poe_fan_temp2_hyst      Temperature delta (in millidegree Celsius) at which
                                 the fan slows down (default 2000)
-        poe_fan_temp3           Temperature (in millicelcius) at which the fan
+        poe_fan_temp3           Temperature (in millidegree Celsius) at which the fan
                                 speeds up (default 55000)
-        poe_fan_temp3_hyst      Temperature delta (in millicelcius) at which
+        poe_fan_temp3_hyst      Temperature delta (in millidegree Celsius) at which
                                 the fan slows down (default 5000)
         i2c                     Control the fan via Linux I2C drivers instead of
                                 the firmware.
@@ -4583,21 +4583,21 @@ Params: poe_fan_temp0           Temperature (in millicelcius) at which the fan
 Name:   rpi-poe-plus
 Info:   Raspberry Pi PoE+ HAT fan
 Load:   dtoverlay=rpi-poe-plus,<param>[=<val>]
-Params: poe_fan_temp0           Temperature (in millicelcius) at which the fan
+Params: poe_fan_temp0           Temperature (in millidegree Celsius) at which the fan
                                 turns on (default 40000)
-        poe_fan_temp0_hyst      Temperature delta (in millicelcius) at which
+        poe_fan_temp0_hyst      Temperature delta (in millidegree Celsius) at which
                                 the fan turns off (default 2000)
-        poe_fan_temp1           Temperature (in millicelcius) at which the fan
+        poe_fan_temp1           Temperature (in millidegree Celsius) at which the fan
                                 speeds up (default 45000)
-        poe_fan_temp1_hyst      Temperature delta (in millicelcius) at which
+        poe_fan_temp1_hyst      Temperature delta (in millidegree Celsius) at which
                                 the fan slows down (default 2000)
-        poe_fan_temp2           Temperature (in millicelcius) at which the fan
+        poe_fan_temp2           Temperature (in millidegree Celsius) at which the fan
                                 speeds up (default 50000)
-        poe_fan_temp2_hyst      Temperature delta (in millicelcius) at which
+        poe_fan_temp2_hyst      Temperature delta (in millidegree Celsius) at which
                                 the fan slows down (default 2000)
-        poe_fan_temp3           Temperature (in millicelcius) at which the fan
+        poe_fan_temp3           Temperature (in millidegree Celsius) at which the fan
                                 speeds up (default 55000)
-        poe_fan_temp3_hyst      Temperature delta (in millicelcius) at which
+        poe_fan_temp3_hyst      Temperature delta (in millidegree Celsius) at which
                                 the fan slows down (default 5000)
         i2c                     Control the fan via Linux I2C drivers instead of
                                 the firmware.


### PR DESCRIPTION
Changed millicelcius into millidegree Celsius and corrected hysteresis spelling