### PR TITLE
overlays: wk2xxx-uart: Add WK2xxx SPI UART overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -379,6 +379,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	waveshare-can-fd-hat-mode-b.dtbo \
 	wifimac.dtbo \
 	wittypi.dtbo \
+	wk2xxx-uart.dtbo \
 	wm8960-soundcard.dtbo \
 	ws2812-pio.dtbo
 

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -6390,6 +6390,8 @@ Info:   Overlay for the WK2xxx SPI to UART bridge (WK2124/WK2132/WK2168/
 Load:   dtoverlay=wk2xxx-uart,<param>=<val>
 Params: ipc1200                 Enable the IPC1200 configuration (SPI0/WK2132)
         sbc2300                 Enable the SBC2300 configuration (SPI1/WK2204)
+        int-gpio                GPIO used for the WK2xxx interrupt.
+        clock-frequency         On-board crystal frequency in Hz.
 
 
 Name:   wm8960-soundcard

--- a/arch/arm/boot/dts/overlays/README
+++ b/arch/arm/boot/dts/overlays/README
@@ -6382,6 +6382,16 @@ Params: led_gpio                GPIO for LED (default "17")
                                 "default-on")
 
 
+Name:   wk2xxx-uart
+Info:   Overlay for the WK2xxx SPI to UART bridge (WK2124/WK2132/WK2168/
+        WK2202/WK2204). Two board configurations are provided:
+        - ipc1200: WK2132 on SPI0 (CE0), crystal 11.0592 MHz, IRQ on GPIO24
+        - sbc2300: WK2204 on SPI1 (CE0), crystal 12 MHz, IRQ on GPIO17
+Load:   dtoverlay=wk2xxx-uart,<param>=<val>
+Params: ipc1200                 Enable the IPC1200 configuration (SPI0/WK2132)
+        sbc2300                 Enable the SBC2300 configuration (SPI1/WK2204)
+
+
 Name:   wm8960-soundcard
 Info:   Overlay for the Waveshare wm8960 soundcard
 Load:   dtoverlay=wm8960-soundcard,<param>=<val>

--- a/arch/arm/boot/dts/overlays/wk2xxx-uart-overlay.dts
+++ b/arch/arm/boot/dts/overlays/wk2xxx-uart-overlay.dts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * WK2xxx SPI UART overlay for EDATEC IPC1200 (SPI0) and SBC2300 (SPI1).
+ *
+ * Updated for the upstream-style wk2xxx driver:
+ *  - uses the standard "interrupt-parent"/"interrupts" properties instead
+ *    of the vendor "irq_gpio" property
+ *  - the gpio-controller/#gpio-cells properties were dropped because the
+ *    driver does not (yet) implement the WK2168 GPIO block
+ */
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&gpio>;
+		__dormant__ {
+			spi0_pins: spi0_pins {
+				brcm,pins = <9 10 11>;
+				brcm,function = <4>;
+			};
+
+			spi0_cs_pins: spi0_cs_pins {
+				brcm,pins = <8>;
+				brcm,function = <1>;
+			};
+
+			spi0_int_pins: spi0_int_pins {
+				brcm,pins = <24>;
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
+			cs-gpios = <&gpio 8 1>;
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			wk2xxx_spi0: wk2xxx@0 {
+				compatible = "wkmic,wk2132";
+				reg = <0>; /* CE0 */
+				spi-max-frequency = <10000000>;
+				clock-frequency = <11059200>; /* on-board crystal 11.0592 MHz */
+				interrupt-parent = <&gpio>;
+				interrupts = <24 IRQ_TYPE_LEVEL_LOW>; /* GPIO24 */
+				pinctrl-0 = <&spi0_int_pins>;
+				pinctrl-names = "default";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&gpio>;
+		__overlay__ {
+			spi1_pins: spi1_pins {
+				brcm,pins = <19 20 21>;
+				brcm,function = <3>;
+			};
+
+			spi1_cs_pins: spi1_cs_pins {
+				brcm,pins = <18>;
+				brcm,function = <1>;
+			};
+
+			spi1_int_pins: spi1_int_pins {
+				brcm,pins = <17>;
+				brcm,function = <0>;
+				brcm,pull = <0>;
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&spi1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi1_pins &spi1_cs_pins>;
+			cs-gpios = <&gpio 18 1>;
+			status = "okay";
+		};
+	};
+
+	fragment@5 {
+		target = <&aux>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target = <&spi1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			wk2xxx_spi1: wk2xxx@0 {
+				compatible = "wkmic,wk2204";
+				reg = <0>; /* CE0 */
+				spi-max-frequency = <10000000>;
+				clock-frequency = <12000000>; /* on-board crystal 12 MHz */
+				interrupt-parent = <&gpio>;
+				interrupts = <17 IRQ_TYPE_LEVEL_LOW>; /* GPIO17 */
+				pinctrl-0 = <&spi1_int_pins>;
+				pinctrl-names = "default";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@7 {
+		target = <&aux>;
+		__dormant__ {
+			status = "disabled";
+		};
+	};
+
+	__overrides__ {
+		ipc1200 = <0>, "+0+1+2-3-4-5-6-7";
+		sbc2300 = <0>, "-0-1-2+3+4+5+6-7";
+	};
+};

--- a/arch/arm/boot/dts/overlays/wk2xxx-uart-overlay.dts
+++ b/arch/arm/boot/dts/overlays/wk2xxx-uart-overlay.dts
@@ -1,12 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0 OR MIT)
 /*
  * WK2xxx SPI UART overlay for EDATEC IPC1200 (SPI0) and SBC2300 (SPI1).
- *
- * Updated for the upstream-style wk2xxx driver:
- *  - uses the standard "interrupt-parent"/"interrupts" properties instead
- *    of the vendor "irq_gpio" property
- *  - the gpio-controller/#gpio-cells properties were dropped because the
- *    driver does not (yet) implement the WK2168 GPIO block
  */
 /dts-v1/;
 /plugin/;
@@ -19,20 +13,14 @@
 	fragment@0 {
 		target = <&gpio>;
 		__dormant__ {
-			spi0_pins: spi0_pins {
+			wk2xxx_spi0_pins: wk2xxx_spi0_pins {
 				brcm,pins = <9 10 11>;
 				brcm,function = <4>;
 			};
 
-			spi0_cs_pins: spi0_cs_pins {
+			wk2xxx_spi0_cs_pins: wk2xxx_spi0_cs_pins {
 				brcm,pins = <8>;
 				brcm,function = <1>;
-			};
-
-			spi0_int_pins: spi0_int_pins {
-				brcm,pins = <24>;
-				brcm,function = <0>;
-				brcm,pull = <0>;
 			};
 		};
 	};
@@ -43,7 +31,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
+			pinctrl-0 = <&wk2xxx_spi0_pins &wk2xxx_spi0_cs_pins>;
 			cs-gpios = <&gpio 8 1>;
 			status = "okay";
 		};
@@ -62,8 +50,6 @@
 				clock-frequency = <11059200>; /* on-board crystal 11.0592 MHz */
 				interrupt-parent = <&gpio>;
 				interrupts = <24 IRQ_TYPE_LEVEL_LOW>; /* GPIO24 */
-				pinctrl-0 = <&spi0_int_pins>;
-				pinctrl-names = "default";
 				status = "okay";
 			};
 		};
@@ -72,20 +58,14 @@
 	fragment@3 {
 		target = <&gpio>;
 		__overlay__ {
-			spi1_pins: spi1_pins {
+			wk2xxx_spi1_pins: wk2xxx_spi1_pins {
 				brcm,pins = <19 20 21>;
 				brcm,function = <3>;
 			};
 
-			spi1_cs_pins: spi1_cs_pins {
+			wk2xxx_spi1_cs_pins: wk2xxx_spi1_cs_pins {
 				brcm,pins = <18>;
 				brcm,function = <1>;
-			};
-
-			spi1_int_pins: spi1_int_pins {
-				brcm,pins = <17>;
-				brcm,function = <0>;
-				brcm,pull = <0>;
 			};
 		};
 	};
@@ -96,7 +76,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&spi1_pins &spi1_cs_pins>;
+			pinctrl-0 = <&wk2xxx_spi1_pins &wk2xxx_spi1_cs_pins>;
 			cs-gpios = <&gpio 18 1>;
 			status = "okay";
 		};
@@ -122,22 +102,15 @@
 				clock-frequency = <12000000>; /* on-board crystal 12 MHz */
 				interrupt-parent = <&gpio>;
 				interrupts = <17 IRQ_TYPE_LEVEL_LOW>; /* GPIO17 */
-				pinctrl-0 = <&spi1_int_pins>;
-				pinctrl-names = "default";
 				status = "okay";
 			};
 		};
 	};
 
-	fragment@7 {
-		target = <&aux>;
-		__dormant__ {
-			status = "disabled";
-		};
-	};
-
 	__overrides__ {
-		ipc1200 = <0>, "+0+1+2-3-4-5-6-7";
-		sbc2300 = <0>, "-0-1-2+3+4+5+6-7";
+		ipc1200 = <0>, "+0+1+2-3-4-5-6";
+		sbc2300 = <0>, "-0-1-2+3+4+5+6";
+		int-gpio = <&wk2xxx_spi0>, "interrupts:0", <&wk2xxx_spi1>, "interrupts:0";
+		clock-frequency = <&wk2xxx_spi0>, "clock-frequency:0", <&wk2xxx_spi1>, "clock-frequency:0";
 	};
 };


### PR DESCRIPTION
Add an overlay for the WK2xxx SPI to UART bridge ICs (WK2124, WK2132, WK2168, WK2202 and WK2204) from WKmic. Two board configurations are provided via mutually-exclusive dormant fragments:
- ipc1200: WK2132 on SPI0 (CE0), crystal 11.0592 MHz, IRQ on GPIO24
- sbc2300: WK2204 on SPI1 (CE0), crystal 12 MHz, IRQ on GPIO17

Both configurations use the standard interrupt-parent/interrupts properties (level-low active) and the clock-frequency property to match the on-board crystals.

Tested on Raspberry Pi 5 boards (EDATEC IPC1200 and SBC2300) with loopback TX/RX tests passing.