### PR TITLE
overlays: ed-ipc: Add EDATEC IPC/EXP unified board overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -63,6 +63,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	draws-pi5.dtbo \
 	dwc-otg-deprecated.dtbo \
 	dwc2.dtbo \
+	ed-ipc.dtbo \
 	edt-ft5406.dtbo \
 	enc28j60.dtbo \
 	enc28j60-spi2.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -1278,6 +1278,59 @@ Params: dr_mode                 Dual role mode: "host", "peripheral" or "otg"
                                 mode
 
 
+Name:   ed-ipc
+Info:   Configures the EDATEC IPC/EXP series hardware peripherals.
+        This overlay provides support for PCA9535 GPIO expanders on
+        the EDATEC industrial PC carrier boards, including interrupt
+        handling, GPIO line names, and optional secondary expander
+        on i2c_arm.
+Load:   dtoverlay=ed-ipc,<param>=<val>
+Params: addr                    I2C address for primary PCA9535 GPIO expander
+                                (default 0x20)
+
+        exp_addr                I2C address for secondary PCA9535 GPIO
+                                expander on i2c_arm (default 0x27)
+
+        ipc3100                 Enable configuration for IPC3100 board
+                                (CM5, i2c_csi_dsi0, PCA int GPIO6)
+
+        ipc2100                 Enable configuration for IPC2100 board
+                                (CM4, i2c_csi_dsi, PCA int GPIO6)
+
+        ipc2210                 Enable configuration for IPC2210 board
+                                (CM4, i2c_csi_dsi, PCA int GPIO6)
+
+        ipc3210                 Enable configuration for IPC3210 board
+                                (CM5, i2c_csi_dsi0, PCA int GPIO6)
+
+        ipc1200                 Enable configuration for IPC1200 board
+                                (CM4, i2c_csi_dsi, PCA int GPIO15)
+
+        ipc3300                 Enable configuration for IPC3300 board
+                                (CM5, i2c_arm, PCA int GPIO38)
+
+        ipc2300                 Enable configuration for IPC2300 board
+                                (CM4, i2c_arm, PCA int GPIO44)
+
+        plc2010                 Enable configuration for PLC2010 board
+                                (i2c_arm, PCA int GPIO7, addr 0x21)
+
+        exp8x8y                 Enable 8-input/8-output expansion module
+                                (CM5, i2c_arm)
+
+        exp4x4y                 Enable 4-input/4-output expansion module
+                                (CM5, i2c_arm, exp at addr 0x21)
+
+        ipc3600                 Enable combined configuration for IPC3600
+                                (IPC3100 + exp8x8y)
+
+        ipc2600                 Enable combined configuration for IPC2600
+                                (IPC2100 + exp8x8y)
+
+        ipc1220                 Enable combined configuration for IPC1220
+                                (IPC1200 + exp4x4y)
+
+
 [ The ds1307-rtc overlay has been deleted. See i2c-rtc. ]
 
 

--- a/arch/arm/boot/dts/overlays/ed-ipc-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ed-ipc-overlay.dts
@@ -1,0 +1,279 @@
+/*
+ * EDATEC IPC/EXP unified board overlay
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+	i2c_frag: fragment@0 {
+		target = <&i2c_csi_dsi0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			pca_base: pca@20 {
+				compatible = "nxp,pca9535";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@100 {
+		target = <&i2c0if>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@101 {
+		target = <&i2c0mux>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@200 {
+		target = <&pca_base>;
+		__dormant__ {
+			gpio-line-names = "5V_GOOD", "LVD", "BUZZER_EN",
+					  "4G_RST", "4G_LED", "USER_LED";
+		};
+	};
+
+	fragment@201 {
+		target = <&pca_base>;
+		__dormant__ {
+			gpio-line-names = "5V_GOOD", "LVD", "BUZZER_EN",
+					  "4G_RST", "4G_LED", "5G_RST",
+					  "5G_PWR_ON", "USER_LED",
+					  "MSATA_PRSNT";
+		};
+	};
+
+	fragment@203 {
+		target = <&pca_base>;
+		__dormant__ {
+			gpio-line-names = "BL_EN_L", "BL_BTN_EN", "BL_BTN_UP",
+					  "BL_BTN_DOWN", "BUZZER_EN",
+					  "4G_RST", "MSATA_PRSNT", "FAN_EN",
+					  "NC", "NC", "NC", "NC",
+					  "NC", "NC", "NC", "PANEL_ON_L";
+		};
+	};
+
+	fragment@205 {
+		target = <&pca_base>;
+		__dormant__ {
+			gpio-line-names = "USB_RST", "WK_RST", "4G_PWR",
+					  "4G_RST", "4G_BOOT",
+					  "4G_LED_REG_RED", "4G_LED_REG_GED",
+					  "4G_LED_SIG_RED", "4G_LED_SIG_GED",
+					  "USER_LED_RED", "USER_LED_GED",
+					  "LCD_RST", "4G_PRESENT",
+					  "IOB1_PRESENT", "IOB2_PRESENT";
+		};
+	};
+
+	fragment@206 {
+		target = <&pca_base>;
+		__dormant__ {
+			gpio-line-names = "4G_RST", "LED_ERR", "LED_UPDATE",
+					  "LED_UDISK_BUSY", "LED_4G_EXP",
+					  "LED_UDISK_DET",
+					  "SW_FACTORY_RST", "SW_IP_ADDR_RST",
+					  "SW_START_STOP", "SW_APP_IMPORT",
+					  "SW_UDISK_REMOVE";
+		};
+	};
+
+	fragment@210 {
+		target = <&pca_base>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupts = <6 2>;		/* IRQ_TYPE_EDGE_FALLING */
+			pinctrl-names = "default";
+			pinctrl-0 = <&pca_irq6>;
+		};
+	};
+
+	fragment@212 {
+		target = <&pca_base>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupts = <38 2>;		/* IPC2300 CM5 */
+			pinctrl-names = "default";
+			pinctrl-0 = <&pca_irq38>;
+		};
+	};
+
+	fragment@213 {
+		target = <&pca_base>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupts = <44 2>;		/* IPC2300 CM4 */
+			pinctrl-names = "default";
+			pinctrl-0 = <&pca_irq44>;
+		};
+	};
+
+	fragment@214 {
+		target = <&pca_base>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupts = <7 2>;		/* PLC2010 */
+			pinctrl-names = "default";
+			pinctrl-0 = <&pca_irq7>;
+		};
+	};
+
+	fragment@310 {
+		target = <&gpio>;
+		__dormant__ {
+			pca_irq6: pca_irq6 {
+				brcm,pins = <6>;
+				brcm,function = <0>;	/* input */
+			};
+		};
+	};
+
+	fragment@312 {
+		target = <&gpio>;
+		__dormant__ {
+			pca_irq38: pca_irq38 {
+				brcm,pins = <38>;
+				brcm,function = <0>;	/* input */
+			};
+		};
+	};
+
+	fragment@313 {
+		target = <&gpio>;
+		__dormant__ {
+			pca_irq44: pca_irq44 {
+				brcm,pins = <44>;
+				brcm,function = <0>;	/* input */
+			};
+		};
+	};
+
+	fragment@314 {
+		target = <&gpio>;
+		__dormant__ {
+			pca_irq7: pca_irq7 {
+				brcm,pins = <7>;
+				brcm,function = <0>;	/* input */
+			};
+		};
+	};
+
+	fragment@400 {
+		target = <&i2c_arm>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			pca_exp: pca@27 {
+				compatible = "nxp,pca9535";
+				reg = <0x27>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@500 {
+		target = <&pca_exp>;
+		__dormant__ {
+			gpio-line-names = "DI0", "DI1", "DI2", "DI3",
+					  "DI4", "DI5", "DI6", "DI7",
+					  "DO0", "DO1", "DO2", "DO3",
+					  "DO4", "DO5", "DO6", "DO7";
+		};
+	};
+
+	fragment@501 {
+		target = <&pca_exp>;
+		__dormant__ {
+			gpio-line-names = "DI4", "DI5", "DI6", "DI7",
+					  "DO4", "DO5", "DO6", "DO7",
+					  "NC", "NC", "NC", "NC",
+					  "NC", "NC", "NC", "NC";
+		};
+	};
+
+	fragment@410 {
+		target = <&pca_exp>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupts = <10 2>;		/* EXP8X8Y */
+			pinctrl-names = "default";
+			pinctrl-0 = <&pca_irq10>;
+		};
+	};
+
+	fragment@411 {
+		target = <&pca_exp>;
+		__dormant__ {
+			interrupt-parent = <&gpio>;
+			interrupts = <4 2>;		/* EXP4X4Y */
+			pinctrl-names = "default";
+			pinctrl-0 = <&pca_irq4>;
+		};
+	};
+
+	fragment@510 {
+		target = <&gpio>;
+		__dormant__ {
+			pca_irq10: pca_irq10 {
+				brcm,pins = <10>;
+				brcm,function = <0>;	/* input */
+			};
+		};
+	};
+
+	fragment@511 {
+		target = <&gpio>;
+		__dormant__ {
+			pca_irq4: pca_irq4 {
+				brcm,pins = <4>;
+				brcm,function = <0>;	/* input */
+			};
+		};
+	};
+
+	__overrides__ {
+		addr = <&pca_base>, "reg:0";
+		exp_addr = <&pca_exp>, "reg:0";
+		ipc3100 = <0>, "+0+200+210+310";
+		ipc2100 = <0>, "+0+200+210+310",
+			  <&i2c_frag>, "target:0=", <&i2c_csi_dsi>;
+		ipc2210 = <0>, "+0+201+210+310",
+			  <&i2c_frag>, "target:0=", <&i2c_csi_dsi>;
+		ipc3210 = <0>, "+0+201+210+310";
+		ipc1200 = <0>, "+0+205",
+			  <&i2c_frag>, "target:0=", <&i2c_csi_dsi>;
+		ipc3300 = <0>, "+0+203+212+312",
+			  <&i2c_frag>, "target:0=", <&i2c_arm>;
+		ipc2300 = <0>, "+0+203+213+313",
+			  <&i2c_frag>, "target:0=", <&i2c_arm>;
+		plc2010 = <0>, "+0+206+214+314",
+			  <&i2c_frag>, "target:0=", <&i2c_arm>,
+			  <&pca_base>, "reg:0=", <0x21>;
+		exp8x8y     = <0>, "+400+500+410+510";	/* default CM5 */
+		exp4x4y     = <0>, "+400+501+411+511",
+			      <&pca_exp>, "reg:0=", <0x21>;	/* default CM5 */
+		ipc3600 = <0>, "+0+200+210+310+400+500+410+510";
+		ipc2600 = <0>, "+0+200+210+310+400+500+410+510",
+			  <&i2c_frag>, "target:0=", <&i2c_csi_dsi>;
+		ipc1220 = <0>, "+0+205+400+501+411+511",
+			  <&i2c_frag>, "target:0=", <&i2c_csi_dsi>,
+			  <&pca_exp>, "reg:0=", <0x21>;
+	};
+};


### PR DESCRIPTION
Add a new device tree overlay `ed-ipc` for EDATEC IPC/EXP series
industrial PC carrier boards (based on Raspberry Pi Compute Module 4/5).

This overlay configures PCA9535 GPIO expanders on both i2c_csi_dsi
and i2c_arm buses, providing support for multiple board profiles and
optional expansion modules.

### Supported board profiles
- ipc2100  — CM4, i2c_csi_dsi, PCA interrupt on GPIO6
- ipc2210  — CM4, i2c_csi_dsi, PCA interrupt on GPIO6
- ipc2300  — CM4, i2c_arm, PCA interrupt on GPIO44
- ipc3100  — CM5, i2c_csi_dsi0, PCA interrupt on GPIO6
- ipc3210  — CM5, i2c_csi_dsi0, PCA interrupt on GPIO6
- ipc3300  — CM5, i2c_arm, PCA interrupt on GPIO38
- ipc1200  — CM4, i2c_csi_dsi, PCA interrupt on GPIO15
- plc2010  — i2c_arm, PCA interrupt on GPIO7, addr 0x21
- ipc3600  — IPC3100 + exp8x8y expansion
- ipc2600  — IPC2100 + exp8x8y expansion
- ipc1220  — IPC1200 + exp4x4y expansion

### Usage example
`dtoverlay=ed-ipc,ipc2600`

### Additional parameters
- `addr`     — I2C address for primary PCA9535 (default 0x20)
- `exp_addr` — I2C address for secondary PCA9535 (default 0x27)
- `exp8x8y`  — Enable 8-input/8-output expansion module (CM5)
- `exp4x4y`  — Enable 4-input/4-output expansion module (CM5)

All fragments use the dormant/override mechanism and have no effect
unless explicitly activated by a board profile parameter.