### PR TITLE
dts: cgroup: remove cgroup_disable=memory parameter

### DIFF
--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi-bt.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi-bt.dtsi
@@ -24,7 +24,7 @@
 
 / {
 	chosen {
-		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0 cgroup_disable=memory";
+		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
 	};
 
 	aliases {

--- a/arch/arm/boot/dts/broadcom/bcm270x.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm270x.dtsi
@@ -4,7 +4,7 @@
 / {
 	chosen: chosen {
 		// Disable audio by default
-		bootargs = "coherent_pool=1M snd_bcm2835.enable_headphones=0 cgroup_disable=memory";
+		bootargs = "coherent_pool=1M snd_bcm2835.enable_headphones=0";
 		stdout-path = "serial0:115200n8";
 	};
 

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
@@ -160,7 +160,7 @@
 
 / {
 	chosen {
-		bootargs = "coherent_pool=1M snd_bcm2835.enable_headphones=0 cgroup_disable=memory numa_policy=interleave";
+		bootargs = "coherent_pool=1M snd_bcm2835.enable_headphones=0 numa_policy=interleave";
 	};
 
 	aliases {

--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
@@ -3,7 +3,7 @@
 
 / {
 	chosen {
-		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0 cgroup_disable=memory numa_policy=interleave nvme.max_host_mem_size_mb=32";
+		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0 numa_policy=interleave nvme.max_host_mem_size_mb=32";
 	};
 
 	__overrides__ {

--- a/arch/arm/boot/dts/broadcom/bcm271x-rpi-bt.dtsi
+++ b/arch/arm/boot/dts/broadcom/bcm271x-rpi-bt.dtsi
@@ -24,7 +24,7 @@
 
 / {
 	chosen {
-		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0 cgroup_disable=memory";
+		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
 	};
 
 	aliases {

--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
@@ -113,7 +113,7 @@ watchdog: &pm {};
 
 / {
 	chosen: chosen {
-		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe cgroup_disable=memory numa_policy=interleave nvme.max_host_mem_size_mb=32";
+		bootargs = "reboot=w coherent_pool=1M 8250.nr_uarts=1 pci=pcie_bus_safe numa_policy=interleave nvme.max_host_mem_size_mb=32";
 		stdout-path = "serial10:115200n8";
 	};
 


### PR DESCRIPTION
This was introduced in commit https://github.com/raspberrypi/linux/commit/86099deff5abf5f63643eecaedb4c11ae77474ce

In issue https://github.com/raspberrypi/linux/issues/6980, it is commented that appending ``cgroup_enable=memory`` fixes the issue. However, as seen in the code changes of the commit, this only works if the kernel in use is Raspberry Pi's own kernel. Kernel from other distros like Ubuntu or Debian doesn't have that patch, so appending ``cgroup_enable=memory`` doesn't solve the issue there. I can confirm that compiling this DTB allows Docker to enforce memory limits.

Given distros like Ubuntu or Debian still rely on the `.dtb` (Debian does it through the `raspi-firmware` package), I think it's sensible to remove this flag altogether. A few Google searches can be found about this topic and, given Docker is now ubiquituous and commonly used, having to manually adjust this is, in my opinion, more problematic than worth it. Most Raspberry Pis have more than 1 GB now so this argument should be opt-in (not opt-out) by default and can be documented elsewhere in case users want to make the most out of their memory (although, in my opinion, this falls more in the area of micro-optimization with negligible returns).