### PR TITLE
ASoC: dwc: Raise sample rate limit to 768kHz

### DIFF
--- a/sound/soc/dwc/dwc-i2s.c
+++ b/sound/soc/dwc/dwc-i2s.c
@@ -813,7 +813,7 @@ static int dw_configure_dai_by_dt(struct dw_i2s_dev *dev,
 	u32 idx2;
 	int ret;
 
-	ret = dw_configure_dai(dev, dw_i2s_dai, SNDRV_PCM_RATE_8000_384000);
+	ret = dw_configure_dai(dev, dw_i2s_dai, SNDRV_PCM_RATE_8000_768000);
 	if (ret < 0)
 		return ret;
 


### PR DESCRIPTION
Regardless of what individual devices can support, there's no harm in allowing users to try higher sample rates.