### PR TITLE
pwm: pio-rp1: don't flag driver as using atomic ops

### DIFF
--- a/drivers/pwm/pwm-pio-rp1.c
+++ b/drivers/pwm/pwm-pio-rp1.c
@@ -224,7 +224,6 @@ static int pwm_pio_rp1_probe(struct platform_device *pdev)
 	pwm_pio_resolution = (1000u * 1000 * 1000 * pwm_loop_ticks) / clock_get_hz(clk_sys);
 
 	chip->ops = &pwm_pio_rp1_ops;
-	chip->atomic = true;
 	chip->npwm = 1;
 
 	platform_set_drvdata(pdev, ppwm);


### PR DESCRIPTION
Apparently this causes splats on 6.18.

see https://forums.raspberrypi.com/viewtopic.php?p=2379491#p2379491