### PR TITLE
overlays: sdhost: Add gpios_22_27 and bus_width parameters

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4737,6 +4737,11 @@ Params: overclock_50            Clock (in MHz) to use when the MMC framework
 
         debug                   Enable debug output (default off)
 
+        gpios_22_27             Route SD0 to GPIO 22-27 (CLK, CMD, DAT0-3)
+                                for use with a secondary SD card slot on
+                                custom carrier boards (e.g. CM4 baseboard).
+                                Applies ALT0 function and appropriate pulls.
+
 
 Name:   sdio
 Info:   Selects the bcm2835-sdhost SD/MMC driver, optionally with overclock,

--- a/arch/arm/boot/dts/overlays/sdhost-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sdhost-overlay.dts
@@ -29,10 +29,30 @@
 		};
 	};
 
+	fragment@3 {
+		target = <&gpio>;
+		__dormant__ {
+			sdhost_gpio_22_27: sdhost_gpio_22_27 {
+				brcm,pins = <22 23 24 25 26 27>;
+				brcm,function = <4>;
+				brcm,pull = <0 2 2 2 2 2>;
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&sdhost>;
+		__dormant__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&sdhost_gpio_22_27>;
+		};
+	};
+
 	__overrides__ {
 		overclock_50     = <&frag0>,"brcm,overclock-50:0";
 		force_pio        = <&frag0>,"brcm,force-pio?";
 		pio_limit        = <&frag0>,"brcm,pio-limit:0";
 		debug            = <&frag0>,"brcm,debug?";
+		gpios_22_27      = <0>,"+3+4";
 	};
 };


### PR DESCRIPTION
## Summary
Add `gpios_22_27` and `bus_width` parameters to the sdhost overlay
to support CM4 custom carrier boards that route SD0 to GPIO 22-27.
## Motivation
Some CM4 carrier boards (e.g. industrial IPC boards) wire a secondary
SD card slot to GPIO 22-27 rather than using eMMC. The stock sdhost
overlay provides no way to configure this pinmux, forcing users to
maintain separate out-of-tree overlays.
## Changes
- Add dormant fragment@3: configures GPIO 22-27 to ALT0 (SD0)
- Add dormant fragment@4: binds sdhost to the above pinctrl
- Add `gpios_22_27` override: activates fragments 3 and 4
- Add `bus_width` override: exposes bus-width configuration
- Update README with parameter documentation
## Testing
Verified on CM4 + EDATEC IPC2100 carrier board:
- lsblk shows mmcblk2 correctly detected on GPIO 22-27

```
pi@pi:~ $ lsblk
NAME         MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
loop0          7:0    0    2G  0 loop
mmcblk0      179:0    0 29.1G  0 disk
├─mmcblk0p1  179:1    0  512M  0 part /boot/firmware
└─mmcblk0p2  179:2    0 28.6G  0 part /
mmcblk0boot0 179:32   0    4M  1 disk
mmcblk0boot1 179:64   0    4M  1 disk
mmcblk2      179:96   0 29.7G  0 disk
├─mmcblk2p1  179:97   0  512M  0 part /media/pi/system-boot
└─mmcblk2p2  179:98   0 29.2G  0 part
zram0        254:0    0    2G  0 disk [SWAP]
```

- dmesg confirms sdhost-bcm2835 loaded with DMA

```
pi@pi:~ $ dmesg | grep -iE "sdhost|mmc0|emmc"
[    0.762195] mmc0: SDHCI controller on fe340000.mmc [fe340000.mmc] using ADMA
[    0.800705] sdhost-bcm2835 fe202000.mmc: loaded - DMA enabled (>1)
[    0.819078] mmc0: new high speed DDR MMC card at address 0001
[    0.819531] mmcblk0: mmc0:0001 BJTD4R 29.1 GiB
[    0.821222] mmcblk0: mmc0:0001 BJTD4R 29.1 GiB
[    0.821548] mmcblk0boot0: mmc0:0001 BJTD4R 4.00 MiB
[    0.823176] mmcblk0boot1: mmc0:0001 BJTD4R 4.00 MiB
[    0.824889] mmcblk0rpmb: mmc0:0001 BJTD4R 4.00 MiB, chardev (242:0)
```

- vclog confirms overlay parameters applied correctly

```
004758.485: brfs: File read: /mfs/sd/overlays/sdhost.dtbo
004771.492: Loaded overlay 'sdhost'
004771.503: dtparam: gpios_22_27=on
004771.873: dtparam: bus_width=4
004772.148: dtparam: pio_limit=1
004811.120: brfs: File read: 1451 bytes
```

config.txt used for testing:
  dtoverlay=sdhost,gpios_22_27=on,bus_width=4,pio_limit=1