### PR TITLE
media: rpi-hevc-dec: bound stalled request teardown

### DIFF
--- a/drivers/media/platform/raspberrypi/hevc_dec/hevc_d.c
+++ b/drivers/media/platform/raspberrypi/hevc_dec/hevc_d.c
@@ -194,6 +194,7 @@ static const struct video_device hevc_d_video_device = {
 
 static const struct v4l2_m2m_ops hevc_d_m2m_ops = {
 	.device_run	= hevc_d_device_run,
+	.job_abort	= hevc_d_job_abort,
 };
 
 static const struct media_device_ops hevc_d_m2m_media_ops = {

--- a/drivers/media/platform/raspberrypi/hevc_dec/hevc_d.c
+++ b/drivers/media/platform/raspberrypi/hevc_dec/hevc_d.c
@@ -156,9 +156,9 @@ static int hevc_d_release(struct file *file)
 
 	v4l2_fh_del(&ctx->fh, file);
 
-	v4l2_ctrl_handler_free(&ctx->hdl);
-
 	v4l2_m2m_ctx_release(ctx->fh.m2m_ctx);
+
+	v4l2_ctrl_handler_free(&ctx->hdl);
 
 	v4l2_fh_exit(&ctx->fh);
 	mutex_destroy(&ctx->ctx_mutex);

--- a/drivers/media/platform/raspberrypi/hevc_dec/hevc_d.h
+++ b/drivers/media/platform/raspberrypi/hevc_dec/hevc_d.h
@@ -109,6 +109,8 @@ struct hevc_d_ctx {
 	 * continue (such as running out of CMA)
 	 */
 	int fatal_err;
+	/* Hardware resources shared by the output and capture queues. */
+	bool h265_started;
 
 	/* Lock for queue operations */
 	struct mutex			ctx_mutex;
@@ -154,7 +156,7 @@ struct hevc_d_hw_irq_ent;
 #define HEVC_D_ICTL_ENABLE_UNLIMITED (-1)
 
 struct hevc_d_hw_irq_ctrl {
-	/* Spinlock protecting claim and tail */
+	/* Spinlock protecting the scheduler state */
 	spinlock_t lock;
 	struct hevc_d_hw_irq_ent *claim;
 	struct hevc_d_hw_irq_ent *tail;
@@ -167,6 +169,10 @@ struct hevc_d_hw_irq_ctrl {
 	int enable;
 	/* Thread CB requested */
 	bool thread_reqed;
+	/* Stop dispatch while the hardware is being reset. */
+	bool aborting;
+	atomic_t callbacks;
+	wait_queue_head_t idle;
 };
 
 struct hevc_d_dev {
@@ -185,10 +191,14 @@ struct hevc_d_dev {
 
 	struct clk		*clock;
 	unsigned long		max_clock_rate;
-	/* Protects the shared decoder clock state. */
+	/* Protects clock_users, clock_enabled, and hw_failed. */
 	struct mutex		clock_lock;
+	/* Serializes global hardware recovery. */
+	struct mutex		recovery_lock;
 	unsigned int		clock_users;
 	bool			clock_enabled;
+	bool			hw_failed;
+	int			irq_dec;
 
 	struct hevc_d_hw_irq_ctrl ic_active1;
 	struct hevc_d_hw_irq_ctrl ic_active2;

--- a/drivers/media/platform/raspberrypi/hevc_dec/hevc_d.h
+++ b/drivers/media/platform/raspberrypi/hevc_dec/hevc_d.h
@@ -185,6 +185,10 @@ struct hevc_d_dev {
 
 	struct clk		*clock;
 	unsigned long		max_clock_rate;
+	/* Protects the shared decoder clock state. */
+	struct mutex		clock_lock;
+	unsigned int		clock_users;
+	bool			clock_enabled;
 
 	struct hevc_d_hw_irq_ctrl ic_active1;
 	struct hevc_d_hw_irq_ctrl ic_active2;

--- a/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_h265.c
+++ b/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_h265.c
@@ -1941,6 +1941,40 @@ static int check_status(const struct hevc_d_dev *const dev)
 	return -1;
 }
 
+static void decode_abort(struct hevc_d_dev *const dev, void *v)
+{
+	struct hevc_d_dec_env *const de = v;
+	struct hevc_d_ctx *const ctx = de->ctx;
+	struct hevc_d_slot *const slot = ctx->slots + de->frame_slot;
+	bool finish_job = false;
+
+	if (de->state == HEVC_D_DECODE_END)
+		return;
+
+	slot->refybase = 0;
+	slot->refcbase = 0;
+	slot->colbase = 0;
+
+	if (de->frame_buf) {
+		v4l2_m2m_buf_done(de->frame_buf, VB2_BUF_STATE_ERROR);
+		de->frame_buf = NULL;
+	}
+	if (de->src_buf) {
+		v4l2_m2m_buf_done(de->src_buf, VB2_BUF_STATE_ERROR);
+		de->src_buf = NULL;
+		finish_job = atomic_add_return(-1, &ctx->p1out) >=
+			     HEVC_D_P1BUF_COUNT - 1;
+	}
+	if (de->request) {
+		media_request_manual_complete(de->request);
+		de->request = NULL;
+	}
+
+	dec_env_delete(de);
+	if (finish_job)
+		v4l2_m2m_job_finish(dev->m2m_dev, ctx->fh.m2m_ctx);
+}
+
 static void phase2_done(struct hevc_d_dev *const dev,
 			struct hevc_d_dec_env *const de,
 			enum vb2_buffer_state state)
@@ -2085,7 +2119,7 @@ static void phase1_done(struct hevc_d_dev *const dev,
 	if (atomic_add_return(-1, &ctx->p1out) >= HEVC_D_P1BUF_COUNT - 1)
 		v4l2_m2m_job_finish(dev->m2m_dev, ctx->fh.m2m_ctx);
 
-	hevc_d_hw_irq_active2_claim(dev, &de->irq_ent, p2_cb, de);
+	hevc_d_hw_irq_active2_claim(dev, &de->irq_ent, p2_cb, decode_abort, de);
 }
 
 static void phase1_thread(struct hevc_d_dev *const dev, void *v)
@@ -2227,6 +2261,7 @@ static void dec_state_delete(struct hevc_d_ctx *const ctx)
 
 struct irq_sync {
 	atomic_t done;
+	bool failed;
 	wait_queue_head_t wq;
 	struct hevc_d_hw_irq_ent irq_ent;
 };
@@ -2239,31 +2274,50 @@ static void phase2_sync_claimed(struct hevc_d_dev *const dev, void *v)
 	wake_up(&sync->wq);
 }
 
+static void irq_sync_aborted(struct hevc_d_dev *const dev, void *v)
+{
+	struct irq_sync *const sync = v;
+
+	WRITE_ONCE(sync->failed, true);
+	atomic_set(&sync->done, 1);
+	wake_up(&sync->wq);
+}
+
 static void phase1_sync_claimed(struct hevc_d_dev *const dev, void *v)
 {
 	struct irq_sync *const sync = v;
 
 	hevc_d_hw_irq_active1_enable_claim(dev, 1);
-	hevc_d_hw_irq_active2_claim(dev, &sync->irq_ent, phase2_sync_claimed, sync);
+	hevc_d_hw_irq_active2_claim(dev, &sync->irq_ent, phase2_sync_claimed,
+				    irq_sync_aborted, sync);
 }
 
 /* Sync with IRQ operations
  *
  * Claims phase1 and phase2 in turn and waits for the phase2 claim so any
- * pending IRQ ops will have completed by the time this returns
+ * pending IRQ ops will have completed by the time this returns.
  *
  * phase1 has counted enables so must reenable once claimed
  * phase2 has unlimited enables
  */
-static void irq_sync(struct hevc_d_dev *const dev)
+static int irq_sync(struct hevc_d_dev *const dev)
 {
-	struct irq_sync sync;
+	struct irq_sync sync = {};
 
 	atomic_set(&sync.done, 0);
 	init_waitqueue_head(&sync.wq);
 
-	hevc_d_hw_irq_active1_claim(dev, &sync.irq_ent, phase1_sync_claimed, &sync);
-	wait_event(sync.wq, atomic_read(&sync.done));
+	hevc_d_hw_irq_active1_claim(dev, &sync.irq_ent, phase1_sync_claimed,
+				    irq_sync_aborted, &sync);
+	if (!wait_event_timeout(sync.wq, atomic_read(&sync.done),
+				msecs_to_jiffies(1000))) {
+		v4l2_err(&dev->v4l2_dev,
+			 "decoder did not become idle; resetting hardware\n");
+		WRITE_ONCE(sync.failed, true);
+		hevc_d_hw_recover(dev);
+	}
+
+	return READ_ONCE(sync.failed) ? -EIO : 0;
 }
 
 static void h265_ctx_uninit(struct hevc_d_dev *const dev, struct hevc_d_ctx *ctx)
@@ -2289,7 +2343,9 @@ void hevc_d_h265_stop(struct hevc_d_ctx *ctx)
 {
 	struct hevc_d_dev *const dev = ctx->dev;
 
-	irq_sync(dev);
+	if (irq_sync(dev))
+		v4l2_warn(&dev->v4l2_dev,
+			  "aborted incomplete decode requests during stop\n");
 	h265_ctx_uninit(dev, ctx);
 }
 
@@ -2367,7 +2423,7 @@ void hevc_d_h265_trigger(struct hevc_d_ctx *ctx)
 	if (atomic_add_return(1, &ctx->p1out) < HEVC_D_P1BUF_COUNT)
 		v4l2_m2m_job_finish(dev->m2m_dev, ctx->fh.m2m_ctx);
 
-	hevc_d_hw_irq_active1_claim(dev, &de->irq_ent, p1_cb, de);
+	hevc_d_hw_irq_active1_claim(dev, &de->irq_ent, p1_cb, decode_abort, de);
 }
 
 static int try_ctrl_sps(struct v4l2_ctrl *ctrl)

--- a/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_h265.c
+++ b/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_h265.c
@@ -2413,6 +2413,14 @@ static int try_ctrl_sps(struct v4l2_ctrl *ctrl)
 	return 0;
 }
 
+void hevc_d_job_abort(void *priv)
+{
+	struct hevc_d_ctx *const ctx = priv;
+
+	ctx->fatal_err = 1;
+	v4l2_m2m_job_finish(ctx->dev->m2m_dev, ctx->fh.m2m_ctx);
+}
+
 const struct v4l2_ctrl_ops hevc_d_hevc_sps_ctrl_ops = {
 	.try_ctrl = try_ctrl_sps,
 };

--- a/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_h265.h
+++ b/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_h265.h
@@ -18,5 +18,6 @@ void hevc_d_h265_stop(struct hevc_d_ctx *ctx);
 void hevc_d_h265_trigger(struct hevc_d_ctx *ctx);
 
 void hevc_d_device_run(void *priv);
+void hevc_d_job_abort(void *priv);
 
 #endif

--- a/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_hw.c
+++ b/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_hw.c
@@ -299,33 +299,49 @@ void hevc_d_hw_irq_active2_irq(struct hevc_d_dev *dev,
 	pre_irq(dev, ient, irq_cb, ctx, &dev->ic_active2);
 }
 
-/*
- * Stop the clock for this context
- * clk_disable_unprepare does ref counting so this will not actually
- * disable the clock if there are other running contexts
- */
 void hevc_d_hw_stop_clock(struct hevc_d_dev *dev)
 {
-	clk_disable_unprepare(dev->clock);
+	mutex_lock(&dev->clock_lock);
+	if (WARN_ON(!dev->clock_users))
+		goto unlock;
+
+	if (!--dev->clock_users && dev->clock_enabled) {
+		clk_disable_unprepare(dev->clock);
+		dev->clock_enabled = false;
+	}
+
+unlock:
+	mutex_unlock(&dev->clock_lock);
 }
 
-/* Always starts the clock if it isn't already on this ctx */
 int hevc_d_hw_start_clock(struct hevc_d_dev *dev)
 {
-	int rv;
+	int rv = 0;
+
+	mutex_lock(&dev->clock_lock);
+	if (dev->clock_users) {
+		++dev->clock_users;
+		goto unlock;
+	}
 
 	rv = clk_set_min_rate(dev->clock, dev->max_clock_rate);
 	if (rv) {
 		dev_err(dev->dev, "Failed to set clock rate\n");
-		return rv;
+		goto unlock;
 	}
 
 	rv = clk_prepare_enable(dev->clock);
 	if (rv) {
 		dev_err(dev->dev, "Failed to enable clock\n");
-		return rv;
+		goto unlock;
 	}
-	return 0;
+
+	dev->clock_users = 1;
+	dev->clock_enabled = true;
+
+unlock:
+	mutex_unlock(&dev->clock_lock);
+	return rv;
 }
 
 static int hw_setup(struct hevc_d_dev *dev)
@@ -375,6 +391,7 @@ int hevc_d_hw_probe(struct hevc_d_dev *dev)
 
 	ictl_init(&dev->ic_active1, HEVC_D_P2BUF_COUNT);
 	ictl_init(&dev->ic_active2, HEVC_D_ICTL_ENABLE_UNLIMITED);
+	mutex_init(&dev->clock_lock);
 
 	dev->base_irq = devm_platform_ioremap_resource_byname(dev->pdev, "intc");
 	if (IS_ERR(dev->base_irq))

--- a/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_hw.c
+++ b/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_hw.c
@@ -11,6 +11,7 @@
  * Copyright (C) 2018 Bootlin
  */
 #include <linux/clk.h>
+#include <linux/delay.h>
 #include <linux/interrupt.h>
 #include <linux/platform_device.h>
 
@@ -45,7 +46,7 @@ static void pre_irq(struct hevc_d_dev *dev, struct hevc_d_hw_irq_ent *ient,
 /* Should be called from inside ictl->lock */
 static inline bool sched_enabled(const struct hevc_d_hw_irq_ctrl * const ictl)
 {
-	return ictl->no_sched <= 0 && ictl->enable;
+	return !ictl->aborting && ictl->no_sched <= 0 && ictl->enable;
 }
 
 /* Should be called from inside ictl->lock & after checking sched_enabled() */
@@ -54,6 +55,7 @@ static inline void set_claimed(struct hevc_d_hw_irq_ctrl * const ictl)
 	if (ictl->enable > 0)
 		--ictl->enable;
 	ictl->no_sched = 1;
+	atomic_inc(&ictl->callbacks);
 }
 
 /* Should be called from inside ictl->lock */
@@ -80,6 +82,7 @@ static void sched_cb(struct hevc_d_dev * const dev,
 {
 	while (ient) {
 		unsigned long flags;
+		struct hevc_d_hw_irq_ent *next;
 
 		ient->cb(dev, ient->v);
 
@@ -90,9 +93,13 @@ static void sched_cb(struct hevc_d_dev * const dev,
 		 * on entry to cb
 		 */
 		--ictl->no_sched;
-		ient = get_sched(ictl);
+		next = get_sched(ictl);
 
 		spin_unlock_irqrestore(&ictl->lock, flags);
+
+		if (atomic_dec_and_test(&ictl->callbacks))
+			wake_up(&ictl->idle);
+		ient = next;
 	}
 }
 
@@ -119,6 +126,8 @@ static void do_irq(struct hevc_d_dev * const dev,
 	spin_lock_irqsave(&ictl->lock, flags);
 	ient = ictl->irq;
 	ictl->irq = NULL;
+	if (ient)
+		atomic_inc(&ictl->callbacks);
 	spin_unlock_irqrestore(&ictl->lock, flags);
 
 	sched_cb(dev, ictl, ient);
@@ -126,18 +135,23 @@ static void do_irq(struct hevc_d_dev * const dev,
 
 static void do_claim(struct hevc_d_dev * const dev,
 		     struct hevc_d_hw_irq_ent *ient,
-		     const hevc_d_irq_callback cb, void * const v,
+		     const hevc_d_irq_callback cb,
+		     const hevc_d_irq_callback abort, void * const v,
 		     struct hevc_d_hw_irq_ctrl * const ictl)
 {
 	unsigned long flags;
+	bool abort_now = false;
 
 	ient->next = NULL;
 	ient->cb = cb;
+	ient->abort = abort;
 	ient->v = v;
 
 	spin_lock_irqsave(&ictl->lock, flags);
 
-	if (ictl->claim) {
+	if (ictl->aborting || READ_ONCE(dev->hw_failed)) {
+		abort_now = true;
+	} else if (ictl->claim) {
 		/* If we have a Q then add to end */
 		ictl->tail->next = ient;
 		ictl->tail = ient;
@@ -157,7 +171,10 @@ static void do_claim(struct hevc_d_dev * const dev,
 
 	spin_unlock_irqrestore(&ictl->lock, flags);
 
-	sched_cb(dev, ictl, ient);
+	if (abort_now)
+		abort(dev, ient->v);
+	else
+		sched_cb(dev, ictl, ient);
 }
 
 /* Enable n claims.
@@ -191,6 +208,9 @@ static void ictl_init(struct hevc_d_hw_irq_ctrl * const ictl, int enables)
 	ictl->no_sched = 0;
 	ictl->enable = enables;
 	ictl->thread_reqed = false;
+	ictl->aborting = false;
+	atomic_set(&ictl->callbacks, 0);
+	init_waitqueue_head(&ictl->idle);
 }
 
 static void ictl_uninit(struct hevc_d_hw_irq_ctrl * const ictl)
@@ -237,6 +257,8 @@ static void do_thread(struct hevc_d_dev * const dev,
 		ient = ictl->irq;
 		ictl->thread_reqed = false;
 		ictl->irq = NULL;
+		if (ient)
+			atomic_inc(&ictl->callbacks);
 	}
 
 	spin_unlock_irqrestore(&ictl->lock, flags);
@@ -273,9 +295,10 @@ void hevc_d_hw_irq_active1_enable_claim(struct hevc_d_dev *dev,
 
 void hevc_d_hw_irq_active1_claim(struct hevc_d_dev *dev,
 				 struct hevc_d_hw_irq_ent *ient,
-				 hevc_d_irq_callback ready_cb, void *ctx)
+				 hevc_d_irq_callback ready_cb,
+				 hevc_d_irq_callback abort_cb, void *ctx)
 {
-	do_claim(dev, ient, ready_cb, ctx, &dev->ic_active1);
+	do_claim(dev, ient, ready_cb, abort_cb, ctx, &dev->ic_active1);
 }
 
 void hevc_d_hw_irq_active1_irq(struct hevc_d_dev *dev,
@@ -287,9 +310,10 @@ void hevc_d_hw_irq_active1_irq(struct hevc_d_dev *dev,
 
 void hevc_d_hw_irq_active2_claim(struct hevc_d_dev *dev,
 				 struct hevc_d_hw_irq_ent *ient,
-				 hevc_d_irq_callback ready_cb, void *ctx)
+				 hevc_d_irq_callback ready_cb,
+				 hevc_d_irq_callback abort_cb, void *ctx)
 {
-	do_claim(dev, ient, ready_cb, ctx, &dev->ic_active2);
+	do_claim(dev, ient, ready_cb, abort_cb, ctx, &dev->ic_active2);
 }
 
 void hevc_d_hw_irq_active2_irq(struct hevc_d_dev *dev,
@@ -320,7 +344,10 @@ int hevc_d_hw_start_clock(struct hevc_d_dev *dev)
 
 	mutex_lock(&dev->clock_lock);
 	if (dev->clock_users) {
-		++dev->clock_users;
+		if (READ_ONCE(dev->hw_failed))
+			rv = -EIO;
+		else
+			++dev->clock_users;
 		goto unlock;
 	}
 
@@ -338,10 +365,118 @@ int hevc_d_hw_start_clock(struct hevc_d_dev *dev)
 
 	dev->clock_users = 1;
 	dev->clock_enabled = true;
+	if (READ_ONCE(dev->hw_failed)) {
+		u32 irq_stat;
+
+		irq_write(dev, ARG_IC_ICTRL,
+			  ARG_IC_ICTRL_ACTIVE1_EN_SET |
+			  ARG_IC_ICTRL_ACTIVE2_EN_SET);
+		irq_stat = irq_read(dev, ARG_IC_ICTRL);
+		irq_write(dev, ARG_IC_ICTRL, irq_stat);
+	}
+	WRITE_ONCE(dev->hw_failed, false);
 
 unlock:
 	mutex_unlock(&dev->clock_lock);
 	return rv;
+}
+
+static void ictl_set_aborting(struct hevc_d_hw_irq_ctrl *ictl)
+{
+	unsigned long flags;
+
+	spin_lock_irqsave(&ictl->lock, flags);
+	ictl->aborting = true;
+	spin_unlock_irqrestore(&ictl->lock, flags);
+}
+
+static struct hevc_d_hw_irq_ent *ictl_detach(struct hevc_d_hw_irq_ctrl *ictl,
+					     int enables)
+{
+	struct hevc_d_hw_irq_ent *head;
+	unsigned long flags;
+
+	spin_lock_irqsave(&ictl->lock, flags);
+	head = ictl->irq;
+	if (head)
+		head->next = ictl->claim;
+	else
+		head = ictl->claim;
+	ictl->claim = NULL;
+	ictl->tail = NULL;
+	ictl->irq = NULL;
+	ictl->no_sched = 0;
+	ictl->enable = enables;
+	ictl->thread_reqed = false;
+	spin_unlock_irqrestore(&ictl->lock, flags);
+
+	return head;
+}
+
+static void abort_entries(struct hevc_d_dev *dev,
+			  struct hevc_d_hw_irq_ent *ient)
+{
+	while (ient) {
+		struct hevc_d_hw_irq_ent *next = ient->next;
+
+		ient->abort(dev, ient->v);
+		ient = next;
+	}
+}
+
+static void ictl_resume(struct hevc_d_hw_irq_ctrl *ictl)
+{
+	unsigned long flags;
+
+	spin_lock_irqsave(&ictl->lock, flags);
+	ictl->aborting = false;
+	spin_unlock_irqrestore(&ictl->lock, flags);
+}
+
+/*
+ * Stop both hardware phases before returning any DMA buffers. The clock gate
+ * is the only reset exposed by the firmware clock binding.
+ */
+void hevc_d_hw_recover(struct hevc_d_dev *dev)
+{
+	struct hevc_d_hw_irq_ent *active1;
+	struct hevc_d_hw_irq_ent *active2;
+	u32 irq_stat;
+
+	mutex_lock(&dev->recovery_lock);
+	ictl_set_aborting(&dev->ic_active1);
+	ictl_set_aborting(&dev->ic_active2);
+
+	disable_irq(dev->irq_dec);
+	wait_event(dev->ic_active1.idle,
+		   !atomic_read(&dev->ic_active1.callbacks));
+	wait_event(dev->ic_active2.idle,
+		   !atomic_read(&dev->ic_active2.callbacks));
+
+	active1 = ictl_detach(&dev->ic_active1, HEVC_D_P2BUF_COUNT);
+	active2 = ictl_detach(&dev->ic_active2,
+			      HEVC_D_ICTL_ENABLE_UNLIMITED);
+
+	irq_stat = irq_read(dev, ARG_IC_ICTRL);
+	irq_write(dev, ARG_IC_ICTRL, irq_stat);
+
+	mutex_lock(&dev->clock_lock);
+	if (dev->clock_enabled) {
+		clk_disable_unprepare(dev->clock);
+		dev->clock_enabled = false;
+		usleep_range(1000, 2000);
+	}
+	/* All existing streams must stop before the next clock start. */
+	WRITE_ONCE(dev->hw_failed, true);
+	mutex_unlock(&dev->clock_lock);
+
+	abort_entries(dev, active1);
+	abort_entries(dev, active2);
+
+	ictl_resume(&dev->ic_active1);
+	ictl_resume(&dev->ic_active2);
+	enable_irq(dev->irq_dec);
+	mutex_unlock(&dev->recovery_lock);
 }
 
 static int hw_setup(struct hevc_d_dev *dev)
@@ -392,6 +527,7 @@ int hevc_d_hw_probe(struct hevc_d_dev *dev)
 	ictl_init(&dev->ic_active1, HEVC_D_P2BUF_COUNT);
 	ictl_init(&dev->ic_active2, HEVC_D_ICTL_ENABLE_UNLIMITED);
 	mutex_init(&dev->clock_lock);
+	mutex_init(&dev->recovery_lock);
 
 	dev->base_irq = devm_platform_ioremap_resource_byname(dev->pdev, "intc");
 	if (IS_ERR(dev->base_irq))
@@ -416,6 +552,7 @@ int hevc_d_hw_probe(struct hevc_d_dev *dev)
 	irq_dec = platform_get_irq(dev->pdev, 0);
 	if (irq_dec < 0)
 		return irq_dec;
+	dev->irq_dec = irq_dec;
 	ret = devm_request_threaded_irq(dev->dev, irq_dec,
 					hevc_d_irq_irq,
 					hevc_d_irq_thread,

--- a/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_hw.h
+++ b/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_hw.h
@@ -19,6 +19,7 @@
 struct hevc_d_hw_irq_ent {
 	struct hevc_d_hw_irq_ent *next;
 	hevc_d_irq_callback cb;
+	hevc_d_irq_callback abort;
 	void *v;
 };
 
@@ -293,7 +294,8 @@ void hevc_d_hw_irq_active1_enable_claim(struct hevc_d_dev *dev,
 /* Auto release once all CBs called */
 void hevc_d_hw_irq_active1_claim(struct hevc_d_dev *dev,
 				 struct hevc_d_hw_irq_ent *ient,
-				 hevc_d_irq_callback ready_cb, void *ctx);
+				 hevc_d_irq_callback ready_cb,
+				 hevc_d_irq_callback abort_cb, void *ctx);
 /* May only be called in claim cb */
 void hevc_d_hw_irq_active1_irq(struct hevc_d_dev *dev,
 			       struct hevc_d_hw_irq_ent *ient,
@@ -306,7 +308,8 @@ void hevc_d_hw_irq_active1_thread(struct hevc_d_dev *dev,
 /* Auto release once all CBs called */
 void hevc_d_hw_irq_active2_claim(struct hevc_d_dev *dev,
 				 struct hevc_d_hw_irq_ent *ient,
-				 hevc_d_irq_callback ready_cb, void *ctx);
+				 hevc_d_irq_callback ready_cb,
+				 hevc_d_irq_callback abort_cb, void *ctx);
 /* May only be called in claim cb */
 void hevc_d_hw_irq_active2_irq(struct hevc_d_dev *dev,
 			       struct hevc_d_hw_irq_ent *ient,
@@ -314,6 +317,7 @@ void hevc_d_hw_irq_active2_irq(struct hevc_d_dev *dev,
 
 int hevc_d_hw_start_clock(struct hevc_d_dev *dev);
 void hevc_d_hw_stop_clock(struct hevc_d_dev *dev);
+void hevc_d_hw_recover(struct hevc_d_dev *dev);
 
 int hevc_d_hw_probe(struct hevc_d_dev *dev);
 void hevc_d_hw_remove(struct hevc_d_dev *dev);

--- a/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_video.c
+++ b/drivers/media/platform/raspberrypi/hevc_dec/hevc_d_video.c
@@ -551,20 +551,27 @@ static int hevc_d_start_streaming(struct vb2_queue *vq, unsigned int count)
 {
 	struct hevc_d_ctx *ctx = vb2_get_drv_priv(vq);
 	struct hevc_d_dev *dev = ctx->dev;
+	struct vb2_queue *src_vq;
+	struct vb2_queue *dst_vq;
 	int ret = 0;
 
 	v4l2_m2m_update_start_streaming_state(ctx->fh.m2m_ctx, vq);
 
-	if (V4L2_TYPE_IS_OUTPUT(vq->type)) {
-		ret = hevc_d_hw_start_clock(dev);
-		if (ret)
-			goto fail_cleanup;
+	src_vq = v4l2_m2m_get_src_vq(ctx->fh.m2m_ctx);
+	dst_vq = v4l2_m2m_get_dst_vq(ctx->fh.m2m_ctx);
+	if (ctx->h265_started || !vb2_start_streaming_called(src_vq) ||
+	    !vb2_start_streaming_called(dst_vq))
+		return 0;
 
-		ret = hevc_d_h265_start(ctx);
-		if (ret)
-			goto fail_stop_clock;
-	}
+	ret = hevc_d_hw_start_clock(dev);
+	if (ret)
+		goto fail_cleanup;
 
+	ret = hevc_d_h265_start(ctx);
+	if (ret)
+		goto fail_stop_clock;
+
+	ctx->h265_started = true;
 	return 0;
 
 fail_stop_clock:
@@ -580,14 +587,13 @@ static void hevc_d_stop_streaming(struct vb2_queue *vq)
 	struct hevc_d_ctx *ctx = vb2_get_drv_priv(vq);
 	struct hevc_d_dev *dev = ctx->dev;
 
-	if (V4L2_TYPE_IS_OUTPUT(vq->type)) {
+	if (ctx->h265_started) {
+		ctx->h265_started = false;
 		hevc_d_h265_stop(ctx);
 		hevc_d_hw_stop_clock(dev);
 	}
 
 	hevc_d_queue_cleanup(vq, VB2_BUF_STATE_ERROR);
-
-	vb2_wait_for_all_buffers(vq);
 
 	v4l2_m2m_update_stop_streaming_state(ctx->fh.m2m_ctx, vq);
 }


### PR DESCRIPTION
## Summary

A stalled phase-one or phase-two HEVC request can block `streamoff()` and file release indefinitely. The blocked request retains its buffers and CMA allocation, and `rpi_hevc_dec` cannot unload.

The capture queue can stop before the output queue. The existing output-only cleanup therefore cannot make teardown bounded.

This series:

- implements the missing mem2mem `job_abort` callback;
- tracks users of the shared decoder clock;
- starts hardware after both queues start and lets either queue stop it once;
- adds a one-second bounded scheduler drain;
- resets failed hardware before returning DMA buffers;
- completes detached source buffers, capture buffers, and media requests with an error;
- removes the unbounded `vb2_wait_for_all_buffers()` call; and
- releases mem2mem queues before their request control handler.

## Reproduction

Three concurrent 1080p HEVC streams from a Jetson publisher stopped producing completion interrupts. Process teardown remained blocked in:

```text
vb2_wait_for_all_buffers
hevc_d_stop_streaming
__vb2_queue_cancel
v4l2_m2m_ctx_release
hevc_d_release
```

The process could not be killed, the module could not unload, and the machine required a reboot.

## Validation

Tested on Raspberry Pi 5 with `6.18.39+rpt-rpi-2712`.

- Built the cumulative module against the matching packaged kernel headers.
- Confirmed matching vermagic and zero unresolved symbol references.
- Passed `checkpatch.pl --strict` for all three patches.
- Decoded a complete 640x360 Main-profile HEVC fixture.
- Repeated decode and close five times.
- Decoded three fixture streams concurrently.
- Closed a truncated-stream decode without blocking.
- Unloaded and reloaded `rpi_hevc_dec` after the tests.
- Preserved CMA exactly: 514048 KiB free before and after.
- Observed zero decoder D-state threads and zero kernel faults.

The live three-camera Jetson failure also reproduced after the patch. The bounded recovery logged:

```text
decoder did not become idle; resetting hardware
aborted incomplete decode requests during stop
```

The iced operator exited in 1.132 seconds. All decoder device handles closed, the module unloaded and reloaded, CMA returned to 514048 KiB free, and no decoder D-state thread or kernel fault remained.
