### PR TITLE
overlays: Add Sixfab M1M PCIe Gen3 AI HAT+

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -269,6 +269,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	seeed-can-fd-hat-v2.dtbo \
 	sh1106-spi.dtbo \
 	si446x-spi0.dtbo \
+	sixfab_m1m.dtbo \
 	smi.dtbo \
 	smi-dev.dtbo \
 	smi-nand.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4822,6 +4822,12 @@ Params: speed                   SPI bus speed (default 4000000)
         reset_pin               GPIO pin for RESET (default 27)
 
 
+Name:   sixfab_m1m
+Info:   Overlay for the Sixfab M1M PCIe Gen3 AI HAT+
+Load:   dtoverlay=sixfab_m1m
+Params: <None>
+
+
 Name:   smi
 Info:   Enables the Secondary Memory Interface peripheral. Uses GPIOs 2-25!
 Load:   dtoverlay=smi

--- a/arch/arm/boot/dts/overlays/sixfab_m1m-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sixfab_m1m-overlay.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/dts-v1/;
+/plugin/;
+/ {
+	compatible = "brcm,bcm2712";
+	fragment@0 {
+		target = <&pciex1>;
+		__overlay__ {
+			status = "okay";
+			max-link-speed = <3>;
+		};
+	};
+};


### PR DESCRIPTION
This PR adds the device tree overlay for the Sixfab M1M AI HAT+, enabling PCIe Gen3 speeds. It complies with the standard HAT+ specification. Tested on Raspberry Pi 5.