### PR TITLE
Revert "bcmgenet: constrain max DMA burst length"

### DIFF
--- a/drivers/net/ethernet/broadcom/genet/bcmgenet.h
+++ b/drivers/net/ethernet/broadcom/genet/bcmgenet.h
@@ -34,7 +34,7 @@
 #define ENET_PAD		8
 #define ENET_MAX_MTU_SIZE	(ETH_DATA_LEN + ETH_HLEN + VLAN_HLEN + \
 				 ENET_BRCM_TAG_LEN + ETH_FCS_LEN + ENET_PAD)
-#define DMA_MAX_BURST_LENGTH    0x08
+#define DMA_MAX_BURST_LENGTH    0x10
 
 /* misc. configuration */
 #define MAX_NUM_OF_FS_RULES		16


### PR DESCRIPTION
While debugging the genet issue, I spotted another redundant downstream patch.

fd2e5044b7d8 dropped DMA_MAX_BURST_LENGTH from 0x10 to 0x08 back in 2018 to work around BCM2711 TX DMA timeouts. @lategoodbye's upstream a50e3a9931c1 made this obsolete a year later by adding `bcmgenet_plat_data` and pinning 0x08 for BCM2711 only.

So the global override has already been a no-op on Pi hardware for a while.