### PR TITLE
net: bcm: genet: Increase max MTU supported

### DIFF
--- a/drivers/net/ethernet/broadcom/genet/bcmgenet.c
+++ b/drivers/net/ethernet/broadcom/genet/bcmgenet.c
@@ -49,7 +49,7 @@
 #define GENET_Q0_TX_BD_CNT	\
 	(TOTAL_DESC - priv->hw_params->tx_queues * priv->hw_params->tx_bds_per_q)
 
-#define RX_BUF_LENGTH		2048
+#define RX_BUF_LENGTH		10240
 #define SKB_ALIGNMENT		32
 
 /* Tx/Rx DMA register offset, skip 256 descriptors */
@@ -2616,6 +2616,14 @@ static void init_umac(struct bcmgenet_priv *priv)
 	reg |= RBUF_ALIGN_2B | RBUF_64B_EN;
 	bcmgenet_rbuf_writel(priv, reg, RBUF_CTRL);
 
+	/* 8 bit register, units of 16 bytes, and should be aligned to burst
+	 * size (256bytes). So max threshold of 3840 bytes to meet these
+	 * criteria.
+	 * (There will also be a 64 byte status block, giving 3904 bytes total)
+	 */
+	reg = 0xf0;
+	bcmgenet_rbuf_writel(priv, reg, RBUF_PKT_RDY_THLD);
+
 	/* enable rx checksumming */
 	reg = bcmgenet_rbuf_readl(priv, RBUF_CHK_CTRL);
 	reg |= RBUF_RXCHK_EN | RBUF_L3_PARSE_DIS;
@@ -3955,6 +3963,10 @@ static int bcmgenet_probe(struct platform_device *pdev)
 	priv->tx_pause = 1;
 	priv->rx_pause = 1;
 
+	dev->mtu = ETH_DATA_LEN;
+	dev->min_mtu = ETH_MIN_MTU;
+	dev->max_mtu = ENET_MAX_MTU_SIZE;
+
 	SET_NETDEV_DEV(dev, &pdev->dev);
 	dev_set_drvdata(&pdev->dev, dev);
 	dev->watchdog_timeo = 2 * HZ;
@@ -4021,7 +4033,7 @@ static int bcmgenet_probe(struct platform_device *pdev)
 
 	/* Mii wait queue */
 	init_waitqueue_head(&priv->wq);
-	/* Always use RX_BUF_LENGTH (2KB) buffer for all chips */
+	/* Always use RX_BUF_LENGTH (10KB) buffer for all chips */
 	priv->rx_buf_len = RX_BUF_LENGTH;
 	INIT_WORK(&priv->bcmgenet_irq_work, bcmgenet_irq_task);
 

--- a/drivers/net/ethernet/broadcom/genet/bcmgenet.h
+++ b/drivers/net/ethernet/broadcom/genet/bcmgenet.h
@@ -27,13 +27,13 @@
 /* which ring is descriptor based */
 #define DESC_INDEX				16
 
-/* Body(1500) + EH_SIZE(14) + VLANTAG(4) + BRCMTAG(6) + FCS(4) = 1528.
- * 1536 is multiple of 256 bytes
+/* The hardware is always triggering on 3840bytes received or end of packet, and
+ * the driver doesn't handle fragmentation.
+ * With that threshold, packets with an MTU of up to 3824 are received
+ * correctly.
  */
 #define ENET_BRCM_TAG_LEN	6
-#define ENET_PAD		8
-#define ENET_MAX_MTU_SIZE	(ETH_DATA_LEN + ETH_HLEN + VLAN_HLEN + \
-				 ENET_BRCM_TAG_LEN + ETH_FCS_LEN + ENET_PAD)
+#define ENET_MAX_MTU_SIZE	3824
 #define DMA_MAX_BURST_LENGTH    0x10
 
 /* misc. configuration */
@@ -218,6 +218,8 @@ struct bcmgenet_rx_stats64 {
 #define  RBUF_64B_EN			(1 << 0)
 #define  RBUF_ALIGN_2B			(1 << 1)
 #define  RBUF_BAD_DIS			(1 << 2)
+
+#define RBUF_PKT_RDY_THLD		0x08
 
 #define RBUF_STATUS			0x0C
 #define  RBUF_STATUS_WOL		(1 << 0)


### PR DESCRIPTION
The hardware has a RBUF_PKT_RDY_THLD register to the threshold value at which it raises an interrupt during receive. This is an 8bit register in units of 16bytes, and the value should be a multiple of the burst size of 256bytes. That corresponds to a register value of 0xf0, resulting in a max MTU of 3824.

This also increases the receive buffer size to 10240 bytes in the hope that we can add handling for fragmented receives (multiple notifications).

See #5561. Gets some improvement on jumbo frame support. Waiting for info from Broadcom for further improvements.