### PR TITLE
ASoC: hifiberry-studio: add AES CS Mode control (channel status format)

### DIFF
--- a/sound/soc/bcm/hifiberry_studio.c
+++ b/sound/soc/bcm/hifiberry_studio.c
@@ -106,6 +106,7 @@
 #define GAIN_CH6			0x87
 #define GAIN_CH7			0x88
 #define MUTE_INPUTS			0x89
+#define DIGI_CS_FORMAT			0x90	/* AES channel status format */
 #define CLOCK_CONSUMER_MODE		0x00
 #define CLOCK_PROVIDER_MODE		0x01
 
@@ -289,6 +290,7 @@ static bool hb_studio_readable_reg(struct device *dev, unsigned int reg)
 	case UUID:
 	case DAC_STATE:
 	case CARD_BUSY:
+	case DIGI_CS_FORMAT:
 	case CARD_RESET:
 	case CARD_CLOCK_MODE:
 	case CARD_CLK_ACT:
@@ -341,6 +343,8 @@ static const char * const adc_att_texts[] = {
 	"Clip att. off", "-3dB", "-4dB", "-5dB", "-6dB",
 	};
 static const char * const dix_clk_texts[] = {"TX", "RX"};
+static const char * const cs_mode_texts[] = {"Consumer", "Professional",
+					     "Professional CRC"};
 
 struct hb_studio_vol_control_single {
 	unsigned int reg;
@@ -617,6 +621,10 @@ static const struct hb_studio_enum_control hb_studio_dix_clk_enum_ctls[] = {
 	{ CARD_CLK_OVRWR, 0, 0x01, dix_clk_texts, ARRAY_SIZE(dix_clk_texts) },
 };
 
+static const struct hb_studio_enum_control hb_studio_cs_mode_enum_ctls[] = {
+	{ DIGI_CS_FORMAT, 0, 0x03, cs_mode_texts, ARRAY_SIZE(cs_mode_texts) },
+};
+
 static const struct snd_kcontrol_new hb_studio_gen_controls_single[] = {
 	ENUM_CTL_SINGLE("DAC Filter", hb_studio_play_enum_ctls[1]),
 	ENUM_CTL_SINGLE("Output Mute", hb_studio_play_enum_ctls[2]),
@@ -641,6 +649,7 @@ static const struct snd_kcontrol_new dix_controls_single[] = {
 	ENUM_CTL_SINGLE("Input Mute", hb_studio_rec_enum_ctls[1]),
 	ENUM_CTL_SINGLE_RO_GET("Current Sample Rate", hb_studio_samplerate_ctl,
 				hb_studio_samplerate_get),
+	ENUM_CTL_SINGLE("AES CS Mode", hb_studio_cs_mode_enum_ctls[0]),
 };
 
 static int snd_rpi_hifiberry_studio_hw_params(


### PR DESCRIPTION
Adds an enum control on HiFiBerry Studio Digi (AES) cards to select the channel status format transmitted by the DIT, backed by controller register 0x90 (DIGI_CS_FORMAT in the card firmware register map):

| Mode | Behaviour |
|---|---|
| Consumer | IEC 60958-3 channel status (no CRCC defined) |
| Professional | AES3, byte 5 = 0 (spec-literal; the CRCC in byte 23 is invalid, since the DIX9211 can only program channel status bytes 0-5 and transmits bytes 6-23 as zero) |
| Professional CRC | AES3, byte 5 carries the CRC fixup value that makes the CRCC over bytes 0-22 come out 0x00, matching the zero byte 23 the chip transmits (firmware default) |

The control is registered only for the AES card type (same gating as the existing Clock mode / Current Sample Rate controls); DAC8x cards are unaffected.

Verified on a Studio Digi I/O on CM5: channel status decode and CRC validity confirmed on an Audio Precision analyzer in all three modes (Professional CRC validates, Professional raw shows the expected invalid CRCC, Consumer decodes as consumer format), audio pass-through unaffected at 44.1-192 kHz.