### PR TITLE
clk: bcm: rpi: Restore the requested rate when preparing a clock

### DIFF
--- a/drivers/clk/bcm/clk-raspberrypi.c
+++ b/drivers/clk/bcm/clk-raspberrypi.c
@@ -306,8 +306,14 @@ static int raspberrypi_fw_prepare(struct clk_hw *hw)
 		return ret;
 	}
 
+	/*
+	 * Set the clock rate to the maximum possible rate or restore the rate
+	 * the consumer requested.
+	 */
 	if (variant->maximize)
 		ret = raspberrypi_fw_set_rate(hw, variant->max_rate, 0);
+	else
+		ret = raspberrypi_fw_set_rate(hw, clk_hw_get_rate(hw), 0);
 
 	return ret;
 }


### PR DESCRIPTION
Lowering the rate on unprepare writes to the firmware directly, so the rate the clock framework has cached keeps describing a state the hardware is no longer in.

Nothing puts that rate back. A consumer that requests the same rate it had requested before the clock was unprepared is short-circuited by clk_core_set_rate_nolock(), which skips clocks that are already at the requested rate, so .set_rate is never reached. The clock is re-enabled at the rate unprepare left behind, and neither the consumer nor the framework has any indication that the request had no effect.

Restore the rate the framework last resolved when preparing a clock, so that lowering the rate on unprepare stays invisible to consumers.