### PR TITLE
dtoverlays: Add overrides for regulator delays on imx708

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -3131,6 +3131,10 @@ Params: rotation                Mounting rotation of the camera sensor (0 or
                                 Compute Module (CSI0, i2c_vc, and cam0_reg).
         link-frequency          Allowable link frequency values to use in Hz:
                                 450000000 (default), 447000000, 453000000.
+        reg-startup-delay-us    Override the regulator startup delay value.
+                                (default 70000 us)
+        reg-off-on-delay-us     Override the regulator min off-on delay value.
+                                (default 30000 us)
 
 
 Name:   interludeaudio-analog

--- a/arch/arm/boot/dts/overlays/imx708-overlay.dts
+++ b/arch/arm/boot/dts/overlays/imx708-overlay.dts
@@ -95,6 +95,8 @@
 		vcm = <&vcm_node>, "status",
 		      <0>, "=4";
 		link-frequency = <&cam_endpoint>,"link-frequencies#0";
+		reg-startup-delay-us = <&cam_reg>,"startup-delay-us:0";
+		reg-off-on-delay-us = <&cam_reg>,"off-on-delay-us:0";
 	};
 };
 


### PR DESCRIPTION
The Arducam imx708 modules seem slow to start up. Add overrides so that users can change them easily.

https://forums.raspberrypi.com/viewtopic.php?t=398874