### PR TITLE
mailbox: rp1: Set txpoll_period = 0

### DIFF
--- a/drivers/mailbox/rp1-mailbox.c
+++ b/drivers/mailbox/rp1-mailbox.c
@@ -169,7 +169,7 @@ static int rp1_mbox_probe(struct platform_device *pdev)
 		return -ENOMEM;
 
 	mbox->controller.txdone_poll = true;
-	mbox->controller.txpoll_period = 5;
+	mbox->controller.txpoll_period = 0;
 	mbox->controller.ops = &rp1_mbox_chan_ops;
 	mbox->controller.of_xlate = &rp1_mbox_xlate;
 	mbox->controller.dev = dev;


### PR DESCRIPTION
Since upstream commit [1], RP1 mailbox performance has been terrible. Setting txpoll_period to 0 seems to reverse the change, with no obvious negative repercussions.

See: https://forums.raspberrypi.com/viewtopic.php?p=2379836#p2379836

Signed-off-by: Phil Elwell <phil@raspberrypi.com>

[1] commit c58e9456e30c ("mailbox: Fix NULL message support in
    mbox_send_message()")