### PR TITLE
input: goodix: Include I2C details in names for the devices

### DIFF
--- a/drivers/input/touchscreen/goodix.c
+++ b/drivers/input/touchscreen/goodix.c
@@ -1150,7 +1150,10 @@ static int goodix_configure_dev(struct goodix_ts_data *ts)
 		return -ENOMEM;
 	}
 
-	ts->input_dev->name = "Goodix Capacitive TouchScreen";
+	snprintf(ts->name, GOODIX_NAME_MAX_LEN, "%s Goodix Capacitive TouchScreen",
+		 dev_name(&ts->client->dev));
+
+	ts->input_dev->name = ts->name;
 	ts->input_dev->phys = "input/ts";
 	ts->input_dev->id.bustype = BUS_I2C;
 	ts->input_dev->id.vendor = 0x0416;

--- a/drivers/input/touchscreen/goodix.h
+++ b/drivers/input/touchscreen/goodix.h
@@ -57,6 +57,8 @@
 #define GOODIX_CONFIG_MAX_LENGTH		240
 #define GOODIX_MAX_KEYS				7
 
+#define GOODIX_NAME_MAX_LEN			38
+
 enum goodix_irq_pin_access_method {
 	IRQ_PIN_ACCESS_NONE,
 	IRQ_PIN_ACCESS_GPIO,
@@ -90,6 +92,7 @@ struct goodix_ts_data {
 	int gpio_int_idx;
 	char id[GOODIX_ID_MAX_LEN + 1];
 	char cfg_name[64];
+	char name[GOODIX_NAME_MAX_LEN];
 	u16 version;
 	bool reset_controller_at_probe;
 	bool load_cfg_from_disk;


### PR DESCRIPTION
This commit got lost going from 6.8 to 6.9, but has only just been noticed (by @spl237)

libinput uses the input device name alone. If you have two identical input devices, then there is no way to differentiate between them, and in the case of touchscreens that means no way to associate them with the appropriate display device.

Add the I2C bus and address to the start of the input device name so that the name is always unique within the system.

