### PR TITLE
Revert "drm/v3d: Increase the autosuspend delay"

### DIFF
--- a/drivers/gpu/drm/v3d/v3d_drv.c
+++ b/drivers/gpu/drm/v3d/v3d_drv.c
@@ -431,7 +431,7 @@ static int v3d_platform_drm_probe(struct platform_device *pdev)
 
 	v3d_init_hw_state(v3d);
 
-	pm_runtime_set_autosuspend_delay(dev, 100);
+	pm_runtime_set_autosuspend_delay(dev, 50);
 	pm_runtime_use_autosuspend(dev);
 
 	ret = drm_dev_register(drm, 0);


### PR DESCRIPTION
This reverts commit 3341dd2bc43865b6424d95623065aff51470c15d.

After #7400, this commit is no longer needed. After further analysis, the 100ms autosuspend delay was only ever a workaround: shorter delays caused more frequent runtime suspend/resume cycles on the BCM2711, which exposed the cache and MMU coherency bugs as random GPU hangs.

With those hangs resolved, the inflated delay is no longer necessary. Reduce it from 100ms to 50ms so the GPU power domain can be released sooner once the GPU goes idle.

---

I tested locally with delays as low as 2ms without issues after #7400, but 50ms is a good compromise for a GPU like V3D.