### PR TITLE
gpiolib: Don't bypass SRCU when CONFIG_LOCKDEP is enabled

### DIFF
--- a/drivers/gpio/gpiolib.c
+++ b/drivers/gpio/gpiolib.c
@@ -53,7 +53,12 @@
 
 #define dont_test_bit(b,d) (0)
 
-#define REJECT_HOTPLUG_TAX 1
+/*
+ * The SRCU bypass below skips srcu_read_lock() while the core retains its
+ * lockdep_assert_held(&gc->gpiodev->srcu) checks, so every gpiod_*() call
+ * splats under lockdep. Keep the optimisation for production builds only.
+ */
+#define REJECT_HOTPLUG_TAX (!IS_ENABLED(CONFIG_LOCKDEP))
 
 #if REJECT_HOTPLUG_TAX
 


### PR DESCRIPTION
Commit 6c967417fe83 ("gpiolib: Avoid the hotplug performance reduction") stubs out gpiolib's SRCU read-side locking to recover the throughput lost to the hotplug interlock. That trade-off is deliberate, but it leaves the core's lockdep_assert_held(&gc->gpiodev->srcu) checks in place while the lock is never actually taken. Since those are WARN_ON(), every GPIO access splats with CONFIG_LOCKDEP=y and the log fills up with backtraces.

Therefore, only enable REJECT_HOTPLUG_TAX when CONFIG_LOCKDEP is disabled. This way, the optimisation is kept for production builds, but developers can still debug the kernel with lockdep enabled.

---

I found this issue while testing the DRM scheduler series for VC4 with LOCKDEP enabled. This commit might be useful for other RPi developers in the kernel, but I can understand that it also brings the maintenance cost of increasing the delta to upstream. If you believe that it's not worth the cost, feel free to close this MR.