### PR TITLE
net: bcmgenet: restore PHY power management flags

### DIFF
--- a/drivers/net/ethernet/broadcom/genet/bcmmii.c
+++ b/drivers/net/ethernet/broadcom/genet/bcmmii.c
@@ -306,7 +306,9 @@ int bcmgenet_mii_probe(struct net_device *dev)
 	struct device_node *dn = kdev->of_node;
 	phy_interface_t phy_iface = priv->phy_interface;
 	struct phy_device *phydev;
-	u32 phy_flags = 0;
+	u32 phy_flags = PHY_BRCM_AUTO_PWRDWN_ENABLE |
+			PHY_BRCM_DIS_TXCRXC_NOENRGY |
+			PHY_BRCM_IDDQ_SUSPEND;
 	int ret;
 
 	/* Communicate the integrated PHY revision */


### PR DESCRIPTION
Restore PHY_BRCM_AUTO_PWRDWN_ENABLE, PHY_BRCM_DIS_TXCRXC_NOENRGY and PHY_BRCM_IDDQ_SUSPEND in bcmgenet_mii_probe(), reverting the downstream hunk that snuck into 7dd290a74745 ("xhci: add quirk...") back in March 2022.

That hunk worked around raspberrypi/rpi-eeprom#417: on Pi 4B rev 1.1 only, the bootloader couldn't recover the PHY from IDDQ-SR after a kernel reboot. CM4 and newer Pi 4B revs were never affected. The rpi-eeprom fix shipped in April 2022 (release c68f0c06) and the issue was closed a month later.

With the bootloader fix ~4 years deployed, drop the kernel-side workaround and get back the "several hundreds of milliwatts" of idle power savings Florian quoted in the issue thread.