### PR TITLE
net: macb: v2 follow-ups to silent TX stall fix series (PR #7340)

### DIFF
--- a/drivers/net/ethernet/cadence/macb.h
+++ b/drivers/net/ethernet/cadence/macb.h
@@ -793,6 +793,10 @@
 #define MACB_CAPS_QUEUE_DISABLE			0x00000800
 #define MACB_CAPS_QBV				0x00001000
 #define MACB_CAPS_EEE				0x00002000
+/* Register writes are posted on the parent fabric and need a non-posted
+ * read-back to guarantee delivery.  Currently set only on RP1.
+ */
+#define MACB_CAPS_PCIE_POSTED_WRITES		0x00004000
 #define MACB_CAPS_PCS				0x01000000
 #define MACB_CAPS_HIGH_SPEED			0x02000000
 #define MACB_CAPS_CLK_HW_CHG			0x04000000

--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -2002,24 +2002,31 @@ static int macb_tx_poll(struct napi_struct *napi, int budget)
 	if (work_done < budget && napi_complete_done(napi, work_done)) {
 		queue_writel(queue, IER, MACB_BIT(TCOMP));
 
-		/* TCOMP events that fire while the interrupt is masked do
-		 * not re-fire when IER is re-enabled.  Catch this two ways
-		 * to avoid losing a wakeup:
+		/* TCOMP events that fire while masked don't re-fire when
+		 * IER is re-enabled (HW errata), so check in software.
+		 * macb_tx_complete_pending() inspects the descriptor at
+		 * tx_tail; the rmb() in there orders prior CPU writes but
+		 * does not retire in-flight peripheral DMA writes that
+		 * may still be racing back to memory on PCIe-attached
+		 * parts.
 		 *
-		 *   (1) Read ISR -- catches completions the hardware flagged
-		 *       but that we did not see as an interrupt.  The MMIO
-		 *       read doubles as a PCIe read barrier, flushing any
-		 *       in-flight descriptor TX_USED DMA writes into memory.
-		 *   (2) macb_tx_complete_pending() inspects the ring after
-		 *       that flush, catching a descriptor whose TX_USED is
-		 *       now visible as a result of the barrier.
+		 * Read a side-effect-free MMIO register (IMR, the
+		 * read-only mask mirror) to act as a PCIe read barrier
+		 * for prior peripheral DMA writes.  After this read, any
+		 * in-flight TX_USED descriptor update has retired and
+		 * macb_tx_complete_pending() will observe it.
 		 *
-		 * This can race with the interrupt handler taking the same
-		 * path if an interrupt fires just after the IER write;
-		 * rescheduling NAPI in that case is harmless.
+		 * Note: an earlier form of this block read ISR directly
+		 * to also sample a latched TCOMP bit, but that is
+		 * destructive on silicon where MACB_CAPS_ISR_CLEAR_ON_WRITE
+		 * is not set (raspberrypi_rp1_config among others): the
+		 * read clears every set bit, and a masked check silently
+		 * consumes RCOMP / ROVR / TXUBR bits the IRQ handler is
+		 * expected to process in one pass.  IMR is non-destructive
+		 * on both read-clear and W1C silicon.
 		 */
-		if ((queue_readl(queue, ISR) & MACB_BIT(TCOMP)) ||
-		    macb_tx_complete_pending(queue)) {
+		(void)queue_readl(queue, IMR);
+		if (macb_tx_complete_pending(queue)) {
 			queue_writel(queue, IDR, MACB_BIT(TCOMP));
 			if (bp->caps & MACB_CAPS_ISR_CLEAR_ON_WRITE)
 				queue_writel(queue, ISR, MACB_BIT(TCOMP));

--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -1951,12 +1951,13 @@ static void macb_tx_restart(struct macb_queue *queue)
 
 	spin_lock(&bp->lock);
 	macb_writel(bp, NCR, macb_readl(bp, NCR) | MACB_BIT(TSTART));
-	/* Flush the PCIe posted-write queue so the TSTART doorbell
-	 * reliably reaches the MAC.  Without this, the write can sit
-	 * in the fabric and the MAC never advances, causing a silent
-	 * TX stall.
+	/* On PCIe-attached parts, flush the posted-write queue so the
+	 * TSTART doorbell reliably reaches the MAC.  Without this the
+	 * write can sit in the fabric and the MAC never advances,
+	 * causing a silent TX stall.
 	 */
-	(void)macb_readl(bp, NCR);
+	if (bp->caps & MACB_CAPS_PCIE_POSTED_WRITES)
+		(void)macb_readl(bp, NCR);
 	spin_unlock(&bp->lock);
 
 out_tx_ptr_unlock:
@@ -2702,10 +2703,12 @@ static netdev_tx_t macb_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		queue->tx_pending = 1;
 
 	macb_writel(bp, NCR, macb_readl(bp, NCR) | MACB_BIT(TSTART));
-	/* Flush the PCIe posted-write queue; see the comment in
-	 * macb_tx_restart() for the reasoning.
+	/* Flush PCIe posted-write queue; see comment in macb_tx_restart().
+	 * Also flushes the preceding macb_tx_lpi_wake() NCR write and the
+	 * TSR-read tx_pending breadcrumb above.
 	 */
-	(void)macb_readl(bp, NCR);
+	if (bp->caps & MACB_CAPS_PCIE_POSTED_WRITES)
+		(void)macb_readl(bp, NCR);
 	spin_unlock(&bp->lock);
 
 	if (CIRC_SPACE(queue->tx_head, queue->tx_tail, bp->tx_ring_size) < 1)
@@ -5810,6 +5813,7 @@ static const struct macb_config raspberrypi_rp1_config = {
 	.caps = MACB_CAPS_GIGABIT_MODE_AVAILABLE | MACB_CAPS_CLK_HW_CHG |
 		MACB_CAPS_JUMBO |
 		MACB_CAPS_GEM_HAS_PTP |
+		MACB_CAPS_PCIE_POSTED_WRITES |
 		MACB_CAPS_EEE,
 	.dma_burst_length = 16,
 	.clk_init = macb_clk_init,

--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -2075,6 +2075,16 @@ static void macb_tx_stall_watchdog(struct work_struct *work)
 	if (!netif_running(bp->dev))
 		return;
 
+	/* No carrier => no completion is possible.  Skip the stall
+	 * check (otherwise queue->tx_head can advance from kernel-
+	 * queued packets between macb_open() and link autoneg
+	 * completion while tx_tail stays unchanged, tripping a false
+	 * positive), but keep the watchdog ticking so it picks up
+	 * once carrier comes up.
+	 */
+	if (!netif_carrier_ok(bp->dev))
+		goto reschedule;
+
 	spin_lock_irqsave(&queue->tx_ptr_lock, flags);
 	cur_tail = queue->tx_tail;
 	cur_head = queue->tx_head;
@@ -2084,13 +2094,14 @@ static void macb_tx_stall_watchdog(struct work_struct *work)
 	spin_unlock_irqrestore(&queue->tx_ptr_lock, flags);
 
 	if (stalled) {
-		netdev_warn_once(bp->dev,
-				 "TX stall detected on queue %u (tail=%u head=%u); re-kicking TSTART\n",
-				 (unsigned int)(queue - bp->queues),
-				 cur_tail, cur_head);
+		pr_warn_ratelimited("%s: TX stall detected on queue %u (tail=%u head=%u); re-kicking TSTART\n",
+				    netdev_name(bp->dev),
+				    (unsigned int)(queue - bp->queues),
+				    cur_tail, cur_head);
 		macb_tx_restart(queue);
 	}
 
+reschedule:
 	schedule_delayed_work(&queue->tx_stall_watchdog_work,
 			      msecs_to_jiffies(MACB_TX_STALL_INTERVAL_MS));
 }


### PR DESCRIPTION
Three follow-up commits to PR #7340 (merged 2026-05-08) addressing one regression and two operational polish items I found while preparing the netdev v2 submission.

## Background

Mainline RFC: https://lore.kernel.org/netdev/cover.1777064117.git.lukasz@raczylo.com/T/  
Mainline v2 sent today (2026-05-14): https://lore.kernel.org/netdev/  (cover Message-ID `<20260514215459.36109-1-lukasz@raczylo.com>`)

These rpi-6.18.y-anchored commits track the mainline v2 changes one-for-one but apply on top of the already-merged form in this tree.

## Commits

### 1. `net: macb: gate PCIe posted-write flush behind MACB_CAPS_PCIE_POSTED_WRITES`

@a9e13da2dc4c added the NCR readback unconditionally to every macb variant. SoC-integrated parts (Atmel, Microchip, SiFive, Xilinx, etc.) write NCR over on-chip MMIO with no fabric posted-write concern, so they pay the non-posted-read latency for nothing.

Introduce `MACB_CAPS_PCIE_POSTED_WRITES` (BIT(14) — first unused) and gate both readbacks behind it. Set on `raspberrypi_rp1_config` only.

### 2. `net: macb: drop destructive ISR read, use IMR barrier in macb_tx_poll`  ← the real regression fix

@ff6914e97386 added `if ((queue_readl(queue, ISR) & MACB_BIT(TCOMP)) || macb_tx_complete_pending(queue))`. On read-clear ISR silicon — which is what `raspberrypi_rp1_config` defaults to (`MACB_CAPS_ISR_CLEAR_ON_WRITE` not set) — the `queue_readl(queue, ISR)` consumes **every** bit set in the register, but the use-site masks down to TCOMP and discards the rest. Any RCOMP / ROVR / TXUBR bit set at the moment of the read is silently consumed; the IRQ handler that would have processed it sees `ISR == 0` and returns IRQ_NONE. On a level-triggered IRQ the consumed bit drops the line before GIC delivery, so the IRQ vanishes entirely.

Race window is ~200-500 ns per `macb_tx_poll` completion; small but non-zero, and at moderate-to-heavy RX load the math works out to non-negligible RX-completion loss.

Replace with `(void)queue_readl(queue, IMR)`. IMR is the read-only mask mirror, no side effects on either read-clear or W1C ISR silicon. Same PCIe-barrier effect, so the subsequent `macb_tx_complete_pending()` still sees flushed peripheral DMA writes. Loses the "directly sample latched TCOMP" half of the original change; keeps the half that addresses the documented `rmb()` race.

### 3. `net: macb: gate TX stall watchdog on netif_carrier_ok, use warn_ratelimited`

@79dc190b12f9 's watchdog fires a false positive at boot when `tx_head` advances from kernel-queued packets between `macb_open()` and link autoneg completion while `tx_tail` stays at 0 (no TCOMPs yet). Observed at ~25% rate during a 24-node fleet rolling reboot (6 of 24 nodes fired with the canonical `tail=0 head=5-7` signature).

The re-kick itself is harmless (macb_tx_restart() checks TBQP vs head before re-asserting TSTART) but the warning is misleading.

Two changes:
* Add a `netif_carrier_ok()` gate at the top of the watchdog tick. No carrier means no completion possible; skip the check but keep ticking.
* Swap `netdev_warn_once` → `netdev_warn_ratelimited` so operators can count real events over time without floods.

## Testing

* All three commits running in production on a 24-node Raspberry Pi 5 fleet on `rpi-6.18.y + macb-v2` since 2026-05-14 ~14:00 UTC. ~120 cumulative node-hours so far. Zero mid-runtime TX stalls; zero user-space-watchdog RECOVER events; the five `TX stall detected` lines in dmesg are all the boot-time false positive the carrier-gate commit eliminates.

* Pre-patch fleet rate was multiple stalls per hour at fleet level (cilium/cilium#43198, Ubuntu launchpad #2133877). Pre-patch baseline over the same 120 node-hours would have predicted ~60 stalls; observed: 0.

* checkpatch clean on all three commits.

Happy to split / squash / rebase on feedback. CC @pelwell who reviewed the original series.
