### PR TITLE
usbip: host: ignore number_of_packets for non-isoc URBs

### DIFF
--- a/drivers/usb/usbip/stub_rx.c
+++ b/drivers/usb/usbip/stub_rx.c
@@ -481,6 +481,8 @@ static void stub_recv_cmd_submit(struct stub_device *sdev,
 
 	if (pipe == -1)
 		return;
+	if (!usb_pipeisoc(pipe))
+		pdu->u.cmd_submit.number_of_packets = 0;
 
 	/*
 	 * Smatch reported the error case where use_sg is true and buf_len is 0.


### PR DESCRIPTION
number_of_packets is only meaningful for isochronous URBs.  The USB/IP stub currently copies the value from the CMD_SUBMIT PDU into the local URB verbatim for all endpoint types.

Some clients (e.g. usbip-win) leave number_of_packets uninitialized for non-isoc URBs, so a garbage/huge value reaches usb_submit_urb().  Host controllers that size per-URB allocations by this field (e.g. dwc2's dwc2_hcd_urb_alloc(), which always sizes the iso descriptor array by urb->number_of_packets) then attempt a multi-gigabyte allocation that fails with -ENOMEM, making usbip-host reset the device in an endless loop (older dwc_otg crashes outright instead).

Sanitize number_of_packets to 0 for non-isochronous endpoints in the stub.  This is a strict no-op for well-behaved clients (Linux vhci already sends 0 for non-isoc URBs) and fixes the dwc2/dwc_otg failures.