### PR TITLE
nvme-pci: DMA unmap the correct regions in nvme_free_sgls

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -763,8 +763,8 @@ static void nvme_unmap_data(struct request *req)
 
 	if (!blk_rq_dma_unmap(req, dma_dev, &iod->dma_state, iod->total_len)) {
 		if (nvme_pci_cmd_use_sgl(&iod->cmd))
-			nvme_free_sgls(req, iod->descriptors[0],
-				       &iod->cmd.common.dptr.sgl);
+			nvme_free_sgls(req, &iod->cmd.common.dptr.sgl,
+			               iod->descriptors[0]);
 		else
 			nvme_free_prps(req);
 	}


### PR DESCRIPTION
N.B. I had to drop the `attrs` parameter that `nvme_free_sgls` has gained in the newer kernels. This presumably explains why it wasn't backported despite the `Fixes:` tag (it's still disappointing, though).

[ commit a54afbc8a2138f8c2490510cf26cde188d480c43 upstream ]

The call to nvme_free_sgls() in nvme_unmap_data() has the sg_list and sge parameters swapped.  This wasn't noticed by the compiler because both share the same type.  On a Xen PV hardware domain, and possibly any other architectures that takes that path, this leads to corruption of the NVMe contents.

Fixes: f0887e2a52d4 ("nvme-pci: create common sgl unmapping helper")
Reviewed-by: Christoph Hellwig <hch@lst.de>