### PR TITLE
staging: vchiq_arm: use one DMA device to map and unmap bulk pagelists

### DIFF
--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
@@ -1474,8 +1474,8 @@ cleanup_pagelistinfo(struct vchiq_instance *instance, struct vchiq_pagelist_info
 		dma_pool_free(g_dma_pool, pagelistinfo->pagelist,
 			      pagelistinfo->dma_addr);
 	} else {
-		dma_free_coherent(g_dma_dev, pagelistinfo->pagelist_buffer_size,
-				pagelistinfo->pagelist, pagelistinfo->dma_addr);
+		dma_free_coherent(instance->state->dev, pagelistinfo->pagelist_buffer_size,
+				  pagelistinfo->pagelist, pagelistinfo->dma_addr);
 	}
 }
 
@@ -1641,7 +1641,7 @@ create_pagelist(struct vchiq_instance *instance, struct vchiq_bulk *bulk)
 		count -= len;
 	}
 
-	dma_buffers = dma_map_sg(instance->state->dev,
+	dma_buffers = dma_map_sg(g_dma_dev,
 				 scatterlist,
 				 num_pages,
 				 pagelistinfo->dma_dir);


### PR DESCRIPTION
Fixes #7493 — full analysis, reproducer, and oops there.

Since the pagelist code moved into vchiq_core.c, `create_pagelist()` maps the bulk scatterlist with `instance->state->dev` while `free_pagelist()`/`cleanup_pagelistinfo()` unmap with `g_dma_dev` (on BCM2711 the `brcm,bcm2711-dma` device resolved for `use_36bit_addrs`, with different dma-ranges), and the coherent pagelist buffer is allocated on `instance->state->dev` but freed on `g_dma_dev`. This breaks every userspace `/dev/vchiq` bulk transfer on Pi 4 arm64: the VPU is handed 36-bit pagelist entries computed under the wrong device's dma-ranges (bulk writes arrive as garbage, sustained load wedges the VPU), and the first bulk read oopses in `free_pagelist()` on the `DMA_FROM_DEVICE` unmap cache invalidate.

This restores the pairing rpi-6.12.y shipped (map/unmap on `g_dma_dev`, coherent alloc/free on `instance->state->dev`), which is the last known-working combination.

Verified on a Pi 4B Rev 1.5 (2GB): on stock 6.18.34+rpt a `vc.ril.video_splitter` payload loopback from a 64-bit userland oopses as in the issue and `vc.ril.video_decode` never decodes; on rpi-6.18.y with this patch the loopback round-trips byte-identical and H.264 decode from a 64-bit process runs at full rate (26k frames / 600 s soak, clean dmesg).

Context: 64-bit userland MMAL work discussed in the "Porting Linux VCHIQ Driver To 64 Bit" forum thread.