### PR TITLE
Fixup CFE and Unicam RGB/BGR888 handling

### DIFF
--- a/drivers/media/i2c/tc358743.c
+++ b/drivers/media/i2c/tc358743.c
@@ -756,7 +756,6 @@ static void tc358743_set_ref_clk(struct v4l2_subdev *sd)
 static void tc358743_set_csi_color_space(struct v4l2_subdev *sd)
 {
 	struct tc358743_state *state = to_state(sd);
-	struct device *dev = &state->i2c_client->dev;
 
 	switch (state->mbus_fmt_code) {
 	case MEDIA_BUS_FMT_UYVY8_1X16:
@@ -772,17 +771,7 @@ static void tc358743_set_csi_color_space(struct v4l2_subdev *sd)
 		mutex_unlock(&state->confctl_mutex);
 		break;
 	case MEDIA_BUS_FMT_RGB888_1X24:
-		/*
-		 * The driver was initially introduced with RGB888
-		 * support, but CSI really means BGR.
-		 *
-		 * Since we might have applications that would have
-		 * hard-coded the RGB888, let's support both.
-		 */
-		dev_warn_once(dev, "RGB format isn't actually supported by the hardware. The application should be fixed to use BGR.");
-		fallthrough;
-	case MEDIA_BUS_FMT_BGR888_1X24:
-		v4l2_dbg(2, debug, sd, "%s: BGR 888 24-bit\n", __func__);
+		v4l2_dbg(2, debug, sd, "%s: RGB 888 24-bit\n", __func__);
 		i2c_wr8_and_or(sd, VOUT_SET2,
 				~(MASK_SEL422 | MASK_VOUT_422FIL_100) & 0xff,
 				0x00);
@@ -1443,26 +1432,11 @@ static int tc358743_log_status(struct v4l2_subdev *sd)
 	v4l2_info(sd, "Stopped: %s\n",
 			(i2c_rd16(sd, CSI_STATUS) & MASK_S_HLT) ?
 			"yes" : "no");
-
-	switch (state->mbus_fmt_code) {
-	case MEDIA_BUS_FMT_BGR888_1X24:
-		/*
-		 * The driver was initially introduced with RGB888
-		 * support, but CSI really means BGR.
-		 *
-		 * Since we might have applications that would have
-		 * hard-coded the RGB888, let's support both.
-		 */
-	case MEDIA_BUS_FMT_RGB888_1X24:
-		v4l2_info(sd, "Color space: BGR 888 24-bit\n");
-		break;
-	case MEDIA_BUS_FMT_UYVY8_1X16:
-		v4l2_info(sd, "Color space: YCbCr 422 16-bit\n");
-		break;
-	default:
-		v4l2_info(sd, "Color space: Unsupported\n");
-		break;
-	}
+	v4l2_info(sd, "Color space: %s\n",
+			state->mbus_fmt_code == MEDIA_BUS_FMT_UYVY8_1X16 ?
+			"YCbCr 422 16-bit" :
+			state->mbus_fmt_code == MEDIA_BUS_FMT_RGB888_1X24 ?
+			"RGB 888 24-bit" : "Unsupported");
 
 	v4l2_info(sd, "-----%s status-----\n", is_hdmi(sd) ? "HDMI" : "DVI-D");
 	v4l2_info(sd, "HDCP encrypted content: %s\n",
@@ -1799,17 +1773,10 @@ static int tc358743_enum_mbus_code(struct v4l2_subdev *sd,
 {
 	switch (code->index) {
 	case 0:
-		code->code = MEDIA_BUS_FMT_BGR888_1X24;
+		code->code = MEDIA_BUS_FMT_RGB888_1X24;
 		break;
 	case 1:
 		code->code = MEDIA_BUS_FMT_UYVY8_1X16;
-		break;
-	case 2:
-		/*
-		 * We need to keep RGB888 for backward compatibility,
-		 * but we should list it last for userspace to pick BGR.
-		 */
-		code->code = MEDIA_BUS_FMT_RGB888_1X24;
 		break;
 	default:
 		return -EINVAL;
@@ -1820,7 +1787,6 @@ static int tc358743_enum_mbus_code(struct v4l2_subdev *sd,
 static u32 tc358743_g_colorspace(u32 code)
 {
 	switch (code) {
-	case MEDIA_BUS_FMT_BGR888_1X24:
 	case MEDIA_BUS_FMT_RGB888_1X24:
 		return V4L2_COLORSPACE_SRGB;
 	case MEDIA_BUS_FMT_UYVY8_1X16:
@@ -1858,8 +1824,7 @@ static int tc358743_set_fmt(struct v4l2_subdev *sd,
 	u32 code = format->format.code; /* is overwritten by get_fmt */
 	int ret = tc358743_get_fmt(sd, sd_state, format);
 
-	if (code == MEDIA_BUS_FMT_BGR888_1X24 ||
-	    code == MEDIA_BUS_FMT_RGB888_1X24 ||
+	if (code == MEDIA_BUS_FMT_RGB888_1X24 ||
 	    code == MEDIA_BUS_FMT_UYVY8_1X16)
 		format->format.code = code;
 	format->format.colorspace = tc358743_g_colorspace(format->format.code);
@@ -2279,7 +2244,7 @@ static int tc358743_probe(struct i2c_client *client)
 	if (err < 0)
 		goto err_hdl;
 
-	state->mbus_fmt_code = MEDIA_BUS_FMT_BGR888_1X24;
+	state->mbus_fmt_code = MEDIA_BUS_FMT_RGB888_1X24;
 
 	sd->dev = &client->dev;
 

--- a/drivers/media/platform/broadcom/bcm2835-unicam.c
+++ b/drivers/media/platform/broadcom/bcm2835-unicam.c
@@ -342,12 +342,12 @@ static const struct unicam_format_info unicam_image_formats[] = {
 		.csi_dt		= MIPI_CSI2_DT_RGB565,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_RGB24, /* rgb */
-		.code		= MEDIA_BUS_FMT_RGB888_1X24,
+		.code		= MEDIA_BUS_FMT_BGR888_1X24,
 		.depth		= 24,
 		.csi_dt		= MIPI_CSI2_DT_RGB888,
 	}, {
 		.fourcc		= V4L2_PIX_FMT_BGR24, /* bgr */
-		.code		= MEDIA_BUS_FMT_BGR888_1X24,
+		.code		= MEDIA_BUS_FMT_RGB888_1X24,
 		.depth		= 24,
 		.csi_dt		= MIPI_CSI2_DT_RGB888,
 	}, {
@@ -2148,22 +2148,45 @@ static int unicam_video_link_validate(struct media_link *link)
 		const struct v4l2_pix_format *fmt = &node->fmt.fmt.pix;
 		const struct unicam_format_info *fmtinfo;
 
-		fmtinfo = unicam_find_format_by_fourcc(fmt->pixelformat,
-						       UNICAM_SD_PAD_SOURCE_IMAGE);
+		fmtinfo = unicam_find_format_by_code(format->code,
+						     UNICAM_SD_PAD_SOURCE_IMAGE);
 		if (WARN_ON(!fmtinfo)) {
 			ret = -EPIPE;
 			goto out;
 		}
 
-		if (fmtinfo->code != format->code ||
-		    fmt->height != format->height ||
+		/*
+		 * Unicam initially associated BGR24 to BGR888_1X24 and RGB24 to
+		 * RGB888_1X24.
+		 *
+		 * In order to allow the applications using the old behaviour to
+		 * run, let's accept the old combination, but warn about it.
+		 */
+		if (fmtinfo->fourcc != fmt->pixelformat) {
+			if ((fmt->pixelformat == V4L2_PIX_FMT_BGR24 &&
+			     format->code == MEDIA_BUS_FMT_BGR888_1X24) ||
+			    (fmt->pixelformat == V4L2_PIX_FMT_RGB24 &&
+			     format->code == MEDIA_BUS_FMT_RGB888_1X24)) {
+				dev_warn_once(node->dev->dev,
+					      "Incorrect pixel format %p4cc for 0x%04x. Fix your application to use %p4cc.\n",
+					      &fmt->pixelformat, format->code, &fmtinfo->fourcc);
+			} else {
+				dev_dbg(node->dev->dev,
+					"image: format mismatch: 0x%04x <=> %p4cc\n",
+					format->code, &fmt->pixelformat);
+				ret = -EPIPE;
+				goto out;
+			}
+		}
+
+		if (fmt->height != format->height ||
 		    fmt->width != format->width ||
 		    fmt->field != format->field) {
 			dev_dbg(node->dev->dev,
-				"image: (%u x %u) 0x%08x %s != (%u x %u) 0x%08x %s\n",
-				fmt->width, fmt->height, fmtinfo->code,
+				"image: (%u x %u) %s != (%u x %u) %s\n",
+				fmt->width, fmt->height,
 				v4l2_field_names[fmt->field],
-				format->width, format->height, format->code,
+				format->width, format->height,
 				v4l2_field_names[format->field]);
 			ret = -EPIPE;
 		}

--- a/drivers/media/platform/raspberrypi/rp1-cfe/cfe-fmts.h
+++ b/drivers/media/platform/raspberrypi/rp1-cfe/cfe-fmts.h
@@ -62,13 +62,13 @@ static const struct cfe_fmt formats[] = {
 	},
 	{
 		.fourcc = V4L2_PIX_FMT_RGB24, /* rgb */
-		.code = MEDIA_BUS_FMT_RGB888_1X24,
+		.code = MEDIA_BUS_FMT_BGR888_1X24,
 		.depth = 24,
 		.csi_dt = MIPI_CSI2_DT_RGB888,
 	},
 	{
 		.fourcc = V4L2_PIX_FMT_BGR24, /* bgr */
-		.code = MEDIA_BUS_FMT_BGR888_1X24,
+		.code = MEDIA_BUS_FMT_RGB888_1X24,
 		.depth = 24,
 		.csi_dt = MIPI_CSI2_DT_RGB888,
 	},

--- a/drivers/media/platform/raspberrypi/rp1-cfe/cfe.c
+++ b/drivers/media/platform/raspberrypi/rp1-cfe/cfe.c
@@ -1807,12 +1807,29 @@ static int cfe_video_link_validate(struct media_link *link)
 			goto out;
 		}
 
-		fmt = find_format_by_code_and_fourcc(source_fmt->code,
-						     pix_fmt->pixelformat);
+		fmt = find_format_by_code(source_fmt->code);
+
 		if (!fmt) {
-			cfe_err(cfe, "Format mismatch!\n");
+			cfe_err(cfe, "Format mismatch - unknown code!\n");
 			ret = -EINVAL;
 			goto out;
+		}
+
+		if (fmt->fourcc != pix_fmt->pixelformat) {
+			if ((pix_fmt->pixelformat == V4L2_PIX_FMT_BGR24 &&
+			     source_fmt->code == MEDIA_BUS_FMT_BGR888_1X24) ||
+			    (pix_fmt->pixelformat == V4L2_PIX_FMT_RGB24 &&
+			     source_fmt->code == MEDIA_BUS_FMT_RGB888_1X24)) {
+				dev_warn_once(&cfe->pdev->dev,
+					      "Incorrect pixel format %p4cc for 0x%04x. Fix your application to use %p4cc.\n",
+					      &pix_fmt->pixelformat,
+					      source_fmt->code, &fmt->fourcc);
+			} else {
+				cfe_err(cfe, "Format mismatch! Code %u fourcc %p4cc\n",
+					source_fmt->code, &pix_fmt->pixelformat);
+				ret = -EINVAL;
+				goto out;
+			}
 		}
 	} else if (is_csi2_node(node) && is_meta_output_node(node)) {
 		struct v4l2_meta_format *meta_fmt = &node->meta_fmt.fmt.meta;

--- a/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
@@ -1676,7 +1676,6 @@ static int cfe_video_link_validate(struct cfe_node *node,
 	if (is_image_output_node(node)) {
 		struct v4l2_pix_format *pix_fmt = &node->vid_fmt.fmt.pix;
 		const struct cfe_fmt *fmt = NULL;
-		unsigned int i;
 
 		if (remote_fmt->width != pix_fmt->width ||
 		    remote_fmt->height != pix_fmt->height) {
@@ -1687,16 +1686,28 @@ static int cfe_video_link_validate(struct cfe_node *node,
 			return -EINVAL;
 		}
 
-		for (i = 0; i < ARRAY_SIZE(formats); i++) {
-			if (formats[i].code == remote_fmt->code &&
-			    formats[i].fourcc == pix_fmt->pixelformat) {
-				fmt = &formats[i];
-				break;
-			}
-		}
+		fmt = find_format_by_code(remote_fmt->code);
+
 		if (!fmt) {
-			cfe_err("Format mismatch!\n");
+			cfe_err("Format not found. %08x %p4cc\n",
+				remote_fmt->code, &pix_fmt->pixelformat);
 			return -EINVAL;
+		}
+
+		if (fmt->fourcc != pix_fmt->pixelformat) {
+			if ((pix_fmt->pixelformat == V4L2_PIX_FMT_BGR24 &&
+			     remote_fmt->code == MEDIA_BUS_FMT_BGR888_1X24) ||
+			    (pix_fmt->pixelformat == V4L2_PIX_FMT_RGB24 &&
+			     remote_fmt->code == MEDIA_BUS_FMT_RGB888_1X24)) {
+				dev_warn_once(&cfe->pdev->dev,
+					      "Incorrect pixel format %p4cc for 0x%04x. Fix your application to use %p4cc.\n",
+					      &pix_fmt->pixelformat,
+					      remote_fmt->code, &fmt->fourcc);
+			} else {
+				cfe_err("Format mismatch! Code %u fourcc %p4cc\n",
+					remote_fmt->code, &pix_fmt->pixelformat);
+				return -EINVAL;
+			}
 		}
 	} else if (is_csi2_node(node) && is_meta_output_node(node)) {
 		struct v4l2_meta_format *meta_fmt = &node->meta_fmt.fmt.meta;

--- a/drivers/media/platform/raspberrypi/rp1_cfe/cfe_fmts.h
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/cfe_fmts.h
@@ -63,13 +63,13 @@ static const struct cfe_fmt formats[] = {
 	},
 	{
 		.fourcc = V4L2_PIX_FMT_RGB24, /* rgb */
-		.code = MEDIA_BUS_FMT_RGB888_1X24,
+		.code = MEDIA_BUS_FMT_BGR888_1X24,
 		.depth = 24,
 		.csi_dt = MIPI_CSI2_DT_RGB888,
 	},
 	{
 		.fourcc = V4L2_PIX_FMT_BGR24, /* bgr */
-		.code = MEDIA_BUS_FMT_BGR888_1X24,
+		.code = MEDIA_BUS_FMT_RGB888_1X24,
 		.depth = 24,
 		.csi_dt = MIPI_CSI2_DT_RGB888,
 	},


### PR DESCRIPTION
Upstream changed their minds over how to solve the mismatch, hence reverting the patch I had pushed, cherry-picking the Unicam fix, and then applying the same to both mainline and downstream CFE drivers.

Ideally we do want to fix the downstream Unicam driver too, but doing so is a chunk trickier as it doesn't just use the Media Controller link_validate call. That one can follow later when time allows.