### PR TITLE
usb: dwc2: gadget: Demote stall-related messages

### DIFF
--- a/drivers/usb/dwc2/gadget.c
+++ b/drivers/usb/dwc2/gadget.c
@@ -1087,7 +1087,7 @@ static void dwc2_hsotg_start_req(struct dwc2_hsotg *hsotg,
 	ctrl = dwc2_readl(hsotg, epctrl_reg);
 
 	if (index && ctrl & DXEPCTL_STALL) {
-		dev_warn(hsotg->dev, "%s: ep%d is stalled\n", __func__, index);
+		dev_dbg(hsotg->dev, "%s: ep%d is stalled\n", __func__, index);
 		return;
 	}
 
@@ -4393,7 +4393,7 @@ static int dwc2_hsotg_ep_sethalt(struct usb_ep *ep, int value, bool now)
 	u32 epctl;
 	u32 xfertype;
 
-	dev_info(hs->dev, "%s(ep %p %s, %d)\n", __func__, ep, ep->name, value);
+	dev_dbg(hs->dev, "%s(ep %p %s, %d)\n", __func__, ep, ep->name, value);
 
 	if (index == 0) {
 		if (value)


### PR DESCRIPTION
Endpoint stalling is a feature, not an error; the mass storage gadget driver makes use of it in the course of normal operation. The dwc2 gadget driver has some info- and warning-level messages that look like messages added during the driver's development and never cleaned up.

Demote those message to the debug level to reduce log spam and avoid users wasting time worrying about them.

See: https://github.com/raspberrypi/linux/issues/7452