### PR TITLE
overlays: Add ramoops-pi5

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -245,6 +245,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	qca7000-uart0.dtbo \
 	ramoops.dtbo \
 	ramoops-pi4.dtbo \
+	ramoops-pi5.dtbo \
 	rootmaster.dtbo \
 	rotary-encoder.dtbo \
 	rp1-pio-uart.dtbo \

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4475,17 +4475,11 @@ Params: base-addr               Where to place the capture buffer (default
 
 
 Name:   ramoops-pi4
-Info:   The version of the ramoops overlay for the Pi 4 family. It should be
-        loaded automatically if dtoverlay=ramoops is specified on a Pi 4.
-Load:   dtoverlay=ramoops-pi4,<param>=<val>
-Params: base-addr               Where to place the capture buffer (default
-                                0x0b000000)
-        total-size              How much memory to allocate altogether (in
-                                bytes - default 64kB)
-        record-size             How much space to use for each capture, i.e.
-                                total-size / record-size = number of captures
-                                (default 16kB)
-        console-size            Size of non-panic dmesg captures (default 0)
+Info:   See ramoops
+
+
+Name:   ramoops-pi5
+Info:   See ramoops
 
 
 Name:   rootmaster

--- a/arch/arm/boot/dts/overlays/overlay_map.dts
+++ b/arch/arm/boot/dts/overlays/overlay_map.dts
@@ -274,11 +274,14 @@
 	ramoops {
 		bcm2835;
 		bcm2711 = "ramoops-pi4";
-		bcm2712 = "ramoops-pi4";
+		bcm2712 = "ramoops-pi5";
 	};
 
 	ramoops-pi4 {
 		bcm2711;
+	};
+
+	ramoops-pi5 {
 		bcm2712;
 	};
 

--- a/arch/arm/boot/dts/overlays/ramoops-pi5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ramoops-pi5-overlay.dts
@@ -1,0 +1,25 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2712";
+
+	fragment@0 {
+		target = <&rmem>;
+		__overlay__ {
+			ramoops: ramoops@b000000 {
+				compatible = "ramoops";
+				reg = <0x0 0x0b000000 0x0 0x10000>; /* 64kB */
+				record-size = <0x4000>; /* 16kB */
+				console-size = <0>; /* disabled by default */
+			};
+		};
+	};
+
+	__overrides__ {
+		base-addr = <&ramoops>,"reg#0";
+		total-size = <&ramoops>,"reg#8";
+		record-size = <&ramoops>,"record-size:0";
+		console-size = <&ramoops>,"console-size:0";
+	};
+};


### PR DESCRIPTION
The Pi 5 dts uses 64-bit sizes in some places, and the ramoops overlay needs to be updated accordingly.

See: https://github.com/raspberrypi/linux/issues/7517