### PR TITLE
staging: vchiq_arm: Use the correct DMA device

### DIFF
--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_arm.c
@@ -300,7 +300,7 @@ static int vchiq_platform_init(struct platform_device *pdev, struct vchiq_state 
 	}
 
 	g_dma_dev = dma_dev ?: dev;
-	g_dma_pool = dmam_pool_create("vchiq_scatter_pool", dev,
+	g_dma_pool = dmam_pool_create("vchiq_scatter_pool", g_dma_dev,
 				      VCHIQ_DMA_POOL_SIZE,
 				      drv_mgmt->info->cache_line_size, 0);
 	if (!g_dma_pool) {

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
@@ -1547,7 +1547,7 @@ create_pagelist(struct vchiq_instance *instance, struct vchiq_bulk *bulk)
 	 * list
 	 */
 	if (pagelist_size > VCHIQ_DMA_POOL_SIZE) {
-		pagelist = dma_alloc_coherent(instance->state->dev, pagelist_size, &dma_addr,
+		pagelist = dma_alloc_coherent(g_dma_dev, pagelist_size, &dma_addr,
 						GFP_KERNEL);
 		is_from_pool = false;
 	} else {
@@ -1641,7 +1641,7 @@ create_pagelist(struct vchiq_instance *instance, struct vchiq_bulk *bulk)
 		count -= len;
 	}
 
-	dma_buffers = dma_map_sg(instance->state->dev,
+	dma_buffers = dma_map_sg(g_dma_dev,
 				 scatterlist,
 				 num_pages,
 				 pagelistinfo->dma_dir);


### PR DESCRIPTION
On Pi 4 it is necessary to use DMA address mappings that are correct for the 40-bit DMA controller in order to access the whole of RAM.

See: https://github.com/raspberrypi/linux/issues/7493

Fixes: 35ef14168c34 ("staging: vchiq_arm: Set up dma ranges on child devices")