### PR TITLE
overlays: i2c-fan: add compatible for upstream compatibility

### DIFF
--- a/arch/arm/boot/dts/overlays/i2c-fan-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c-fan-overlay.dts
@@ -17,7 +17,7 @@
 			status = "okay";
 
 			emc2301: emc2301@2f {
-				compatible = "microchip,emc2301";
+				compatible = "microchip,emc2301", "microchip,emc2305";
 				reg = <0x2f>;
 				#cooling-cells = <0x02>;
 			};


### PR DESCRIPTION
The way upstream deals with compatibles is to add emc2305 and then deal with the variations in the driver as it's detectable so add emc2305 to the compat so we work with the upstream driver.