### PR TITLE
drm/vc4: hdmi: Remove duplicate hotplug helper call

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -366,12 +366,6 @@ static void vc4_hdmi_handle_hotplug(struct vc4_hdmi *vc4_hdmi,
 	int ret;
 
 	/*
-	 * Needs to be called for both connects and disconnects for HDMI
-	 * audio hotplug to work correctly.
-	 */
-	drm_atomic_helper_connector_hdmi_hotplug(connector, status);
-
-	/*
 	 * NOTE: This function should really be called with vc4_hdmi->mutex
 	 * held, but doing so results in reentrancy issues since
 	 * cec_s_phys_addr() might call .adap_enable, which leads to that


### PR DESCRIPTION
vc4_hdmi_handle_hotplug() calls drm_atomic_helper_connector_hdmi_hotplug() twice: once from the downstream commit 7a761a6d884d ("vc4: Add jack detection to HDMI audio driver") and once from the upstream code it was rebased onto, which gained the same call in commit 34f051accedb ("drm/vc4: hdmi: Call HDMI hotplug helper on disconnect").

The helper reads the EDID over DDC, so every detect currently performs two full EDID reads and signals the audio jack state twice. Drop the duplicate and keep the call where upstream has it, after the locking comment.

Fixes: 7a761a6d884d ("vc4: Add jack detection to HDMI audio driver")