### PR TITLE
Partially revert "ata: ahci: force 32-bit DMA for JMicron JMB582/JMB585"

### DIFF
--- a/drivers/ata/ahci.c
+++ b/drivers/ata/ahci.c
@@ -216,7 +216,7 @@ static const struct ata_port_info ahci_port_info[] = {
 	/* JMicron JMB582/585: 64-bit DMA is broken, force 32-bit */
 	[board_ahci_jmb585] = {
 		AHCI_HFLAGS	(AHCI_HFLAG_IGN_IRQ_IF_ERR |
-				 AHCI_HFLAG_32BIT_ONLY),
+				 0*AHCI_HFLAG_32BIT_ONLY),
 		.flags		= AHCI_FLAG_COMMON,
 		.pio_mask	= ATA_PIO4,
 		.udma_mask	= ATA_UDMA6,


### PR DESCRIPTION
This reverts commit 105c42566a550e2d05fc14f763216a8765ee5d0e.

Between [1] and this reversion of it, all users of the JMB582/JMB585 on Raspberry Pi 5 have been forced to use the pcie-32bit-dma overlay.

The reasoning behind the patch is either inherently flawed or does not apply on a Pi 5, since all inbound memory accesses are by default above 4GB and yet seem to work.

See: https://github.com/raspberrypi/linux/issues/7355
     https://forums.raspberrypi.com/viewtopic.php?p=2374573&sid=a9d90a55d42694d4f24bf03946e44a4f#p2374573

Signed-off-by: Phil Elwell <phil@raspberrypi.com>

[1] commit 105c42566a55 ("ata: ahci: force 32-bit DMA for JMicron JMB582/JMB585")