### PR TITLE
CFE/Unicam: Fix breakage from #7406

### DIFF
--- a/drivers/media/platform/broadcom/bcm2835-unicam.c
+++ b/drivers/media/platform/broadcom/bcm2835-unicam.c
@@ -2162,7 +2162,8 @@ static int unicam_video_link_validate(struct media_link *link)
 		 * In order to allow the applications using the old behaviour to
 		 * run, let's accept the old combination, but warn about it.
 		 */
-		if (fmtinfo->fourcc != fmt->pixelformat) {
+		if (fmt->pixelformat != fmtinfo->fourcc &&
+		    fmt->pixelformat != fmtinfo->unpacked_fourcc) {
 			if ((fmt->pixelformat == V4L2_PIX_FMT_BGR24 &&
 			     format->code == MEDIA_BUS_FMT_BGR888_1X24) ||
 			    (fmt->pixelformat == V4L2_PIX_FMT_RGB24 &&

--- a/drivers/media/platform/raspberrypi/rp1-cfe/cfe.c
+++ b/drivers/media/platform/raspberrypi/rp1-cfe/cfe.c
@@ -1815,7 +1815,9 @@ static int cfe_video_link_validate(struct media_link *link)
 			goto out;
 		}
 
-		if (fmt->fourcc != pix_fmt->pixelformat) {
+		if (fmt->fourcc != pix_fmt->pixelformat &&
+		    fmt->remap[CFE_REMAP_16BIT] != pix_fmt->pixelformat &&
+		    fmt->remap[CFE_REMAP_COMPRESSED] != pix_fmt->pixelformat)  {
 			if ((pix_fmt->pixelformat == V4L2_PIX_FMT_BGR24 &&
 			     source_fmt->code == MEDIA_BUS_FMT_BGR888_1X24) ||
 			    (pix_fmt->pixelformat == V4L2_PIX_FMT_RGB24 &&

--- a/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
+++ b/drivers/media/platform/raspberrypi/rp1_cfe/cfe.c
@@ -1694,7 +1694,9 @@ static int cfe_video_link_validate(struct cfe_node *node,
 			return -EINVAL;
 		}
 
-		if (fmt->fourcc != pix_fmt->pixelformat) {
+		if (fmt->fourcc != pix_fmt->pixelformat &&
+		    fmt->remap[CFE_REMAP_16BIT] != pix_fmt->pixelformat &&
+		    fmt->remap[CFE_REMAP_COMPRESSED] != pix_fmt->pixelformat)  {
 			if ((pix_fmt->pixelformat == V4L2_PIX_FMT_BGR24 &&
 			     remote_fmt->code == MEDIA_BUS_FMT_BGR888_1X24) ||
 			    (pix_fmt->pixelformat == V4L2_PIX_FMT_RGB24 &&


### PR DESCRIPTION
I missed a follow up patch from upstream in #7406, and then copied the same error into the CFE driver.

Fix them up. (The Unicam patch hasn't been accepted and merged upstream, but has R-b responses).