### PR TITLE
r8152: add vendor/device ID for CoreChips SR9900

### DIFF
--- a/drivers/net/usb/r8152.c
+++ b/drivers/net/usb/r8152.c
@@ -10062,6 +10062,7 @@ static const struct usb_device_id rtl8152_table[] = {
 	{ USB_DEVICE(VENDOR_ID_DELL,    0xb097) },
 	{ USB_DEVICE(VENDOR_ID_ASUS,    0x1976) },
 	{ USB_DEVICE(VENDOR_ID_TRENDNET, 0xe02b) },
+	{ USB_DEVICE(0x0fe6, 0x9900) },
 	{}
 };
 


### PR DESCRIPTION
The CoreChips SR9900 (0x0fe6:0x9900) is a USB 2.0 10/100 Ethernet adapter. 
Testing shows it works correctly with the r8152 driver, reaching wire speed (94 Mbps) with zero packet loss on both TCP and UDP.

Tested on Raspberry Pi, including hotplug and extended data transfer.