### PR TITLE
Input: goodix - defer probe when externally reset controller does not answer

### DIFF
--- a/drivers/input/touchscreen/goodix.c
+++ b/drivers/input/touchscreen/goodix.c
@@ -1378,6 +1378,17 @@ reset:
 			ts->reset_controller_at_probe = true;
 			goto reset;
 		}
+		/*
+		 * Without reset/irq GPIOs the controller reset is sequenced
+		 * externally (e.g. by the display MCU on the Raspberry Pi
+		 * Touch Display 2) and the controller may simply not be out
+		 * of reset yet. Defer probing so it is retried once the rest
+		 * of the display stack has been brought up.
+		 */
+		if (ts->irq_pin_access_method == IRQ_PIN_ACCESS_NONE)
+			return dev_err_probe(&client->dev, -EPROBE_DEFER,
+					     "I2C communication failure: %d\n",
+					     error);
 		dev_err(&client->dev, "I2C communication failure: %d\n", error);
 		return error;
 	}


### PR DESCRIPTION
On some devices the reset line of the touch controller is sequenced by
external logic rather than by GPIOs under control of the goodix driver.
On the Raspberry Pi Touch Display 2, for example, the reset line is
managed by a microcontroller on the display. In such configurations the
driver has neither a reset GPIO nor access to the irq pin
(IRQ_PIN_ACCESS_NONE), so when the initial I2C test fails there is no
controller-reset retry path and probing fails permanently with -EIO.
Whether the controller answers the first I2C test depends on probe
timing relative to the external reset sequencing, which can shift
between kernel versions and configurations.

Return -EPROBE_DEFER in this case so probing is retried later, in
particular after other drivers (such as the DSI panel driver behind
which the display MCU is brought up) have been bound.

---

**Note:** This addresses a regression observed on Home Assistant OS 18.1 (kernel 6.18.x), where the Goodix touch controller of the Raspberry Pi Touch Display 2 stopped probing with `I2C communication failure: -5`, see home-assistant/operating-system#4846.

Related reports of the same failure signature:
- Touch Display 2 touch not working after warm reboot on Raspberry Pi OS (`Error reading 1 bytes from 0x8140: -5`, `probe with driver Goodix-TS failed with error -5`; the `rmmod goodix_ts && modprobe goodix_ts` workaround reported there is the manual equivalent of the deferred probe retry): https://forums.raspberrypi.com/viewtopic.php?t=389937
- Possibly related: Goodix touchscreen probe failure (`I2C communication failure: -6`) on Pi 5 with a Waveshare panel: #6456

This is untested on my end, but it seems a very plausible fix. Hence I did not send it upstream for now — but since the affected code path is unmodified mainline code, if this turns out to be the correct fix, anyone is welcome to pick it up and upstream it.

Note on the advisory checkpatch failure: the commit uses the `Assisted-by: AGENT_NAME:MODEL_VERSION` tag as accepted by current mainline checkpatch/docs; the 6.18-based checkpatch here predates that tag, hence the warning/error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)