### PR TITLE
overlays: mcp23s17, pifacedigital: Encode spi-present-mask as u8

### DIFF
--- a/arch/arm/boot/dts/overlays/mcp23s17-overlay.dts
+++ b/arch/arm/boot/dts/overlays/mcp23s17-overlay.dts
@@ -97,7 +97,7 @@
 				compatible = "microchip,mcp23s08";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi0-0-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s08-spi0-0-present parameter */
 				reg = <0>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -120,7 +120,7 @@
 				compatible = "microchip,mcp23s08";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi0-1-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s08-spi0-1-present parameter */
 				reg = <1>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -143,7 +143,7 @@
 				compatible = "microchip,mcp23s08";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi1-0-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s08-spi1-0-present parameter */
 				reg = <0>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -166,7 +166,7 @@
 				compatible = "microchip,mcp23s08";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi1-1-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s08-spi1-1-present parameter */
 				reg = <1>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -189,7 +189,7 @@
 				compatible = "microchip,mcp23s08";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi1-2-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s08-spi1-2-present parameter */
 				reg = <2>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -212,7 +212,7 @@
 				compatible = "microchip,mcp23s08";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi2-0-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s08-spi2-0-present parameter */
 				reg = <0>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -235,7 +235,7 @@
 				compatible = "microchip,mcp23s08";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi2-1-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s08-spi2-1-present parameter */
 				reg = <1>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -258,7 +258,7 @@
 				compatible = "microchip,mcp23s08";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s08-spi2-2-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s08-spi2-2-present parameter */
 				reg = <2>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -281,7 +281,7 @@
 				compatible = "microchip,mcp23s17";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi0-0-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s17-spi0-0-present parameter */
 				reg = <0>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -304,7 +304,7 @@
 				compatible = "microchip,mcp23s17";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi0-1-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s17-spi0-1-present parameter */
 				reg = <1>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -327,7 +327,7 @@
 				compatible = "microchip,mcp23s17";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi1-0-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s17-spi1-0-present parameter */
 				reg = <0>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -350,7 +350,7 @@
 				compatible = "microchip,mcp23s17";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi1-1-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s17-spi1-1-present parameter */
 				reg = <1>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -373,7 +373,7 @@
 				compatible = "microchip,mcp23s17";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi1-2-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s17-spi1-2-present parameter */
 				reg = <2>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -396,7 +396,7 @@
 				compatible = "microchip,mcp23s17";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi2-0-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s17-spi2-0-present parameter */
 				reg = <0>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -419,7 +419,7 @@
 				compatible = "microchip,mcp23s17";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi2-1-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s17-spi2-1-present parameter */
 				reg = <1>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -442,7 +442,7 @@
 				compatible = "microchip,mcp23s17";
 				gpio-controller;
 				#gpio-cells = <2>;
-				microchip,spi-present-mask = <0x00>;  /* overwritten by mcp23s17-spi2-2-present parameter */
+				microchip,spi-present-mask = /bits/ 8 <0x00>;  /* overwritten by mcp23s17-spi2-2-present parameter */
 				reg = <2>;
 				spi-max-frequency = <500000>;
 				status = "okay";
@@ -727,22 +727,22 @@
 	};
 
 	__overrides__ {
-		s08-spi0-0-present = <0>,"+0+8",  <&mcp23s08_00>,"microchip,spi-present-mask:0";
-		s08-spi0-1-present = <0>,"+1+9",  <&mcp23s08_01>,"microchip,spi-present-mask:0";
-		s08-spi1-0-present = <0>,"+2+10", <&mcp23s08_10>,"microchip,spi-present-mask:0";
-		s08-spi1-1-present = <0>,"+3+11", <&mcp23s08_11>,"microchip,spi-present-mask:0";
-		s08-spi1-2-present = <0>,"+4+12", <&mcp23s08_12>,"microchip,spi-present-mask:0";
-		s08-spi2-0-present = <0>,"+5+13", <&mcp23s08_20>,"microchip,spi-present-mask:0";
-		s08-spi2-1-present = <0>,"+6+14", <&mcp23s08_21>,"microchip,spi-present-mask:0";
-		s08-spi2-2-present = <0>,"+7+15", <&mcp23s08_22>,"microchip,spi-present-mask:0";
-		s17-spi0-0-present = <0>,"+0+16", <&mcp23s17_00>,"microchip,spi-present-mask:0";
-		s17-spi0-1-present = <0>,"+1+17", <&mcp23s17_01>,"microchip,spi-present-mask:0";
-		s17-spi1-0-present = <0>,"+2+18", <&mcp23s17_10>,"microchip,spi-present-mask:0";
-		s17-spi1-1-present = <0>,"+3+19", <&mcp23s17_11>,"microchip,spi-present-mask:0";
-		s17-spi1-2-present = <0>,"+4+20", <&mcp23s17_12>,"microchip,spi-present-mask:0";
-		s17-spi2-0-present = <0>,"+5+21", <&mcp23s17_20>,"microchip,spi-present-mask:0";
-		s17-spi2-1-present = <0>,"+6+22", <&mcp23s17_21>,"microchip,spi-present-mask:0";
-		s17-spi2-2-present = <0>,"+7+23", <&mcp23s17_22>,"microchip,spi-present-mask:0";
+		s08-spi0-0-present = <0>,"+0+8",  <&mcp23s08_00>,"microchip,spi-present-mask.0";
+		s08-spi0-1-present = <0>,"+1+9",  <&mcp23s08_01>,"microchip,spi-present-mask.0";
+		s08-spi1-0-present = <0>,"+2+10", <&mcp23s08_10>,"microchip,spi-present-mask.0";
+		s08-spi1-1-present = <0>,"+3+11", <&mcp23s08_11>,"microchip,spi-present-mask.0";
+		s08-spi1-2-present = <0>,"+4+12", <&mcp23s08_12>,"microchip,spi-present-mask.0";
+		s08-spi2-0-present = <0>,"+5+13", <&mcp23s08_20>,"microchip,spi-present-mask.0";
+		s08-spi2-1-present = <0>,"+6+14", <&mcp23s08_21>,"microchip,spi-present-mask.0";
+		s08-spi2-2-present = <0>,"+7+15", <&mcp23s08_22>,"microchip,spi-present-mask.0";
+		s17-spi0-0-present = <0>,"+0+16", <&mcp23s17_00>,"microchip,spi-present-mask.0";
+		s17-spi0-1-present = <0>,"+1+17", <&mcp23s17_01>,"microchip,spi-present-mask.0";
+		s17-spi1-0-present = <0>,"+2+18", <&mcp23s17_10>,"microchip,spi-present-mask.0";
+		s17-spi1-1-present = <0>,"+3+19", <&mcp23s17_11>,"microchip,spi-present-mask.0";
+		s17-spi1-2-present = <0>,"+4+20", <&mcp23s17_12>,"microchip,spi-present-mask.0";
+		s17-spi2-0-present = <0>,"+5+21", <&mcp23s17_20>,"microchip,spi-present-mask.0";
+		s17-spi2-1-present = <0>,"+6+22", <&mcp23s17_21>,"microchip,spi-present-mask.0";
+		s17-spi2-2-present = <0>,"+7+23", <&mcp23s17_22>,"microchip,spi-present-mask.0";
 		s08-spi0-0-int-gpio = <0>,"+24+32", <&spi0_0_int_pins>,"brcm,pins:0", <&mcp23s08_00>,"interrupts:0";
 		s08-spi0-1-int-gpio = <0>,"+25+33", <&spi0_1_int_pins>,"brcm,pins:0", <&mcp23s08_01>,"interrupts:0";
 		s08-spi1-0-int-gpio = <0>,"+26+34", <&spi1_0_int_pins>,"brcm,pins:0", <&mcp23s08_10>,"interrupts:0";

--- a/arch/arm/boot/dts/overlays/pifacedigital-overlay.dts
+++ b/arch/arm/boot/dts/overlays/pifacedigital-overlay.dts
@@ -89,7 +89,7 @@
 				reg = <0>;
 
 				/* Set devices present with 8-bit mask. */
-				microchip,spi-present-mask = <0x01>;
+				microchip,spi-present-mask = /bits/ 8 <0x01>;
 				spi-max-frequency = <500000>;
 
 				gpio-controller;
@@ -139,6 +139,6 @@
 	};
 
 	__overrides__ {
-		spi-present-mask = <&pfdigital>, "microchip,spi-present-mask:0";
+		spi-present-mask = <&pfdigital>, "microchip,spi-present-mask.0";
 	};
 };


### PR DESCRIPTION
Since upstream commit b0c13ec17438 ("pinctrl: mcp23s08: Read
spi-present-mask as u8 not u32"), backported to stable, the driver
reads microchip,spi-present-mask with device_property_read_u8. The
overlays declared the property as a 32-bit cell, so the driver now
reads the first (zero) byte of the big-endian value and probing fails
with "invalid spi-present-mask".

Declare the property as a single byte with /bits/ 8, as the binding
specifies, and change the parameter overrides to byte writes ('.'
separator) to match.

See: https://github.com/raspberrypi/linux/issues/7561