### PR TITLE
dtoverlays: HyperPixel 2 Round: Add PWM Backlight support.

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -5722,6 +5722,7 @@ Params: disable-touch           Disables the touch controller
         touchscreen-inverted-y  Inverts Y direction of touch controller
         touchscreen-swapped-x-y Swaps X & Y axes of touch controller
         rotate                  Display rotation {0,90,180,270} (default 0)
+        backlight-pwm           Use PWM instead of GPIO for backlight
 
 
 Name:   vc4-kms-dpi-hyperpixel4

--- a/arch/arm/boot/dts/overlays/vc4-kms-dpi-hyperpixel2r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/vc4-kms-dpi-hyperpixel2r-overlay.dts
@@ -31,7 +31,6 @@
 					reg = <0>;
 					/* 100 kHz */
 					spi-max-frequency = <100000>;
-					backlight = <&backlight>;
 					rotation = <0>;
 
 					port {
@@ -40,11 +39,6 @@
 						};
 					};
 				};
-			};
-
-			backlight: backlight {
-				compatible = "gpio-backlight";
-				gpios = <&gpio 19 0>;
 			};
 		};
 	};
@@ -103,12 +97,71 @@
 		};
 	};
 
+	fragment@4 {
+		target = <&panel>;
+		__overlay__ {
+			backlight = <&backlight>;
+		};
+	};
+
+	fragment@5 {
+		target-path = "/";
+		__overlay__ {
+			backlight: backlight {
+				compatible = "gpio-backlight";
+				gpios = <&gpio 19 0>;
+			};
+		};
+	};
+
+	fragment@6 {
+		target = <&panel>;
+		__dormant__ {
+			backlight = <&backlight_pwm>;
+		};
+	};
+
+	fragment@7 {
+		target-path = "/";
+		__dormant__ {
+			backlight_pwm: backlight_pwm {
+				compatible = "pwm-backlight";
+				pwms = <&pwm 1 200000 0>;
+				brightness-levels = <0 255>;
+				num-interpolated-steps = <255>;
+				default-brightness-level = <1>;
+			};
+
+		};
+	};
+
+	fragment@8 {
+		target = <&pwm>;
+		__dormant__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&pwm_pins>;
+			assigned-clock-rates = <1000000>;
+			status = "okay";
+		};
+	};
+
+	fragment@9 {
+		target = <&gpio>;
+		__dormant__ {
+			pwm_pins: pwm_pins {
+				brcm,pins = <19>;
+				brcm,function = <2>; /* Alt5 */
+			};
+		};
+	};
+
 	__overrides__ {
 		disable-touch = <0>,"-3";
 		touchscreen-inverted-x = <&polytouch>,"touchscreen-inverted-x?";
 		touchscreen-inverted-y = <&polytouch>,"touchscreen-inverted-y!";
 		touchscreen-swapped-x-y = <&polytouch>,"touchscreen-swapped-x-y!";
 		rotate = <&panel>, "rotation:0";
+		backlight-pwm = <0>,"-4-5+6+7+8+9";
 	};
 
 };


### PR DESCRIPTION
Borrowing heavily from vc4-kms-dpi.dtsi, but targeting the pin configuration for HyperPixel 2r.

Adding `dtparam=backlight-pwm` will replace the on/off GPIO backlight control with PWM.

Tested on a Pi Zero 2, Trixie, 6.12.75+rpt-rpi-v8. Some further testing and/or confirmation I haven't done something very silly would be appreciated.