### PR TITLE
staging: vc04_services: fix pointer arithmetic in create_pagelist

### DIFF
--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
@@ -1590,8 +1590,8 @@ create_pagelist(struct vchiq_instance *instance, struct vchiq_bulk *bulk)
 		for (actual_pages = 0; actual_pages < num_pages;
 		     actual_pages++) {
 			struct page *pg =
-			        vmalloc_to_page((void *)((char *)bulk->offset + 
-						(actual_pages * PAGE_SIZE)))
+				vmalloc_to_page((void *)((char *)bulk->offset +
+						 (actual_pages * PAGE_SIZE)));
 
 			size_t bytes = PAGE_SIZE - off;
 

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
@@ -1590,7 +1590,7 @@ create_pagelist(struct vchiq_instance *instance, struct vchiq_bulk *bulk)
 		for (actual_pages = 0; actual_pages < num_pages;
 		     actual_pages++) {
 			struct page *pg =
-				vmalloc_to_page((void *)((char *)bulk->offset +
+				vmalloc_to_page(((void *)bulk->offset +
 						 (actual_pages * PAGE_SIZE)));
 
 			size_t bytes = PAGE_SIZE - off;

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
@@ -1592,7 +1592,6 @@ create_pagelist(struct vchiq_instance *instance, struct vchiq_bulk *bulk)
 			struct page *pg =
 				vmalloc_to_page(((void *)bulk->offset +
 						 (actual_pages * PAGE_SIZE)));
-
 			size_t bytes = PAGE_SIZE - off;
 
 			if (!pg) {

--- a/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
+++ b/drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c
@@ -1590,8 +1590,9 @@ create_pagelist(struct vchiq_instance *instance, struct vchiq_bulk *bulk)
 		for (actual_pages = 0; actual_pages < num_pages;
 		     actual_pages++) {
 			struct page *pg =
-				vmalloc_to_page(((unsigned int *)bulk->offset +
-						 (actual_pages * PAGE_SIZE)));
+			        vmalloc_to_page((void *)((char *)bulk->offset + 
+						(actual_pages * PAGE_SIZE)))
+
 			size_t bytes = PAGE_SIZE - off;
 
 			if (!pg) {


### PR DESCRIPTION
### Summary

Fix a pointer-arithmetic bug in the vmalloc handling path of `create_pagelist()`.

### Problem

In `drivers/staging/vc04_services/interface/vchiq_arm/vchiq_core.c`:

```c
struct page *pg =
    vmalloc_to_page(((unsigned int *)bulk->offset +
                     (actual_pages * PAGE_SIZE)));
```

Adding an integer to an unsigned int * multiplies the offset by sizeof(unsigned int) (4). Consequently the address becomes:bulk->offset + (actual_pages * PAGE_SIZE * 4)instead of the intended:bulk->offset + (actual_pages * PAGE_SIZE)Only the first page is correct; later pages are wrong. This can lead to
incorrect DMA mappings, data corruption, or NULL page pointers.

