### PR TITLE
Diagnostic patch - one reversion

### DIFF
--- a/drivers/net/can/spi/mcp251x.c
+++ b/drivers/net/can/spi/mcp251x.c
@@ -1212,11 +1212,7 @@ static int mcp251x_open(struct net_device *net)
 	}
 
 	mutex_lock(&priv->mcp_lock);
-	ret = mcp251x_power_enable(priv->transceiver, 1);
-	if (ret) {
-		dev_err(&spi->dev, "failed to enable transceiver power: %pe\n", ERR_PTR(ret));
-		goto out_close_candev;
-	}
+	mcp251x_power_enable(priv->transceiver, 1);
 
 	priv->force_quit = 0;
 	priv->tx_skb = NULL;
@@ -1263,7 +1259,6 @@ out_free_irq:
 	mcp251x_hw_sleep(spi);
 out_close:
 	mcp251x_power_enable(priv->transceiver, 0);
-out_close_candev:
 	close_candev(net);
 	mutex_unlock(&priv->mcp_lock);
 	if (release_irq)
@@ -1499,25 +1494,11 @@ static int __maybe_unused mcp251x_can_resume(struct device *dev)
 {
 	struct spi_device *spi = to_spi_device(dev);
 	struct mcp251x_priv *priv = spi_get_drvdata(spi);
-	int ret = 0;
 
-	if (priv->after_suspend & AFTER_SUSPEND_POWER) {
-		ret = mcp251x_power_enable(priv->power, 1);
-		if (ret) {
-			dev_err(dev, "failed to restore power: %pe\n", ERR_PTR(ret));
-			return ret;
-		}
-	}
-
-	if (priv->after_suspend & AFTER_SUSPEND_UP) {
-		ret = mcp251x_power_enable(priv->transceiver, 1);
-		if (ret) {
-			dev_err(dev, "failed to restore transceiver power: %pe\n", ERR_PTR(ret));
-			if (priv->after_suspend & AFTER_SUSPEND_POWER)
-				mcp251x_power_enable(priv->power, 0);
-			return ret;
-		}
-	}
+	if (priv->after_suspend & AFTER_SUSPEND_POWER)
+		mcp251x_power_enable(priv->power, 1);
+	if (priv->after_suspend & AFTER_SUSPEND_UP)
+		mcp251x_power_enable(priv->transceiver, 1);
 
 	if (priv->after_suspend & (AFTER_SUSPEND_POWER | AFTER_SUSPEND_UP))
 		queue_work(priv->wq, &priv->restart_work);


### PR DESCRIPTION
Revert "can: mcp251x: add error handling for power enable in open and resume"

This reverts commit a06d3a9309733402aaad7ae0a848ea1afd0aac76.

See: https://github.com/raspberrypi/trixie-feedback/issues/76
