### PR TITLE
Revert "random: do not use jump labels before they are initialized"

### DIFF
--- a/drivers/char/random.c
+++ b/drivers/char/random.c
@@ -859,14 +859,6 @@ void __init random_init_early(const char *command_line)
 	unsigned long entropy[BLAKE2S_BLOCK_SIZE / sizeof(long)];
 	size_t i, longs, arch_bits;
 
-	/*
-	 * If we were initialized by the bootloader before jump labels are
-	 * initialized, then we should enable the static branch here, where
-	 * it's guaranteed that jump labels have been initialized.
-	 */
-	if (!static_branch_likely(&crng_is_ready) && crng_init >= CRNG_READY)
-		crng_set_ready(NULL);
-
 #if defined(LATENT_ENTROPY_PLUGIN)
 	static const u8 compiletime_seed[BLAKE2S_BLOCK_SIZE] __initconst __latent_entropy;
 	_mix_pool_bytes(compiletime_seed, sizeof(compiletime_seed));


### PR DESCRIPTION
This reverts commit 89a64d88e3c762d2666ec5b9bc115c94de764c2c.

The commit this is reverting was part of a pre-release fix to an early 5.19 rc issue. It ended up being replaced by an identically named commit, but this fragment was unintentionally retained as a partial duplicate.

Drop the duplicate.

See: https://github.com/raspberrypi/linux/issues/7424