### PR TITLE
ASoC: hdmi-codec: Fall back to a valid channel allocation

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_hdmi.c
+++ b/drivers/gpu/drm/vc4/vc4_hdmi.c
@@ -2167,8 +2167,17 @@ static int vc4_hdmi_audio_cpu_dai_probe(struct snd_soc_dai *dai)
 	return 0;
 }
 
+static int vc4_hdmi_audio_cpu_dai_startup(struct snd_pcm_substream *substream,
+					  struct snd_soc_dai *dai)
+{
+	/* hdmi-codec has no channel allocation for odd channel counts */
+	return snd_pcm_hw_constraint_step(substream->runtime, 0,
+					  SNDRV_PCM_HW_PARAM_CHANNELS, 2);
+}
+
 static const struct snd_soc_dai_ops vc4_snd_dai_ops = {
 	.probe  = vc4_hdmi_audio_cpu_dai_probe,
+	.startup = vc4_hdmi_audio_cpu_dai_startup,
 };
 
 static struct snd_soc_dai_driver vc4_hdmi_audio_cpu_dai_drv = {

--- a/sound/soc/codecs/hdmi-codec.c
+++ b/sound/soc/codecs/hdmi-codec.c
@@ -362,6 +362,10 @@ static int hdmi_codec_get_ch_alloc_table_idx(struct hdmi_codec_priv *hcp,
 	unsigned long spk_mask;
 	const struct hdmi_codec_cea_spk_alloc *cap = hdmi_codec_channel_alloc;
 
+	/* Index 0 is CA 0x00, which is valid for any sink */
+	if (channels <= 2)
+		return 0;
+
 	spk_alloc = drm_eld_get_spk_alloc(hcp->eld);
 	spk_mask = hdmi_codec_spk_mask_from_alloc(spk_alloc);
 


### PR DESCRIPTION
hdmi_codec_get_ch_alloc_table_idx() only succeeds when it finds a CEA channel allocation whose speaker mask is a subset of the one advertised in the sink's ELD. Every allocation in the table contains the front pair, and the only escape hatch requires the ELD speaker allocation byte to be entirely zero (the unplugged case), so a sink that advertises speakers without setting bit 0 (FL/FR) matches nothing at all and the function returns -EINVAL.

A Philips 77OLED809 does exactly that. Its Speaker Allocation Data Block is 0x7e, declaring LFE1, FC, BL/BR, BC, FLc/FRc and RLC/RRC but no front pair. CTA-861 defines bit 0 as FL/FR and attaches no further requirement to it, so edid-decode -c passes this EDID, but with the bit clear there is no allocation left to select. Playback then fails for every channel count, including the 2 channel LPCM that is the only uncompressed format the set accepts:

  hdmi-audio-codec hdmi-audio-codec.1.auto: Not able to map channels to speakers (-22)
  hdmi-audio-codec hdmi-audio-codec.1.auto: ASoC: error at snd_soc_pcm_dai_prepare on i2s-hifi: -22

This repeats for as long as userspace retries the open, and leaves no usable HDMI audio output.

Handle it the way hdmi_channel_allocation_spk_alloc_blk() in the HDA driver always has: return CA 0x00 for two channels or fewer without consulting the ELD at all, and where the speaker mask matches nothing, substitute the first allocation with the requested channel count rather than failing.

The fallback is restricted to sinks advertising more than the front pair. hdmi_codec_chmap_ctl_get() indexes the installed channel map array by ca_id, and hdmi_codec_eld_chmap() only installs the ca_id-indexed 8 channel maps under that same condition. hdmi_codec_stereo_chmaps has no entry beyond CA 0x00, so returning a higher ca_id with that array installed would read out of bounds.

Well-formed ELDs are unaffected: every speaker allocation that previously selected an allocation still selects the same one.

See: https://github.com/raspberrypi/linux/issues/7603