### PR TITLE
dtoverlays: sdhost: Add preserve_mmc parameter

### DIFF
--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -4830,6 +4830,10 @@ Params: overclock_50            Clock (in MHz) to use when the MMC framework
                                 custom carrier boards (e.g. CM4 baseboard).
                                 Applies ALT0 function and appropriate pulls.
 
+        preserve_mmc            Don't disable the other MMC interfaces
+                                (mmc/mmcnr). Useful on Compute Module
+                                when using gpios_22_27 with WiFi.
+
 
 Name:   sdio
 Info:   Selects the bcm2835-sdhost SD/MMC driver, optionally with overclock,

--- a/arch/arm/boot/dts/overlays/sdhost-overlay.dts
+++ b/arch/arm/boot/dts/overlays/sdhost-overlay.dts
@@ -54,5 +54,6 @@
 		pio_limit        = <&frag0>,"brcm,pio-limit:0";
 		debug            = <&frag0>,"brcm,debug?";
 		gpios_22_27      = <0>,"+3+4";
+		preserve_mmc     = <0>,"-1-2";
 	};
 };


### PR DESCRIPTION
Add a preserve_mmc parameter to the sdhost overlay that allows removing fragment@1 and fragment@2 (which disable mmc and mmcnr). This is needed on Compute Module when using gpios_22_27 mode, since disabling the other MMC interfaces would break WiFi on CM.
Signed-off-by: zjzhao <zjzhao@edatec.cn>